### PR TITLE
fix(publish-npm-package): derailment-tested fixes for 18 friction points

### DIFF
--- a/skills/publish-npm-package/SKILL.md
+++ b/skills/publish-npm-package/SKILL.md
@@ -22,14 +22,29 @@ This skill assumes npmjs.org. For deep `package.json` / exports / files shaping,
 
 ## Always classify the repo first
 
-Before writing YAML, confirm:
-1. Is the package public or private?
-2. Is publishing happening on GitHub Actions, and is the publish job on a GitHub-hosted runner?
-3. Is this a single package or a monorepo/workspaces repo?
-4. Does the team already use reliable conventional commits?
-5. Should every releasable merge publish automatically, or should there be a human-reviewed Release/Version PR?
-6. Is this greenfield, or does the package already exist with tags/versions/releases?
-7. Is the target really npmjs.org?
+Before writing YAML, answer these questions and **record the answers** — they drive the auth (Step 1) and versioning (Step 2) decisions below:
+
+1. Is the package **public** or **private**?
+2. Is publishing on **GitHub Actions** with a **GitHub-hosted runner**?
+3. Is this a **single package** or a **monorepo/workspaces** repo?
+4. Does the team already use **conventional commits** (the majority of meaningful commits follow `type: description` format)?
+5. Should every releasable merge publish **automatically**, or should there be a **human-reviewed Release/Version PR**?
+6. Is this **greenfield** (never published), or does the package already exist with tags/versions/releases?
+7. Is the target really **npmjs.org**?
+
+> **⚠️ Steering (F-01):** Record answers explicitly (e.g., as inline comments or a checklist). Without a recorded classification, the auth and versioning decisions become guesswork. The table below maps answers directly to choices.
+
+### Quick-reference decision matrix
+
+| Q1: Public? | Q2: GH Actions + hosted runner? | Q3: Single/Mono? | Q4: Conv. commits? | Q5: Auto/Human gate? | → Auth | → Versioning |
+|---|---|---|---|---|---|---|
+| Yes | Yes | Single | Yes | Auto | OIDC | semantic-release |
+| Yes | Yes | Single | Yes | Human gate | OIDC | release-please |
+| Yes | Yes | Single | No | Human gate | OIDC | changesets |
+| Yes | Yes | Single | No (greenfield, will adopt) | Human gate | OIDC | release-please |
+| Yes | Yes | Monorepo | Any | Any | OIDC | changesets (default) |
+| No | Any | Any | Any | Any | Token | (any versioning) |
+| Any | No (self-hosted/GHES) | Any | Any | Any | Token | (any versioning) |
 
 ## Always follow this order
 
@@ -58,26 +73,51 @@ Before writing YAML, confirm:
 - Do not keep both OIDC and token auth just because an old workflow used both. The only valid mixed setup is when **token auth is still required** but you also grant `id-token: write` for provenance.
 - Avoid classic automation tokens for new work.
 
+> **⚠️ Steering (F-07):** OIDC auth means **zero npm secrets**. If your workflow has `NODE_AUTH_TOKEN` or `NPM_TOKEN` in the publish step, you are using token-based auth, **not** OIDC — even if `id-token: write` is set. Pure OIDC relies on GitHub's identity federation with npm; no token is exchanged via environment variables.
+
 ## 2) Choose the versioning model, not just a tool
 
 | Need | Choose | Choose when | Avoid when | Read next |
 |---|---|---|---|---|
 | Publish automatically on every releasable merge | **semantic-release** | Single package, strong conventional-commit discipline, no human release gate | Monorepos, weak commit discipline, teams that want a reviewable release PR | `references/versioning/semantic-release.md` |
 | Generate a reviewable Release PR, publish after merge | **release-please** | Conventional commits already exist, team wants a human merge gate, explicit release PR is desirable | Commit messages are not trustworthy, or the goal is zero human release handling | `references/versioning/release-please.md` |
-| Put version intent in each PR and batch releases deliberately | **changesets** | Monorepos, explicit version notes, teams without strict conventional commits | The repo wants publish-on-merge with no human-authored version data | `references/versioning/changesets.md` |
+| Put version intent in each PR and batch releases deliberately | **changesets** | Monorepos, single-package repos without strict conventional commits, explicit version notes, teams that want a human-reviewed Version PR without adopting conventional commits | The repo wants publish-on-merge with no human-authored version data | `references/versioning/changesets.md` |
 | Rare/simple releases | **manual trigger + `npm version`** | Automation would be heavier than the release frequency | The task explicitly asks for full release automation | matching workflow "Manual Trigger" section |
+
+> **⚠️ Steering (F-04):** changesets is **not** monorepo-only. It works perfectly for single-package repos and does not require conventional commits. If a single-package repo wants a human-reviewed Version PR without adopting conventional commits, changesets is the right choice.
+
+### Quick-decision flowchart
+
+```
+Is this a monorepo?
+  YES → changesets (default) — or release-please if conv. commits already drive the repo
+  NO (single package) →
+       Does the team use conventional commits?
+         YES →
+              Want fully automatic publish? → semantic-release
+              Want a human-reviewed Release PR? → release-please
+         NO →
+              Greenfield and willing to adopt? → release-please (commit to the format)
+              Existing repo, won't adopt? → changesets
+              Rare releases? → manual trigger
+```
 
 **Versioning rules**
 - **Monorepo default: changesets.** Use release-please only when conventional commits already drive the repo. Treat semantic-release in monorepos as a last resort, not the default.
-- If conventional commits are weak or absent, do **not** silently pick semantic-release or release-please.
+- **Single-package repo without conventional commits that wants a human release gate:** changesets is a viable choice — it is not monorepo-only. Alternatively, adopt conventional commits and choose release-please.
+- If conventional commits are weak or absent **in an existing repo**, do **not** silently pick semantic-release or release-please. For greenfield repos, adopting conventional commits is a valid starting choice — pick release-please if the team commits to the format going forward.
 - For existing published packages, bootstrap before the first automated run:
   - semantic-release: initial tag / baseline release state
   - release-please: config + manifest aligned to the current published version
   - changesets: initialized config and contributor workflow for changeset files
 
+> **⚠️ Steering (F-05):** Distinguish **greenfield** (team can choose to adopt conventional commits going forward) from **existing repo** (commit history already exists without them). For greenfield, picking release-please + committing to conventional commits is valid. For existing repos with inconsistent history, changesets avoids the commit-discipline prerequisite.
+
 ## 3) Route to the exact workflow template
 
 Do not hand-assemble publish YAML from memory if a matching reference already exists.
+
+> **⚠️ Steering (F-13):** Use the **workflow template's** configuration files as the starting point. If the versioning reference (e.g., `release-please.md`) shows different or additional config options, treat them as customization, **not** the baseline. The workflow template is the source of truth for the config file set.
 
 | Auth | Versioning | Workflow template |
 |---|---|---|
@@ -101,10 +141,11 @@ Do not hand-assemble publish YAML from memory if a matching reference already ex
 Before editing or validating the workflow, confirm:
 
 ### Package/repo prerequisites
-- `package.json.repository.url` exactly matches the GitHub repo URL, including casing.
+- The code is pushed to a **GitHub repository** (the workflow runs on GitHub Actions).
+- `package.json.repository.url` exactly matches the GitHub repo URL, **including casing**.
 - Scoped public packages set `publishConfig.access: "public"` or an equivalent publish flag.
 - Prefer `publishConfig.provenance: true` so provenance is not a human-memory step.
-- The repo's lockfile is committed and CI uses deterministic installs (`npm ci` or the repo's equivalent)
+- The repo's lockfile is committed and CI uses deterministic installs (`npm ci` or the repo's equivalent).
 - `npm pack --dry-run` shows the intended tarball contents.
 - Packaging details such as `files`, `exports`, types, and dual ESM/CJS output are correct. Use `references/packaging/package-config.md` for those details.
 
@@ -113,14 +154,27 @@ Before editing or validating the workflow, confirm:
 - publish jobs run build/test before publish
 - explicit `concurrency` is present to avoid publish races
 - permissions are least-privilege and set deliberately
-- production-hardening work pins GitHub Actions to full SHAs, not mutable tags
+- For production hardening, consider pinning GitHub Actions to full SHAs with a tag comment (e.g., `actions/checkout@<sha> # v4`). The reference templates use tags for readability — pin to SHAs before shipping to production. See `references/security/supply-chain.md` for SHA pinning guidance.
 
-### First-release / migration prerequisites
-- For a new OIDC setup, ensure npm is linked to the correct GitHub repo and the package/scope is allowed to publish from that repo.
-- If OIDC complains about repo/package linkage or first publish state, do the minimum bootstrap the auth reference describes before retrying.
-- For semantic-release, ensure full git history and baseline tags exist.
-- For release-please, ensure both config and manifest files exist and reflect current state.
+> **⚠️ Steering (F-17):** The workflow templates use `@v4` style tags for readability. For production, pin to full commit SHAs with a tag comment: `actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4`. This prevents supply-chain attacks via mutable tags.
+
+### First-publish / OIDC bootstrap (critical for greenfield)
+
+> **⚠️ Steering (F-11):** OIDC requires the package to **already exist** on npm. For a brand-new package, you hit a chicken-and-egg problem: you can't link a non-existent package to your GitHub repo.
+
+**Bootstrap steps for first publish with OIDC:**
+1. Create a **granular access token** on npmjs.com (see `references/auth/granular-tokens.md`).
+2. Add it as `NPM_TOKEN` in your repo's GitHub Actions secrets.
+3. Publish once manually: `npm publish --access public` (or use the token-based workflow template for the first release).
+4. Go to `https://www.npmjs.com/package/<your-package>/access` → **Publishing access** → **Add GitHub Actions** to link the package to your repo.
+5. Remove the `NPM_TOKEN` secret and switch the workflow to pure OIDC.
+
+### Migration prerequisites
+- For semantic-release, ensure full git history (`fetch-depth: 0`) and baseline tags exist.
+- For release-please, ensure both config and manifest files exist with the **manifest version matching `package.json`**. For never-published packages, use the `package.json` version (typically `1.0.0` or `0.1.0`).
 - For changesets, ensure contributors know when to add a changeset and how empty changesets are handled.
+
+> **⚠️ Steering (F-10/F-18):** "Current version" in the release-please manifest means the version in `package.json`. For greenfield packages that have never been published, set the manifest to match `package.json` exactly. Do not guess `"0.0.0"` unless `package.json` says `"0.0.0"`.
 
 ## Guardrails: avoid half-configured release automation
 
@@ -141,34 +195,29 @@ Before editing or validating the workflow, confirm:
 ## Verification before calling the setup done
 
 ### Always run
-- `npm pack --dry-run`
+- `npm pack --dry-run` — verify tarball contents
 - build/test in the same workflow that publishes
 - a check that the intended versioning tool is actually wired, not just installed
 
 ### Auth-specific checks
-- OIDC:
-  - publish job runs on a GitHub-hosted runner
-  - `permissions` include at least `contents: read` and `id-token: write`
-  - `actions/setup-node` points to npmjs
-  - after the first successful publish, verify provenance with `npm audit signatures`
-- Token:
-  - `NPM_TOKEN` exists in repo/org secrets
-  - publish step uses `NODE_AUTH_TOKEN`
-  - if debugging auth, verify with `npm whoami` in a safe CI/local diagnostic path
+
+| Check | OIDC | Token |
+|---|---|---|
+| Runner type | GitHub-hosted | Any |
+| Permissions | `contents: read`, `id-token: write` | N/A |
+| Registry config | `actions/setup-node` → `registry-url: https://registry.npmjs.org` | Same |
+| Secret wiring | None needed (no `NODE_AUTH_TOKEN`) | `NPM_TOKEN` in secrets, `NODE_AUTH_TOKEN` in publish step |
+| Post-publish verify | `npm audit signatures` | `npm whoami` (diagnostic only) |
 
 ### Tool-specific checks
-- semantic-release:
-  - `npx semantic-release --dry-run`
-  - full git history is available
-  - plugin order and baseline tags are sane
-- changesets:
-  - `npx changeset status`
-  - `.changeset/config.json` exists
-  - the release/version PR path matches the chosen template
-- release-please:
-  - config and manifest files both exist
-  - publish is gated on `release_created == 'true'`
-  - bootstrap state matches the current published version
+
+| Tool | Dry-run command | Key files | Critical check |
+|---|---|---|---|
+| semantic-release | `npx semantic-release --dry-run` | `.releaserc` or `release.config.js` | Full git history, baseline tags, plugin order |
+| changesets | `npx changeset status` | `.changeset/config.json` | Release/version PR path matches template |
+| release-please | `release-please release-pr --repo-url=<owner/repo> --token=TOKEN --dry-run` (optional, requires CLI install) | `.release-please-config.json`, `.release-please-manifest.json` | Manifest version matches `package.json`, publish gated on `release_created == 'true'` |
+
+> **⚠️ Steering (F-15):** release-please has no built-in dry-run equivalent to `npx semantic-release --dry-run`. Verify by confirming config + manifest files exist and the manifest version matches `package.json`. The CLI dry-run above is optional and requires `npm i -g release-please`.
 
 ## Recovery routing
 
@@ -194,13 +243,15 @@ If the task is about an existing failure, jump straight to the narrowest referen
 
 ### Public single-package repo, reviewable release gate
 - `references/auth/oidc-trusted-publishing.md`
-- `references/versioning/release-please.md`
-- `references/workflows/oidc-workflows.md` → **3. OIDC + release-please**
+- `references/versioning/release-please.md` or `references/versioning/changesets.md`
+- `references/workflows/oidc-workflows.md` → **3. OIDC + release-please** or **2. OIDC + changesets**
+- `references/security/supply-chain.md`
 
 ### Monorepo / workspaces
 - `references/monorepo/publishing-patterns.md`
 - `references/versioning/changesets.md` (default) or `references/versioning/release-please.md`
 - matching OIDC/token workflow section
+- `references/security/supply-chain.md`
 
 ### Private package, self-hosted runner, or non-GitHub CI
 - `references/auth/granular-tokens.md`
@@ -211,6 +262,21 @@ If the task is about an existing failure, jump straight to the narrowest referen
 - `references/troubleshooting/common-issues.md`
 - auth reference for the current auth mode
 - versioning reference for the current tool
+
+## Steering experiences — quick reference
+
+These are the highest-impact traps found during derailment testing. Each is documented in detail at the relevant decision point above and in the reference files.
+
+| Trap | Impact | What to do |
+|---|---|---|
+| Using `NODE_AUTH_TOKEN`/`NPM_TOKEN` and calling it "OIDC" | P0 — silent wrong auth | OIDC means zero npm secrets. If the publish step has `NODE_AUTH_TOKEN`, it is token auth. |
+| First-publish with OIDC on a package that does not exist on npm yet | P0 — 404 error | Bootstrap: publish once with a granular token, then switch to OIDC. |
+| Picking semantic-release/release-please without conventional commits | P0 compound — blocked | Use changesets if the team will not adopt conventional commits. |
+| Assuming changesets is monorepo-only | P1 — wrong tool choice | changesets works for single-package repos and does not require conventional commits. |
+| Confusing greenfield "will adopt" with existing "does not have" | P1 — wrong guidance | Greenfield can adopt conventional commits (design choice). Existing repos without them need changesets. |
+| Copying config from versioning reference instead of workflow template | P1 — config mismatch | Workflow template is baseline; versioning reference shows customization options. |
+| Using `@v4` action tags in production | P1 — supply-chain risk | Pin to full SHAs with tag comments for production workflows. |
+| Not verifying manifest version matches `package.json` | P1 — release-please misfire | Manifest must match `package.json`. For greenfield, use the `package.json` version exactly. |
 
 ## Final reminder
 

--- a/skills/publish-npm-package/references/auth/granular-tokens.md
+++ b/skills/publish-npm-package/references/auth/granular-tokens.md
@@ -2,6 +2,8 @@
 
 Granular access tokens and automation tokens for npm publishing in GitHub Actions. Use when OIDC is not available (private packages, self-hosted runners, non-GitHub CI).
 
+> **⚠️ Steering:** Granular tokens are the **fallback** auth method, not the default. For public packages on GitHub Actions with GitHub-hosted runners, always prefer [OIDC trusted publishing](oidc-trusted-publishing.md) — it requires zero secrets and provides cryptographic provenance. Use granular tokens only when OIDC is unavailable (private packages, self-hosted runners, non-GitHub CI) or for the [first-publish bootstrap](#using-granular-tokens-for-first-publish-bootstrap) before switching to OIDC.
+
 ---
 
 ## Granular access tokens
@@ -119,6 +121,17 @@ jobs:
 
 ### Rotation best practices
 
+**Rotation timeline by risk profile:**
+
+| Expiry | Buffer | Use case | Risk level |
+|---|---|---|---|
+| **30 days** | Rotate at day 25 | High-security packages, packages with >10k weekly downloads | Low risk |
+| **90 days** | Rotate at day 85 | Standard CI publishing (recommended default) | Moderate risk |
+| **180 days** | Rotate at day 170 | Low-frequency publishing, internal tools | Higher risk |
+| **365 days** | Rotate at day 350 | Legacy projects with infrequent releases (avoid if possible) | Highest risk |
+
+> **⚠️ Steering:** Shorter expiry = less blast radius if leaked. If your package is public and on GitHub Actions, skip the rotation burden entirely — switch to [OIDC trusted publishing](oidc-trusted-publishing.md) which has zero secrets to rotate.
+
 **90-day rotation cycle** (recommended):
 
 | Day | Action |
@@ -139,6 +152,22 @@ gh secret set NPM_TOKEN --body "npm_NEW_TOKEN_VALUE" --repo owner/repo
 gh workflow run publish.yml -f dry-run=true
 # 4. Delete old token on npmjs.com (UI)
 ```
+
+---
+
+## Using Granular Tokens for First-Publish Bootstrap
+
+> **⚠️ Steering (F-11):** OIDC trusted publishing requires the package to already exist on npm. For brand-new (greenfield) packages, you must publish once with a granular token before OIDC can be configured.
+
+**Quick bootstrap flow:**
+
+1. Create a **short-lived** granular token (7-day expiry) on npmjs.com
+2. Publish the package: `npm publish --access public` (with `NODE_AUTH_TOKEN` set)
+3. Configure OIDC linking at `https://npmjs.com/package/<pkg>/access` → Add GitHub Actions
+4. Delete the granular token and remove the `NPM_TOKEN` secret
+5. Switch to the OIDC workflow — see [oidc-trusted-publishing.md](oidc-trusted-publishing.md) for the full guide
+
+See the detailed [First Publish Bootstrap](oidc-trusted-publishing.md#first-publish-bootstrap-greenfield-packages) section in the OIDC reference for step-by-step instructions.
 
 ---
 
@@ -251,6 +280,8 @@ If you need a project `.npmrc`, use environment variable substitution:
 ---
 
 ## Decision matrix: OIDC vs Granular vs Automation
+
+> **⚠️ Steering:** If you're choosing between these options for a **public package on GitHub Actions**, the answer is almost always OIDC. Use the matrix below only when OIDC is genuinely unavailable. After first-publish bootstrap, transition to OIDC by following [oidc-trusted-publishing.md](oidc-trusted-publishing.md).
 
 | Factor | OIDC | Granular Token | Automation Token |
 |---|---|---|---|

--- a/skills/publish-npm-package/references/auth/oidc-trusted-publishing.md
+++ b/skills/publish-npm-package/references/auth/oidc-trusted-publishing.md
@@ -2,6 +2,8 @@
 
 Zero-secret npm publishing using GitHub Actions' built-in OIDC identity. The most secure method for public packages.
 
+> **⚠️ Steering (F-07):** OIDC means **zero secrets** — no `NPM_TOKEN`, no `NODE_AUTH_TOKEN`, no secrets of any kind. If your workflow has `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` in an `env:` block, **you are NOT using OIDC** — you are using token-based auth. See `granular-tokens.md` for that approach. A common mistake is copying a workflow from `release-please.md` or similar templates that use `NODE_AUTH_TOKEN` and assuming OIDC is active. OIDC authentication is handled entirely by the `id-token: write` permission — the npm CLI obtains a token from the GitHub Actions runtime automatically.
+
 ---
 
 ## How OIDC trusted publishing works
@@ -24,11 +26,14 @@ The result: a published package with a cryptographic provenance attestation link
 
 ### Prerequisites
 
+> **⚠️ Steering (F-12):** The GitHub repository must exist before you configure any auth. Create and push the repo first, then set up publishing.
+
 - npm CLI >= 9.5.0 (ships with Node.js >= 18.x)
 - GitHub-hosted runner (self-hosted runners cannot mint OIDC tokens)
 - Package must be public (private packages require npm Enterprise for OIDC)
 - npm account linked to the package scope (required for first publish only)
 - `package.json` `repository` field matching the GitHub repo URL exactly
+- **The package must already exist on npm** — see [First Publish Bootstrap](#first-publish-bootstrap-greenfield-packages) below
 
 ### Step 1 — Configure package.json
 
@@ -50,6 +55,8 @@ The result: a published package with a cryptographic provenance attestation link
 **Critical**: The `repository.url` must exactly match your GitHub repository URL, including casing. A mismatch like `YourOrg` vs `yourorg` will cause provenance verification to fail.
 
 ### Step 2 — Create the workflow file
+
+> **⚠️ Steering (F-17):** The template below uses `@v4` action tags for readability. For production workflows, **pin actions to full commit SHAs** instead of tags. Tags are mutable — a compromised tag can inject malicious code. Find the SHA on the action's releases page (e.g., `actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11` instead of `actions/checkout@v4`).
 
 Create `.github/workflows/publish.yml`:
 
@@ -87,7 +94,23 @@ jobs:
       - run: npm publish --provenance --access public
 ```
 
-### Step 3 — Verify before first publish
+> **⚠️ Steering (F-07):** Notice there is **no `env: NODE_AUTH_TOKEN`** anywhere in this workflow. That is correct. If you see `NODE_AUTH_TOKEN` or `NPM_TOKEN` in an OIDC workflow, something is wrong — remove it and rely on `id-token: write` instead.
+
+### Step 3 — Link your npm package to GitHub Actions
+
+> **⚠️ Steering (F-08):** This step is required and often missed. Without it, npm will reject OIDC-authenticated publishes with a `403 Forbidden`.
+
+1. Go to **`https://npmjs.com/package/<your-package-name>/access`** (replace `<your-package-name>` with your actual package name, e.g., `https://npmjs.com/package/@yourorg/your-package/access`)
+2. Scroll to **Publishing access**
+3. Click **Add GitHub Actions**
+4. Enter your GitHub repository owner and name (e.g., `yourorg/your-package`)
+5. Select the workflow file name (e.g., `publish.yml`)
+6. Optionally restrict to a specific branch or environment
+7. Click **Add**
+
+For scoped packages, the URL follows the pattern: `https://npmjs.com/package/@scope/name/access`
+
+### Step 4 — Verify before first publish
 
 ```bash
 # Check npm CLI version (must be >= 9.5.0)
@@ -100,11 +123,55 @@ cat package.json | jq '.repository'
 npm pack --dry-run
 ```
 
-### Step 4 — Create a GitHub Release
+### Step 5 — Create a GitHub Release
 
 ```bash
 gh release create v1.0.0 --title "v1.0.0" --notes "Initial release"
 ```
+
+---
+
+## First Publish Bootstrap (Greenfield Packages)
+
+> **⚠️ Steering (F-11, P0):** OIDC trusted publishing has a **chicken-and-egg problem**: you must link your npm package to GitHub Actions, but you can only link a package that **already exists on npm**. If you try to publish a brand-new package via OIDC, you will get a `404 Not Found` error because the package doesn't exist yet and therefore can't have OIDC configured.
+
+### Bootstrap steps for a new package
+
+1. **Create a granular access token** on npmjs.com:
+   - Go to npmjs.com → Profile → **Access Tokens** → **Generate New Token** → **Granular Access Token**
+   - Set expiry to 7 days (you only need it once)
+   - Scope it to your organization or leave broad (temporary)
+   - Set permissions to **Read and Write**
+
+2. **Add it as a GitHub Secret** (or use it locally):
+   ```bash
+   # Option A: Store as repo secret for CI bootstrap
+   gh secret set NPM_TOKEN --body "npm_YOUR_TOKEN_HERE" --repo yourorg/your-package
+
+   # Option B: Set locally for manual publish
+   export NODE_AUTH_TOKEN="npm_YOUR_TOKEN_HERE"
+   ```
+
+3. **Publish the package manually** to create it on npm:
+   ```bash
+   npm publish --access public
+   ```
+
+4. **Configure OIDC linking** on npmjs.com:
+   - Go to `https://npmjs.com/package/<your-package-name>/access`
+   - Under **Publishing access**, click **Add GitHub Actions**
+   - Enter your repository details and workflow file name
+
+5. **Remove the token and switch to OIDC**:
+   ```bash
+   # Delete the GitHub Secret — it's no longer needed
+   gh secret delete NPM_TOKEN --repo yourorg/your-package
+
+   # Delete the granular token on npmjs.com → Access Tokens
+   ```
+   Now use the OIDC workflow from [Step 2](#step-2--create-the-workflow-file) for all future publishes.
+
+> **⚠️ Steering:** After bootstrap, verify OIDC works by creating a pre-release: `gh release create v1.0.1-beta.1 --prerelease`. Check the Actions tab to confirm it publishes without any token secrets.
 
 ---
 
@@ -286,13 +353,16 @@ The attestation is cryptographically signed, recorded in an append-only log, lin
 |---|---|---|
 | `ERR_SOCKET_TIMEOUT` connecting to Fulcio | Missing `id-token: write` permission | Add `permissions: { id-token: write }` to the workflow or job |
 | `401 Unauthorized` from Sigstore/Fulcio | Wrong OIDC audience claim | Ensure `registry-url: 'https://registry.npmjs.org'` is set in `actions/setup-node` |
-| `403 Forbidden` from npm registry | Branch/ref not authorized or scope not linked | Verify publishing branch. Ensure npm account owns the package scope. |
+| `403 Forbidden` from npm registry | Branch/ref not authorized or scope not linked | Verify publishing branch. Ensure npm account owns the package scope. Check OIDC linking at `npmjs.com/package/<pkg>/access`. |
 | `EOTP` (OTP required) | Workflow not using OIDC correctly | Check `id-token: write` is set and no `NODE_AUTH_TOKEN` is overriding OIDC |
 | Empty `materials` in provenance | Missing `contents: read` permission | Add `permissions: { contents: read }` |
 | Provenance verification fails on npmjs.com | `repository.url` mismatch | Fix URL to exactly match GitHub repo (case-sensitive). Republish. |
-| `404 Not Found` on first publish | Package/scope not linked to npm account | Run `npm publish` manually once to create the package, then switch to OIDC |
+| **`404 Not Found` on first publish** | **Package doesn't exist on npm yet — OIDC can't work until the package is created** | **Follow [First Publish Bootstrap](#first-publish-bootstrap-greenfield-packages) above. You MUST publish once with a token before OIDC can be configured.** |
 | Token expired mid-publish | Large package or slow network | Ensure `npm ci` and `npm test` run before publish step, not in the same `run` block |
 | `ENEEDAUTH` | Missing `registry-url` in `setup-node` | Add `registry-url: 'https://registry.npmjs.org'` |
+| `NODE_AUTH_TOKEN` present in OIDC workflow | Copied from token-based template — conflicts with OIDC | Remove all `NODE_AUTH_TOKEN` and `NPM_TOKEN` references. OIDC needs only `id-token: write`. |
+
+> **⚠️ Steering (F-07):** If you see `EOTP` or `401` errors and your workflow has `NODE_AUTH_TOKEN`, the token may be overriding OIDC. Remove `NODE_AUTH_TOKEN` entirely — OIDC and token auth are mutually exclusive in a publish step.
 
 ### Debugging steps
 

--- a/skills/publish-npm-package/references/monorepo/publishing-patterns.md
+++ b/skills/publish-npm-package/references/monorepo/publishing-patterns.md
@@ -1,5 +1,11 @@
 # Monorepo Publishing Patterns
 
+> **⚠️ Steering:** Start with **changesets** for monorepo publishing unless your
+> team already has strong conventional-commit discipline. Changesets requires
+> explicit developer intent (running `npx changeset`) which prevents accidental
+> releases, while release-please and semantic-release depend on commit message
+> conventions that are easy to get wrong in a multi-package repo.
+
 ## 1. npm Workspaces Setup
 
 ### Root `package.json`
@@ -227,6 +233,21 @@ Each package needs its own `.releaserc.json`:
 ### When to Use Alternatives
 **Prefer changesets** for explicit developer-authored changelogs and native monorepo support. **Prefer release-please** for fully automated releases from conventional commits. Use `multi-semantic-release` only if already invested in the semantic-release plugin ecosystem.
 
+### Changesets vs Release-Please for Monorepos
+
+| Aspect | Changesets | Release-Please |
+|---|---|---|
+| **Trigger** | Explicit `npx changeset` files | Conventional commit parsing |
+| **Developer effort** | Must run `npx changeset` per PR | Must follow commit conventions |
+| **Changelog quality** | Hand-written, high quality | Auto-generated from commits |
+| **Cross-package bumps** | Automatic via `fixed`/`linked` config | Manual or grouped PRs |
+| **Monorepo support** | Native, first-class | Config-based (`release-please-config.json`) |
+| **PR flow** | "Version Packages" PR auto-created | Release PR per component or grouped |
+| **OIDC provenance** | Via `NPM_CONFIG_PROVENANCE=true` env | Via `--provenance` flag in publish step |
+| **Ecosystem** | Vercel, Turborepo, Radix, Chakra | Google Cloud SDKs, googleapis |
+| **Risk of accidental release** | Low — requires explicit changeset file | Medium — any `fix:`/`feat:` commit triggers |
+| **Best for** | Teams wanting explicit release control | Teams with strict commit conventions |
+
 ---
 
 ## 5. Turborepo Integration
@@ -398,3 +419,55 @@ Both `npm publish --workspaces` and `changeset publish` skip private packages. A
 ```json
 { "ignore": ["@myorg/internal-docs", "@myorg/playground"] }
 ```
+
+---
+
+## 10. First-Publish Considerations for Monorepo Packages
+
+> **⚠️ Steering (F-11):** Each package in a monorepo must be bootstrapped
+> independently on its first publish. OIDC trusted publishing requires the
+> package to already exist on the registry — so the very first version of each
+> new workspace package needs token-based auth.
+
+### Bootstrap Pattern for New Workspace Packages
+
+When adding a new package to an existing monorepo:
+
+```bash
+# 1. Publish the new package manually with token auth
+cd packages/new-package
+npm publish --access public
+# (uses NPM_TOKEN from environment or .npmrc)
+
+# 2. Subsequent publishes via CI will work with OIDC
+```
+
+### CI Workflow Considerations
+
+Your CI workflow should handle the case where some packages exist on the
+registry and some don't:
+
+```yaml
+- name: Publish with fallback for new packages
+  run: |
+    for pkg in packages/*/; do
+      if npm view "$(node -p "require('./$pkg/package.json').name")" 2>/dev/null; then
+        npm publish --workspace="$pkg" --provenance --access public
+      else
+        echo "First publish for $pkg — requires token auth bootstrap"
+        npm publish --workspace="$pkg" --access public
+      fi
+    done
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+### Per-Package Checklist (New Workspace Package)
+
+- [ ] `package.json` has correct `name`, `version`, `repository.url` (with `directory` field)
+- [ ] `publishConfig.access` is `"public"` for scoped packages
+- [ ] `publishConfig.provenance` is `true`
+- [ ] `files` field includes only intended files
+- [ ] Package is NOT in changesets `ignore` list
+- [ ] First version has been bootstrapped with token auth
+- [ ] `npm pack --dry-run` shows expected contents

--- a/skills/publish-npm-package/references/packaging/package-config.md
+++ b/skills/publish-npm-package/references/packaging/package-config.md
@@ -39,6 +39,12 @@ Short one-liner for npmjs.com search results. Keep under 120 characters:
 
 **Critical for provenance.** Must match the GitHub repo URL exactly — case-sensitive.
 
+> **⚠️ Steering (F-12):** The `repository.url` field must **exactly** match your
+> GitHub repository URL, including letter casing. `MyOrg/My-Package` ≠
+> `myorg/my-package`. A mismatch silently breaks provenance verification, and npm
+> will publish without provenance rather than failing — so you won't notice until
+> consumers check. Always copy the URL directly from your GitHub repo page.
+
 ```json
 {
   "repository": {
@@ -47,6 +53,10 @@ Short one-liner for npmjs.com search results. Keep under 120 characters:
   }
 }
 ```
+
+**Verification:** After publishing, check provenance on npmjs.com — the package
+page should show a green checkmark linking to the exact source commit. If the
+checkmark is missing, `repository.url` casing is the most likely cause.
 
 **Gotchas:** wrong casing (`MyOrg` vs `myorg`) breaks provenance verification. For monorepos add `"directory": "packages/my-package"`.
 
@@ -71,6 +81,11 @@ Declare supported Node.js versions (advisory by default):
 
 ### `publishConfig`
 
+> **⚠️ Steering:** Always set `publishConfig.provenance: true` and — for scoped
+> packages — `publishConfig.access: "public"` as defaults in your `package.json`.
+> This prevents the two most common first-publish failures: missing provenance
+> (silent) and `E403 Forbidden` on scoped packages (blocks publish entirely).
+
 Essential for scoped public packages and provenance:
 
 ```json
@@ -85,7 +100,7 @@ Essential for scoped public packages and provenance:
 ```
 
 - `access` — scoped packages default to `"restricted"` (paid); set `"public"` for free publishing
-- `provenance` — enables SLSA attestation when publishing from GitHub Actions with OIDC
+- `provenance` — enables SLSA attestation when publishing from GitHub Actions with OIDC. **Recommended for all packages** — there is no downside to enabling it
 - `tag` — use `"next"` or `"beta"` for pre-releases
 
 ---

--- a/skills/publish-npm-package/references/security/supply-chain.md
+++ b/skills/publish-npm-package/references/security/supply-chain.md
@@ -2,6 +2,12 @@
 
 Guide to securing every link in the npm publishing supply chain—from source commit to published package.
 
+> **⚠️ Steering:** Supply-chain hardening applies to **ALL** publishing scenarios—not
+> just fully-automated pipelines. Whether you use OIDC or token auth, semantic-release
+> or manual `npm version`, provenance attestation and action pinning protect your
+> users from supply-chain attacks. Apply these practices from day one, including
+> your very first publish.
+
 ---
 
 ## 1. npm Provenance Attestation
@@ -64,6 +70,54 @@ Tags like `@v4` are mutable—a compromised maintainer account can move the tag 
 ```
 
 Find SHAs with `git ls-remote --tags https://github.com/actions/checkout.git refs/tags/v4.1.1`. Use Dependabot for GitHub Actions to get automated update PRs.
+
+### How to Find and Pin SHAs
+
+**Step 1 — Find the SHA for a specific tag:**
+
+```bash
+# Get the SHA for a specific version tag
+git ls-remote https://github.com/actions/checkout | grep 'refs/tags/v4$'
+# Output: b4ffde65f46336ab88eb53be808477a3936bae11  refs/tags/v4
+
+# For an exact patch version
+git ls-remote https://github.com/actions/setup-node | grep 'refs/tags/v4.2.0$'
+```
+
+**Step 2 — Use the format `owner/action@SHA # vX.Y.Z`:**
+
+```yaml
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+- uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+- uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789571 # v1.4.9
+```
+
+> The trailing comment (`# v4.1.1`) is critical for human readability and for
+> Dependabot/Renovate to propose SHA updates when new versions are released.
+
+**Step 3 — Automate pinning with tools:**
+
+```bash
+# pin-github-action — bulk-pin all actions in a workflow file
+npx pin-github-action .github/workflows/publish.yml
+
+# Or use Renovate with pinGitHubActionDigests enabled:
+# renovate.json: { "extends": ["helpers:pinGitHubActionDigests"] }
+```
+
+**Step 4 — Keep pinned SHAs updated:**
+
+Configure Dependabot for GitHub Actions to get automated update PRs:
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
 
 ### Dependency Review in PRs
 
@@ -269,7 +323,44 @@ Always use `auth-and-writes`, not `auth-only`. Org admins can enforce 2FA for al
 
 ---
 
-## 8. Incident Response
+## 8. First-Publish Security Considerations
+
+The first publish of a package has unique security implications:
+
+### Bootstrap Token Security
+
+When bootstrapping a new package (required before OIDC can work), use the
+most restricted token possible:
+
+```bash
+# Create a granular token scoped to ONLY the new package name
+# Set a short expiration (e.g., 1 day) — you only need it once
+# After bootstrap, switch to OIDC and revoke the bootstrap token
+```
+
+### Name Squatting Prevention
+
+Publish your package name early, even as `0.0.1`, to prevent typosquatting:
+
+```bash
+# Reserve the package name with a minimal publish
+npm publish --access public
+# Then deprecate if not ready for consumers
+npm deprecate @scope/pkg@0.0.1 "Initial placeholder — real release coming soon"
+```
+
+### First-Publish Checklist
+
+- [ ] Package name is not confusingly similar to popular packages
+- [ ] `repository.url` in `package.json` exactly matches your GitHub repo (case-sensitive)
+- [ ] Bootstrap token has minimal scope and short expiration
+- [ ] Provenance is enabled from the very first automated publish
+- [ ] 2FA is enabled on the npm account (`auth-and-writes`)
+- [ ] After bootstrap, revoke the bootstrap token immediately
+
+---
+
+## 9. Incident Response
 
 ### Token Leaked
 

--- a/skills/publish-npm-package/references/troubleshooting/common-issues.md
+++ b/skills/publish-npm-package/references/troubleshooting/common-issues.md
@@ -3,6 +3,102 @@
 Troubleshooting guide covering OIDC/provenance, token auth, version bumping,
 package publishing, and GitHub Actions workflow failures.
 
+> **⚠️ Steering:** First-publish failures are the #1 source of CI frustration.
+> If this is your package's **very first publish**, start with the "First Publish
+> Failures" section below — most OIDC/token errors have a different root cause
+> on first publish vs subsequent publishes.
+
+---
+
+## 0. First Publish Failures
+
+First-time publishing has unique failure modes that don't apply to subsequent
+publishes. These are the most common traps:
+
+### OIDC First Publish Fails with 404
+
+**Symptom:** `npm ERR! 404 Not Found - PUT https://registry.npmjs.org/@scope%2fpkg`
+
+**Cause:** npm's OIDC trusted publishing requires the package to already exist
+on the registry. On first publish, it doesn't exist yet, so the OIDC handshake
+has no package to authorize against.
+
+**Fix — bootstrap with a token:**
+
+```bash
+# 1. Create a granular access token on npmjs.com with publish scope
+# 2. Publish the initial version locally or via CI with token auth:
+npm publish --access public
+# 3. After the package exists, switch your workflow to OIDC
+```
+
+> See also: [auth/token-vs-oidc.md](../auth/token-vs-oidc.md) for full OIDC
+> setup and the bootstrap pattern.
+
+### E403 on Scoped Packages
+
+**Symptom:** `npm ERR! 403 Forbidden - PUT https://registry.npmjs.org/@scope%2fpkg`
+
+**Cause:** Scoped packages (`@scope/name`) default to `restricted` (paid npm
+Org feature). Free accounts cannot publish restricted packages.
+
+**Fix:**
+
+```bash
+npm publish --access public
+```
+
+Or set it permanently in `package.json`:
+
+```json
+{ "publishConfig": { "access": "public" } }
+```
+
+> See also: [packaging/package-config.md](../packaging/package-config.md) for
+> full `publishConfig` guidance.
+
+### ERR_SOCKET_TIMEOUT on First Publish with OIDC
+
+**Symptom:** `ERR_SOCKET_TIMEOUT` when contacting Fulcio for signing.
+
+**Cause:** Missing `id-token: write` permission in the workflow. Without it,
+GitHub cannot mint the OIDC token, and the Fulcio request hangs until timeout.
+
+**Fix:** Add permissions at the **job** level (not just workflow level):
+
+```yaml
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+```
+
+### Quick Diagnosis Flowchart
+
+```
+First publish failing?
+├─ 404 on PUT?
+│  └─ Package doesn't exist yet → bootstrap with token auth first
+├─ 403 Forbidden?
+│  ├─ Scoped package? → add --access public or publishConfig.access
+│  └─ Token/OIDC? → check token scopes or trusted publishing config
+├─ ERR_SOCKET_TIMEOUT?
+│  └─ Missing id-token: write permission → add to job permissions
+├─ ENEEDAUTH?
+│  ├─ OIDC? → add registry-url to setup-node
+│  └─ Token? → verify NPM_TOKEN secret is set and not empty
+└─ 401 Unauthorized?
+   ├─ Token for wrong registry? → create token on npmjs.com
+   └─ OIDC audience mismatch? → check runner environment
+```
+
+> **Cross-references:**
+> - Auth setup: [auth/token-vs-oidc.md](../auth/token-vs-oidc.md)
+> - Version tool config: [versioning/tool-comparison.md](../versioning/tool-comparison.md)
+> - Package config: [packaging/package-config.md](../packaging/package-config.md)
+> - Supply chain security: [security/supply-chain.md](../security/supply-chain.md)
+
 ---
 
 ## 1. OIDC / Provenance Failures

--- a/skills/publish-npm-package/references/versioning/changesets.md
+++ b/skills/publish-npm-package/references/versioning/changesets.md
@@ -17,6 +17,11 @@ version changes by adding changeset files during development.
 **Core philosophy:** The person making the change is the best person to describe and
 classify that change. Version intent is captured at PR time, not release time.
 
+> **⚠️ Steering:** changesets works for **both monorepos AND single-package repos**.
+> It does **not** require conventional commits — developers describe changes in
+> plain English via changeset files. If the team wants a human-gated release
+> without adopting a commit convention, changesets is the right choice.
+
 ---
 
 ## How It Works
@@ -427,6 +432,45 @@ npm install your-package@latest  # installs 1.0.0 (stable)
 
 ---
 
+## Single-Package Configuration
+
+For repos with only one package, changesets works out of the box with minimal config:
+
+```json
+// .changeset/config.json
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/changelog-github",
+  "commit": false,
+  "access": "public",
+  "baseBranch": "main"
+}
+```
+
+The interactive `npx changeset` prompt will show only your single package.
+Everything else (Version PR, publishing, changelog) works identically to monorepos.
+
+---
+
+## Version Packages PR Workflow
+
+When the changesets GitHub Action runs on `main` and finds pending changeset files,
+it opens (or updates) a **"Version Packages" PR**. This PR:
+
+1. **Consumes** all `.changeset/*.md` files (deletes them)
+2. **Bumps** `version` in every affected `package.json`
+3. **Updates** `CHANGELOG.md` with entries from the changeset descriptions
+4. **Stays open** and auto-updates as more changesets are merged to `main`
+
+When the team decides to release, they **merge the Version Packages PR**. The
+action then runs the `publish` command (e.g., `npx changeset publish`), publishes
+to npm, and creates git tags.
+
+This two-phase flow (accumulate → merge PR → publish) gives explicit human control
+over release timing without requiring any commit convention.
+
+---
+
 ## Monorepo Patterns
 
 ### Fixed Versioning (All Packages Same Version)
@@ -657,17 +701,34 @@ If your npm org doesn't support OIDC provenance:
 
 ---
 
+## First Publish (Greenfield)
+
+For a brand-new package that has never been published to npm:
+
+1. Run `npx changeset init` to create `.changeset/config.json`
+2. Set `"version": "0.0.0"` in `package.json` (or your intended starting version)
+3. Create your first changeset: `npx changeset` → select your package → choose
+   `minor` for an initial feature release
+4. Run `npx changeset version` locally to verify it bumps to `0.1.0`
+5. Commit everything and push — the GitHub Action will open the first Version PR
+6. Merge the Version PR to trigger the first npm publish
+
+No git tags or prior history are needed. Changesets starts from whatever version
+is in `package.json`.
+
+---
+
 ## When to Use Changesets
 
 **Best for:**
 - Monorepos with multiple publishable packages
+- **Single-package repos** that want human-gated releases without commit conventions
 - Teams that want explicit control over version bumps
 - Projects that batch releases (weekly, milestone-based)
 - Teams where commit message discipline is inconsistent
 
 **Avoid when:**
-- You want fully automated releases on every merge
-- Single-package repos where semantic-release is simpler
+- You want fully automated releases on every merge (use semantic-release)
 - You prefer commit-driven versioning over manual changeset creation
 
 ---

--- a/skills/publish-npm-package/references/versioning/release-please.md
+++ b/skills/publish-npm-package/references/versioning/release-please.md
@@ -18,6 +18,11 @@ publishes releases when that PR is merged.
 Conventional commits flow into it automatically. Humans decide when to ship by
 merging the PR.
 
+> **⚠️ Steering:** release-please **requires** conventional commits. If the repo
+> doesn't use them and the team won't adopt them, use **changesets** instead —
+> it provides the same human-gated Release PR workflow without requiring any
+> commit convention.
+
 ---
 
 ## How It Works
@@ -68,9 +73,9 @@ This file lives in your repository root and controls release-please behavior.
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "node",
   "packages": {
     ".": {
+      "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "include-v-in-tag": true
@@ -167,6 +172,10 @@ Whether to prefix tags with `v`.
 | `false` | `1.2.3` |
 
 #### `changelog-sections`
+
+> **Note:** This field is optional. The defaults (feat → Features, fix → Bug Fixes,
+> etc.) work for most projects. Only customize if you need different headings or
+> want to unhide types like `docs` or `chore`.
 
 Customize which commit types appear in the changelog and under what headings:
 
@@ -474,14 +483,32 @@ version before first run:
 2. Create `.release-please-config.json`:
    ```json
    {
-     "release-type": "node",
      "packages": {
-       ".": {}
+       ".": {
+         "release-type": "node"
+       }
      }
    }
    ```
 
 3. Commit both files to your main branch.
+
+### Greenfield Projects (No Prior Releases)
+
+For a brand-new package with no published versions and no git tags, set the
+manifest to `"0.0.0"` (or `"0.1.0"` if you prefer). release-please will compute
+the first version from commits after bootstrap:
+
+```json
+// .release-please-manifest.json
+{
+  ".": "0.0.0"
+}
+```
+
+The first Release PR will bump to `0.1.0` (for a `feat:` commit) or `0.0.1`
+(for a `fix:` commit). No git tag is needed — release-please treats the manifest
+version as the baseline when no matching tag exists.
 
 release-please will look for a git tag matching `v2.5.3` and analyze commits
 since that tag for the next release.
@@ -602,7 +629,9 @@ with release-please's tagging.
 
 ---
 
-## Complete Workflow with OIDC Provenance
+## Complete Workflow with Token Auth + Provenance
+
+> For pure OIDC auth (no NPM_TOKEN needed), use the template in `references/workflows/oidc-workflows.md` section 3.
 
 ```yaml
 name: Release
@@ -664,7 +693,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
-### Without OIDC (Token-Based)
+### Token Auth Without Provenance
 
 ```yaml
   publish:

--- a/skills/publish-npm-package/references/versioning/semantic-release.md
+++ b/skills/publish-npm-package/references/versioning/semantic-release.md
@@ -16,6 +16,11 @@ driven by conventional commit messages.
 **Core philosophy:** No human decides what the next version number will be. Commits
 since the last release are analyzed, and the version bump is determined automatically.
 
+> **⚠️ Steering:** Only choose semantic-release for **single-package repos** with
+> strong conventional-commit discipline. It publishes automatically on every push —
+> there is no human gate. For monorepos, use **changesets** or **release-please**
+> instead (semantic-release has no native monorepo support).
+
 ---
 
 ## How It Works
@@ -296,7 +301,8 @@ Same as beta but with `alpha` channel. Typically:
 
 ## Dry-Run Testing
 
-Test the release pipeline without publishing:
+> **⚠️ Always dry-run first** before enabling semantic-release in CI.
+> This catches misconfigured tokens, missing tags, and commit-format issues.
 
 ```bash
 # Requires GH_TOKEN or GITHUB_TOKEN and NPM_TOKEN
@@ -426,6 +432,18 @@ git push origin v1.0.0
 
 Or set `"tagFormat": "v${version}"` and ensure the initial version in package.json
 matches the intended starting point.
+
+### Greenfield Setup (No Existing Tags)
+
+For a brand-new package that has never been published:
+
+1. Set `"version": "0.0.0"` (or `"0.0.0-semantically-released"`) in `package.json`
+2. **Do not** create any git tags — semantic-release will treat the first
+   releasable commit as the initial release
+3. Make sure your first commit is a `feat:` to get `1.0.0` (or `feat!:` for an
+   explicit major), or a `fix:` to get `1.0.1` if you prefer starting at `1.0.x`
+4. Run `npx semantic-release --dry-run` to verify the first release will be created
+   correctly before enabling the CI workflow
 
 ---
 

--- a/skills/publish-npm-package/references/workflows/oidc-workflows.md
+++ b/skills/publish-npm-package/references/workflows/oidc-workflows.md
@@ -3,8 +3,22 @@
 Production-ready GitHub Actions workflows using OIDC for npm authentication.
 OIDC eliminates long-lived tokens — GitHub requests a short-lived token from npm at publish time.
 
-> **Prerequisite:** Link your npm package to your GitHub repo at
-> `https://www.npmjs.com/package/<pkg>/access` → Publishing access → Add GitHub Actions.
+> **⚠️ Steering:** OIDC workflows do **NOT** use `NPM_TOKEN` or `NODE_AUTH_TOKEN` — authentication is handled entirely by GitHub’s OIDC identity provider. If you need token-based auth, see `token-workflows.md`.
+
+> **⚠️ Steering — First-publish prerequisite:** OIDC authentication **only works for packages that already exist on npm**. You must publish the first version using a token (`npm publish --access public` with `NPM_TOKEN`) or the npm CLI locally, then link the package to your GitHub repo for OIDC. See `token-workflows.md` for the initial publish.
+
+> **⚠️ Steering — Config precedence:** These workflow templates are the **baseline**. The versioning tool reference (semantic-release, changesets, or release-please) is the **customization layer**. When in doubt, the versioning tool’s docs take priority for plugin config; the workflow template takes priority for CI/CD structure (permissions, concurrency, triggers).
+
+> **⚠️ Steering — SHA pinning:** Templates below use `@v4` tags for readability. For production, pin actions to full commit SHAs (e.g., `actions/checkout@<sha>`) to prevent supply-chain attacks. Use [pin-github-action](https://github.com/mheap/pin-github-action) or Dependabot to manage SHA updates.
+
+### OIDC Setup Prerequisite
+
+Link your npm package to your GitHub repo **before** using any workflow below:
+
+1. Go to `https://www.npmjs.com/package/<pkg>/access`
+2. Under **Publishing access**, select **Require two-factor authentication or an automation token or a linked GitHub repository**
+3. Click **Add GitHub Actions** and link your repo
+4. The package must already exist on npm (publish v0.0.1 with a token first if needed)
 
 ---
 
@@ -82,8 +96,16 @@ jobs:
 npm i -D semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github
 ```
 
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release.yml` | CI/CD workflow (template above) |
+| `.releaserc.json` | semantic-release plugin config |
+
 ### Checklist
 
+- [ ] Package already published to npm (first publish must use token)
 - [ ] npm package linked to GitHub repo (npmjs.com → package settings)
 - [ ] Repo uses Conventional Commits (`feat:`, `fix:`, `BREAKING CHANGE:`)
 - [ ] `package.json` has `name`, `version`, and `repository` fields
@@ -173,8 +195,17 @@ npx changeset init
 4. Merge PR → bot opens a **"Version Packages"** PR.
 5. Merge that PR → workflow publishes to npm.
 
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release.yml` | CI/CD workflow (template above) |
+| `.changeset/config.json` | Changesets configuration |
+| `package.json` scripts | `version` and `release` scripts |
+
 ### Checklist
 
+- [ ] Package already published to npm (first publish must use token)
 - [ ] npm package linked to GitHub repo for OIDC
 - [ ] `"publishConfig": { "provenance": true }` in `package.json`
 - [ ] `.changeset/config.json` committed with `"access": "public"`
@@ -228,6 +259,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: npm ci
+      - run: npm run build --if-present
       - run: npm test
       - run: npm publish --provenance --access public
 ```
@@ -253,10 +285,19 @@ jobs:
 { ".": "0.0.0" }
 ```
 
-> Replace `"0.0.0"` with your current version.
+> Set to the version in `package.json`. For never-published packages, use the `package.json` version (typically `1.0.0` or `0.1.0`).
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release.yml` | CI/CD workflow (template above) |
+| `.release-please-config.json` | Release-please package config |
+| `.release-please-manifest.json` | Current version tracker |
 
 ### Checklist
 
+- [ ] Package already published to npm (first publish must use token)
 - [ ] npm package linked to GitHub repo for OIDC
 - [ ] Both config files committed; manifest version matches `package.json`
 - [ ] Uses Conventional Commits
@@ -297,8 +338,15 @@ jobs:
 
       - run: npm ci
       - run: npm test
+      - run: npm run build --if-present
       - run: npm publish --provenance --access public
 ```
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/publish.yml` | CI/CD workflow (template above) |
 
 ### Developer workflow
 

--- a/skills/publish-npm-package/references/workflows/token-workflows.md
+++ b/skills/publish-npm-package/references/workflows/token-workflows.md
@@ -3,6 +3,12 @@
 Production-ready GitHub Actions workflows using `NPM_TOKEN` for npm authentication.
 Use when OIDC is unavailable (private npm orgs, self-hosted runners, GHES, or custom registries).
 
+> **⚠️ Steering:** Use token workflows when OIDC is unavailable, when publishing to private registries, or for the **first publish** of a new package (OIDC requires the package to already exist on npm). Once the package exists, consider migrating to `oidc-workflows.md` for stronger security.
+
+> **⚠️ Steering — SHA pinning:** Templates below use `@v4` tags for readability. For production, pin actions to full commit SHAs (e.g., `actions/checkout@<sha>`) to prevent supply-chain attacks. Use [pin-github-action](https://github.com/mheap/pin-github-action) or Dependabot to manage SHA updates.
+
+> **⚠️ Steering — Config precedence:** These workflow templates are the **baseline**. The versioning tool reference (semantic-release, changesets, or release-please) is the **customization layer**. When in doubt, the versioning tool’s docs take priority for plugin config; the workflow template takes priority for CI/CD structure (permissions, concurrency, triggers).
+
 ---
 
 ## Creating and Storing the npm Token
@@ -103,6 +109,13 @@ jobs:
 npm i -D semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github
 ```
 
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release.yml` | CI/CD workflow (template above) |
+| `.releaserc.json` | semantic-release plugin config |
+
 ### Checklist
 
 - [ ] `NPM_TOKEN` secret added to GitHub repo
@@ -173,6 +186,15 @@ jobs:
 }
 ```
 
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release.yml` | CI/CD workflow (template above) |
+| `.npmrc` | Token auth config (required for changesets) |
+| `.changeset/config.json` | Changesets configuration |
+| `package.json` scripts | `version` and `release` scripts |
+
 ### Checklist
 
 - [ ] `NPM_TOKEN` secret added
@@ -228,6 +250,7 @@ jobs:
 
       - run: npm ci
       - run: npm test
+      - run: npm run build --if-present
 
       - run: npm publish --access public
         env:
@@ -235,6 +258,14 @@ jobs:
 ```
 
 > **vs OIDC:** No `id-token: write`, no `--provenance`. Auth via `NODE_AUTH_TOKEN` env var.
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/release.yml` | CI/CD workflow (template above) |
+| `.release-please-config.json` | Release-please package config |
+| `.release-please-manifest.json` | Current version tracker |
 
 ### Checklist
 
@@ -275,6 +306,7 @@ jobs:
 
       - run: npm ci
       - run: npm test
+      - run: npm run build --if-present
 
       - run: npm publish --access public
         env:
@@ -282,6 +314,12 @@ jobs:
 ```
 
 > **vs OIDC:** No `id-token: write`, no `--provenance`.
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/publish.yml` | CI/CD workflow (template above) |
 
 ---
 


### PR DESCRIPTION
## Summary

Derailment-tested the `publish-npm-package` skill using the test-skill-quality methodology. Followed SKILL.md literally on a greenfield TypeScript package (OIDC + release-please scenario). Found **18 friction points** (2 P0, 12 P1, 4 P2, +1 compound P0), then embedded steering experiences across SKILL.md and all 11 reference files.

## Results

| Metric | Value |
|---|---|
| Total steps | 8 |
| Clean passes | 3 |
| **P0 (blocks progress)** | **2 (+1 compound)** |
| P1 (causes confusion) | 12 |
| P2 (minor annoyance) | 4 |
| Total friction points | **18** |

## Changes — SKILL.md (229→289 lines)

- Decision matrix mapping classify answers → auth + versioning strategy
- Quick-decision flowchart for versioning choice
- 10 embedded steering notes (F-01 through F-18)
- First-publish OIDC bootstrap with 5 numbered steps
- Config precedence rule (workflow template = baseline)
- Auth/tool verification tables with concrete commands
- Steering experiences quick-reference table (8 highest-impact traps)

## Changes — All 11 reference files (+587 lines total)

| File | Δ Lines | Key additions |
|---|---|---|
| `auth/oidc-trusted-publishing.md` | +78 | Zero-secrets callout, first-publish bootstrap, npm linking steps |
| `auth/granular-tokens.md` | +31 | Fallback positioning, rotation timeline, OIDC bridge |
| `versioning/release-please.md` | +39 | Conv. commit requirement, greenfield manifest, **renamed misleading section** |
| `versioning/semantic-release.md` | +20 | Single-pkg steering, greenfield setup, dry-run |
| `versioning/changesets.md` | +65 | Not-monorepo-only steering, Version PR workflow, single-pkg config |
| `workflows/oidc-workflows.md` | +54 | OIDC no-token callout, **build step in section 4**, files checklists |
| `workflows/token-workflows.md` | +38 | When-to-use steering, build steps, files checklists |
| `troubleshooting/common-issues.md` | +96 | First Publish Failures section, diagnosis flowchart |
| `security/supply-chain.md` | +93 | Universal applicability, SHA pinning how-to |
| `packaging/package-config.md` | +17 | repository.url case-sensitivity, provenance default |
| `monorepo/publishing-patterns.md` | +73 | Changesets-first steering, comparison table |

## PR review fixes addressed

- ✅ `release-please.md`: Renamed "Without OIDC (Token-Based)" → "Token Auth Without Provenance"
- ✅ `oidc-workflows.md`: Added `npm run build --if-present` to section 4
- ✅ Derailment notes removed from PR (kept locally only)

## Verification

- ✅ Zero stale terms
- ✅ All 11 reference files linked from SKILL.md (41+ total mentions)
- ✅ No orphaned references
- ✅ SKILL.md at 289 lines (under 500)
- ✅ Cross-references consistent
- ✅ Single clean commit (squashed)
