### PR TITLE
fix(build-skills): Address 18 friction points from derailment testing

### DIFF
--- a/skills/build-skills/SKILL.md
+++ b/skills/build-skills/SKILL.md
@@ -77,7 +77,7 @@ Only execute this step if step 1 classified the job as **Full research path**. S
 - Read `references/research-workflow.md` for the complete research protocol.
 - Verify `skill-dl` is available: `skill-dl --version`. If missing, see `references/remote-sources.md` for installation. If unavailable and installation is not possible, use the `skills-as-context-search-skills` and `skills-as-context-get-skill-details` tools (requires the skills.sh MCP server), or search GitHub manually for repositories containing SKILL.md files.
 - Use `skill-dl search` with 3–20 space-separated keywords to discover candidates: `skill-dl search mcp server typescript sdk --top 20`. It outputs a prioritized markdown table to stdout.
-- Use `skill-dl` to download selected candidates, or run `bash references/skill-research.sh <keyword1> <keyword2> ...` for end-to-end parallel discovery and download in one command.
+- Use `skill-dl` to download selected candidates, or run `bash references/skill-research.sh "keyword1,keyword2,keyword3"` for end-to-end parallel discovery and download in one command.
 - See `references/remote-sources.md` for more `skill-dl` usage patterns and download options.
 - Prefer a few diverse, relevant sources over many near-duplicates.
 - Create `skills.markdown` in the workspace root summarizing what was downloaded, what was shortlisted, and why, before moving on.
@@ -283,5 +283,5 @@ Quick routing verification:
 
 ```bash
 # Check for orphaned reference files (not mentioned in SKILL.md)
-for f in references/**/*.md; do grep -q "$(basename $f)" SKILL.md || echo "ORPHAN: $f"; done
+for f in $(find references -name '*.md' -type f); do grep -q "$(basename $f)" SKILL.md || echo "ORPHAN: $f"; done
 ```

--- a/skills/build-skills/SKILL.md
+++ b/skills/build-skills/SKILL.md
@@ -32,6 +32,10 @@ Do not use this skill for:
 6. **Keep progressive disclosure clean.** Put trigger logic in frontmatter, workflow and decisions in `SKILL.md`, and bulky detail in `references/`.
 7. **Test before shipping.** Run trigger tests and at least one functional test before declaring done.
 
+## Artifact output
+
+Intermediate artifacts (workspace scan, comparison table, success criteria) appear in conversation output as they are produced — show each one at the step that generates it. Persistent artifacts (`skills.markdown`, final SKILL.md, reference files) are written to disk in the target skill directory.
+
 ## Required workflow
 
 ### 1. Classify the job
@@ -62,16 +66,21 @@ If the skill enhances an MCP, also read `references/patterns/mcp-enhancement.md`
 - Note the reference file naming scheme, nesting depth, and whether routing in `SKILL.md` matches what actually exists on disk.
 - Note repo conventions, existing reference coverage, and obvious gaps before widening scope.
 
+> ⚠️ **Steering (from derailment testing):** Steps 3–4a concentrate 44% of all execution friction. Use the reference routing table to load only 3–5 relevant files per step, not all 22. See `references/steering/derailment-lessons.md` for common traps.
+
 ### 4. Run remote research when the job is non-trivial
 
-Only execute this step if step 1 classified the job as **Full research path**. Skip to step 7 for local-only work.
+Only execute this step if step 1 classified the job as **Full research path**. Skip to step 7 for local-only work (Steps 4–6 produce research artifacts that local-only changes don’t need).
+
+> ⚠️ **Steering:** Downloaded skills frequently violate this skill’s own quality standards (line counts >1000, templates inline, no references). Treat quality problems as signal for your “avoid” column—see `references/research/source-verification.md`.
 
 - Read `references/research-workflow.md` for the complete research protocol.
-- Use `skill-dl search` (3–20 keywords) to discover candidates — it outputs a prioritized markdown table to stdout.
-- Use `skill-dl` to download selected candidates, or run `references/skill-research.sh` for end-to-end parallel discovery and download in one command.
-- See `references/remote-sources.md` for `skill-dl search` usage patterns and download options.
+- Verify `skill-dl` is available: `skill-dl --version`. If missing, see `references/remote-sources.md` for installation. If unavailable and installation is not possible, use the `skills-as-context-search-skills` and `skills-as-context-get-skill-details` tools (requires the skills.sh MCP server), or search GitHub manually for repositories containing SKILL.md files.
+- Use `skill-dl search` with 3–20 space-separated keywords to discover candidates: `skill-dl search mcp server typescript sdk --top 20`. It outputs a prioritized markdown table to stdout.
+- Use `skill-dl` to download selected candidates, or run `bash references/skill-research.sh <keyword1> <keyword2> ...` for end-to-end parallel discovery and download in one command.
+- See `references/remote-sources.md` for more `skill-dl` usage patterns and download options.
 - Prefer a few diverse, relevant sources over many near-duplicates.
-- Emit `skills.markdown` before moving on.
+- Create `skills.markdown` in the workspace root summarizing what was downloaded, what was shortlisted, and why, before moving on.
 
 ### 4a. Read the downloaded corpus thoroughly
 
@@ -83,14 +92,15 @@ For each downloaded skill that made the shortlist:
 - **Tree its `references/` directory** — see what files exist, how they are named, and how deeply they are nested. This reveals the skill's structural philosophy.
 - **Read the 2–3 most relevant reference files** in full — pick based on filenames and the skill's routing logic.
 - **Check `scripts/` if present** — scripts surface automation patterns and validation logic that prose cannot fully convey.
-- **Capture notes per skill**: overall structure, workflow style, reference organization, what it does well, what it does poorly, and 1–2 patterns worth inheriting (with exact relative paths).
+- **Capture notes per skill** (a heading per skill with bullets mapping to comparison table columns): overall structure, workflow style, reference organization, what it does well, what it does poorly, and 1–2 patterns worth inheriting (with exact relative paths).
+
+Downloaded sources may not follow the quality standards this skill enforces (e.g., SKILL.md over 500 lines, missing reference routing). Note these issues — they inform the "avoid" column of your comparison table.
 
 The notes you capture here are the raw material for the comparison table in step 5. If you skip reading, the comparison table will be fabricated from memory rather than evidence.
 
 ### 5. Compare before synthesizing
 
-- Read the selected local and remote sources that actually matter.
-- Build a markdown comparison table with at least: `Source`, `Focus`, `Strengths`, `Gaps`, `Relevant paths or sections`, and `Inherit / avoid`.
+- Using your notes from Step 4a, build a markdown comparison table with at least: `Source`, `Focus`, `Strengths`, `Gaps`, `Relevant paths or sections`, and `Inherit / avoid`.
 - Every row ends with a decision, not just an observation.
 
 ### 6. Define success criteria
@@ -108,13 +118,15 @@ Before drafting, write down what success looks like:
 - Reuse existing references instead of duplicating them.
 - Add new files only when clearly necessary and explicitly routed.
 - Read `references/authoring/description-engineering.md` to craft the description field.
-- Read `references/checklists/master-checklist.md` for the full quality checklist.
+- During drafting, focus on the key constraints: SKILL.md under 500 lines, every reference file routed, description follows the formula. Run the full `references/checklists/master-checklist.md` audit in Step 9.
 
 ### 8. Test the skill
 
-- **Trigger tests:** Write 5+ should-trigger queries and 5+ should-NOT-trigger queries. Run each one by pasting it as a new message in Claude.ai (with only this skill enabled) or Claude Code, and record whether the skill loaded. See `references/authoring/testing-methodology.md` for the full testing guide.
+- **Trigger tests:** Write 5+ should-trigger queries and 5+ should-NOT-trigger queries. For revisions, run each one by pasting it as a new message in Claude.ai (with only this skill enabled) or Claude Code, and record whether the skill loaded. For new skills, verify the description against your test queries manually; run live trigger tests after installation. See `references/authoring/testing-methodology.md` for the full testing guide.
 - **Functional test:** Run at least one complete functional test of the primary workflow end-to-end.
 - **Self-check:** Ask Claude "When would you use [skill-name]?" and verify the answer matches your intent.
+
+> ⚠️ **Steering:** For a NEW skill, install the draft to `~/.claude/skills/[name]/` before testing triggers. Trigger tests fail silently if the skill isn’t loaded. For REVISIONS, test against the currently installed version.
 
 ### 9. Finish with repo-fit and cleanup checks
 
@@ -141,7 +153,7 @@ Before drafting, write down what success looks like:
 | Do this | Not that |
 |---|---|
 | inventory the workspace and read local source files first | start from remote search results or a remembered template |
-| emit `skills.markdown` for non-trivial research | claim research happened because you skimmed URLs |
+| create `skills.markdown` for non-trivial research | claim research happened because you skimmed URLs |
 | build a comparison table before drafting | mentally blend sources and jump to the final `SKILL.md` |
 | route detailed guidance to existing references | stuff `SKILL.md` with tutorials, examples, or duplicated checklists |
 | inherit patterns selectively with repo-fit reasoning | copy the most detailed source and rename it |
@@ -149,19 +161,23 @@ Before drafting, write down what success looks like:
 | add negative triggers when scope is broad | let the skill fire on every tangentially related query |
 | use validation scripts for deterministic checks | rely on prose like "validate properly" |
 | read each downloaded skill's SKILL.md fully, tree its references/, and read the 2–3 most relevant reference files | skim titles and match counts, then fabricate a comparison from memory |
+| verify tool prerequisites before using them (`skill-dl --version`) | assume tools are installed because the skill mentions them |
+| show intermediate artifacts at the step that produces them | batch all output to the end or leave output location ambiguous |
+| distinguish creation vs. revision paths in testing | write test instructions that only work for one path |
 
 ## Output contract
 
 Unless the user wants a different format, show work in this order:
 
-1. workspace scan summary
-2. skill type classification (Document/Asset, Workflow, MCP Enhancement)
-3. research summary with `skills.markdown` or an explicit reason research was not required
-4. markdown comparison table (required for the full research path)
-5. selection and synthesis strategy
-6. generated or revised skill artifacts
-7. trigger test results
-8. final repo-fit and cleanup checks
+1. skill type classification (after Step 2)
+2. workspace scan summary (after Step 3)
+3. research summary with `skills.markdown` or explicit skip reason (after Step 4)
+4. markdown comparison table (after Step 5, required for the full research path)
+5. success criteria (after Step 6)
+6. selection and synthesis strategy (after Step 7)
+7. generated or revised skill artifacts (after Step 7)
+8. trigger test results (after Step 8)
+9. final repo-fit and cleanup checks (after Step 9)
 
 ## Reference routing
 
@@ -213,6 +229,12 @@ Load the smallest relevant set for the branch of work you are in.
 | `references/iteration/feedback-signals.md` | Interpreting under/over-triggering signals or planning post-ship iteration. |
 | `references/iteration/troubleshooting.md` | Diagnosing upload failures, trigger issues, MCP problems, or instruction-following issues. |
 
+### Steering
+
+| File | Read when |
+|---|---|
+| `references/steering/derailment-lessons.md` | Starting any skill build or revision, or when hitting friction during execution. Contains learned pitfalls from real testing. |
+
 ### Distribution
 
 | File | Read when |
@@ -250,9 +272,16 @@ Before you finish, confirm all of the following:
 - [ ] `SKILL.md` body is under 500 lines
 - [ ] `SKILL.md` contains decisions and routing, not bulky reference content
 - [ ] every reference file is explicitly routed
-- [ ] no orphaned files in `references/`
+- [ ] routing verification: `for f in $(find references -name '*.md' -type f); do grep -q "$(basename $f)" SKILL.md || echo "ORPHAN: $f"; done`
 - [ ] the final result is clearly synthesized from evidence and comparison
 - [ ] no dead weight was added just because another skill had it
 - [ ] at least 3 trigger tests passed (should-trigger and should-NOT-trigger)
 - [ ] primary workflow completes without error in at least one test
 - [ ] for full quality: ran `references/checklists/master-checklist.md`
+
+Quick routing verification:
+
+```bash
+# Check for orphaned reference files (not mentioned in SKILL.md)
+for f in references/**/*.md; do grep -q "$(basename $f)" SKILL.md || echo "ORPHAN: $f"; done
+```

--- a/skills/build-skills/references/authoring/description-engineering.md
+++ b/skills/build-skills/references/authoring/description-engineering.md
@@ -238,3 +238,8 @@ Why: `<` and `>` can inject instructions into the agent's system prompt.
 - No "claude" or "anthropic" in the skill name (reserved by Anthropic)
 - Descriptions appear in the system prompt — treat them as security-sensitive
 - YAML safe parsing prevents code execution in frontmatter
+
+
+---
+
+> **Steering tip:** Test your description against both should-trigger and should-NOT-trigger queries before finalizing. A description that triggers too broadly is worse than one that triggers too narrowly.

--- a/skills/build-skills/references/authoring/skillmd-format.md
+++ b/skills/build-skills/references/authoring/skillmd-format.md
@@ -285,3 +285,8 @@ export function UserCard({ name, email }: UserCardProps) {
   );
 }
 ```
+
+
+---
+
+> **Steering tip:** When this file's guidance conflicts with a downloaded skill's structure, this file wins. Downloaded skills are evidence, not templates. See `references/steering/derailment-lessons.md` Trap 4 for details.

--- a/skills/build-skills/references/authoring/testing-methodology.md
+++ b/skills/build-skills/references/authoring/testing-methodology.md
@@ -224,3 +224,55 @@ Before shipping, verify all of the following:
 - [ ] Error handling works for at least one failure case
 - [ ] Results are consistent across 3+ runs
 - [ ] Token usage is reasonable for the task
+
+
+---
+
+## Creation vs. revision testing paths
+
+Testing differs significantly between creating a new skill and revising an existing one. Use the appropriate path:
+
+### Path A: Testing a NEW skill
+
+**Setup required before testing:**
+1. Create the skill directory: `mkdir -p ~/.claude/skills/[skill-name]/`
+2. Copy your draft: `cp SKILL.md ~/.claude/skills/[skill-name]/`
+3. Copy references: `cp -r references/ ~/.claude/skills/[skill-name]/`
+4. Restart Claude or reload skills
+
+**Trigger testing (new skill):**
+- Open a fresh Claude conversation with only this skill enabled
+- Paste each should-trigger query as a new message
+- Record whether the skill actually loaded (check for skill-specific behavior)
+- **Critical:** Trigger tests fail silently if the skill isn't installed. A "pass" with an uninstalled skill is a false positive.
+
+**Functional testing (new skill):**
+- Run the complete primary workflow end-to-end
+- Verify all output contract items are produced
+- Check that reference routing loads the correct files
+
+### Path B: Testing a REVISION
+
+**Setup:**
+- The skill is already installed — test against the current version first
+- Then install the revision and re-test
+
+**Trigger testing (revision):**
+- Run the same trigger queries against both old and new versions
+- Verify the revision doesn't break existing triggers
+- If scope changed, add new should-trigger and should-NOT-trigger queries
+
+**Functional testing (revision):**
+- Focus on the changed functionality
+- Verify unchanged workflows still work
+- Run at least one full end-to-end test
+
+### Common testing mistakes
+
+| Mistake | Impact | Fix |
+|---|---|---|
+| Testing triggers without installing | False positives | Always install before trigger testing |
+| Only testing the happy path | Misses edge cases | Include at least 2 edge cases |
+| Testing only creation OR revision | Other path untested | Document which path you tested |
+| No should-NOT-trigger queries | Over-triggering undetected | Always include 5+ negative queries |
+| Skipping functional test | Workflow bugs ship | Run at least one end-to-end |

--- a/skills/build-skills/references/checklists/master-checklist.md
+++ b/skills/build-skills/references/checklists/master-checklist.md
@@ -1,12 +1,17 @@
 # Master Skill Checklist
 
+> **Phase routing:** Not every checklist item applies at every stage. Items marked "DRAFT ESSENTIAL" (Phases 0-3) should be checked before sharing any draft. Items marked "FINAL AUDIT ONLY" (Phases 4+) are for comprehensive quality passes before publishing.
+>
+> **Quick start for drafts:** Search this file for "DRAFT ESSENTIAL" to find the minimum viable checks.
+
+
 Comprehensive checklist covering every phase of skill development. 90+ items organized by phase. Every item is binary (yes/no), specific, and verifiable.
 
 Use the full checklist for published skills. Use Phase 0-3 for personal skills. Skip Phase 6-7 for non-published skills.
 
 ---
 
-## Phase 0: Before You Start
+## Phase 0 — ✅ DRAFT ESSENTIAL: Before You Start
 
 Planning and preparation before writing any files.
 
@@ -26,7 +31,7 @@ Planning and preparation before writing any files.
 
 ---
 
-## Phase 1: Frontmatter Quality
+## Phase 1 — ✅ DRAFT ESSENTIAL: Frontmatter Quality
 
 The frontmatter determines whether Claude ever loads your skill.
 
@@ -68,7 +73,7 @@ The frontmatter determines whether Claude ever loads your skill.
 
 ---
 
-## Phase 2: Body Structure
+## Phase 2 — ✅ DRAFT ESSENTIAL: Body Structure
 
 The SKILL.md body is the core instruction set.
 
@@ -104,7 +109,7 @@ The SKILL.md body is the core instruction set.
 
 ---
 
-## Phase 3: Reference Files
+## Phase 3 — ✅ DRAFT ESSENTIAL: Reference Files
 
 Reference files provide depth without bloating SKILL.md.
 
@@ -132,7 +137,7 @@ Reference files provide depth without bloating SKILL.md.
 
 ---
 
-## Phase 4: Content Quality
+## Phase 4 — 🔍 FINAL AUDIT ONLY: Content Quality
 
 The content must be accurate, current, and synthesized — not copied.
 
@@ -163,7 +168,7 @@ The content must be accurate, current, and synthesized — not copied.
 
 ---
 
-## Phase 5: Testing
+## Phase 5 — 🔍 FINAL AUDIT ONLY: Testing
 
 Testing validates that the skill works correctly in practice.
 
@@ -189,7 +194,7 @@ Testing validates that the skill works correctly in practice.
 
 ---
 
-## Phase 6: Publishing
+## Phase 6 — 🔍 FINAL AUDIT ONLY: Publishing
 
 Preparing the skill for public distribution.
 
@@ -214,7 +219,7 @@ Preparing the skill for public distribution.
 
 ---
 
-## Phase 7: Post-Ship Monitoring
+## Phase 7 — 🔍 FINAL AUDIT ONLY: Post-Ship Monitoring
 
 Ongoing maintenance after the skill is live.
 

--- a/skills/build-skills/references/comparison-workflow.md
+++ b/skills/build-skills/references/comparison-workflow.md
@@ -76,3 +76,55 @@ Avoid these failure modes:
 - inheriting everything from the most detailed source
 - using the comparison section as a hidden draft of the final skill
 - deciding on the final structure before the evidence is compared
+
+
+---
+
+## Per-skill notes template
+
+Use this template when examining each downloaded skill. Fill it out before writing your comparison table row:
+
+```markdown
+### [Skill Name]
+- **Source:** [GitHub URL or skill-dl ID]
+- **SKILL.md lines:** [count]
+- **Has references/?:** [yes/no, file count]
+- **Tier:** [1/2/3 per source-patterns.md quality spectrum]
+
+#### Strengths (inherit)
+- [specific pattern with file reference]
+
+#### Weaknesses (avoid)
+- [specific anti-pattern with evidence]
+
+#### Adaptable ideas
+- [pattern that needs structural adjustment]
+```
+
+## Comparison table columns
+
+Your markdown comparison table should include these columns:
+
+| Column | Purpose | Example |
+|---|---|---|
+| Skill name | Identifier | `build-mcp-server` |
+| Source | Where found | `skill-dl` / GitHub / skills.sh |
+| Tier | Quality level | 1 / 2 / 3 |
+| Lines (SKILL.md) | Size indicator | 287 |
+| Ref files | Decomposition quality | 12 |
+| Key strength | Best inherit candidate | "Clean MCP tool routing" |
+| Key weakness | Primary avoid signal | "No output contract" |
+| Verdict | Use decision | Inherit routing / Avoid structure |
+
+## Completeness gate
+
+Before moving from comparison (Step 5) to synthesis (Step 7), verify:
+
+- [ ] At least 3 skills compared in detail (not just listed)
+- [ ] Every comparison row has both "strength" and "weakness" entries
+- [ ] At least one Tier 1 reference identified (or documented why none exist)
+- [ ] At least 2 "avoid" patterns documented across all sources
+- [ ] Per-skill notes exist for every skill in the comparison table
+- [ ] Quality tiers assigned using the spectrum from `source-patterns.md`
+
+If fewer than 3 skills are available, document the search terms used and why more weren't found. A thin comparison is acceptable when justified; a fabricated one never is.

--- a/skills/build-skills/references/examples/anti-patterns.md
+++ b/skills/build-skills/references/examples/anti-patterns.md
@@ -417,3 +417,80 @@ Before publishing, verify none of these apply:
 - [ ] No iteration plan after deployment (AP-22)
 - [ ] Using prose instead of scripts for deterministic checks (AP-23)
 - [ ] Reserved name containing "claude" or "anthropic" (AP-24)
+
+
+---
+
+## Derailment anti-patterns (AP-D1 through AP-D7)
+
+These anti-patterns were discovered through systematic derailment testing of the build-skills workflow.
+
+### AP-D1: Reference overload
+
+**Pattern:** Loading all 22+ reference files at once during Steps 3-4a.
+
+**Why it fails:** Exhausts context window, causes the agent to lose track of which file informed which decision, and produces outputs that blend information without attribution.
+
+**Fix:** Load only the 3-5 files relevant to the current step. Use the reference routing table in SKILL.md to select files.
+
+**Detection:** Agent has read more than 5 reference files before completing Step 4.
+
+### AP-D2: Output batching
+
+**Pattern:** Producing all output artifacts at the end instead of showing them at the step that produces them.
+
+**Why it fails:** Prevents intermediate review, makes errors harder to catch, and creates a wall of output that's difficult to validate.
+
+**Fix:** Show each artifact immediately after the step that produces it. Follow the timing hints in the output contract.
+
+**Detection:** Agent reaches Step 7 without having shown any intermediate output.
+
+### AP-D3: Tool assumption
+
+**Pattern:** Assuming `skill-dl` or other tools are installed because the skill mentions them.
+
+**Why it fails:** First command fails, requiring backtracking and context recovery. Often leads to the agent fabricating results instead of using fallback methods.
+
+**Fix:** Run `skill-dl --version` before first use. Have the fallback chain ready: skill-dl > MCP tools > manual GitHub search.
+
+**Detection:** A tool command fails with "command not found" during execution.
+
+### AP-D4: Quality blindness
+
+**Pattern:** Treating all downloaded skills as high-quality references regardless of their actual quality.
+
+**Why it fails:** Produces comparison tables with only positive entries, missing the critical "avoid" patterns that inform synthesis decisions.
+
+**Fix:** Apply the quality spectrum from `source-patterns.md`. Assign tiers. Document anti-patterns in the "avoid" column.
+
+**Detection:** Comparison table has no "avoid" entries or all skills are rated positively.
+
+### AP-D5: Path confusion
+
+**Pattern:** Writing test instructions that assume creation when the task is revision (or vice versa).
+
+**Why it fails:** For new skills, trigger tests silently pass because the skill isn't installed. For revisions, tests miss regression against the existing version.
+
+**Fix:** Explicitly identify which path you're on. Follow the creation vs. revision testing paths in `testing-methodology.md`.
+
+**Detection:** All trigger tests "pass" but the skill wasn't installed before testing.
+
+### AP-D6: Research scope creep
+
+**Pattern:** Downloading 20+ skills and reading all of them without a stopping criterion.
+
+**Why it fails:** Consumes the entire research budget on discovery, leaving no time for deep comparison. Produces broad but shallow analysis.
+
+**Fix:** Set a research budget before starting (see `research-workflow.md` phase gates). Stop when you have 3+ viable comparison entries.
+
+**Detection:** More than 10 skills downloaded or more than 3 steps spent on research alone.
+
+### AP-D7: Checklist as workflow
+
+**Pattern:** Treating the master checklist as a sequential todo list, working through all 100+ items for every task.
+
+**Why it fails:** Simple revisions take as long as full builds. Checklist fatigue leads to rubber-stamping later items.
+
+**Fix:** Use phase markers: "DRAFT ESSENTIAL" items (Phases 0-3) for every task, "FINAL AUDIT ONLY" items (Phases 4+) only for comprehensive quality passes.
+
+**Detection:** Running Phase 6+ checklist items before having a complete draft.

--- a/skills/build-skills/references/iteration/feedback-signals.md
+++ b/skills/build-skills/references/iteration/feedback-signals.md
@@ -199,3 +199,8 @@ name: old-skill
 description: "[DEPRECATED] Use new-skill instead. This skill is no longer maintained."
 ---
 ```
+
+
+---
+
+> **Steering tip:** Under-triggering and over-triggering require different fixes. Check `references/iteration/troubleshooting.md` for diagnostic steps before adjusting the description.

--- a/skills/build-skills/references/iteration/troubleshooting.md
+++ b/skills/build-skills/references/iteration/troubleshooting.md
@@ -312,3 +312,8 @@ Skill problem?
     ├── Disable unused skills
     └── Use progressive disclosure (references/)
 ```
+
+
+---
+
+> **Steering tip:** When diagnosing trigger issues, distinguish between "skill not loaded" (installation problem) and "skill loaded but didn't activate" (description problem). For new skills, verify installation first — see `references/steering/derailment-lessons.md` Trap 5.

--- a/skills/build-skills/references/patterns/mcp-enhancement.md
+++ b/skills/build-skills/references/patterns/mcp-enhancement.md
@@ -212,3 +212,8 @@ skill-name/
 | Assuming auth never expires | Token expiry causes silent failures | Add auth verification step |
 | Ignoring rate limits | Bulk operations hit API limits | Add pagination and throttling guidance |
 | No fallback for MCP-down scenarios | Skill is useless without MCP | Provide manual alternative steps |
+
+
+---
+
+> **Steering tip:** MCP tool availability varies by environment. Always document fallback approaches when your skill depends on specific MCP servers.

--- a/skills/build-skills/references/patterns/workflow-patterns.md
+++ b/skills/build-skills/references/patterns/workflow-patterns.md
@@ -283,3 +283,8 @@ Primary: Sequential (overall workflow)
 ```
 
 Keep the primary pattern visible in SKILL.md. Move secondary pattern details to reference files.
+
+
+---
+
+> **Steering tip:** Workflow patterns should produce visible artifacts at each phase boundary. If your workflow produces output only at the end, add intermediate checkpoints. See the output contract timing hints in SKILL.md.

--- a/skills/build-skills/references/remote-sources.md
+++ b/skills/build-skills/references/remote-sources.md
@@ -37,6 +37,27 @@ skill-dl search "typescript" "type safety" "strict mode" "ts config" "compilatio
 
 For each candidate, capture: skill name, owner/repo, detail URL, keywords matched, match count, and selection rationale.
 
+## Prerequisites
+
+Before using any remote source tools, verify availability:
+
+```bash
+# Primary tool
+skill-dl --version 2>/dev/null && echo "skill-dl ready" || echo "NOT AVAILABLE"
+
+# MCP fallback
+# skills-as-context-search-skills — available if skills.sh MCP server is configured
+# skills-as-context-get-skill-details — available if skills.sh MCP server is configured
+```
+
+**Fallback chain:**
+1. `skill-dl` (preferred) — CLI tool for searching and downloading skills
+2. `skills-as-context-search-skills` + `skills-as-context-get-skill-details` (MCP) — requires skills.sh MCP server
+3. Manual GitHub search — search for repositories containing SKILL.md files
+
+Use the first available option. Document which method you used in your research summary.
+
+
 ## Downloading with skill-dl
 
 `skill-dl` is the CLI tool for batch-downloading skills from Playbooks URLs.
@@ -132,3 +153,47 @@ After download:
 3. Cite relative paths in comparison table
 4. Inherit patterns selectively
 5. Rewrite the final result to be original and repo-fit
+
+---
+
+## Search usage examples
+
+### skill-dl search patterns
+```bash
+# Broad discovery
+skill-dl search typescript mcp server --top 20
+
+# Narrow by domain
+skill-dl search react testing component --top 10
+
+# Framework-specific
+skill-dl search nextjs app-router authentication --top 15
+```
+
+### MCP tool patterns
+When using `skills-as-context-search-skills`:
+- Use specific, descriptive queries (not single keywords)
+- Request enough results to compare: aim for 10-20 results
+- Follow up with `skills-as-context-get-skill-details` for the most promising candidates
+
+### Manual GitHub search patterns
+When both skill-dl and MCP tools are unavailable:
+- Search: `filename:SKILL.md [topic keywords]`
+- Filter by recently updated repositories
+- Look for repos with a `references/` directory structure
+- Prefer repos with multiple files (indicates decomposed content)
+
+## Quality assessment checklist
+
+For each downloaded skill, quickly assess:
+
+| Check | Command/Method | Pass criteria |
+|---|---|---|
+| SKILL.md size | `wc -l SKILL.md` | Under 500 lines |
+| Has references | `ls references/ 2>/dev/null` | Directory exists with files |
+| Frontmatter valid | Check first 5 lines | Has name + description |
+| Description length | Count characters | Under 1024 chars |
+| No angle brackets | `grep '[<>]' SKILL.md` | No matches in frontmatter |
+| Routing table | `grep '### ' SKILL.md` | Has section-based routing |
+
+Skills failing 3+ checks are Tier 3 — use only as anti-pattern examples.

--- a/skills/build-skills/references/research-workflow.md
+++ b/skills/build-skills/references/research-workflow.md
@@ -139,3 +139,83 @@ Avoid these mistakes:
 - copying downloaded skills instead of distilling them
 - packaging the transient research corpus into the final skill by default
 - skipping the downloaded corpus scan and pretending the research already happened
+
+
+---
+
+## Phase gates
+
+Research has three phases. Complete each gate before advancing:
+
+### Phase 1: Discovery (budget: 10 minutes)
+**Goal:** Find candidate skills to compare.
+**Gate:** Have 5-15 candidate names/URLs identified.
+**Tools:** `skill-dl search`, `skills-as-context-search-skills`, GitHub search.
+
+### Phase 2: Download and triage (budget: 15 minutes)
+**Goal:** Download candidates and quick-assess quality.
+**Gate:** Have 3-8 downloaded skills with size/tier noted.
+**Actions:**
+1. Download top candidates: `skill-dl download <id>`
+2. For each: `wc -l SKILL.md` and `tree references/ 2>/dev/null`
+3. Assign quality tier (see `source-patterns.md`)
+4. Drop Tier 3 sources unless needed as anti-pattern examples
+
+### Phase 3: Deep read (budget: 20 minutes)
+**Goal:** Read the best candidates thoroughly for comparison.
+**Gate:** Per-skill notes completed for 3-5 top candidates.
+**Actions:**
+1. Read SKILL.md fully for each selected candidate
+2. Read 2-3 most relevant reference files per candidate
+3. Fill out per-skill notes template (see `comparison-workflow.md`)
+4. Write comparison table
+
+**Total research budget: 45 minutes maximum.** If you haven't reached Phase 3 after 30 minutes, stop discovery and work with what you have.
+
+## Scoping guidance
+
+### When to do full research
+- Building a new skill from scratch
+- Major revision changing the skill's scope or type
+- User explicitly requests competitive analysis
+
+### When to do minimal research (Phase 1 only)
+- Adding a single reference file
+- Fixing bugs in existing content
+- Updating for API/tool changes
+- User says "just fix X"
+
+### When to skip research entirely
+- Typo fixes, formatting changes
+- Adding content the user has already written
+- Reorganizing existing content without changing substance
+
+## Prerequisite verification
+
+Before starting research, verify your tools are available:
+
+```bash
+# Required for research
+skill-dl --version 2>/dev/null || echo "skill-dl not available - use MCP fallback"
+
+# Optional but helpful
+which jq 2>/dev/null || echo "jq not available - JSON parsing will be manual"
+```
+
+**If skill-dl is unavailable:**
+1. Try the MCP tools: `skills-as-context-search-skills` and `skills-as-context-get-skill-details`
+2. If MCP tools are also unavailable: search GitHub manually for repos with SKILL.md files
+3. Document which method you used in your research summary
+
+## Time budget enforcement
+
+Track your research time against these limits:
+
+| Phase | Budget | Stop signal |
+|---|---|---|
+| Discovery | 10 min | Found 5+ candidates OR exhausted 3 search strategies |
+| Download + triage | 15 min | Have 3+ triaged candidates OR downloaded 10 candidates |
+| Deep read | 20 min | Have 3+ per-skill notes OR read 5 skills in detail |
+| **Total** | **45 min** | Move to comparison regardless of completeness |
+
+If you exceed a phase budget, move to the next phase with what you have. Incomplete research with honest documentation is better than exhaustive research that delays synthesis.

--- a/skills/build-skills/references/research/source-verification.md
+++ b/skills/build-skills/references/research/source-verification.md
@@ -222,3 +222,45 @@ When evaluating any source, watch for:
 | No mention of trade-offs | One-sided view |
 | Broken links or missing files | Unmaintained |
 | Conflicting advice within the same source | Incoherent |
+
+
+---
+
+## Quick quality rubric
+
+Use this rubric for rapid assessment of downloaded skills. Score each criterion 0-2:
+
+| Criterion | 0 (Poor) | 1 (Acceptable) | 2 (Good) |
+|---|---|---|---|
+| **Structure** | No references/, everything in SKILL.md | Has references/ but poorly organized | Clean references/ with logical grouping |
+| **Size** | SKILL.md > 500 lines | 300-500 lines | Under 300 lines |
+| **Routing** | No routing table | File list without context | "Read when" routing with context |
+| **Frontmatter** | Missing or invalid | Present but incomplete | Complete with valid name + description |
+| **Decomposition** | Single monolithic file | Some splitting, inconsistent | Well-decomposed, no file > 500 lines |
+| **Actionability** | Vague instructions | Some concrete steps | Clear, testable instructions |
+
+**Scoring:**
+- **10-12:** Tier 1 - Production-ready reference
+- **6-9:** Tier 2 - Useful but flawed, extract ideas carefully
+- **0-5:** Tier 3 - Anti-pattern source, use only as negative example
+
+**Quick assessment command sequence:**
+```bash
+# Run these 4 commands for any downloaded skill:
+wc -l SKILL.md
+ls references/ 2>/dev/null | wc -l
+head -5 SKILL.md  # Check frontmatter
+grep -c '### ' SKILL.md  # Count routing sections
+```
+
+**Assessment output template:**
+```
+Skill: [name]
+SKILL.md lines: [n]
+Reference files: [n]
+Frontmatter: [valid/invalid]
+Routing sections: [n]
+Score: [0-12]
+Tier: [1/2/3]
+Decision: [inherit/adapt/avoid]
+```

--- a/skills/build-skills/references/skill-research.sh
+++ b/skills/build-skills/references/skill-research.sh
@@ -11,12 +11,12 @@
 #   - If not available, see references/remote-sources.md for alternatives
 #
 # Basic usage:
-#   bash references/skill-research.sh <keyword1> <keyword2> [keyword3...]
+#   bash references/skill-research.sh "keyword1,keyword2,keyword3" [output-dir] [max-parallel]
 #
 # Examples:
-#   bash references/skill-research.sh typescript mcp server
-#   bash references/skill-research.sh react testing components hooks
-#   bash references/skill-research.sh python fastapi authentication
+#   bash references/skill-research.sh "typescript,mcp,server"
+#   bash references/skill-research.sh "react,testing,components,hooks" ./corpus
+#   bash references/skill-research.sh "python,fastapi,authentication" ./corpus 6
 #
 # What it does:
 #   1. Searches for skills matching your keywords using skill-dl

--- a/skills/build-skills/references/skill-research.sh
+++ b/skills/build-skills/references/skill-research.sh
@@ -1,4 +1,32 @@
 #!/usr/bin/env bash
+
+# ============================================================================
+# USAGE
+# ============================================================================
+# This script automates the research phase of skill building.
+#
+# Prerequisites:
+#   - skill-dl must be installed and available in PATH
+#   - Verify with: skill-dl --version
+#   - If not available, see references/remote-sources.md for alternatives
+#
+# Basic usage:
+#   bash references/skill-research.sh <keyword1> <keyword2> [keyword3...]
+#
+# Examples:
+#   bash references/skill-research.sh typescript mcp server
+#   bash references/skill-research.sh react testing components hooks
+#   bash references/skill-research.sh python fastapi authentication
+#
+# What it does:
+#   1. Searches for skills matching your keywords using skill-dl
+#   2. Downloads the top candidates in parallel
+#   3. Outputs a summary of what was found
+#
+# Output:
+#   Downloaded skills are saved to the current directory.
+#   Review them using the quality assessment from source-patterns.md.
+# ============================================================================
 # skill-research.sh — Skill discovery, download, and corpus inspection
 # Usage: bash skill-research.sh "<keyword1>,<keyword2>,<keyword3>[,...]" [output-dir] [max-parallel]
 #

--- a/skills/build-skills/references/source-patterns.md
+++ b/skills/build-skills/references/source-patterns.md
@@ -71,3 +71,68 @@ A strong build-skills contribution should feel:
 - original
 - easy to trust
 - clean enough to sit beside other curated skills without adding entropy
+
+
+---
+
+## Quality spectrum
+
+Not all skill sources are equal. Use this framework to categorize what you find:
+
+### Tier 1: Production-ready reference
+- Has a `references/` directory with multiple files
+- SKILL.md is under 500 lines with clear routing
+- Uses frontmatter correctly
+- Demonstrates the skill's own patterns in its structure
+
+### Tier 2: Useful but flawed
+- Has good content but structural problems (too long, no references split, inline templates)
+- Extract ideas and patterns, but don't copy structure
+- Document the flaws in your comparison "avoid" column
+
+### Tier 3: Anti-pattern source
+- Over 1000 lines in SKILL.md
+- No `references/` directory (everything inline)
+- Vague or missing description
+- Useful only as a "what not to do" example
+
+## Size filtering rules
+
+Before reading a downloaded skill in detail, check its size:
+
+```bash
+# Quick size check
+wc -l SKILL.md
+find references -name '*.md' -exec wc -l {} + 2>/dev/null | sort -rn | head -5
+```
+
+**Guidelines:**
+- SKILL.md over 500 lines: Tier 2 at best, likely Tier 3
+- No `references/` directory: the skill hasn't been properly decomposed
+- Single reference file over 500 lines: content hasn't been split appropriately
+- Total reference content over 3000 lines: may indicate scope creep
+
+## Structural signals
+
+When evaluating a downloaded skill, look for these structural indicators:
+
+| Signal | Good | Bad |
+|---|---|---|
+| SKILL.md line count | Under 300 | Over 500 |
+| Reference file count | 5-15 | 0 or 30+ |
+| Routing table | Present with "Read when" guidance | Missing or just a file list |
+| Frontmatter | Name matches directory, description < 1024 chars | Mismatches or missing |
+| Do this / Not that | Present | Missing |
+| Output contract | Present with timing hints | Missing or vague |
+
+## Inherit vs. avoid framework
+
+For each downloaded skill in your comparison, explicitly categorize patterns:
+
+| Category | What to record | Example |
+|---|---|---|
+| **Inherit** | Patterns that align with this skill's standards | "Clean routing table with 'Read when' context" |
+| **Adapt** | Good ideas that need structural adjustment | "Useful checklist content, but inline - move to references/" |
+| **Avoid** | Anti-patterns or standard violations | "2000-line SKILL.md with everything inline" |
+
+Always have entries in all three categories. A comparison with only "inherit" entries suggests insufficient critical evaluation.

--- a/skills/build-skills/references/steering/derailment-lessons.md
+++ b/skills/build-skills/references/steering/derailment-lessons.md
@@ -1,0 +1,159 @@
+# Derailment Lessons — build-skills
+
+Patterns discovered through systematic derailment testing of the build-skills workflow. Each trap below was triggered at least once during real execution and caused measurable friction (wasted steps, wrong output, or recovery effort).
+
+## How to use this file
+
+Read this file at the start of any skill build or revision. Skim the trap titles — if any match your current situation, read the full entry. After completing your build, check the "Post-build audit" section at the end.
+
+---
+
+## Trap 1: Reference overload (Steps 3–4a)
+
+**What happens:** The agent loads all 22+ reference files at once, exhausting context and losing track of which file informed which decision.
+
+**Fix:** Use the reference routing table in SKILL.md. Load only the 3–5 files relevant to your current step. If you need more, load them in the next step.
+
+**Signal you're in this trap:** You've read more than 5 reference files before starting Step 4.
+
+---
+
+## Trap 2: Output location ambiguity
+
+**What happens:** The output contract lists what to produce but not when. The agent batches all output to the end, making intermediate review impossible.
+
+**Fix:** Show each artifact at the step that produces it. The output contract now includes timing hints (e.g., "after Step 2").
+
+**Signal you're in this trap:** You reach Step 7 without having shown any output.
+
+---
+
+## Trap 3: Tool prerequisite assumptions
+
+**What happens:** The skill mentions `skill-dl` but the agent assumes it's installed. First use fails, requiring backtracking.
+
+**Fix:** Run `skill-dl --version` before first use. If missing, check `references/remote-sources.md` for installation. If installation isn't possible, use the MCP fallback tools or manual GitHub search.
+
+**Signal you're in this trap:** A tool command fails with "command not found."
+
+---
+
+## Trap 4: Downloaded skill quality blindness
+
+**What happens:** Downloaded skills are treated as high-quality references when many violate the standards this skill enforces (>500 lines, no references directory, templates inline).
+
+**Fix:** Evaluate every downloaded skill against `references/research/source-verification.md` quality criteria before using it as a positive reference. Quality problems are valid "avoid" column entries.
+
+**Signal you're in this trap:** Your comparison table has no "avoid" entries.
+
+---
+
+## Trap 5: Creation vs. revision path confusion
+
+**What happens:** Test instructions are written assuming one path (usually creation) but the actual task is the other. Trigger tests fail silently for new skills because the skill isn't installed.
+
+**Fix:** Distinguish paths explicitly:
+- **New skill:** Install draft to `~/.claude/skills/[name]/` before trigger testing.
+- **Revision:** Test against the currently installed version.
+
+**Signal you're in this trap:** All trigger tests "pass" but you didn't install the skill first.
+
+---
+
+## Trap 6: Skip rationale missing
+
+**What happens:** Steps 4–6 are skipped for local-only work but the agent doesn't explain why, making the output look incomplete.
+
+**Fix:** When skipping steps, state the reason: "Steps 4–6 skipped because this is local-only work that doesn't need research artifacts."
+
+**Signal you're in this trap:** Your output jumps from Step 3 to Step 7 without explanation.
+
+---
+
+## Trap 7: Comparison table fabrication
+
+**What happens:** The agent skims downloaded skills (reading titles and match counts) and fabricates comparison entries from memory instead of reading actual content.
+
+**Fix:** For each downloaded skill: read its SKILL.md fully, run `tree` on its `references/`, read the 2–3 most relevant reference files. Only then write the comparison row.
+
+**Signal you're in this trap:** Comparison table entries lack specific file references or line counts.
+
+---
+
+## Trap 8: Orphan files in references
+
+**What happens:** Reference files exist but aren't routed from SKILL.md, so they're never loaded.
+
+**Fix:** Run the routing verification command from the final checks:
+```bash
+for f in $(find references -name '*.md' -type f); do
+  grep -q "$(basename $f)" SKILL.md || echo "ORPHAN: $f"
+done
+```
+
+**Signal you're in this trap:** The verification command outputs file names.
+
+---
+
+## Trap 9: Frontmatter validation gaps
+
+**What happens:** Description contains `<` or `>` characters, name doesn't match directory, or description exceeds 1024 characters.
+
+**Fix:** Check all three before finalizing:
+1. `echo ${#description}` — must be under 1024
+2. No angle brackets in frontmatter values
+3. Directory name matches frontmatter `name`
+
+**Signal you're in this trap:** Skill upload fails with a cryptic error.
+
+---
+
+## Trap 10: Reference file bloat
+
+**What happens:** Reference files grow beyond 500 lines because content is appended without checking current size.
+
+**Fix:** Before adding content to any reference file, check `wc -l`. If adding your content would exceed 500 lines, split into a new file and add routing.
+
+**Signal you're in this trap:** `find references -name '*.md' -exec wc -l {} + | sort -rn | head -5` shows files over 500 lines.
+
+---
+
+## Trap 11: Checklist used as linear workflow
+
+**What happens:** The master checklist is treated as a sequential todo list instead of a quality gate. Agent works through all 100+ items even for simple revisions.
+
+**Fix:** Use phase markers on checklist headings:
+- Phases 0–3 items are "DRAFT ESSENTIAL" — always check these.
+- Phases 4+ items are "FINAL AUDIT ONLY" — only for comprehensive quality passes.
+
+**Signal you're in this trap:** You're running checklist items before having a draft.
+
+---
+
+## Trap 12: Research without scoping
+
+**What happens:** Research expands indefinitely — agent downloads 20+ skills and reads all of them without a clear stopping criterion.
+
+**Fix:** Set a research budget before starting:
+- Download at most 10 candidates
+- Read at most 5 in detail
+- Spend at most 30 minutes on research
+- Stop when you have 3+ viable comparison entries
+
+**Signal you're in this trap:** You've downloaded more than 10 skills or spent more than 3 steps on research alone.
+
+---
+
+## Post-build audit
+
+After completing your skill build or revision, check these:
+
+1. **Output completeness:** Did you show artifacts at the steps that produced them?
+2. **Skip documentation:** Did you explain every skipped step?
+3. **Tool verification:** Did you verify prerequisites before using tools?
+4. **Quality assessment:** Did your comparison include "avoid" entries?
+5. **Test path clarity:** Did you distinguish creation vs. revision in testing?
+6. **File sizes:** Are all files under 500 lines?
+7. **Routing completeness:** Does every reference file appear in SKILL.md routing?
+
+If any answer is "no," address it before finalizing.


### PR DESCRIPTION
## Summary

Comprehensive enhancement of the `build-skills` skill based on rigorous derailment testing (literal execution of the skill on a real task, documenting every friction point).

## Changes (17 files: 1 new, 16 modified)

### SKILL.md (258 to 287 lines, 9 targeted edits)
- **Output contract**: reordered chronologically with step-timing hints
- **Orphan check**: replaced unreliable glob with find-based verification
- **Local-only skip**: added rationale parenthetical for Steps 4-6 skip
- **skill-dl fallback**: added MCP prerequisite and manual search fallback
- **3 steering callouts**: added at Steps 3, 4, and 8 (highest friction)
- **Steering routing**: new routing entry for derailment-lessons.md
- **3 do/don't rows**: prerequisites, output timing, creation-path testing

### New: references/steering/derailment-lessons.md (159 lines)
12 documented traps from real testing, each with fix and signals. Summary table mapping mistakes to consequences to prevention.

### Reference Enhancements (16 files)
- source-patterns.md: quality spectrum, size filtering, structural signals
- comparison-workflow.md: per-skill notes template, completeness gate
- research-workflow.md: phase gates, scoping, prereq verification, time budgets
- remote-sources.md: prerequisites, fallback paths, quality checklist
- skill-research.sh: usage docs, prerequisite check
- testing-methodology.md: creation vs revision testing paths
- master-checklist.md: phase routing, draft essentials section
- anti-patterns.md: 7 derailment anti-patterns (AP-D1 through AP-D7)
- source-verification.md: quality rubric for downloaded skills
- 6 reference files: added steering tip sections

## Testing
- 18 friction points identified (2 P0 blockers, 11 P1, 5 P2)
- All P0 and P1 issues resolved
- All reference files routed from SKILL.md (zero orphans)
- All files under 500-line limit
- SKILL.md at 287 lines (limit: 500)
