### PR TITLE
Add build-copilot-sdk-app skill

### DIFF
--- a/NAMING.md
+++ b/NAMING.md
@@ -91,6 +91,7 @@ When renaming a published skill:
 
 ## Current Canonical Skill Names
 
+- `build-copilot-sdk-app`
 - `build-daisyui-mcp`
 - `build-mcp-sdk-server`
 - `build-mcp-use-apps`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-20 skills for AI coding agents — agent configuration, code review setup, design extraction, MCP tooling, browser automation, planning, research, framework guides, language standards, UI component libraries, and CI/CD.
+21 skills for AI coding agents — agent configuration, code review setup, design extraction, MCP tooling, browser automation, planning, research, framework guides, SDK guides, language standards, UI component libraries, and CI/CD.
 
 ## Install the full pack
 
@@ -186,6 +186,20 @@ Deep reference skills for specific frameworks and tools.
 ```bash
 npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/build-supastarter-app
 npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/debug-tauri-devtools
+```
+
+---
+
+## SDK Guides
+
+Deep reference skills for building applications with AI platform SDKs.
+
+| Skill | What it does |
+|---|---|
+| **[build-copilot-sdk-app](skills/build-copilot-sdk-app/)** | Complete developer guide for the GitHub Copilot SDK (`@github/copilot-sdk`) in TypeScript/Node.js — client setup, sessions, custom tools with Zod schemas, streaming events (47 event types), permissions, hooks, custom agents, MCP servers, skills, BYOK providers, plan/autopilot/fleet modes, multi-client architectures, and Ralph loop autonomous dev patterns. Includes 10 reference docs: client/transport, sessions, tools/schemas, events/streaming, permissions/user-input, hooks, agents/MCP/skills, auth/BYOK, advanced patterns, and complete type reference. |
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/build-copilot-sdk-app
 ```
 
 ---

--- a/skills/build-copilot-sdk-app/SKILL.md
+++ b/skills/build-copilot-sdk-app/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: build-copilot-sdk-app
+description: Use skill if you are building TypeScript applications with the GitHub Copilot SDK (@github/copilot-sdk), including sessions, tools, streaming, hooks, custom agents, or BYOK.
+---
+
+# Build Copilot SDK App
+
+Build applications powered by GitHub Copilot using the `@github/copilot-sdk` TypeScript/Node.js package (v0.1.32+, protocol v3). The SDK communicates with the Copilot CLI over JSON-RPC (stdio or TCP) and exposes a session-based API for sending prompts, receiving streamed responses, registering custom tools, handling permissions, and managing agent workflows.
+
+## Decision tree
+
+```
+What do you need?
+│
+├── New app from scratch
+│   ├── Install & basic example ──────────► Quick start (below)
+│   ├── Client options & transport ───────► references/client-and-transport.md
+│   └── Authentication ──────────────────► references/auth-and-byok.md
+│
+├── Sessions
+│   ├── Create / resume / disconnect ────► references/sessions.md
+│   ├── Infinite sessions & compaction ──► references/sessions.md
+│   └── Persistence & resumption ────────► references/sessions.md
+│
+├── Messages & streaming
+│   ├── send / sendAndWait ──────────────► Quick start (below)
+│   ├── Streaming deltas ────────────────► references/events-and-streaming.md
+│   └── All 47 event types ─────────────► references/events-and-streaming.md
+│
+├── Custom tools
+│   ├── defineTool with Zod ─────────────► references/tools-and-schemas.md
+│   ├── JSON Schema tools ──────────────► references/tools-and-schemas.md
+│   └── Override built-in tools ────────► references/tools-and-schemas.md
+│
+├── Permissions & user input
+│   ├── Permission handler ─────────────► references/permissions-and-user-input.md
+│   ├── askUser / onUserInputRequest ───► references/permissions-and-user-input.md
+│   └── Elicitation (MCP forms) ────────► references/permissions-and-user-input.md
+│
+├── Hooks (lifecycle interceptors)
+│   ├── Pre/post tool use ──────────────► references/hooks.md
+│   ├── Prompt modification ────────────► references/hooks.md
+│   └── Session lifecycle & errors ─────► references/hooks.md
+│
+├── Agents, MCP & skills
+│   ├── Custom agents ──────────────────► references/agents-mcp-skills.md
+│   ├── MCP server config ─────────────► references/agents-mcp-skills.md
+│   ├── Skills system ─────────────────► references/agents-mcp-skills.md
+│   └── CLI extensions (.mjs) ─────────► references/agents-mcp-skills.md
+│
+├── Advanced patterns
+│   ├── Plan / autopilot / interactive ─► references/advanced-patterns.md
+│   ├── Fleet mode ─────────────────────► references/advanced-patterns.md
+│   ├── Multi-client architecture ──────► references/advanced-patterns.md
+│   ├── Ralph loop (autonomous dev) ───► references/advanced-patterns.md
+│   ├── Steering & queueing ───────────► references/advanced-patterns.md
+│   └── System message modes ──────────► references/advanced-patterns.md
+│
+├── Auth & BYOK
+│   ├── GitHub OAuth / tokens ──────────► references/auth-and-byok.md
+│   └── Bring Your Own Key ────────────► references/auth-and-byok.md
+│
+└── Type reference
+    └── All interfaces & RPC methods ──► references/types-reference.md
+```
+
+## Quick start
+
+```bash
+npm install @github/copilot-sdk tsx
+```
+
+Requires Node.js >= 20 and Copilot CLI installed (`copilot --version`).
+
+### Minimal example
+
+```typescript
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+
+const client = new CopilotClient();
+
+const session = await client.createSession({
+  model: "gpt-4.1",
+  onPermissionRequest: approveAll,
+});
+
+const response = await session.sendAndWait({ prompt: "What is 2 + 2?" });
+console.log(response?.data.content);
+
+await session.disconnect();
+await client.stop();
+```
+
+### With streaming
+
+```typescript
+const session = await client.createSession({
+  model: "gpt-4.1",
+  streaming: true,
+  onPermissionRequest: approveAll,
+});
+
+session.on("assistant.message_delta", (event) => {
+  process.stdout.write(event.data.deltaContent);
+});
+
+session.on("session.idle", () => console.log("\n--- done ---"));
+
+await session.send({ prompt: "Explain TypeScript generics" });
+```
+
+### With a custom tool
+
+```typescript
+import { CopilotClient, defineTool, approveAll } from "@github/copilot-sdk";
+import { z } from "zod";
+
+const getWeather = defineTool("get_weather", {
+  description: "Get current weather for a city",
+  parameters: z.object({
+    city: z.string().describe("City name"),
+  }),
+  handler: async ({ city }) => ({
+    city,
+    temperature: "62°F",
+    condition: "cloudy",
+  }),
+});
+
+const client = new CopilotClient();
+const session = await client.createSession({
+  model: "gpt-4.1",
+  tools: [getWeather],
+  onPermissionRequest: approveAll,
+});
+
+const response = await session.sendAndWait({
+  prompt: "What's the weather in San Francisco?",
+});
+console.log(response?.data.content);
+
+await session.disconnect();
+await client.stop();
+```
+
+## Key patterns
+
+### Send-and-wait vs fire-and-forget
+
+```typescript
+// Blocking — waits for session.idle, returns last assistant.message
+const response = await session.sendAndWait(
+  { prompt: "Hello" },
+  30_000, // optional timeout in ms
+);
+
+// Non-blocking — returns immediately, events arrive via session.on()
+await session.send({ prompt: "Start a long task..." });
+```
+
+### Event subscription (typed + wildcard)
+
+```typescript
+// Typed — only fires for the specific event type
+const unsub = session.on("tool.execution_complete", (event) => {
+  console.log(`${event.data.toolName}: ${event.data.success}`);
+});
+
+// Wildcard — fires for every event
+session.on((event) => {
+  if (event.type === "session.error") {
+    console.error(event.data.message);
+  }
+});
+
+unsub(); // unsubscribe
+```
+
+### Session persistence
+
+```typescript
+// Create with a stable ID
+const session = await client.createSession({
+  sessionId: "user-123-conversation",
+  model: "gpt-4.1",
+  onPermissionRequest: approveAll,
+});
+await session.sendAndWait({ prompt: "Let's discuss TypeScript" });
+await session.disconnect(); // preserves state on disk
+
+// Resume later (same or different client)
+const resumed = await client.resumeSession("user-123-conversation", {
+  onPermissionRequest: approveAll,
+});
+```
+
+### Handling askUser programmatically
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  onUserInputRequest: async (request) => {
+    if (request.choices?.length) {
+      return { answer: request.choices[0], wasFreeform: false };
+    }
+    return { answer: "Yes, proceed", wasFreeform: true };
+  },
+});
+```
+
+### Plan / autopilot mode
+
+```typescript
+await session.rpc.mode.set({ mode: "plan" });
+
+session.on("exit_plan_mode.requested", (event) => {
+  console.log("Plan ready:", event.data.summary);
+  session.rpc.mode.set({ mode: "autopilot" });
+});
+```
+
+### Abort in-flight work
+
+```typescript
+await session.send({ prompt: "Run sleep 100" });
+await session.abort(); // cancels current work; session remains usable
+```
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| `onPermissionRequest` missing | Required on every `createSession`/`resumeSession`. Use `approveAll` for unattended operation. |
+| `sendAndWait` timeout | Default is 60s. Pass explicit timeout: `sendAndWait(opts, 300_000)`. Timeout does NOT abort in-flight work. |
+| Streaming events not arriving | Set `streaming: true` in SessionConfig. |
+| `cliUrl` + `useStdio` | Mutually exclusive. `cliUrl` connects to external server; `useStdio` spawns child process. |
+| `console.log` in extensions | stdout is reserved for JSON-RPC. Use `session.log()` instead. |
+| Tool name collision in extensions | Tool names must be globally unique across all extensions. |
+| BYOK without `model` | `model` is required when using `provider` config. |
+| Race condition on event registration | Register `session.on()` before calling `session.send()`. |

--- a/skills/build-copilot-sdk-app/references/advanced-patterns.md
+++ b/skills/build-copilot-sdk-app/references/advanced-patterns.md
@@ -1,0 +1,409 @@
+# Advanced Patterns
+
+## Plan / autopilot / interactive modes
+
+The session supports three execution modes:
+
+| Mode | Behavior |
+|------|----------|
+| `interactive` | Default. Agent asks before executing. |
+| `plan` | Agent writes a plan to `plan.md` instead of executing. |
+| `autopilot` | Agent executes without asking for confirmation. |
+
+### Mode RPC methods
+
+```typescript
+// Get current mode
+const { mode } = await session.rpc.mode.get();
+// mode: "interactive" | "plan" | "autopilot"
+
+// Set mode
+await session.rpc.mode.set({ mode: "plan" });
+await session.rpc.mode.set({ mode: "autopilot" });
+await session.rpc.mode.set({ mode: "interactive" });
+```
+
+### Plan mode workflow
+
+```typescript
+// 1. Switch to plan mode
+await session.rpc.mode.set({ mode: "plan" });
+
+// 2. Send task — agent writes a plan instead of executing
+await session.send({ prompt: "Refactor the auth module" });
+
+// 3. Listen for plan completion
+session.on("exit_plan_mode.requested", (event) => {
+  console.log("Plan summary:", event.data.summary);
+  console.log("Plan content:", event.data.planContent);
+  console.log("Available actions:", event.data.actions);
+  console.log("Recommended:", event.data.recommendedAction);
+
+  // 4. Approve: switch to autopilot to execute
+  session.rpc.mode.set({ mode: "autopilot" });
+});
+
+// Mode change confirmed via event:
+session.on("session.mode_changed", (event) => {
+  console.log(`${event.data.previousMode} → ${event.data.newMode}`);
+});
+```
+
+### Plan RPC methods
+
+```typescript
+// Read the plan
+const plan = await session.rpc.plan.read();
+// { exists: boolean, content: string | null, path: string | null }
+
+// Update the plan
+await session.rpc.plan.update({ content: "# Updated Plan\n..." });
+
+// Delete the plan
+await session.rpc.plan.delete();
+```
+
+### Plan change events
+
+```typescript
+session.on("session.plan_changed", (event) => {
+  console.log(`Plan ${event.data.operation}`);
+  // operation: "create" | "update" | "delete"
+});
+```
+
+## Fleet mode
+
+Fleet mode activates a background fleet of agents with an optional prompt:
+
+```typescript
+const result = await session.rpc.fleet.start({ prompt: "Review all files" });
+// { started: boolean }
+```
+
+## Multi-client architecture
+
+Multiple SDK clients can connect to the same CLI server and session via TCP.
+
+### Setup
+
+```typescript
+// Client 1: starts the CLI server
+const client1 = new CopilotClient({ useStdio: false });
+const session1 = await client1.createSession({
+  tools: [toolA],
+  onPermissionRequest: approveAll,
+});
+
+// Get the port
+const actualPort = (client1 as any).actualPort;
+
+// Client 2: connects to the same server
+const client2 = new CopilotClient({ cliUrl: `localhost:${actualPort}` });
+const session2 = await client2.resumeSession(session1.sessionId, {
+  tools: [toolB],           // toolB added to session; toolA preserved
+  onPermissionRequest: approveAll,
+});
+// Model now sees both toolA and toolB
+```
+
+### Multi-client behaviors
+
+- **Tools**: unioned from all connected clients. If a client disconnects, its tools are removed.
+- **Events**: ALL events broadcast to ALL connected clients (via session events).
+- **Permissions**: `permission.requested` broadcasts to all; first response wins.
+- **External tools**: `external_tool.requested` broadcasts; the client with the matching handler responds.
+
+### Observer client pattern
+
+A client that only watches (never responds to permissions):
+
+```typescript
+const observer = await client2.resumeSession(sessionId, {
+  onPermissionRequest: () => new Promise(() => {}), // never resolves
+});
+observer.on((event) => {
+  console.log(`[observer] ${event.type}`);
+});
+```
+
+## Ralph loop (autonomous development)
+
+Fresh-context-per-iteration pattern for unattended AI development:
+
+```typescript
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { readFile } from "node:fs/promises";
+
+async function ralphLoop(promptFile: string, maxIterations = 50) {
+  const client = new CopilotClient();
+  await client.start();
+
+  try {
+    const prompt = await readFile(promptFile, "utf-8");
+
+    for (let i = 1; i <= maxIterations; i++) {
+      console.log(`--- Iteration ${i}/${maxIterations} ---`);
+
+      const session = await client.createSession({
+        model: "gpt-5.1-codex-mini",
+        workingDirectory: process.cwd(),
+        onPermissionRequest: approveAll,
+      });
+
+      session.on((event) => {
+        if (event.type === "tool.execution_start") {
+          console.log(`  tool: ${event.data.toolName}`);
+        }
+      });
+
+      try {
+        await session.sendAndWait({ prompt }, 600_000); // 10 min timeout
+      } finally {
+        await session.disconnect(); // fresh context next iteration
+      }
+    }
+  } finally {
+    await client.stop();
+  }
+}
+```
+
+### Ralph loop design principles
+
+1. **Fresh context per iteration**: `disconnect()` after every pass — no context accumulation
+2. **Disk as shared state**: `IMPLEMENTATION_PLAN.md` is the coordination mechanism between iterations
+3. **Backpressure**: Tests/builds in `AGENTS.md` reject bad work before committing
+4. **Two modes**: `plan` generates the plan; `build` implements from it
+5. **`workingDirectory`**: pins sessions so file paths resolve correctly
+6. **`approveAll`**: enables fully unattended operation
+
+### Required project files
+
+```
+project-root/
+├── PROMPT_plan.md          # planning mode instructions
+├── PROMPT_build.md         # building mode instructions
+├── AGENTS.md               # build/test/lint commands (keep < 60 lines)
+├── IMPLEMENTATION_PLAN.md  # shared state between iterations
+├── specs/                  # requirement specifications
+└── src/                    # source code
+```
+
+## Steering and queueing
+
+### Message modes
+
+```typescript
+// Enqueue (default) — queued if session is busy
+await session.send({ prompt: "Task 1", mode: "enqueue" });
+
+// Immediate — interrupts current work
+await session.send({ prompt: "URGENT: stop and do this", mode: "immediate" });
+```
+
+### Pending messages
+
+```typescript
+session.on("pending_messages.modified", () => {
+  console.log("Message queue changed");
+});
+```
+
+## System message modes
+
+```typescript
+// Append mode (default): adds to Copilot's built-in system prompt
+systemMessage: {
+  mode: "append",
+  content: "Always respond in bullet points.",
+}
+
+// Replace mode: replaces the entire system prompt (removes all SDK guardrails)
+systemMessage: {
+  mode: "replace",
+  content: "You are a specialized code reviewer. Only review code, nothing else.",
+}
+
+// Context injection pattern:
+systemMessage: {
+  content: `
+<context>
+You are analyzing PRs for: ${owner}/${repo}
+Project uses: React 19, TypeScript 5.7
+</context>
+<instructions>
+- Use GitHub MCP Server tools to fetch PR data
+- Focus on security and performance
+</instructions>
+`,
+}
+```
+
+## Workspace file operations
+
+When infinite sessions are enabled, access workspace files:
+
+```typescript
+// List workspace files
+const { files } = await session.rpc.workspace.listFiles();
+
+// Read a workspace file
+const { content } = await session.rpc.workspace.readFile({ path: "plan.md" });
+
+// Create/update a workspace file
+await session.rpc.workspace.createFile({
+  path: "notes.md",
+  content: "# Session Notes\n...",
+});
+```
+
+### Workspace file events
+
+```typescript
+session.on("session.workspace_file_changed", (event) => {
+  console.log(`File ${event.data.operation}: ${event.data.path}`);
+  // operation: "create" | "update"
+});
+```
+
+## Compaction (manual trigger)
+
+```typescript
+const result = await session.rpc.compaction.compact();
+// { success: boolean, tokensRemoved: number, messagesRemoved: number }
+```
+
+## Abort pattern
+
+```typescript
+// Start long-running work
+await session.send({ prompt: "Analyze every file in the repo" });
+
+// Monitor progress
+session.on("tool.execution_start", (event) => {
+  console.log(`Running: ${event.data.toolName}`);
+});
+
+// Abort after timeout or user request
+setTimeout(async () => {
+  await session.abort();
+  // session.idle event fires after abort completes
+  // Session remains usable for new messages
+}, 60_000);
+```
+
+## Backend service pattern
+
+```typescript
+import express from "express";
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+
+const client = new CopilotClient({ cliUrl: "localhost:4321" });
+const app = express();
+
+app.post("/api/chat", async (req, res) => {
+  const { sessionId, message } = req.body;
+
+  let session;
+  try {
+    session = await client.resumeSession(sessionId, {
+      onPermissionRequest: approveAll,
+    });
+  } catch {
+    session = await client.createSession({
+      sessionId,
+      model: "gpt-4.1",
+      onPermissionRequest: approveAll,
+    });
+  }
+
+  const response = await session.sendAndWait({ prompt: message });
+  res.json({ content: response?.data.content });
+});
+```
+
+## Model management
+
+```typescript
+// List available models
+const models = await client.listModels();
+for (const model of models) {
+  console.log(`${model.id}: ${model.name}`);
+  console.log(`  Vision: ${model.capabilities.supports.vision}`);
+  console.log(`  Context: ${model.capabilities.limits.max_context_window_tokens}`);
+  if (model.policy) console.log(`  Policy: ${model.policy.state}`);
+  if (model.billing) console.log(`  Multiplier: ${model.billing.multiplier}`);
+}
+
+// Switch model mid-session
+await session.setModel("gpt-5");
+
+// Get current model
+const { modelId } = await session.rpc.model.getCurrent();
+
+// Switch with reasoning effort
+await session.rpc.model.switchTo({
+  modelId: "gpt-5",
+  reasoningEffort: "high",
+});
+```
+
+## Scaling patterns
+
+### Isolated CLI per user
+
+```typescript
+class CLIPool {
+  private servers = new Map<string, CopilotClient>();
+
+  async getClient(userId: string, token: string): Promise<CopilotClient> {
+    if (!this.servers.has(userId)) {
+      const client = new CopilotClient({
+        githubToken: token,
+        useLoggedInUser: false,
+      });
+      await client.start();
+      this.servers.set(userId, client);
+    }
+    return this.servers.get(userId)!;
+  }
+}
+```
+
+### Shared CLI with session isolation
+
+```typescript
+const client = new CopilotClient({ cliUrl: "localhost:4321" });
+
+// Use unique session IDs per user
+const session = await client.createSession({
+  sessionId: `${userId}-${purpose}-${Date.now()}`,
+  onPermissionRequest: approveAll,
+});
+```
+
+### Session cleanup
+
+```typescript
+const sessions = await client.listSessions();
+const maxAge = 30 * 60 * 1000; // 30 minutes
+for (const s of sessions) {
+  if (Date.now() - s.modifiedTime.getTime() > maxAge) {
+    await client.deleteSession(s.sessionId);
+  }
+}
+```
+
+## Health check
+
+```typescript
+async function checkHealth(): Promise<boolean> {
+  try {
+    const status = await client.getStatus();
+    return status !== undefined;
+  } catch {
+    return false;
+  }
+}
+```

--- a/skills/build-copilot-sdk-app/references/agents-mcp-skills.md
+++ b/skills/build-copilot-sdk-app/references/agents-mcp-skills.md
@@ -1,0 +1,309 @@
+# Agents, MCP, and Skills
+
+## Custom agents
+
+Define agents with specialized personas, tool sets, and MCP servers:
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  customAgents: [
+    {
+      name: "code-reviewer",
+      displayName: "Code Reviewer",
+      description: "Reviews code for quality and security",
+      prompt: "You are a senior code reviewer. Focus on security, performance, and maintainability.",
+      tools: ["bash", "view", "grep"],  // restrict available tools
+      infer: true,                       // model auto-routes to this agent
+    },
+    {
+      name: "test-writer",
+      displayName: "Test Writer",
+      description: "Writes comprehensive tests",
+      prompt: "You write thorough unit and integration tests.",
+      tools: null,                       // null = all tools available
+      infer: true,
+      mcpServers: {                      // agent-specific MCP servers
+        playwright: {
+          type: "local",
+          command: "npx",
+          args: ["@playwright/mcp@latest"],
+          tools: ["*"],
+        },
+      },
+    },
+  ],
+  agent: "code-reviewer",  // activate this agent at session start
+});
+```
+
+### CustomAgentConfig
+
+```typescript
+interface CustomAgentConfig {
+  name: string;                              // unique identifier
+  displayName?: string;                      // human-readable name
+  description?: string;                      // shown to model for routing
+  tools?: string[] | null;                   // null/undefined = all tools
+  prompt: string;                            // system prompt for this agent
+  mcpServers?: Record<string, MCPServerConfig>; // agent-specific MCP servers
+  infer?: boolean;                           // default true — auto-route based on user intent
+}
+```
+
+### Agent RPC methods
+
+```typescript
+// List available agents
+const agents = await session.rpc.agent.list();
+// { agents: [{ name, displayName, description }] }
+
+// Get current agent
+const current = await session.rpc.agent.getCurrent();
+// { agent: { name, displayName, description } | null }
+
+// Switch to an agent
+await session.rpc.agent.select({ name: "test-writer" });
+
+// Deselect (back to default)
+await session.rpc.agent.deselect();
+```
+
+### Agent events
+
+```typescript
+session.on("subagent.selected", (event) => {
+  console.log(`Agent activated: ${event.data.agentName}`);
+  console.log(`Tools: ${event.data.tools}`); // string[] | null
+});
+
+session.on("subagent.deselected", () => {
+  console.log("Back to default agent");
+});
+
+session.on("subagent.started", (event) => {
+  console.log(`Sub-agent started: ${event.data.agentName}`);
+  console.log(`Description: ${event.data.agentDescription}`);
+});
+
+session.on("subagent.completed", (event) => {
+  console.log(`Sub-agent done: ${event.data.agentName}`);
+});
+
+session.on("subagent.failed", (event) => {
+  console.error(`Sub-agent error: ${event.data.error}`);
+});
+```
+
+## MCP servers
+
+Configure MCP servers per-session to extend the model's tool set.
+
+### Local/stdio MCP server
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  mcpServers: {
+    github: {
+      type: "local",        // or "stdio"
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-github"],
+      tools: ["*"],          // "*" = all tools; or list specific names
+      env: {
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      },
+      cwd: "/path/to/workdir",
+      timeout: 30000,
+    },
+  },
+});
+```
+
+### Remote HTTP/SSE MCP server
+
+```typescript
+mcpServers: {
+  "remote-api": {
+    type: "http",            // or "sse"
+    url: "https://api.githubcopilot.com/mcp/",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    tools: ["*"],
+    timeout: 30000,
+  },
+}
+```
+
+### MCPServerConfig types
+
+```typescript
+interface MCPLocalServerConfig {
+  type?: "local" | "stdio";
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  tools: string[];     // ["*"] for all, or specific tool names
+  timeout?: number;
+}
+
+interface MCPRemoteServerConfig {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  tools: string[];
+  timeout?: number;
+}
+```
+
+### MCP in custom agents
+
+Agents can have their own MCP servers that activate only when the agent is selected:
+
+```typescript
+customAgents: [{
+  name: "mcp-agent",
+  prompt: "Use MCP tools to complete tasks.",
+  mcpServers: {
+    "agent-server": {
+      type: "local",
+      command: "node",
+      args: ["/path/to/server.mjs"],
+      tools: ["*"],
+    },
+  },
+}]
+```
+
+### MCP on resume
+
+MCP servers can be added or changed when resuming a session:
+
+```typescript
+const session = await client.resumeSession("my-session", {
+  onPermissionRequest: approveAll,
+  mcpServers: {
+    newServer: {
+      type: "local",
+      command: "my-server",
+      args: [],
+      tools: ["*"],
+    },
+  },
+});
+```
+
+## Skills
+
+Skills are markdown files that inject instructions into the model's context.
+
+### Skill directory structure
+
+```
+skills-dir/
+  my-skill/
+    SKILL.md
+```
+
+### SKILL.md format
+
+```markdown
+---
+name: my-skill
+description: A skill that adds project-specific context
+---
+
+# Instructions
+
+Always use our internal API client from `src/api/client.ts`.
+Never use `fetch` directly — always go through the API layer.
+```
+
+### Session configuration
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  skillDirectories: ["/path/to/skills"],
+  disabledSkills: ["skill-to-disable"], // disable by name
+});
+```
+
+### Skill events
+
+```typescript
+session.on("skill.invoked", (event) => {
+  console.log(`Skill: ${event.data.name}`);
+  console.log(`Path: ${event.data.path}`);
+  console.log(`Content: ${event.data.content}`);
+  console.log(`Allowed tools: ${event.data.allowedTools}`);
+});
+```
+
+## CLI extensions (.mjs)
+
+Extensions run inside the Copilot CLI process and extend its capabilities.
+
+### File location
+
+```
+.github/extensions/<name>/extension.mjs
+```
+
+### Minimal extension
+
+```javascript
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  tools: [{
+    name: "my_tool",
+    description: "Does something useful",
+    parameters: {
+      type: "object",
+      properties: { input: { type: "string" } },
+      required: ["input"],
+    },
+    handler: async (args) => `Result: ${args.input}`,
+  }],
+  hooks: {
+    onPreToolUse: async (input) => ({ permissionDecision: "allow" }),
+  },
+});
+```
+
+### Extension rules
+
+- Only `.mjs` files (TypeScript `.ts` not supported)
+- Use `session.log()` for output — **never** `console.log()` (stdout is JSON-RPC)
+- Tool names must be globally unique across all extensions
+- Extensions reload on `/clear` — all in-memory state is lost
+- Do not call `session.send()` synchronously from `onUserPromptSubmitted` — use `setTimeout`
+
+### Extension session API
+
+```typescript
+// session from joinSession has full CopilotSession API:
+await session.send({ prompt: "..." });
+await session.sendAndWait({ prompt: "..." });
+await session.log("message", { level: "info", ephemeral: true });
+session.on("assistant.message", (event) => { /* ... */ });
+session.workspacePath; // string | undefined
+session.rpc;          // typed RPC access
+```
+
+### Scaffold a new extension
+
+From within the CLI, use the built-in tool:
+```
+extensions_manage({ operation: "scaffold", name: "my-extension" })
+```
+
+Then reload:
+```
+extensions_reload({})
+```

--- a/skills/build-copilot-sdk-app/references/auth-and-byok.md
+++ b/skills/build-copilot-sdk-app/references/auth-and-byok.md
@@ -1,0 +1,234 @@
+# Authentication and BYOK
+
+## Authentication methods
+
+| Method | Use Case | Copilot Subscription Required |
+|--------|----------|-------------------------------|
+| Signed-in user (default) | Interactive apps | Yes |
+| GitHub OAuth | Apps on behalf of users | Yes |
+| Environment variables | CI/CD, automation | Yes |
+| BYOK (Bring Your Own Key) | Own API keys | No |
+
+## Default: signed-in user
+
+User runs `copilot` CLI and signs in. SDK uses stored credentials automatically.
+
+```typescript
+const client = new CopilotClient(); // no config needed
+```
+
+## GitHub OAuth
+
+Pass user access token from OAuth flow:
+
+```typescript
+const client = new CopilotClient({
+  githubToken: userAccessToken, // gho_xxx or ghu_xxx
+  useLoggedInUser: false,
+});
+```
+
+### Supported token types
+
+| Prefix | Type | Supported |
+|--------|------|-----------|
+| `gho_` | OAuth user access tokens | Yes |
+| `ghu_` | GitHub App user access tokens | Yes |
+| `github_pat_` | Fine-grained PATs | Yes |
+| `ghp_` | Classic PATs (deprecated) | **No** |
+
+### OAuth callback handler
+
+```typescript
+async function handleOAuthCallback(code: string): Promise<string> {
+  const response = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+  const data = await response.json();
+  return data.access_token; // gho_xxx
+}
+```
+
+### Per-user client pattern
+
+```typescript
+const clients = new Map<string, CopilotClient>();
+
+function getClientForUser(userId: string, token: string): CopilotClient {
+  if (!clients.has(userId)) {
+    clients.set(userId, new CopilotClient({
+      githubToken: token,
+      useLoggedInUser: false,
+    }));
+  }
+  return clients.get(userId)!;
+}
+```
+
+## Environment variables
+
+Priority order (checked automatically):
+
+1. `COPILOT_GITHUB_TOKEN` (recommended)
+2. `GH_TOKEN` (GitHub CLI compatible)
+3. `GITHUB_TOKEN` (GitHub Actions compatible)
+
+No code changes needed — SDK auto-detects.
+
+### Full auth priority order
+
+1. Explicit `githubToken` in constructor
+2. `CAPI_HMAC_KEY` or `COPILOT_HMAC_KEY` env vars
+3. `GITHUB_COPILOT_API_TOKEN` with `COPILOT_API_URL`
+4. Env var tokens (`COPILOT_GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN`)
+5. Stored OAuth credentials from CLI login
+6. `gh auth` credentials
+
+## BYOK (Bring Your Own Key)
+
+Use your own API keys. No Copilot subscription required.
+
+### ProviderConfig
+
+```typescript
+interface ProviderConfig {
+  type?: "openai" | "azure" | "anthropic";  // default "openai"
+  wireApi?: "completions" | "responses";     // default "completions"
+  baseUrl: string;                           // REQUIRED
+  apiKey?: string;
+  bearerToken?: string;                      // takes precedence over apiKey
+  azure?: {
+    apiVersion?: string;                     // default "2024-10-21"
+  };
+}
+```
+
+### Wire API formats
+
+- `"completions"` (default) — Chat Completions API (`/chat/completions`). Use for most models.
+- `"responses"` — Responses API. Use for GPT-5 series models.
+
+### Provider examples
+
+**OpenAI:**
+```typescript
+provider: {
+  type: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: process.env.OPENAI_API_KEY,
+}
+```
+
+**Azure OpenAI (native endpoint):**
+```typescript
+provider: {
+  type: "azure",
+  baseUrl: "https://my-resource.openai.azure.com", // just the host
+  apiKey: process.env.AZURE_API_KEY,
+}
+```
+
+**Azure AI Foundry (OpenAI-compatible):**
+```typescript
+provider: {
+  type: "openai",
+  baseUrl: "https://your-resource.openai.azure.com/openai/v1/",
+  apiKey: process.env.AZURE_API_KEY,
+}
+```
+
+**Anthropic:**
+```typescript
+provider: {
+  type: "anthropic",
+  baseUrl: "https://api.anthropic.com",
+  apiKey: process.env.ANTHROPIC_API_KEY,
+}
+```
+
+**Ollama (local, no key):**
+```typescript
+provider: {
+  type: "openai",
+  baseUrl: "http://localhost:11434/v1",
+}
+```
+
+**vLLM / LiteLLM:**
+```typescript
+provider: {
+  type: "openai",
+  baseUrl: "http://localhost:8000/v1",
+  apiKey: process.env.VLLM_API_KEY,
+}
+```
+
+### BYOK requires `model`
+
+```typescript
+// WRONG — will error:
+await client.createSession({
+  provider: { type: "openai", baseUrl: "..." },
+  onPermissionRequest: approveAll,
+});
+
+// CORRECT:
+await client.createSession({
+  model: "gpt-4",
+  provider: { type: "openai", baseUrl: "..." },
+  onPermissionRequest: approveAll,
+});
+```
+
+### Custom model listing
+
+Override `client.listModels()` for BYOK:
+
+```typescript
+const client = new CopilotClient({
+  onListModels: () => [{
+    id: "my-model",
+    name: "My Custom Model",
+    capabilities: {
+      supports: { vision: false, reasoningEffort: false },
+      limits: { max_context_window_tokens: 128000 },
+    },
+  }],
+});
+```
+
+Results are cached after first call.
+
+### BYOK limitations
+
+- Static API keys or bearer tokens only (no Entra ID / Managed Identity auto-refresh)
+- `bearerToken` is static — no automatic refresh for short-lived tokens
+- Rate limits are provider-specific
+- Usage tracked by your provider, not GitHub
+- Premium request quotas are not consumed
+
+## Auth status check
+
+```typescript
+const auth = await client.getAuthStatus();
+// {
+//   isAuthenticated: true,
+//   authType: "user" | "env" | "gh-cli" | "hmac" | "api-key" | "token",
+//   host: "github.com",
+//   login: "username",
+//   statusMessage: "Authenticated via user credentials"
+// }
+```
+
+## Quota check
+
+```typescript
+const quota = await client.rpc.account.getQuota();
+// { quotaSnapshots: { "chat": { entitlementRequests, usedRequests, remainingPercentage, ... } } }
+```

--- a/skills/build-copilot-sdk-app/references/client-and-transport.md
+++ b/skills/build-copilot-sdk-app/references/client-and-transport.md
@@ -1,0 +1,249 @@
+# Client and Transport
+
+## CopilotClient constructor
+
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+const client = new CopilotClient(options?: CopilotClientOptions);
+```
+
+### CopilotClientOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `cliPath` | `string` | bundled CLI | Path to CLI executable |
+| `cliArgs` | `string[]` | `[]` | Extra CLI arguments (inserted before SDK-managed args) |
+| `cwd` | `string` | `process.cwd()` | Working directory for CLI process |
+| `port` | `number` | `0` (random) | TCP port (TCP mode only) |
+| `useStdio` | `boolean` | `true` | Use stdio transport (default) |
+| `isChildProcess` | `boolean` | `false` | SDK runs as child of Copilot CLI |
+| `cliUrl` | `string` | — | Connect to existing server (`"host:port"`, `"http://host:port"`, or `"port"`) |
+| `logLevel` | `"none"\|"error"\|"warning"\|"info"\|"debug"\|"all"` | `"debug"` | CLI log level |
+| `autoStart` | `boolean` | `true` | Auto-start CLI on first use |
+| `autoRestart` | `boolean` | `true` | Auto-restart if CLI crashes |
+| `env` | `Record<string, string\|undefined>` | `process.env` | Environment for CLI process |
+| `githubToken` | `string` | — | GitHub token (passed as `COPILOT_SDK_AUTH_TOKEN` env var) |
+| `useLoggedInUser` | `boolean` | `true` (`false` when `githubToken` set) | Use stored OAuth/gh-cli tokens |
+| `onListModels` | `() => Promise<ModelInfo[]> \| ModelInfo[]` | — | Custom model listing (BYOK mode) |
+
+### Mutual exclusion rules
+
+- `cliUrl` cannot be used with `useStdio: true` or `cliPath`
+- `isChildProcess` requires `useStdio` and cannot be used with `cliUrl`
+- `githubToken` and `useLoggedInUser` cannot be used with `cliUrl`
+
+## Transport modes
+
+### 1. Stdio (default)
+
+SDK spawns CLI as child process, communicates via stdin/stdout pipes.
+
+```typescript
+const client = new CopilotClient(); // useStdio: true is default
+// or explicitly:
+const client = new CopilotClient({ useStdio: true });
+```
+
+CLI spawn args: `--headless --no-auto-update --log-level <level> --stdio`
+
+Best for: local development, single-process apps, desktop apps.
+
+### 2. TCP
+
+SDK spawns CLI with `--port`, connects via `net.Socket`.
+
+```typescript
+const client = new CopilotClient({ useStdio: false, port: 4321 });
+// port: 0 for random available port
+```
+
+CLI spawn args: `--headless --no-auto-update --log-level <level> --port <n>`
+
+Best for: multi-client architectures where multiple SDK instances connect to one CLI.
+
+### 3. External server
+
+SDK connects to a pre-existing CLI server via TCP. No process spawning.
+
+```typescript
+const client = new CopilotClient({ cliUrl: "localhost:4321" });
+// Also accepts: "4321", "http://localhost:4321", "https://host:port"
+```
+
+Start CLI separately:
+```bash
+copilot --headless --port 4321
+```
+
+Best for: backend services, Docker deployments, scaling patterns.
+
+### 4. Child process mode
+
+SDK is itself a child of the Copilot CLI. Used by CLI extensions (.mjs).
+
+```typescript
+// Do not use directly. Use joinSession from extension module instead:
+import { joinSession } from "@github/copilot-sdk/extension";
+const session = await joinSession({ onPermissionRequest: approveAll });
+```
+
+## Lifecycle methods
+
+### start()
+
+```typescript
+await client.start();
+```
+
+Lifecycle: `disconnected → connecting → connected`
+
+1. Spawns CLI process (unless external server)
+2. Connects transport (stdio or TCP)
+3. Protocol negotiation: pings server, verifies `2 ≤ protocolVersion ≤ 3`
+4. Timeout: 10 seconds
+
+Usually not needed — `autoStart: true` starts on first `createSession()`.
+
+### stop()
+
+```typescript
+const errors: Error[] = await client.stop();
+```
+
+Graceful shutdown:
+1. Disconnects all sessions (3 retries with exponential backoff)
+2. Disposes connection
+3. Kills CLI process
+4. Returns collected errors
+
+### forceStop()
+
+```typescript
+await client.forceStop();
+```
+
+Immediate: SIGKILL, no cleanup, errors ignored.
+
+### getState()
+
+```typescript
+const state: ConnectionState = client.getState();
+// "disconnected" | "connecting" | "connected" | "error"
+```
+
+### ping()
+
+```typescript
+const result = await client.ping("hello");
+// { message: "pong: hello", timestamp: "...", protocolVersion: 3 }
+```
+
+### getStatus()
+
+```typescript
+const status: GetStatusResponse = await client.getStatus();
+// { version: "1.0.0", protocolVersion: 3 }
+```
+
+### getAuthStatus()
+
+```typescript
+const auth: GetAuthStatusResponse = await client.getAuthStatus();
+// { isAuthenticated: true, authType: "user", host: "github.com", login: "username" }
+```
+
+### listModels()
+
+```typescript
+const models: ModelInfo[] = await client.listModels();
+// Cached after first call. Cleared on stop().
+// When onListModels was provided: calls that instead.
+```
+
+## Session management on client
+
+```typescript
+// List persisted sessions
+const sessions: SessionMetadata[] = await client.listSessions(filter?);
+
+// Delete a persisted session
+await client.deleteSession("session-id");
+
+// Get last session ID
+const lastId: string | undefined = await client.getLastSessionId();
+
+// TUI+server mode only:
+const fgId = await client.getForegroundSessionId();
+await client.setForegroundSessionId("session-id");
+```
+
+### SessionListFilter
+
+```typescript
+interface SessionListFilter {
+  cwd?: string;
+  gitRoot?: string;
+  repository?: string; // "owner/repo"
+  branch?: string;
+}
+```
+
+## Client lifecycle events
+
+Subscribe to session lifecycle events (not session content events):
+
+```typescript
+// Typed
+const unsub = client.on("session.created", (event) => {
+  console.log("New session:", event.sessionId);
+});
+
+// Wildcard
+client.on((event) => {
+  // event.type: "session.created" | "session.deleted" | "session.updated"
+  //           | "session.foreground" | "session.background"
+});
+```
+
+## Protocol version negotiation
+
+- SDK protocol version: **3** (current)
+- Minimum server version accepted: **2**
+- v2 servers: tool calls/permission requests arrive as JSON-RPC requests; SDK adapts them to v3 handlers transparently
+- v3 servers: tool calls/permission requests arrive as broadcast session events
+
+## Docker deployment
+
+```bash
+docker run -d --name copilot-cli -p 4321:4321 \
+  -e COPILOT_GITHUB_TOKEN="$TOKEN" \
+  ghcr.io/github/copilot-cli:latest --headless --port 4321
+```
+
+```typescript
+const client = new CopilotClient({
+  cliUrl: process.env.CLI_URL || "localhost:4321",
+});
+```
+
+## Graceful shutdown pattern
+
+```typescript
+process.on("SIGINT", async () => {
+  const errors = await client.stop();
+  if (errors.length > 0) console.error("Cleanup errors:", errors);
+  process.exit(0);
+});
+
+// With force-stop fallback:
+const stopPromise = client.stop();
+const timeout = new Promise((_, reject) =>
+  setTimeout(() => reject(new Error("Timeout")), 5000)
+);
+try {
+  await Promise.race([stopPromise, timeout]);
+} catch {
+  await client.forceStop();
+}
+```

--- a/skills/build-copilot-sdk-app/references/events-and-streaming.md
+++ b/skills/build-copilot-sdk-app/references/events-and-streaming.md
@@ -1,0 +1,279 @@
+# Events and Streaming
+
+## Event subscription API
+
+```typescript
+// Typed — fires only for the specific event type
+const unsub = session.on("assistant.message", (event) => {
+  console.log(event.data.content);
+});
+
+// Wildcard — fires for every event
+session.on((event) => {
+  switch (event.type) {
+    case "assistant.message": /* ... */ break;
+    case "session.idle": /* ... */ break;
+  }
+});
+
+// Unsubscribe
+unsub();
+```
+
+## Event base fields
+
+Every event shares:
+
+```typescript
+{
+  id: string;              // UUID v4
+  type: string;            // event type
+  timestamp: string;       // ISO 8601
+  parentId: string | null; // linked chain (null for first)
+  ephemeral?: boolean;     // true = not persisted to disk
+  data: { ... };           // type-specific payload
+}
+```
+
+## Streaming
+
+Enable with `streaming: true` in SessionConfig:
+
+```typescript
+const session = await client.createSession({
+  streaming: true,
+  onPermissionRequest: approveAll,
+});
+
+let fullMessage = "";
+
+session.on("assistant.message_delta", (event) => {
+  process.stdout.write(event.data.deltaContent);
+  fullMessage += event.data.deltaContent;
+});
+
+session.on("assistant.reasoning_delta", (event) => {
+  // Reasoning/thinking chunks (if model supports it)
+  console.log("[thinking]", event.data.deltaContent);
+});
+
+session.on("assistant.message", (event) => {
+  // Final complete message (also arrives after all deltas)
+  console.log("\nFinal:", event.data.content);
+});
+
+session.on("session.idle", () => {
+  console.log("--- turn complete ---");
+});
+```
+
+### Streaming pattern with waitForIdle
+
+```typescript
+let idleResolve: (() => void) | null = null;
+const waitForIdle = () => new Promise<void>((r) => { idleResolve = r; });
+
+session.on((event) => {
+  if (event.type === "assistant.message_delta") {
+    process.stdout.write(event.data.deltaContent ?? "");
+  } else if (event.type === "session.idle") {
+    idleResolve?.();
+  } else if (event.type === "session.error") {
+    console.error(event.data.message);
+    idleResolve?.();
+  }
+});
+
+let idle = waitForIdle();
+await session.send({ prompt: "Hello" });
+await idle;
+
+// For subsequent turns:
+idle = waitForIdle();
+await session.send({ prompt: "Follow up" });
+await idle;
+```
+
+## All event types by category
+
+### Session lifecycle
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `session.start` | no | `sessionId, version, selectedModel?, context?` |
+| `session.resume` | no | `resumeTime, eventCount, context?` |
+| `session.idle` | **yes** | `backgroundTasks?: { agents: [], shells: [] }` |
+| `session.error` | no | `errorType, message, stack?, statusCode?` |
+| `session.title_changed` | **yes** | `title: string` |
+| `session.info` | no | `infoType, message` |
+| `session.warning` | no | `warningType, message` |
+| `session.model_change` | no | `previousModel?, newModel` |
+| `session.mode_changed` | no | `previousMode, newMode` (`"interactive"\|"plan"\|"autopilot"`) |
+| `session.plan_changed` | no | `operation: "create"\|"update"\|"delete"` |
+| `session.workspace_file_changed` | no | `path, operation: "create"\|"update"` |
+| `session.handoff` | no | `handoffTime, sourceType, summary?` |
+| `session.truncation` | no | `tokenLimit, tokensRemovedDuringTruncation, ...` |
+| `session.snapshot_rewind` | **yes** | `upToEventId, eventsRemoved` |
+| `session.shutdown` | no | `shutdownType, totalPremiumRequests, codeChanges, modelMetrics` |
+| `session.context_changed` | no | `cwd, gitRoot?, repository?, branch?` |
+| `session.usage_info` | **yes** | `tokenLimit, currentTokens, messagesLength` |
+| `session.compaction_start` | no | `data: {}` |
+| `session.compaction_complete` | no | `success, tokensRemoved?, checkpointPath?` |
+| `session.task_complete` | no | `summary?` |
+
+### User / pending messages
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `user.message` | no | `content, attachments?, source?, agentMode?` |
+| `pending_messages.modified` | **yes** | `data: {}` |
+
+User message `agentMode`: `"interactive"\|"plan"\|"autopilot"\|"shell"`
+
+Attachment types: `file`, `directory`, `selection`, `github_reference`
+
+### Assistant
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `assistant.turn_start` | no | `turnId, interactionId?` |
+| `assistant.intent` | **yes** | `intent: string` |
+| `assistant.reasoning` | no | `reasoningId, content` |
+| `assistant.reasoning_delta` | **yes** | `reasoningId, deltaContent` |
+| `assistant.streaming_delta` | **yes** | `totalResponseSizeBytes` |
+| `assistant.message` | no | `messageId, content, toolRequests?, phase?, outputTokens?` |
+| `assistant.message_delta` | **yes** | `messageId, deltaContent, parentToolCallId?` |
+| `assistant.turn_end` | no | `turnId` |
+| `assistant.usage` | **yes** | `model, inputTokens?, outputTokens?, cost?, duration?` |
+
+`toolRequests` on `assistant.message`:
+```typescript
+toolRequests?: Array<{
+  toolCallId: string;
+  name: string;
+  arguments?: string;
+  type?: "function" | "custom";
+}>;
+```
+
+### Tool execution
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `tool.user_requested` | no | `toolCallId, toolName, arguments?` |
+| `tool.execution_start` | no | `toolCallId, toolName, arguments?, mcpServerName?, parentToolCallId?` |
+| `tool.execution_partial_result` | **yes** | `toolCallId, partialOutput` |
+| `tool.execution_progress` | **yes** | `toolCallId, progressMessage` |
+| `tool.execution_complete` | no | `toolCallId, success, result?, error?, parentToolCallId?` |
+
+Tool result types in `tool.execution_complete`:
+- `{ type: "text", text }`
+- `{ type: "terminal", text, exitCode?, cwd? }`
+- `{ type: "image", data, mimeType }`
+- `{ type: "resource_link", name, uri }`
+- `{ type: "resource", resource: { uri, text? } }`
+
+### Skill
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `skill.invoked` | no | `name, path, content, allowedTools?, pluginName?` |
+
+### Sub-agent
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `subagent.started` | no | `toolCallId, agentName, agentDisplayName, agentDescription` |
+| `subagent.completed` | no | `toolCallId, agentName, agentDisplayName` |
+| `subagent.failed` | no | `toolCallId, agentName, error` |
+| `subagent.selected` | no | `agentName, agentDisplayName, tools` |
+| `subagent.deselected` | no | `data: {}` |
+
+`parentToolCallId` on various events links sub-agent activity to the parent tool call.
+
+### Hook
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `hook.start` | no | `hookInvocationId, hookType, input?` |
+| `hook.end` | no | `hookInvocationId, hookType, output?, success, error?` |
+
+### System
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `system.message` | no | `content, role: "system"\|"developer"` |
+| `system.notification` | no | `content, kind: agent_completed\|shell_completed\|shell_detached_completed` |
+| `abort` | no | `reason: string` |
+
+### Permission
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `permission.requested` | **yes** | `requestId, permissionRequest` |
+| `permission.completed` | **yes** | `requestId, result: { kind }` |
+
+### User input / elicitation
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `user_input.requested` | **yes** | `requestId, question, choices?, allowFreeform?` |
+| `user_input.completed` | **yes** | `requestId` |
+| `elicitation.requested` | **yes** | `requestId, message, requestedSchema` |
+| `elicitation.completed` | **yes** | `requestId` |
+
+### External tool (v3 broadcast)
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `external_tool.requested` | **yes** | `requestId, sessionId, toolCallId, toolName, arguments?` |
+| `external_tool.completed` | **yes** | `requestId` |
+
+### Command / plan mode
+
+| Type | Ephemeral | Key Data |
+|------|-----------|----------|
+| `command.queued` | **yes** | `requestId, command` |
+| `command.completed` | **yes** | `requestId` |
+| `exit_plan_mode.requested` | **yes** | `requestId, summary, planContent, actions, recommendedAction` |
+| `exit_plan_mode.completed` | **yes** | `requestId` |
+
+## Event helper pattern
+
+```typescript
+function getNextEventOfType<T extends SessionEventType>(
+  session: CopilotSession,
+  type: T,
+): Promise<SessionEventPayload<T>> {
+  return new Promise((resolve, reject) => {
+    const unsub = session.on((event) => {
+      if (event.type === type) {
+        unsub();
+        resolve(event as SessionEventPayload<T>);
+      }
+      if (event.type === "session.error") {
+        unsub();
+        reject(new Error(event.data.message));
+      }
+    });
+  });
+}
+```
+
+## session.shutdown event data
+
+Rich session summary including usage metrics:
+
+```typescript
+session.on("session.shutdown", (event) => {
+  const d = event.data;
+  console.log(`Type: ${d.shutdownType}`);       // "routine" | "error"
+  console.log(`Premium requests: ${d.totalPremiumRequests}`);
+  console.log(`Code changes: +${d.codeChanges.linesAdded} -${d.codeChanges.linesRemoved}`);
+  console.log(`Files modified: ${d.codeChanges.filesModified}`);
+  // Per-model metrics:
+  for (const [model, metrics] of Object.entries(d.modelMetrics)) {
+    console.log(`${model}: ${metrics.requests.count} calls, ${metrics.usage.inputTokens} input tokens`);
+  }
+});
+```

--- a/skills/build-copilot-sdk-app/references/hooks.md
+++ b/skills/build-copilot-sdk-app/references/hooks.md
@@ -1,0 +1,341 @@
+# Hooks
+
+Hooks are lifecycle interceptors that fire at specific points during session execution. They can inspect, modify, or block tool calls, prompts, and session lifecycle events.
+
+## Registering hooks
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  hooks: {
+    onPreToolUse: async (input, invocation) => { /* ... */ },
+    onPostToolUse: async (input, invocation) => { /* ... */ },
+    onUserPromptSubmitted: async (input, invocation) => { /* ... */ },
+    onSessionStart: async (input, invocation) => { /* ... */ },
+    onSessionEnd: async (input, invocation) => { /* ... */ },
+    onErrorOccurred: async (input, invocation) => { /* ... */ },
+  },
+});
+```
+
+All hooks receive a base input:
+```typescript
+interface BaseHookInput {
+  timestamp: number;
+  cwd: string;
+}
+```
+
+And an invocation context: `{ sessionId: string }`
+
+## Hook 1: onPreToolUse
+
+Fires **before** a tool executes. Can allow, deny, or modify the tool call.
+
+### Input
+
+```typescript
+interface PreToolUseHookInput extends BaseHookInput {
+  toolName: string;
+  toolArgs: unknown;
+}
+```
+
+### Output
+
+```typescript
+interface PreToolUseHookOutput {
+  permissionDecision?: "allow" | "deny" | "ask";
+  permissionDecisionReason?: string;
+  modifiedArgs?: unknown;
+  additionalContext?: string;
+  suppressOutput?: boolean;
+}
+```
+
+### Examples
+
+**Block dangerous commands:**
+```typescript
+onPreToolUse: async (input) => {
+  if (input.toolName === "bash") {
+    const cmd = String(input.toolArgs?.command || "");
+    if (/rm\s+-rf/i.test(cmd)) {
+      return {
+        permissionDecision: "deny",
+        permissionDecisionReason: "Destructive commands blocked",
+      };
+    }
+  }
+  return { permissionDecision: "allow" };
+}
+```
+
+**Modify tool arguments:**
+```typescript
+onPreToolUse: async (input) => {
+  if (input.toolName === "bash") {
+    return {
+      modifiedArgs: {
+        ...input.toolArgs,
+        command: `${input.toolArgs.command} 2>&1`,
+      },
+    };
+  }
+}
+```
+
+**Inject context before tool runs:**
+```typescript
+onPreToolUse: async (input) => {
+  if (input.toolName === "edit") {
+    return {
+      additionalContext: "Follow our team coding standards: no semicolons, 2-space indent.",
+    };
+  }
+}
+```
+
+## Hook 2: onPostToolUse
+
+Fires **after** a tool executes. Can observe or modify the result.
+
+### Input
+
+```typescript
+interface PostToolUseHookInput extends BaseHookInput {
+  toolName: string;
+  toolArgs: unknown;
+  toolResult: ToolResultObject;
+}
+```
+
+### Output
+
+```typescript
+interface PostToolUseHookOutput {
+  modifiedResult?: ToolResultObject;
+  additionalContext?: string;
+  suppressOutput?: boolean;
+}
+```
+
+### Examples
+
+**Run linter after file edits:**
+```typescript
+onPostToolUse: async (input) => {
+  if (input.toolName === "edit" && input.toolArgs?.path?.endsWith(".ts")) {
+    const lintResult = await runLinter(input.toolArgs.path);
+    return {
+      additionalContext: `Lint result: ${lintResult}`,
+    };
+  }
+}
+```
+
+**Open edited files in VS Code:**
+```typescript
+onPostToolUse: async (input) => {
+  if (input.toolName === "create" || input.toolName === "edit") {
+    const filePath = input.toolArgs?.path;
+    if (filePath) exec(`code "${filePath}"`, () => {});
+  }
+}
+```
+
+## Hook 3: onUserPromptSubmitted
+
+Fires when the user submits a prompt. Can modify the prompt or inject context.
+
+### Input
+
+```typescript
+interface UserPromptSubmittedHookInput extends BaseHookInput {
+  prompt: string;
+}
+```
+
+### Output
+
+```typescript
+interface UserPromptSubmittedHookOutput {
+  modifiedPrompt?: string;
+  additionalContext?: string;
+  suppressOutput?: boolean;
+}
+```
+
+### Examples
+
+**Inject context into every prompt:**
+```typescript
+onUserPromptSubmitted: async (input) => ({
+  additionalContext: "Always respond in bullet points. Follow coding standards.",
+})
+```
+
+**Modify user prompt:**
+```typescript
+onUserPromptSubmitted: async (input) => ({
+  modifiedPrompt: input.prompt.replace(/TODO/g, "ACTION ITEM"),
+})
+```
+
+## Hook 4: onSessionStart
+
+Fires when a session starts or resumes.
+
+### Input
+
+```typescript
+interface SessionStartHookInput extends BaseHookInput {
+  source: "startup" | "resume" | "new";
+  initialPrompt?: string;
+}
+```
+
+### Output
+
+```typescript
+interface SessionStartHookOutput {
+  additionalContext?: string;
+  modifiedConfig?: Record<string, unknown>;
+}
+```
+
+### Example
+
+```typescript
+onSessionStart: async (input) => {
+  if (input.source === "new") {
+    return {
+      additionalContext: `Project context: Using React 19, TypeScript 5.7, Vitest`,
+    };
+  }
+}
+```
+
+## Hook 5: onSessionEnd
+
+Fires when a session ends.
+
+### Input
+
+```typescript
+interface SessionEndHookInput extends BaseHookInput {
+  reason: "complete" | "error" | "abort" | "timeout" | "user_exit";
+  finalMessage?: string;
+  error?: string;
+}
+```
+
+### Output
+
+```typescript
+interface SessionEndHookOutput {
+  suppressOutput?: boolean;
+  cleanupActions?: string[];
+  sessionSummary?: string;
+}
+```
+
+### Example
+
+```typescript
+onSessionEnd: async (input) => {
+  if (input.reason === "error") {
+    await logError(input.error);
+  }
+  return {
+    sessionSummary: "Session completed code review of auth module",
+  };
+}
+```
+
+## Hook 6: onErrorOccurred
+
+Fires when an error occurs. Can control error recovery.
+
+### Input
+
+```typescript
+interface ErrorOccurredHookInput extends BaseHookInput {
+  error: string;
+  errorContext: "model_call" | "tool_execution" | "system" | "user_input";
+  recoverable: boolean;
+}
+```
+
+### Output
+
+```typescript
+interface ErrorOccurredHookOutput {
+  suppressOutput?: boolean;
+  errorHandling?: "retry" | "skip" | "abort";
+  retryCount?: number;
+  userNotification?: string;
+}
+```
+
+### Examples
+
+**Auto-retry model errors:**
+```typescript
+onErrorOccurred: async (input) => {
+  if (input.recoverable && input.errorContext === "model_call") {
+    return { errorHandling: "retry", retryCount: 2 };
+  }
+  return {
+    errorHandling: "abort",
+    userNotification: `Error: ${input.error}`,
+  };
+}
+```
+
+**Skip tool errors, abort system errors:**
+```typescript
+onErrorOccurred: async (input) => {
+  if (input.errorContext === "tool_execution") {
+    return { errorHandling: "skip" };
+  }
+  return { errorHandling: "abort" };
+}
+```
+
+## Hooks vs permissions
+
+| Aspect | Hooks (`onPreToolUse`) | Permissions (`onPermissionRequest`) |
+|--------|------------------------|-------------------------------------|
+| Fires for | ALL tool calls | Only permission-requiring tools |
+| Can modify | Args, context, decision | Only approve/deny |
+| Scope | Built-in + custom tools | Server-defined permission categories |
+| Return type | `PreToolUseHookOutput` | `PermissionRequestResult` |
+
+## Hook events on session
+
+Hook execution is observable via events:
+
+```typescript
+session.on("hook.start", (event) => {
+  console.log(`Hook ${event.data.hookType} starting`);
+});
+
+session.on("hook.end", (event) => {
+  console.log(`Hook ${event.data.hookType}: success=${event.data.success}`);
+  if (event.data.error) console.error(event.data.error.message);
+});
+```
+
+## Internal hook type mapping
+
+| Hook function | RPC hook type |
+|--------------|---------------|
+| `onPreToolUse` | `"preToolUse"` |
+| `onPostToolUse` | `"postToolUse"` |
+| `onUserPromptSubmitted` | `"userPromptSubmitted"` |
+| `onSessionStart` | `"sessionStart"` |
+| `onSessionEnd` | `"sessionEnd"` |
+| `onErrorOccurred` | `"errorOccurred"` |
+
+Hooks that throw are silently caught — the hook returns `undefined` and execution continues.

--- a/skills/build-copilot-sdk-app/references/permissions-and-user-input.md
+++ b/skills/build-copilot-sdk-app/references/permissions-and-user-input.md
@@ -1,0 +1,274 @@
+# Permissions and User Input
+
+## Permission handler (required)
+
+Every `createSession` and `resumeSession` requires `onPermissionRequest`:
+
+```typescript
+import { approveAll } from "@github/copilot-sdk";
+
+// Auto-approve everything (unattended operation):
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+});
+
+// Custom handler:
+const session = await client.createSession({
+  onPermissionRequest: async (request, invocation) => {
+    // request: PermissionRequest
+    // invocation: { sessionId: string }
+    console.log(`Permission request: ${request.kind}`);
+    return { kind: "approved" };
+  },
+});
+```
+
+## PermissionHandler type
+
+```typescript
+type PermissionHandler = (
+  request: PermissionRequest,
+  invocation: { sessionId: string },
+) => Promise<PermissionRequestResult> | PermissionRequestResult;
+```
+
+## PermissionRequest
+
+```typescript
+interface PermissionRequest {
+  kind: "shell" | "write" | "read" | "mcp" | "url" | "memory" | "custom-tool";
+  toolCallId?: string;
+  [key: string]: unknown;
+}
+```
+
+### Permission request kinds and their fields
+
+**shell** — execute a shell command:
+```typescript
+{
+  kind: "shell",
+  toolCallId?: string,
+  fullCommandText: string,
+  intention: string,
+  commands: Array<{ identifier: string; readOnly: boolean }>,
+  possiblePaths: string[],
+  possibleUrls: Array<{ url: string }>,
+  hasWriteFileRedirection: boolean,
+  canOfferSessionApproval: boolean,
+  warning?: string,
+}
+```
+
+**write** — write/edit a file:
+```typescript
+{
+  kind: "write",
+  toolCallId?: string,
+  intention: string,
+  fileName: string,
+  diff: string,
+  newFileContents?: string,
+}
+```
+
+**read** — read a file:
+```typescript
+{
+  kind: "read",
+  toolCallId?: string,
+  intention: string,
+  path: string,
+}
+```
+
+**mcp** — invoke an MCP tool:
+```typescript
+{
+  kind: "mcp",
+  toolCallId?: string,
+  serverName: string,
+  toolName: string,
+  toolTitle: string,
+  args?: unknown,
+  readOnly: boolean,
+}
+```
+
+**url** — access a URL:
+```typescript
+{
+  kind: "url",
+  toolCallId?: string,
+  intention: string,
+  url: string,
+}
+```
+
+**memory** — store a memory:
+```typescript
+{
+  kind: "memory",
+  toolCallId?: string,
+  subject: string,
+  fact: string,
+  citations: unknown,
+}
+```
+
+**custom-tool** — invoke a custom tool:
+```typescript
+{
+  kind: "custom-tool",
+  toolCallId?: string,
+  toolName: string,
+  toolDescription: string,
+  args?: unknown,
+}
+```
+
+## PermissionRequestResult
+
+```typescript
+type PermissionRequestResult =
+  | { kind: "approved" }
+  | { kind: "denied-by-rules"; rules: unknown[] }
+  | { kind: "denied-no-approval-rule-and-could-not-request-from-user" }
+  | { kind: "denied-interactively-by-user"; feedback?: string }
+  | { kind: "denied-by-content-exclusion-policy"; path: string; message: string };
+```
+
+## Permission patterns
+
+### Selective approval
+
+```typescript
+onPermissionRequest: async (request) => {
+  // Approve reads and shell, deny writes
+  if (request.kind === "read" || request.kind === "shell") {
+    return { kind: "approved" };
+  }
+  if (request.kind === "write") {
+    return {
+      kind: "denied-interactively-by-user",
+      feedback: "Write operations are not allowed in this session",
+    };
+  }
+  return { kind: "approved" };
+}
+```
+
+### Interactive approval with UI
+
+```typescript
+onPermissionRequest: async (request, { sessionId }) => {
+  const userApproval = await showPermissionDialog({
+    kind: request.kind,
+    details: request.kind === "shell" ? request.fullCommandText : request.fileName,
+  });
+  if (userApproval) {
+    return { kind: "approved" };
+  }
+  return { kind: "denied-interactively-by-user" };
+}
+```
+
+### Multi-client permission handling
+
+When multiple clients connect to the same session:
+- `permission.requested` event broadcasts to ALL clients
+- First client to respond wins
+- Use a never-resolving handler on observer clients:
+
+```typescript
+// Observer client — never responds to permission requests
+const observerSession = await client2.resumeSession(sessionId, {
+  onPermissionRequest: () => new Promise(() => {}), // never resolves
+});
+```
+
+## User input (askUser)
+
+When the model calls the `ask_user` tool, the SDK invokes `onUserInputRequest`.
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  onUserInputRequest: async (request, invocation) => {
+    // request.question: string    — the model's question
+    // request.choices?: string[]  — optional choice list
+    // request.allowFreeform?: boolean — default true
+
+    // Pick from choices:
+    if (request.choices?.length) {
+      return { answer: request.choices[0], wasFreeform: false };
+    }
+
+    // Freeform answer:
+    return { answer: "Yes, proceed with the changes", wasFreeform: true };
+  },
+});
+```
+
+### UserInputRequest
+
+```typescript
+interface UserInputRequest {
+  question: string;
+  choices?: string[];
+  allowFreeform?: boolean; // default true
+}
+```
+
+### UserInputResponse
+
+```typescript
+interface UserInputResponse {
+  answer: string;
+  wasFreeform: boolean;
+}
+```
+
+### Without onUserInputRequest
+
+If `onUserInputRequest` is not provided and the model calls `ask_user`, the SDK throws. The model receives an error and may retry or proceed differently.
+
+## Elicitation (MCP forms)
+
+For MCP-style structured data collection, the SDK emits `elicitation.requested` events:
+
+```typescript
+session.on("elicitation.requested", (event) => {
+  console.log("Form request:", event.data.message);
+  console.log("Schema:", event.data.requestedSchema);
+  // requestedSchema: { type: "object", properties: {...}, required: [...] }
+  // mode?: "form"
+});
+```
+
+## Permission events on session
+
+All clients connected to a session can observe permission flow:
+
+```typescript
+session.on("permission.requested", (event) => {
+  console.log(`Permission needed: ${event.data.permissionRequest.kind}`);
+});
+
+session.on("permission.completed", (event) => {
+  console.log(`Result: ${event.data.result.kind}`);
+});
+```
+
+## User input events
+
+```typescript
+session.on("user_input.requested", (event) => {
+  console.log(`Question: ${event.data.question}`);
+  console.log(`Choices: ${event.data.choices}`);
+});
+
+session.on("user_input.completed", (event) => {
+  console.log(`Answered request: ${event.data.requestId}`);
+});
+```

--- a/skills/build-copilot-sdk-app/references/sessions.md
+++ b/skills/build-copilot-sdk-app/references/sessions.md
@@ -1,0 +1,262 @@
+# Sessions
+
+## Create a session
+
+```typescript
+const session: CopilotSession = await client.createSession(config: SessionConfig);
+```
+
+### SessionConfig (all fields)
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `onPermissionRequest` | `PermissionHandler` | **YES** | — | Permission handler (no default) |
+| `sessionId` | `string` | no | UUID | Custom session ID for persistence |
+| `clientName` | `string` | no | — | Included in User-Agent header |
+| `model` | `string` | no | — | Model ID (e.g. `"gpt-4.1"`, `"gpt-5"`) |
+| `reasoningEffort` | `ReasoningEffort` | no | — | `"low"\|"medium"\|"high"\|"xhigh"` |
+| `configDir` | `string` | no | — | Override config directory |
+| `tools` | `Tool<any>[]` | no | `[]` | Custom tools |
+| `systemMessage` | `SystemMessageConfig` | no | — | System prompt config |
+| `availableTools` | `string[]` | no | — | Tool allowlist (overrides `excludedTools`) |
+| `excludedTools` | `string[]` | no | — | Tool blocklist |
+| `provider` | `ProviderConfig` | no | — | BYOK provider |
+| `onUserInputRequest` | `UserInputHandler` | no | — | Handler for `ask_user` tool |
+| `hooks` | `SessionHooks` | no | — | Lifecycle hooks |
+| `workingDirectory` | `string` | no | — | Session working directory |
+| `streaming` | `boolean` | no | `false` | Enable streaming events |
+| `mcpServers` | `Record<string, MCPServerConfig>` | no | — | MCP servers |
+| `customAgents` | `CustomAgentConfig[]` | no | — | Custom agents |
+| `agent` | `string` | no | — | Agent to activate at start |
+| `skillDirectories` | `string[]` | no | — | Skill directories to load |
+| `disabledSkills` | `string[]` | no | — | Skills to disable |
+| `infiniteSessions` | `InfiniteSessionConfig` | no | — | Auto-compaction config |
+| `onEvent` | `SessionEventHandler` | no | — | Early event handler (registered before `session.create` RPC) |
+
+## Resume a session
+
+```typescript
+const session = await client.resumeSession(sessionId: string, config: ResumeSessionConfig);
+```
+
+`ResumeSessionConfig` includes all fields from `SessionConfig` except `sessionId`, plus:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `disableResume` | `boolean` | `false` | Skip emitting `session.resume` event |
+
+```typescript
+// Resume with new settings
+const session = await client.resumeSession("user-123", {
+  onPermissionRequest: approveAll,
+  streaming: true,    // can change streaming on resume
+  tools: [newTool],   // can add new tools
+});
+```
+
+## Sending messages
+
+### sendAndWait (blocking)
+
+```typescript
+const response: AssistantMessageEvent | undefined = await session.sendAndWait(
+  options: MessageOptions,
+  timeout?: number, // default 60_000ms
+);
+```
+
+Waits for `session.idle` event. Rejects on `session.error`. Returns the last `assistant.message` event or `undefined`.
+
+### send (fire-and-forget)
+
+```typescript
+const messageId: string = await session.send(options: MessageOptions);
+```
+
+Returns immediately. Events arrive via `session.on()`.
+
+### MessageOptions
+
+```typescript
+interface MessageOptions {
+  prompt: string;
+  attachments?: Array<
+    | { type: "file"; path: string; displayName?: string }
+    | { type: "directory"; path: string; displayName?: string }
+    | { type: "selection"; filePath: string; displayName: string;
+        selection?: { start: { line: number; character: number };
+                      end: { line: number; character: number } };
+        text?: string }
+  >;
+  mode?: "enqueue" | "immediate"; // default "enqueue"
+}
+```
+
+## Session lifecycle
+
+### disconnect()
+
+```typescript
+await session.disconnect();
+```
+
+Sends `session.destroy` RPC. Clears handlers. **Session data on disk is preserved** for later resumption.
+
+### abort()
+
+```typescript
+await session.abort();
+```
+
+Cancels in-flight work. Session remains usable for new messages. An `abort` event is added to history.
+
+### setModel()
+
+```typescript
+await session.setModel("gpt-5");
+```
+
+Switches model mid-session. Takes effect on next message.
+
+### log()
+
+```typescript
+await session.log("Processing...", {
+  level: "info",      // "info" | "warning" | "error"
+  ephemeral: true,    // not persisted to disk
+});
+```
+
+### getMessages()
+
+```typescript
+const messages: SessionEvent[] = await session.getMessages();
+```
+
+Returns full conversation history.
+
+### Symbol.asyncDispose
+
+```typescript
+await using session = await client.createSession({ ... });
+// session.disconnect() called automatically when scope exits
+```
+
+## Session persistence
+
+Sessions are persisted to disk at `~/.copilot/session-state/{sessionId}/`.
+
+```typescript
+// 1. Create with stable ID
+const session = await client.createSession({
+  sessionId: "project-alpha",
+  onPermissionRequest: approveAll,
+});
+await session.sendAndWait({ prompt: "Analyze the codebase" });
+await session.disconnect(); // data stays on disk
+
+// 2. Resume (same or different process/client)
+const resumed = await client.resumeSession("project-alpha", {
+  onPermissionRequest: approveAll,
+});
+// Full context restored — model remembers previous conversation
+
+// 3. List and clean up
+const sessions = await client.listSessions();
+await client.deleteSession("project-alpha"); // removes from disk
+```
+
+### SessionMetadata
+
+```typescript
+interface SessionMetadata {
+  sessionId: string;
+  startTime: Date;
+  modifiedTime: Date;
+  summary?: string;
+  isRemote: boolean;
+  context?: SessionContext;
+}
+
+interface SessionContext {
+  cwd: string;
+  gitRoot?: string;
+  repository?: string; // "owner/repo"
+  branch?: string;
+}
+```
+
+## Infinite sessions and compaction
+
+Keep sessions running indefinitely with automatic context compaction.
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  infiniteSessions: {
+    enabled: true,                          // default true
+    backgroundCompactionThreshold: 0.80,    // start compacting at 80% context usage
+    bufferExhaustionThreshold: 0.95,        // block until compaction done at 95%
+  },
+});
+```
+
+### InfiniteSessionConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable infinite sessions |
+| `backgroundCompactionThreshold` | `number` | `0.80` | Start background compaction at this context usage % |
+| `bufferExhaustionThreshold` | `number` | `0.95` | Block new messages until compaction done at this % |
+
+### Compaction events
+
+```typescript
+session.on("session.compaction_start", () => {
+  console.log("Compacting...");
+});
+
+session.on("session.compaction_complete", (event) => {
+  console.log(`Removed ${event.data.tokensRemoved} tokens`);
+  console.log(`Success: ${event.data.success}`);
+  console.log(`Checkpoint: ${event.data.checkpointPath}`);
+});
+```
+
+### Manual compaction
+
+```typescript
+const result = await session.rpc.compaction.compact();
+// { success, tokensRemoved, messagesRemoved }
+```
+
+### Workspace path
+
+When infinite sessions are enabled, `session.workspacePath` returns a directory containing:
+- `checkpoints/` — compaction checkpoint data
+- `plan.md` — the session plan file
+- `files/` — workspace files
+
+## System message configuration
+
+```typescript
+// Append to Copilot's default system message (default):
+systemMessage: {
+  mode: "append",
+  content: "Always respond in bullet points.",
+}
+
+// Replace entire system message (removes all SDK guardrails):
+systemMessage: {
+  mode: "replace",
+  content: "You are a specialized code reviewer.",
+}
+```
+
+### SystemMessageConfig
+
+```typescript
+type SystemMessageConfig =
+  | { mode?: "append"; content?: string }      // append to default
+  | { mode: "replace"; content: string };       // replace entirely
+```

--- a/skills/build-copilot-sdk-app/references/tools-and-schemas.md
+++ b/skills/build-copilot-sdk-app/references/tools-and-schemas.md
@@ -1,0 +1,216 @@
+# Custom Tools and Schemas
+
+## defineTool (with Zod)
+
+The recommended way to define tools with full TypeScript inference:
+
+```typescript
+import { defineTool } from "@github/copilot-sdk";
+import { z } from "zod";
+
+const myTool = defineTool("encrypt_string", {
+  description: "Encrypts a string using ROT13",
+  parameters: z.object({
+    input: z.string().describe("String to encrypt"),
+    key: z.number().optional().describe("Encryption key"),
+  }),
+  handler: async ({ input, key }, invocation) => {
+    // invocation.sessionId, invocation.toolCallId, invocation.toolName
+    return input.toUpperCase(); // return value sent to model
+  },
+});
+```
+
+`defineTool` signature:
+```typescript
+function defineTool<T>(
+  name: string,
+  config: {
+    description?: string;
+    parameters?: ZodSchema<T> | Record<string, unknown>;
+    handler: ToolHandler<T>;
+    overridesBuiltInTool?: boolean;
+  }
+): Tool<T>
+```
+
+The SDK detects Zod v4 schemas and calls `toJSONSchema()` before sending to CLI.
+
+## Tool with raw JSON Schema
+
+```typescript
+const tools: Tool[] = [{
+  name: "get_secret_number",
+  description: "Gets the secret number for a key",
+  parameters: {
+    type: "object",
+    properties: {
+      key: { type: "string", description: "Lookup key" },
+    },
+    required: ["key"],
+  },
+  handler: async (args: { key: string }) => {
+    return args.key === "ALPHA" ? "54321" : "unknown";
+  },
+}];
+```
+
+## Tool interface
+
+```typescript
+interface Tool<TArgs = unknown> {
+  name: string;
+  description?: string;
+  parameters?: ZodSchema<TArgs> | Record<string, unknown>;
+  handler: ToolHandler<TArgs>;
+  overridesBuiltInTool?: boolean; // must be true to replace built-in tools
+}
+```
+
+## ToolHandler
+
+```typescript
+type ToolHandler<TArgs = unknown> = (
+  args: TArgs,
+  invocation: ToolInvocation,
+) => Promise<unknown> | unknown;
+```
+
+### ToolInvocation
+
+```typescript
+interface ToolInvocation {
+  sessionId: string;
+  toolCallId: string;
+  toolName: string;
+  arguments: unknown;
+}
+```
+
+## Return values
+
+Handlers can return several types:
+
+```typescript
+// Plain string — sent directly to model
+handler: () => "result text"
+
+// Object — JSON.stringify'd and sent to model
+handler: () => ({ cityName: "Paris", temp: 72 })
+
+// null/undefined — sent as empty string
+handler: () => null
+
+// Structured result — full control over result type
+handler: () => ({
+  textResultForLlm: "File created successfully",
+  resultType: "success" as const,
+})
+```
+
+### ToolResultObject
+
+```typescript
+type ToolResultObject = {
+  textResultForLlm: string;
+  binaryResultsForLlm?: ToolBinaryResult[];
+  resultType: "success" | "failure" | "rejected" | "denied";
+  error?: string;
+  sessionLog?: string;
+  toolTelemetry?: Record<string, unknown>;
+};
+
+type ToolBinaryResult = {
+  data: string;        // base64 encoded
+  mimeType: string;
+  type: string;
+  description?: string;
+};
+```
+
+## Error handling in tools
+
+If the handler throws, the SDK catches the error and sends a sanitized error to the model. The raw exception message is NOT exposed.
+
+```typescript
+handler: async (args) => {
+  if (!args.key) {
+    throw new Error("Key is required"); // SDK catches this
+  }
+  return "result";
+}
+```
+
+## Override built-in tools
+
+Set `overridesBuiltInTool: true` to shadow a built-in tool:
+
+```typescript
+const customGrep = defineTool("grep", {
+  description: "Custom grep implementation",
+  parameters: z.object({
+    query: z.string(),
+    path: z.string().optional(),
+  }),
+  handler: ({ query, path }) => `CUSTOM_GREP: ${query} in ${path}`,
+  overridesBuiltInTool: true, // required to replace "grep"
+});
+```
+
+Without `overridesBuiltInTool: true`, registering a tool with a built-in name will error.
+
+## Controlling available tools
+
+```typescript
+const session = await client.createSession({
+  onPermissionRequest: approveAll,
+  // Only allow these built-in tools (overrides excludedTools):
+  availableTools: ["view", "edit", "bash"],
+  // Or exclude specific tools:
+  excludedTools: ["grep", "glob"],
+  // Custom tools are always available regardless of these lists:
+  tools: [myTool],
+});
+```
+
+- `availableTools` is an allowlist — only listed built-in tools are exposed
+- `excludedTools` is a blocklist — listed tools are hidden
+- `availableTools` takes precedence over `excludedTools`
+- Custom tools registered via `tools` are always available
+
+## Listing available tools
+
+```typescript
+const tools = await client.rpc.tools.list({ model: "gpt-4.1" });
+// [{ name, namespacedName?, description, parameters?, instructions? }]
+```
+
+## Tool execution flow (protocol v3)
+
+1. Server sends `external_tool.requested` session event with `{ requestId, toolName, arguments, toolCallId }`
+2. SDK looks up handler by `toolName`
+3. Executes handler: `handler(args, { sessionId, toolCallId, toolName, arguments })`
+4. Normalizes result to string (JSON.stringify if object)
+5. Responds via `session.rpc.tools.handlePendingToolCall({ requestId, result })`
+6. On error: responds with `{ requestId, error: message }`
+
+## Multi-client tool architecture
+
+When multiple clients connect to the same session, their tools are **unioned**:
+
+```typescript
+// Client 1 registers toolA
+const session1 = await client1.createSession({
+  tools: [toolA],
+  onPermissionRequest: approveAll,
+});
+
+// Client 2 joins and registers toolB
+const session2 = await client2.resumeSession(session1.sessionId, {
+  tools: [toolB],
+  onPermissionRequest: approveAll,
+});
+// Model now sees both toolA and toolB
+
+// If client1 disconnects, toolA is removed; toolB persists
+```

--- a/skills/build-copilot-sdk-app/references/types-reference.md
+++ b/skills/build-copilot-sdk-app/references/types-reference.md
@@ -1,0 +1,483 @@
+# Complete Type Reference
+
+## Package exports
+
+```typescript
+// Runtime values
+import {
+  CopilotClient,
+  CopilotSession,
+  defineTool,
+  approveAll,
+} from "@github/copilot-sdk";
+
+// Extension entry point
+import { joinSession } from "@github/copilot-sdk/extension";
+```
+
+## Client types
+
+### CopilotClientOptions
+
+```typescript
+interface CopilotClientOptions {
+  cliPath?: string;
+  cliArgs?: string[];
+  cwd?: string;
+  port?: number;
+  useStdio?: boolean;
+  isChildProcess?: boolean;
+  cliUrl?: string;
+  logLevel?: "none" | "error" | "warning" | "info" | "debug" | "all";
+  autoStart?: boolean;
+  autoRestart?: boolean;
+  env?: Record<string, string | undefined>;
+  githubToken?: string;
+  useLoggedInUser?: boolean;
+  onListModels?: () => Promise<ModelInfo[]> | ModelInfo[];
+}
+```
+
+### ConnectionState
+
+```typescript
+type ConnectionState = "disconnected" | "connecting" | "connected" | "error";
+```
+
+## Session types
+
+### SessionConfig
+
+```typescript
+interface SessionConfig {
+  onPermissionRequest: PermissionHandler;
+  sessionId?: string;
+  clientName?: string;
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  configDir?: string;
+  tools?: Tool<any>[];
+  systemMessage?: SystemMessageConfig;
+  availableTools?: string[];
+  excludedTools?: string[];
+  provider?: ProviderConfig;
+  onUserInputRequest?: UserInputHandler;
+  hooks?: SessionHooks;
+  workingDirectory?: string;
+  streaming?: boolean;
+  mcpServers?: Record<string, MCPServerConfig>;
+  customAgents?: CustomAgentConfig[];
+  agent?: string;
+  skillDirectories?: string[];
+  disabledSkills?: string[];
+  infiniteSessions?: InfiniteSessionConfig;
+  onEvent?: SessionEventHandler;
+}
+```
+
+### ResumeSessionConfig
+
+Same as SessionConfig minus `sessionId`, plus:
+
+```typescript
+interface ResumeSessionConfig {
+  disableResume?: boolean; // skip session.resume event (default false)
+  // ... all other SessionConfig fields
+}
+```
+
+### InfiniteSessionConfig
+
+```typescript
+interface InfiniteSessionConfig {
+  enabled?: boolean;                        // default true
+  backgroundCompactionThreshold?: number;   // default 0.80
+  bufferExhaustionThreshold?: number;       // default 0.95
+}
+```
+
+### SystemMessageConfig
+
+```typescript
+type SystemMessageConfig =
+  | SystemMessageAppendConfig
+  | SystemMessageReplaceConfig;
+
+interface SystemMessageAppendConfig {
+  mode?: "append";
+  content?: string;
+}
+
+interface SystemMessageReplaceConfig {
+  mode: "replace";
+  content: string;
+}
+```
+
+### MessageOptions
+
+```typescript
+interface MessageOptions {
+  prompt: string;
+  attachments?: Array<
+    | { type: "file"; path: string; displayName?: string }
+    | { type: "directory"; path: string; displayName?: string }
+    | { type: "selection"; filePath: string; displayName: string;
+        selection?: { start: { line: number; character: number };
+                      end: { line: number; character: number } };
+        text?: string }
+  >;
+  mode?: "enqueue" | "immediate";
+}
+```
+
+## Tool types
+
+### Tool
+
+```typescript
+interface Tool<TArgs = unknown> {
+  name: string;
+  description?: string;
+  parameters?: ZodSchema<TArgs> | Record<string, unknown>;
+  handler: ToolHandler<TArgs>;
+  overridesBuiltInTool?: boolean;
+}
+```
+
+### ToolHandler
+
+```typescript
+type ToolHandler<TArgs = unknown> = (
+  args: TArgs,
+  invocation: ToolInvocation,
+) => Promise<unknown> | unknown;
+```
+
+### ToolInvocation
+
+```typescript
+interface ToolInvocation {
+  sessionId: string;
+  toolCallId: string;
+  toolName: string;
+  arguments: unknown;
+}
+```
+
+### ToolResultObject
+
+```typescript
+type ToolResultObject = {
+  textResultForLlm: string;
+  binaryResultsForLlm?: ToolBinaryResult[];
+  resultType: "success" | "failure" | "rejected" | "denied";
+  error?: string;
+  sessionLog?: string;
+  toolTelemetry?: Record<string, unknown>;
+};
+
+type ToolBinaryResult = {
+  data: string;        // base64
+  mimeType: string;
+  type: string;
+  description?: string;
+};
+
+type ToolResult = string | ToolResultObject;
+```
+
+### ZodSchema
+
+```typescript
+interface ZodSchema<T = unknown> {
+  _output: T;
+  toJSONSchema(): Record<string, unknown>;
+}
+```
+
+## Permission types
+
+### PermissionHandler
+
+```typescript
+type PermissionHandler = (
+  request: PermissionRequest,
+  invocation: { sessionId: string },
+) => Promise<PermissionRequestResult> | PermissionRequestResult;
+```
+
+### PermissionRequest
+
+```typescript
+interface PermissionRequest {
+  kind: "shell" | "write" | "read" | "mcp" | "url" | "memory" | "custom-tool";
+  toolCallId?: string;
+  [key: string]: unknown;
+}
+```
+
+### PermissionRequestResult
+
+```typescript
+type PermissionRequestResult =
+  | { kind: "approved" }
+  | { kind: "denied-by-rules"; rules: unknown[] }
+  | { kind: "denied-no-approval-rule-and-could-not-request-from-user" }
+  | { kind: "denied-interactively-by-user"; feedback?: string }
+  | { kind: "denied-by-content-exclusion-policy"; path: string; message: string };
+```
+
+## User input types
+
+### UserInputHandler
+
+```typescript
+type UserInputHandler = (
+  request: UserInputRequest,
+  invocation: { sessionId: string },
+) => Promise<UserInputResponse> | UserInputResponse;
+```
+
+### UserInputRequest / Response
+
+```typescript
+interface UserInputRequest {
+  question: string;
+  choices?: string[];
+  allowFreeform?: boolean;
+}
+
+interface UserInputResponse {
+  answer: string;
+  wasFreeform: boolean;
+}
+```
+
+## Hook types
+
+### SessionHooks
+
+```typescript
+interface SessionHooks {
+  onPreToolUse?: (input: PreToolUseHookInput, inv: { sessionId: string }) => Promise<PreToolUseHookOutput | void> | PreToolUseHookOutput | void;
+  onPostToolUse?: (input: PostToolUseHookInput, inv: { sessionId: string }) => Promise<PostToolUseHookOutput | void> | PostToolUseHookOutput | void;
+  onUserPromptSubmitted?: (input: UserPromptSubmittedHookInput, inv: { sessionId: string }) => Promise<UserPromptSubmittedHookOutput | void> | UserPromptSubmittedHookOutput | void;
+  onSessionStart?: (input: SessionStartHookInput, inv: { sessionId: string }) => Promise<SessionStartHookOutput | void> | SessionStartHookOutput | void;
+  onSessionEnd?: (input: SessionEndHookInput, inv: { sessionId: string }) => Promise<SessionEndHookOutput | void> | SessionEndHookOutput | void;
+  onErrorOccurred?: (input: ErrorOccurredHookInput, inv: { sessionId: string }) => Promise<ErrorOccurredHookOutput | void> | ErrorOccurredHookOutput | void;
+}
+```
+
+### Hook input types
+
+```typescript
+interface BaseHookInput { timestamp: number; cwd: string; }
+
+interface PreToolUseHookInput extends BaseHookInput { toolName: string; toolArgs: unknown; }
+interface PostToolUseHookInput extends BaseHookInput { toolName: string; toolArgs: unknown; toolResult: ToolResultObject; }
+interface UserPromptSubmittedHookInput extends BaseHookInput { prompt: string; }
+interface SessionStartHookInput extends BaseHookInput { source: "startup" | "resume" | "new"; initialPrompt?: string; }
+interface SessionEndHookInput extends BaseHookInput { reason: "complete" | "error" | "abort" | "timeout" | "user_exit"; finalMessage?: string; error?: string; }
+interface ErrorOccurredHookInput extends BaseHookInput { error: string; errorContext: "model_call" | "tool_execution" | "system" | "user_input"; recoverable: boolean; }
+```
+
+### Hook output types
+
+```typescript
+interface PreToolUseHookOutput { permissionDecision?: "allow" | "deny" | "ask"; permissionDecisionReason?: string; modifiedArgs?: unknown; additionalContext?: string; suppressOutput?: boolean; }
+interface PostToolUseHookOutput { modifiedResult?: ToolResultObject; additionalContext?: string; suppressOutput?: boolean; }
+interface UserPromptSubmittedHookOutput { modifiedPrompt?: string; additionalContext?: string; suppressOutput?: boolean; }
+interface SessionStartHookOutput { additionalContext?: string; modifiedConfig?: Record<string, unknown>; }
+interface SessionEndHookOutput { suppressOutput?: boolean; cleanupActions?: string[]; sessionSummary?: string; }
+interface ErrorOccurredHookOutput { suppressOutput?: boolean; errorHandling?: "retry" | "skip" | "abort"; retryCount?: number; userNotification?: string; }
+```
+
+## Agent types
+
+### CustomAgentConfig
+
+```typescript
+interface CustomAgentConfig {
+  name: string;
+  displayName?: string;
+  description?: string;
+  tools?: string[] | null;
+  prompt: string;
+  mcpServers?: Record<string, MCPServerConfig>;
+  infer?: boolean;
+}
+```
+
+## MCP types
+
+```typescript
+type MCPServerConfig = MCPLocalServerConfig | MCPRemoteServerConfig;
+
+interface MCPLocalServerConfig {
+  type?: "local" | "stdio";
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  tools: string[];
+  timeout?: number;
+}
+
+interface MCPRemoteServerConfig {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  tools: string[];
+  timeout?: number;
+}
+```
+
+## Provider types
+
+```typescript
+interface ProviderConfig {
+  type?: "openai" | "azure" | "anthropic";
+  wireApi?: "completions" | "responses";
+  baseUrl: string;
+  apiKey?: string;
+  bearerToken?: string;
+  azure?: { apiVersion?: string };
+}
+```
+
+## Model types
+
+```typescript
+interface ModelInfo {
+  id: string;
+  name: string;
+  capabilities: ModelCapabilities;
+  policy?: ModelPolicy;
+  billing?: ModelBilling;
+  supportedReasoningEfforts?: ReasoningEffort[];
+  defaultReasoningEffort?: ReasoningEffort;
+}
+
+interface ModelCapabilities {
+  supports: { vision: boolean; reasoningEffort: boolean };
+  limits: {
+    max_prompt_tokens?: number;
+    max_context_window_tokens: number;
+    vision?: { supported_media_types: string[]; max_prompt_images: number; max_prompt_image_size: number };
+  };
+}
+
+interface ModelPolicy { state: "enabled" | "disabled" | "unconfigured"; terms: string; }
+interface ModelBilling { multiplier: number; }
+type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+```
+
+## Status types
+
+```typescript
+interface GetStatusResponse {
+  version: string;
+  protocolVersion: number;
+}
+
+interface GetAuthStatusResponse {
+  isAuthenticated: boolean;
+  authType?: "user" | "env" | "gh-cli" | "hmac" | "api-key" | "token";
+  host?: string;
+  login?: string;
+  statusMessage?: string;
+}
+```
+
+## Session metadata types
+
+```typescript
+interface SessionMetadata {
+  sessionId: string;
+  startTime: Date;
+  modifiedTime: Date;
+  summary?: string;
+  isRemote: boolean;
+  context?: SessionContext;
+}
+
+interface SessionContext {
+  cwd: string;
+  gitRoot?: string;
+  repository?: string;
+  branch?: string;
+}
+
+interface SessionListFilter {
+  cwd?: string;
+  gitRoot?: string;
+  repository?: string;
+  branch?: string;
+}
+```
+
+## Lifecycle types
+
+```typescript
+type SessionLifecycleEventType =
+  | "session.created" | "session.deleted" | "session.updated"
+  | "session.foreground" | "session.background";
+
+interface SessionLifecycleEvent {
+  type: SessionLifecycleEventType;
+  sessionId: string;
+  metadata?: { startTime: string; modifiedTime: string; summary?: string };
+}
+
+interface ForegroundSessionInfo {
+  sessionId?: string;
+  workspacePath?: string;
+}
+```
+
+## Event handler types
+
+```typescript
+type SessionEventType = SessionEvent["type"];
+type SessionEventPayload<T extends SessionEventType> = Extract<SessionEvent, { type: T }>;
+type TypedSessionEventHandler<T extends SessionEventType> = (event: SessionEventPayload<T>) => void;
+type SessionEventHandler = (event: SessionEvent) => void;
+type SessionLifecycleHandler = (event: SessionLifecycleEvent) => void;
+type TypedSessionLifecycleHandler<K extends SessionLifecycleEventType> = (event: SessionLifecycleEvent & { type: K }) => void;
+```
+
+## RPC methods summary
+
+### Server-scoped (via `client.rpc`)
+
+| Method | Returns |
+|--------|---------|
+| `ping({ message? })` | `{ message, timestamp, protocolVersion }` |
+| `models.list()` | `ModelInfo[]` |
+| `tools.list({ model? })` | `ToolsListResult[]` |
+| `account.getQuota()` | `{ quotaSnapshots }` |
+
+### Session-scoped (via `session.rpc`)
+
+| Method | Returns |
+|--------|---------|
+| `model.getCurrent()` | `{ modelId? }` |
+| `model.switchTo({ modelId, reasoningEffort? })` | `{ modelId? }` |
+| `mode.get()` | `{ mode }` |
+| `mode.set({ mode })` | `{ mode }` |
+| `plan.read()` | `{ exists, content, path }` |
+| `plan.update({ content })` | `{}` |
+| `plan.delete()` | `{}` |
+| `workspace.listFiles()` | `{ files: string[] }` |
+| `workspace.readFile({ path })` | `{ content }` |
+| `workspace.createFile({ path, content })` | `{}` |
+| `fleet.start({ prompt? })` | `{ started }` |
+| `agent.list()` | `{ agents }` |
+| `agent.getCurrent()` | `{ agent }` |
+| `agent.select({ name })` | `{ agent }` |
+| `agent.deselect()` | `{}` |
+| `compaction.compact()` | `{ success, tokensRemoved, messagesRemoved }` |
+| `tools.handlePendingToolCall({ requestId, result?, error? })` | `{ success }` |
+| `permissions.handlePendingPermissionRequest({ requestId, result })` | `{ success }` |
+| `log({ message, level?, ephemeral? })` | `{ eventId }` |


### PR DESCRIPTION
## Summary

- Adds `build-copilot-sdk-app` — a complete developer guide for building TypeScript applications with the GitHub Copilot SDK (`@github/copilot-sdk` v0.1.32+, protocol v3)
- Covers the full SDK surface: client setup, sessions, custom tools with Zod schemas, 47 streaming event types, permissions, hooks, custom agents, MCP servers, skills, BYOK providers, plan/autopilot/fleet modes, multi-client architectures, and Ralph loop autonomous dev patterns
- Includes 10 reference docs (3,312 lines total)

## Files added/modified

**New skill (12 files):**
- `skills/build-copilot-sdk-app/SKILL.md` — decision tree, quick start, key patterns, common pitfalls
- `skills/build-copilot-sdk-app/references/client-and-transport.md` — CopilotClient options, 4 transport modes, lifecycle
- `skills/build-copilot-sdk-app/references/sessions.md` — SessionConfig, create/resume, persistence, infinite sessions
- `skills/build-copilot-sdk-app/references/tools-and-schemas.md` — defineTool, Zod + JSON Schema, ToolResultObject
- `skills/build-copilot-sdk-app/references/events-and-streaming.md` — all 47 event types, streaming delta patterns
- `skills/build-copilot-sdk-app/references/permissions-and-user-input.md` — 7 permission kinds, askUser, elicitation
- `skills/build-copilot-sdk-app/references/hooks.md` — all 6 hooks with input/output types
- `skills/build-copilot-sdk-app/references/agents-mcp-skills.md` — custom agents, MCP config, skills, extensions
- `skills/build-copilot-sdk-app/references/auth-and-byok.md` — OAuth, env vars, 6 BYOK provider configs
- `skills/build-copilot-sdk-app/references/advanced-patterns.md` — plan/autopilot, fleet, multi-client, Ralph loop
- `skills/build-copilot-sdk-app/references/types-reference.md` — complete type reference and RPC method tables

**Repo files updated:**
- `README.md` — added "SDK Guides" category with the new skill, updated skill count to 21
- `NAMING.md` — added `build-copilot-sdk-app` to canonical skill list

## Quality checklist

- [x] Directory name is canonical kebab-case (`build-copilot-sdk-app`)
- [x] `SKILL.md` frontmatter `name` matches directory name
- [x] README label matches canonical name
- [x] Description starts with `Use skill if you are` (23 words)
- [x] All 10 reference files explicitly referenced in `SKILL.md` decision tree
- [x] No stale names, aliases, or broken references
- [x] No eval files, junk files, or `.DS_Store`
- [x] NAMING.md canonical list updated
- [x] Verb prefix follows repo convention (`build-`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
