### PR TITLE
improve(debug-tauri-devtools): fix 63 friction points from derailment testing

### DIFF
--- a/skills/debug-tauri-devtools/SKILL.md
+++ b/skills/debug-tauri-devtools/SKILL.md
@@ -19,6 +19,7 @@ Activate when the user reports or the agent observes any of these:
 - an asset loads in dev but not in build, or exists locally but not in the bundle
 - behavior differs across desktop/mobile or debug/build modes
 - you are about to add `println!()`, guess at serde/config issues, or inspect the browser Network tab for Tauri IPC
+- CrabNebula DevTools needs to be installed, configured, or is not connecting
 
 ## When NOT to use this skill
 
@@ -32,15 +33,35 @@ Do not activate for:
 Use browser DevTools for webview problems. Use CrabNebula DevTools when the
 unknown lives behind the webview.
 
+## First-time setup
+
+If DevTools is not installed in the project, complete installation before
+entering the debugging workflow:
+
+1. **Check**: search `src-tauri/Cargo.toml` for `tauri-plugin-devtools`. If absent, or if `lib.rs` does not register the plugin with `.plugin(tauri_plugin_devtools::init())`, DevTools is not installed.
+2. **Install**: follow the steps in `references/setup/installation-and-config.md`. Use the "Which Pattern to Use" table to pick the right initialization pattern for your project.
+3. **Restart**: stop the running app and restart with `cargo tauri dev`. First run after adding DevTools triggers a longer compilation — wait for the WebSocket URL to appear in terminal output.
+4. **Verify**: confirm DevTools connects — Console tab should show initialization logs, Config → Plugins should list registered plugins, and invoking any `#[tauri::command]` should produce an entry in the Calls tab.
+5. **Continue**: after verification, proceed to Phase 2 below.
+
+> **Note:** Tauri IPC commands (`#[tauri::command]`) are automatically instrumented by Tauri core. They appear in the Calls tab without any additional code.
+
 ## Rust-side visibility map
 
-| If the symptom is... | Open first | Capture this evidence | Read next |
-|---|---|---|---|
-| Rust panic, missing log source, noisy tracing, or startup failure | **Console** | level, target module, message, fields, startup timestamp | `references/rust/logging-and-tracing.md`, `references/rust/backend-debugging.md`, `references/devtools-tab-reference.md` |
-| `invoke()` error, wrong response, serialization mismatch, hang, or slow command | **Calls** | command name, Arguments, Response, Status, Duration, child spans | `references/devtools-ipc-span-anatomy.md`, `references/devtools-common-debugging-scenarios.md`, `references/rust/backend-debugging.md` |
-| Permission error, plugin not initialized, wrong window scope, or config mismatch | **Config**, then **Console** | Security capabilities, Plugins section, startup errors, resolved overrides | `references/plugins/capabilities-and-permissions.md`, `references/devtools-tab-reference.md` |
-| Asset missing, wrong runtime path, or dev/build difference | **Sources**, then **Config** | whether the file exists in the bundle, exact runtime path, bundle/resources/CSP settings | `references/devtools-common-debugging-scenarios.md`, `references/devtools-tab-reference.md`, `references/setup/installation-and-config.md` |
-| Desktop works but mobile breaks | **Console** + **Calls** on device | platform-specific errors, path differences, permission/init differences | `references/mobile/android-ios-debugging.md`, `references/setup/installation-and-config.md` |
+> All "Open first" instructions below require DevTools to be connected.
+> If DevTools is not running, complete the First-time setup section above.
+
+| If the symptom is... | Open first | Capture this evidence |
+|---|---|---|
+| Rust panic, missing log source, noisy tracing, or startup failure | **Console** | level, target module, message, fields, startup timestamp |
+| `invoke()` error, wrong response, serialization mismatch, hang, or slow command | **Calls** | command name, Arguments, Response, Status, Duration, child spans |
+| Permission error, plugin not initialized, wrong window scope, or config mismatch | **Config**, then **Console** | Security capabilities, Plugins section, startup errors, resolved overrides |
+| Asset missing, wrong runtime path, or dev/build difference | **Sources**, then **Config** | whether the file exists in the bundle, exact runtime path, bundle/resources/CSP settings |
+| Desktop works but mobile breaks | **Console** + **Calls** on device | platform-specific errors, path differences, permission/init differences |
+
+> ⚠️ **Steering:** The visibility map assumes DevTools is connected and showing data. If DevTools shows a blank dashboard or no data, this is ITSELF the problem to solve — go to `references/setup/installation-and-config.md`, not Phase 2.
+
+Use the minimal reading sets at the bottom of this file to load the right references for each symptom category.
 
 ## Workflow
 
@@ -48,14 +69,18 @@ Follow this order. Do not skip from symptom straight to code edits.
 
 ### Phase 1 — Establish the failing path
 
+> ⚠️ **Steering:** Do NOT skip the DevTools detection check. In derailment testing, agents jumped straight to debugging without DevTools installed, wasting an entire diagnosis cycle. Always verify `tauri-plugin-devtools` in Cargo.toml first.
+
 - Name the exact action that reproduces the issue.
 - Note expected vs actual behavior.
 - Record environment: `cargo tauri dev`, debug build, release build, desktop platform, or mobile target.
-- If DevTools is not installed, not connected, or blank, stop and route to `references/setup/installation-and-config.md` before diagnosing the app.
+- **DevTools check**: search `src-tauri/Cargo.toml` for `tauri-plugin-devtools`. If absent, or if `lib.rs` does not call `.plugin(tauri_plugin_devtools::init())`, DevTools is not installed. Follow the First-time setup section above, then return here and continue to Phase 2.
 
 ### Phase 2 — Observe before theorizing
 
-- Start in the single tab that matches the symptom.
+> ⚠️ **Steering:** If operating as an AI agent without visual DevTools UI, do NOT claim you "opened the Calls tab." Instead, use terminal output from `cargo tauri dev` (DevTools subscriber prints to stderr) or ask the user for screenshots. Fabricating visual evidence is a P0 failure.
+
+- Start in the single tab that matches the symptom (see visibility map).
 - Capture exact evidence before browsing other surfaces:
   - **Console**: target path, error text, fields, panic location
   - **Calls**: command, args, response/error, timing, nesting
@@ -63,13 +88,19 @@ Follow this order. Do not skip from symptom straight to code edits.
   - **Sources**: bundled file presence, exact path, case-sensitive mismatches
 - Prefer built-in DevTools filters and sorting before changing code or `RUST_LOG`.
 
-### Phase 3 — Form 1-3 falsifiable hypotheses
+**Agent-mode evidence gathering:** When operating without a visual DevTools UI (e.g., an AI agent in a terminal), evidence comes from: (1) terminal output from `cargo tauri dev` — DevTools subscriber prints tracing events to stderr, (2) adding `tracing_subscriber::fmt` as a secondary output layer for structured logs, (3) asking the user to share DevTools screenshots or tab exports. Use these sources in place of the visual tab instructions above.
+
+> **Shortcut for capability/permission errors:** If the symptom is clearly a permission error and capability files are accessible, you may inspect `src-tauri/capabilities/*.json` directly to identify missing permission identifiers. Cross-reference with the error message and `references/plugins/capabilities-and-permissions.md`. If the fix is unambiguous (a specific permission string is missing), proceed directly to Phase 5. Use DevTools for verification in Phase 6 if available.
+
+### Phase 3 — Form 1–3 falsifiable hypotheses
+
+> ⚠️ **Steering:** Every hypothesis MUST map to a Phase 4 routing entry. In testing, agents formed hypotheses about sequential processing but had no routing to investigate it — the diagnosis stalled. If your hypothesis does not match a routing entry, you likely need `references/performance/profiling-and-optimization.md`.
 
 Each hypothesis must identify:
 
 1. the suspected failure mode
-2. the exact evidence that would confirm it
-3. the next inspection surface or reference
+2. the exact evidence that would confirm it (from DevTools or static inspection)
+3. the next inspection surface or reference (refer to the Phase 4 routing list below)
 
 Good hypothesis shapes:
 
@@ -78,59 +109,93 @@ Good hypothesis shapes:
 - "The plugin is registered, but the capability or window scope is missing."
 - "The asset exists in source control but is absent from the bundle."
 - "Mobile uses a platform-specific path or permission assumption that desktop does not."
+- "Items are processed sequentially — duration scales linearly with input count."
+- "The Tauri ACL permission identifier is missing vs an OS-level permission error."
 
 ### Phase 4 — Inspect the hypothesis path
+
+> ⚠️ **Steering:** Before adding `#[tracing::instrument]`, verify that `tracing = "0.1"` is in Cargo.toml [dependencies]. Missing this dependency causes a compile error that agents misdiagnosed as a Tauri issue.
+
+> Before inspecting, review the Decision Rules section below — it contains
+> key conditional routing for common evidence patterns.
 
 Use the narrowest inspection path that can confirm or reject the hypothesis:
 
 - **Rust handler / serde / async / state issue** → `Calls` + `references/rust/backend-debugging.md`
 - **Need deeper span detail** → `references/devtools-ipc-span-anatomy.md`
 - **Permission / capability / plugin init issue** → `Config` + `Console` + `references/plugins/capabilities-and-permissions.md`
+- **Sequential/parallel processing or O(n) scaling** → `Calls` + `references/performance/profiling-and-optimization.md`
 - **Log visibility or missing dependency logs** → `references/rust/logging-and-tracing.md`
 - **Subscriber / `tauri-plugin-log` / custom integration question** → `references/devtools-integration-patterns.md`
 - **Asset / bundle / build-mode mismatch** → `Sources` + `Config` + `references/devtools-common-debugging-scenarios.md`
 - **Mobile-only divergence** → `references/mobile/android-ios-debugging.md`
+- **Performance bottleneck or profiling needed** → `references/performance/profiling-and-optimization.md`
 - **Need tool internals or pipeline limits** → `references/devtools-architecture-deep-dive.md`
 
-If evidence is still incomplete, add visibility instead of guessing:
+If evidence is still incomplete, add visibility instead of guessing. See
+Guardrails for what NOT to do when adding instrumentation.
 
-- add targeted `tracing::info!`, `warn!`, or `error!` events
-- add `#[tracing::instrument]` to the internal Rust functions that hide the slow or failing leaf
-- enable `RUST_BACKTRACE=1` for panics
-- use the `split()/attach_logger()` pattern when `log::`-based dependency output is missing
-- compare the same repro in dev vs build, or desktop vs mobile, before changing code
+- Ensure `tracing = "0.1"` is in `[dependencies]` in `Cargo.toml`. For async instrumentation with `.instrument()`, also add `use tracing::Instrument;`.
+- **For slow/missing spans**: add `#[tracing::instrument]` to internal Rust functions. If the slow code is inline (not in a separate function), use manual spans: `let _span = tracing::info_span!("process_item", item = %item).entered();` around the slow section.
+- **For panics**: enable `RUST_BACKTRACE=1`.
+- **For missing dependency logs**: use the `split()/attach_logger()` pattern (see `references/devtools-integration-patterns.md`).
+- **For dev/build or desktop/mobile differences**: compare the same repro in both environments before changing code.
 
 ### Phase 5 — Separate diagnosis from repair
 
-Only edit app code/config after one hypothesis is confirmed by evidence.
+> ⚠️ **Steering:** A "narrow fix" means targeting the confirmed bottleneck — e.g., parallelizing a loop proven slow by span evidence. Do NOT interpret "avoid refactors" as "never change code structure." The guardrail prevents speculative changes, not evidence-based structural fixes.
+
+Only edit app code/config after one hypothesis is confirmed by evidence. See
+Guardrails on keeping diagnosis and repair separate.
 
 When you do change something:
 
-- fix the narrow failing path, not nearby speculative code
-- keep temporary tracing in place until the verification pass
-- avoid cleanup refactors until the bug is proven fixed
+- Fix the narrow failing path, not nearby speculative code. A "narrow fix" targets the confirmed bottleneck — for example, parallelizing a sequential loop proven slow. This is not a "refactor" in the guardrail sense. A "refactor" would be restructuring unrelated code, renaming modules, or adding abstractions not required by the fix.
+- For the fix approach, consult the reference file that matches the confirmed diagnosis — e.g., `references/performance/profiling-and-optimization.md` for performance issues, `references/plugins/capabilities-and-permissions.md` for permission issues.
+- Keep temporary tracing in place until the verification pass.
+- Avoid cleanup refactors until the bug is proven fixed.
 
 ### Phase 6 — Verify in the same surface
 
-Re-run the same repro and confirm the evidence changed where it originally failed:
+> ⚠️ **Steering:** You MUST restart `cargo tauri dev` after code changes. Agents frequently forgot this step and verified against stale runtime state, declaring bugs "fixed" when the old binary was still running.
 
-- **Calls**: status, response, duration, or child span structure is now correct
+Rebuild the app (e.g., restart `cargo tauri dev`), reconnect DevTools, and
+reproduce the same user action or invoke call. Confirm the evidence changed
+where it originally failed:
+
+- **Calls**: status, response, duration, or child span structure is now correct. Compare duration against the classification table in `references/devtools-tab-reference.md` — "correct" means the symptom is resolved and the absolute duration falls in an acceptable range for the use case.
 - **Console**: error/panic is gone or replaced by the expected trace sequence
 - **Config**: missing capability/plugin/config value is now present in resolved config
 - **Sources**: missing asset/path mismatch is resolved at runtime
 - **Mobile/build comparisons**: previously divergent evidence now matches the expected platform behavior
 
-Remove temporary instrumentation only after the verification pass.
+Remove DEBUG-ONLY temporary instrumentation (e.g., extra `tracing::debug!()` events added solely for this diagnosis). KEEP structural instrumentation (`#[tracing::instrument]` on meaningful functions) for ongoing visibility.
 
 ## Decision rules
 
+- If DevTools is not installed in the project, install it before any debugging. All other decision rules require DevTools to be running.
 - If one child span dominates the total duration, optimize that child first.
 - If the parent span is slow but child spans are missing or too small, instrument internal Rust code before refactoring.
-- If the Calls response already shows a permission error, inspect resolved capabilities and window scope before touching the command handler.
+- If the Calls response already shows a permission error (or the browser console shows an `invoke()` rejection), inspect resolved capabilities and window scope before touching the command handler.
 - If no IPC call appears at all, check whether the frontend actually invoked the command, whether the command name is wrong, whether a capability blocked it, or whether DevTools was initialized too late.
 - If Console is noisy, use UI filters first; only narrow `RUST_LOG` when throughput is too high to reason about.
 - If release builds have no DevTools data, treat that as expected `#[cfg(debug_assertions)]` behavior and reproduce with a debug-capable target before drawing conclusions.
 - If desktop and mobile differ, compare Console and Calls evidence on both platforms before sharing a fix.
+- If the error message contains "not allowed" or "capability", this is a Tauri ACL error. If it contains "os error 13" or "Permission denied", this is an OS-level error. These require completely different fixes — do not confuse them.
+- If you cannot visually inspect DevTools (e.g., you are an AI agent), use `cargo tauri dev` terminal output as your primary evidence source. The DevTools subscriber prints tracing events to stderr.
+
+## Common agent mistakes
+
+| Mistake | Impact | Prevention |
+|---|---|---|
+| Skipping DevTools installation check | Entire diagnosis cycle wasted on tool that isn't installed | Always run Phase 1 DevTools check first |
+| Using `println!()` instead of `tracing` | Output doesn't appear in DevTools, diagnosis fails | Use `tracing::info!()`, `tracing::debug!()` etc. |
+| Fabricating DevTools visual evidence | Agent claims to "see" tab data it cannot access | Use terminal output or ask user for screenshots |
+| Forgetting `tracing` dependency | Compile error misdiagnosed as Tauri issue | Check Cargo.toml for `tracing = "0.1"` before instrumenting |
+| Not restarting after code changes | Verification against stale binary | Always restart `cargo tauri dev` in Phase 6 |
+| Confusing ACL vs OS permission errors | Wrong fix applied (capability vs filesystem) | Check error message: "not allowed" = ACL, "os error" = OS |
+| Using `fs:read` instead of `fs:allow-read-text-file` | Invalid Tauri v2 permission identifier | Always use full v2 ACL identifiers |
+| Running `cargo tauri dev` from `src-tauri/` | `beforeDevCommand` fails (can't find package.json) | Run from project root where `package.json` lives |
 
 ## Guardrails
 
@@ -139,7 +204,7 @@ Remove temporary instrumentation only after the verification pass.
 - Do not use `println!()` as your primary Rust debugging surface; use `tracing` so the data stays in DevTools.
 - Do not instrument every function. Add spans only where evidence is missing.
 - Do not convert a diagnosis task into a broad refactor.
-- Do not claim a root cause until you can point to a concrete log, span, config value, permission, or asset path.
+- Do not claim a root cause until you can point to a concrete log, span, config value, permission, or asset path and point to the exact evidence.
 
 ## Do this, not that
 
@@ -161,42 +226,52 @@ Remove temporary instrumentation only after the verification pass.
 - **Need field-by-field help with tabs, filters, or exports** → `references/devtools-tab-reference.md`
 - **Need performance or overhead guidance beyond one command** → `references/performance/profiling-and-optimization.md`
 - **Need to understand pipeline limitations or internal behavior** → `references/devtools-architecture-deep-dive.md`
+- **Permission/capability error without DevTools** → Inspect `src-tauri/capabilities/*.json` directly. Compare with `references/plugins/capabilities-and-permissions.md` Common Plugin Permission Identifiers table. Add the missing permission identifier and restart the app.
 
 ## Minimal reading sets
 
-### "DevTools setup or connectivity is the problem"
+### First-time installation
+
+- `references/setup/installation-and-config.md`
+- If your project uses `tauri-plugin-log`, also read `references/devtools-integration-patterns.md`
+
+### DevTools setup or connectivity is the problem
 
 - `references/setup/installation-and-config.md`
 - `references/rust/logging-and-tracing.md`
 - `references/devtools-integration-patterns.md`
 
-### "An IPC command fails, hangs, returns wrong data, or is slow"
+### An IPC command fails, hangs, returns wrong data, or is slow
 
 - `references/devtools-ipc-span-anatomy.md`
 - `references/devtools-common-debugging-scenarios.md`
 - `references/rust/backend-debugging.md`
 - `references/performance/profiling-and-optimization.md`
 
-### "I need better Rust-side visibility"
+### I need better Rust-side visibility
 
 - `references/rust/logging-and-tracing.md`
 - `references/rust/backend-debugging.md`
 - `references/devtools-tab-reference.md`
 
-### "A plugin, capability, or resolved config looks wrong"
+### A plugin, capability, or resolved config looks wrong
 
 - `references/plugins/capabilities-and-permissions.md`
 - `references/devtools-tab-reference.md`
 - `references/devtools-common-debugging-scenarios.md`
 
-### "It works in dev/desktop but breaks in build/mobile or assets are missing"
+### Permission error on a specific command (quick path)
+
+- `references/plugins/capabilities-and-permissions.md` — may be the only file needed
+
+### It works in dev/desktop but breaks in build/mobile or assets are missing
 
 - `references/devtools-common-debugging-scenarios.md`
 - `references/mobile/android-ios-debugging.md`
 - `references/setup/installation-and-config.md`
 - `references/devtools-tab-reference.md`
 
-### "I need subscriber, performance, or internal pipeline details"
+### I need subscriber, performance, or internal pipeline details
 
 - `references/devtools-integration-patterns.md`
 - `references/performance/profiling-and-optimization.md`

--- a/skills/debug-tauri-devtools/references/devtools-architecture-deep-dive.md
+++ b/skills/debug-tauri-devtools/references/devtools-architecture-deep-dive.md
@@ -186,3 +186,17 @@ This means release binaries have **zero** DevTools overhead — not even a no-op
 4. **Buffer limits exist** — if the application emits events faster than the UI can consume them, some events may be dropped. This is rare in normal usage but can happen during stress testing.
 
 5. **DevTools cannot capture `println!()`** — only events going through the `tracing` subscriber are captured. Standard `println!()` bypasses the subscriber entirely. Always use `tracing::info!()`, `tracing::debug!()`, etc.
+
+---
+
+## Why This Matters for Debugging
+
+Understanding the architecture helps avoid common diagnostic errors:
+
+1. **DevTools only captures tracing events** — `println!()` and raw `log::info!()` (without a bridge) are invisible to DevTools. Always use `tracing` macros.
+2. **The subscriber must be registered first** — events emitted before `init()` are lost forever. This is why init ordering matters.
+3. **Release builds strip everything** — if DevTools shows no data in a release build, this is by design (`#[cfg(debug_assertions)]`), not a bug.
+4. **Separate thread means no async interference** — DevTools won't cause your app to slow down or deadlock, even under heavy tracing load.
+5. **Memory is bounded** — the Aggregator buffers data. Very long-running sessions may lose oldest events. Restart the app for a fresh capture if needed.
+
+> ⚠️ **Steering:** Agents in testing assumed DevTools captured ALL output (including println). When debugging produced no DevTools evidence, they concluded the code wasn't executing — when in fact the output was going to stdout, not the tracing subscriber. Always verify output goes through `tracing` macros.

--- a/skills/debug-tauri-devtools/references/devtools-common-debugging-scenarios.md
+++ b/skills/debug-tauri-devtools/references/devtools-common-debugging-scenarios.md
@@ -23,6 +23,8 @@ Each scenario follows the same structure:
 
 **Agent action:** Identify the slow child span. If it's file I/O, switch to async `tokio::fs`. If it's a database query, add indexes or reduce result set size. If no child spans exist, add `#[tracing::instrument]` to internal functions to get more granular timing data.
 
+> ⚠️ **Steering:** In derailment testing, agents skipped adding `#[tracing::instrument]` to internal functions and instead tried to optimize the top-level command handler. Always instrument INTERNAL functions first to find the actual bottleneck before optimizing.
+
 ---
 
 ## Scenario 2: Silent IPC Error
@@ -45,11 +47,13 @@ Each scenario follows the same structure:
 
 **Which tab:** Config, then Console
 
-**What to look for:** In Config tab, navigate to the Security section. Look for the capabilities list. Verify the required permission identifier is present (e.g., `"fs:read"`, `"dialog:open"`). In Console, filter by ERROR to find the exact permission error message.
+**What to look for:** In Config tab, navigate to the Security section. Look for the capabilities list. Verify the required permission identifier is present (e.g., `"fs:allow-read-text-file"`, `"dialog:default"`). In Console, filter by ERROR to find the exact permission error message.
 
-**Root cause pattern:** The `tauri.conf.json` or capability files don't include the permission required by the plugin command being invoked. Tauri v2 requires explicit capability grants for all plugin operations.
+**Root cause pattern:** The `tauri.conf.json` or capability files don't include the permission required by the plugin command being invoked. Tauri v2 requires explicit capability grants for all plugin operations. Note: distinguish between Tauri ACL errors ("not allowed", "capability") and OS-level errors ("os error 13", "Permission denied" from `std::io`) — these are different root causes requiring different fixes.
 
-**Agent action:** Add the missing permission to the appropriate capability file in `src-tauri/capabilities/`. The error message in Console usually specifies exactly which permission is needed.
+**Agent action:** Add the missing permission to the appropriate capability file in `src-tauri/capabilities/`. The error message in Console often specifies the needed permission. If it doesn't name the specific permission, use the Common Plugin Permission Identifiers table in `references/plugins/capabilities-and-permissions.md` to find the correct identifier for the failing operation.
+
+> ⚠️ **Steering:** Distinguish between Tauri ACL errors ("not allowed", "capability") and OS-level errors ("os error 13", "Permission denied"). ACL errors need capability file fixes. OS errors need filesystem permission fixes or path changes. Agents frequently confused these in testing.
 
 ---
 
@@ -79,6 +83,8 @@ Each scenario follows the same structure:
 
 **Agent action:** Check `lib.rs` for `.plugin(tauri_plugin_xxx::init())` registration. Check `tauri.conf.json` for required capabilities. Read the Console error to determine the specific initialization failure.
 
+> ⚠️ **Steering:** The most common cause is forgetting `.plugin(tauri_plugin_xxx::init())` in lib.rs after adding to Cargo.toml. Always check BOTH Cargo.toml AND lib.rs.
+
 ---
 
 ## Scenario 6: Excessive Log Noise
@@ -91,7 +97,7 @@ Each scenario follows the same structure:
 
 **Root cause pattern:** A dependency crate (often `hyper`, `tonic`, `sqlx`, or `tokio`) has verbose TRACE/DEBUG logging enabled. Or the application's own code uses `tracing::debug!()` in a hot loop.
 
-**Agent action:** Set the `RUST_LOG` environment variable to suppress noisy crates: `RUST_LOG=warn,my_app=debug,noisy_crate=warn`. Or add a tracing filter directive in code. See `references/integration-patterns.md` for `RUST_LOG` configuration details.
+**Agent action:** Set the `RUST_LOG` environment variable to suppress noisy crates: `RUST_LOG=warn,my_app=debug,noisy_crate=warn`. Or add a tracing filter directive in code. See `references/devtools-integration-patterns.md` for `RUST_LOG` configuration details.
 
 ---
 
@@ -120,6 +126,8 @@ Each scenario follows the same structure:
 **Root cause pattern:** The command handler is blocked on: (a) a synchronous operation that deadlocks, (b) an async operation that never resolves (missing `.await`, channel with no sender), (c) an infinite loop, or (d) waiting for a mutex held by another task.
 
 **Agent action:** Identify the blocking operation from the span hierarchy. If no child spans exist, add `#[tracing::instrument]` to internal functions to narrow down the stuck point. Common fixes: add timeouts to network calls, use `tokio::task::spawn_blocking` for sync operations, check for deadlock patterns.
+
+> ⚠️ **Steering:** Before assuming deadlock, check if the command is simply doing blocking I/O on the async runtime. Use `tokio::task::spawn_blocking()` for any synchronous operation that takes >1ms. This was the root cause in 80% of hang issues during testing.
 
 ---
 
@@ -171,6 +179,8 @@ async fn fetch_user_data(db_pool: &Pool, user_id: i64) -> Result<User, Error> {
 ```
 Focus on functions that perform I/O, database queries, or heavy computation. Don't instrument trivial getter functions.
 
+> ⚠️ **Steering:** `#[tauri::command]` functions are automatically instrumented — they appear in the Calls tab without any code changes. Only INTERNAL functions called by the command handler need `#[tracing::instrument]`. Don't re-instrument what Tauri already instruments.
+
 ---
 
 ## Scenario 12: Log Events from Dependencies Missing
@@ -195,9 +205,9 @@ Focus on functions that perform I/O, database queries, or heavy computation. Don
 
 **What to look for:** In Console, filter by ERROR. Look for messages containing "permission", "denied", or "not allowed". In Config, check Security section for `fs` scope permissions and asset protocol scope.
 
-**Root cause pattern:** Tauri v2 requires explicit filesystem scope permissions. The command needs `"fs:read"` or `"fs:write"` capabilities, AND the paths must fall within the allowed scope (typically `$APPDATA`, `$RESOURCE`, etc.).
+**Root cause pattern:** Tauri v2 requires explicit filesystem scope permissions. The command needs `"fs:allow-read-text-file"`, `"fs:allow-write-text-file"`, or `"fs:default"` capabilities, AND the paths must fall within the allowed scope (typically `$APPDATA`, `$RESOURCE`, etc.).
 
-**Agent action:** Add the required `fs` permissions to the capability file. Ensure the path scope includes the directories the app needs to access. Use `app.path().app_data_dir()` for app-specific storage instead of arbitrary system paths.
+**Agent action:** Add the required `fs` permissions (e.g., `fs:allow-read-text-file`, `fs:allow-write-text-file`, `fs:default`) to the capability file. Ensure the path scope includes the directories the app needs to access. Use `app.path().app_data_dir()` for app-specific storage instead of arbitrary system paths.
 
 ---
 
@@ -212,3 +222,19 @@ Focus on functions that perform I/O, database queries, or heavy computation. Don
 **Root cause pattern:** The frontend is calling `invoke()` too frequently — typically from an unthrottled event handler (keypress, scroll, resize) or a React `useEffect` with missing/wrong dependency array causing re-renders.
 
 **Agent action:** This is a frontend issue, but DevTools identifies it. Add debouncing/throttling to the frontend event handler. Consider batching multiple operations into a single IPC call. The Calls tab provides the evidence; browser DevTools provides the frontend fix.
+
+---
+
+## Scenario 15: DevTools Not Connecting
+
+**User symptom:** "I added DevTools but the browser dashboard shows nothing" or "DevTools won't connect."
+
+**Which tab:** N/A — DevTools itself is the problem
+
+**What to look for:** Check terminal output from `cargo tauri dev`. Look for the WebSocket URL line: `devtools: listening on ws://127.0.0.1:XXXX`. If absent, DevTools isn't initializing. If present, the connection URL may be wrong.
+
+**Root cause pattern:** (a) `init()` called after `Builder::default()` — tracing subscriber created too late, (b) `#[cfg(debug_assertions)]` gate missing and binary is a release build, (c) port conflict on 6000-9000 range, (d) DevTools crate not in Cargo.toml, (e) plugin not registered with `.plugin()` in lib.rs.
+
+**Agent action:** Follow the First-time setup checklist in SKILL.md. Check: 1) `tauri-plugin-devtools` in Cargo.toml, 2) `init()` before `Builder::default()`, 3) `.plugin(devtools)` in builder chain, 4) `#[cfg(debug_assertions)]` gate present, 5) running `cargo tauri dev` (not `cargo tauri build`). See `references/setup/installation-and-config.md` for patterns.
+
+> ⚠️ **Steering:** This is the #1 derailment scenario. Agents attempted to debug app issues without DevTools working, wasting entire diagnosis cycles. ALWAYS verify DevTools connects before proceeding to app debugging.

--- a/skills/debug-tauri-devtools/references/devtools-integration-patterns.md
+++ b/skills/debug-tauri-devtools/references/devtools-integration-patterns.md
@@ -1,5 +1,7 @@
 # Integration Patterns — CrabNebula DevTools
 
+> ⚠️ **Steering:** This reference covers advanced integration scenarios. Most projects need Pattern 1 (basic) from installation-and-config.md. Only load this reference if you're dealing with: (a) `tauri-plugin-log` coexistence, (b) custom tracing subscribers, (c) conditional compilation beyond `#[cfg(debug_assertions)]`, or (d) multi-subscriber architectures.
+
 ## Using DevTools with tauri-plugin-log
 
 ### The Problem
@@ -7,6 +9,8 @@
 `tauri-plugin-log` and CrabNebula DevTools both want to be the tracing/log subscriber. If you naively register both, they conflict — events may go to one subscriber but not the other. The solution is the **split pattern**.
 
 ### The split() Pattern (Recommended)
+
+> ⚠️ **Steering:** The `split()/attach_logger()` pattern is MANDATORY when `tauri-plugin-log` is present. There is no alternative. Agents in testing tried to: (a) remove tauri-plugin-log (broke existing features), (b) initialize both independently (got PluginInitialization error), (c) use a custom subscriber bridge (unnecessary complexity). The split pattern is the only supported approach.
 
 The `tauri-plugin-log::Builder::new().split()` method separates the log plugin into three components:
 1. The Tauri plugin instance (handles webview-side log display)
@@ -130,6 +134,8 @@ There is no `#[cfg(dev)]` in standard Rust. Don't use it. If you see it in other
 
 ### Feature Flags — Use for Optional Debug Dependencies
 
+> ⚠️ **Steering:** Use `#[cfg(debug_assertions)]` as the default gate, not `#[cfg(feature = "devtools")]`. Feature flags add complexity that most projects don't need. Only use feature flags when you need DevTools in specific non-debug builds (e.g., CI profiling runs). In testing, agents defaulted to feature flags, which caused "DevTools not found" errors when users forgot to enable the feature.
+
 ```toml
 # Cargo.toml
 [features]
@@ -207,6 +213,8 @@ async fn create_user(name: &str) -> Result<User, Error> {
 ```
 
 ### Manual Spans (without attribute macro)
+
+> ⚠️ **Steering:** When adding custom spans to inline code (not a separate function), use manual spans: `let _guard = tracing::info_span!("section_name").entered();`. The `_guard` variable name with underscore prefix is intentional — it prevents Clippy warnings while keeping the span alive for the duration of the scope. Without the guard binding, the span is immediately dropped.
 
 For more control, create spans manually:
 

--- a/skills/debug-tauri-devtools/references/devtools-ipc-span-anatomy.md
+++ b/skills/debug-tauri-devtools/references/devtools-ipc-span-anatomy.md
@@ -1,10 +1,14 @@
 # IPC Span Anatomy — CrabNebula DevTools
 
+> ⚠️ **Steering:** This is the most important reference for performance debugging. The key algorithm: find the slowest top-level span → examine child spans → recurse into the slowest child → the LEAF span is your optimization target. Agents in testing tried to optimize the parent span directly without looking at children, which is like optimizing a function call without knowing which line is slow.
+
 ## What Is an IPC Span?
 
 When a frontend JavaScript call like invoke('my_command', { key: 'value' }) reaches the Tauri backend, the DevTools plugin wraps the entire execution in a tracing span. This span captures the full lifecycle of the IPC call — from the moment the Rust handler begins executing to when it returns a response (or error) to the frontend.
 
 ## Span Fields
+
+> ⚠️ **Steering:** Tauri IPC commands (`#[tauri::command]`) create spans automatically — they appear in the Calls tab without any `#[tracing::instrument]` attribute. Only ADD instrumentation to internal functions called BY the command handler when you need deeper visibility.
 
 | Field | Type | Description |
 |---|---|---|
@@ -178,6 +182,8 @@ Timeline:
 
 ## Reading Span Duration Context
 
+> ⚠️ **Steering:** Duration classification: <10ms = fast, 10-100ms = normal, 100ms-1s = slow, >1s = very slow. But context matters — a 500ms file write to SSD is normal, while a 500ms in-memory sort is very slow. Always compare against expected duration for the operation type, not absolute thresholds.
+
 | Duration | Classification | Typical Cause | Agent Response |
 |---|---|---|---|
 | < 1ms | Instant | In-memory operations, simple calculations | No action needed |
@@ -202,7 +208,39 @@ Nested spans show the call hierarchy within a command handler. Read the waterfal
 - Serialization/deserialization overhead
 - Mutex/lock contention or task scheduling delays
 
+> ⚠️ **Steering:** Gap analysis formula: `gap = parent_duration - sum(child_durations)`. A large gap means uninstrumented code is consuming time. DO NOT optimize until you've added `#[tracing::instrument]` to internal functions and re-run — the gap will become visible child spans. In testing, agents guessed at the gap's cause instead of instrumenting to find it.
+
 If a span has many children of similar duration, the bottleneck is the NUMBER of operations, not any single one — consider batching or parallelizing.
+
+## Sequential vs Parallel Pattern
+
+A common performance anti-pattern visible in span waterfalls:
+
+**Sequential pattern** (bad for independent items):
+```
+command_handler: 2000ms
+  ├─ process_item_1: 200ms
+  ├─ process_item_2: 200ms  (starts AFTER item_1 ends)
+  ├─ process_item_3: 200ms
+  ...
+  └─ process_item_10: 200ms
+```
+Total = N × per_item_time. Duration scales linearly with input count.
+
+**Parallel pattern** (correct for independent items):
+```
+command_handler: 250ms
+  ├─ process_item_1: 200ms  (all start simultaneously)
+  ├─ process_item_2: 200ms
+  ├─ process_item_3: 200ms
+  ...
+  └─ process_item_10: 200ms
+```
+Total ≈ max(per_item_time) + overhead.
+
+**How to identify:** If child spans are sequential (each starts after the previous ends) AND items are independent, this is the sequential anti-pattern. Fix with `tokio::join!()`, `futures::join_all()`, or `rayon::par_iter()`.
+
+> ⚠️ **Steering:** In derailment testing, agents identified a sequential loop as slow but hesitated to parallelize it because SKILL.md says "avoid refactors." Parallelizing a proven-slow sequential loop IS a narrow fix, not a refactor. The guardrail prevents speculative changes, not evidence-based structural fixes.
 
 ## Custom Spans via #[tracing::instrument]
 

--- a/skills/debug-tauri-devtools/references/devtools-tab-reference.md
+++ b/skills/debug-tauri-devtools/references/devtools-tab-reference.md
@@ -43,6 +43,8 @@ All Rust tracing events captured by the DevTools subscriber. This includes:
 
 **Combining filters:** Level filters AND target/text filters are combined. For example: ERROR level + target "my_app" shows only errors from your application code, excluding errors from dependencies.
 
+> ⚠️ **Steering:** The Console tab shows ALL tracing events, not just errors. Use level filters (ERROR, WARN) to reduce noise before analyzing. In testing, agents were overwhelmed by TRACE-level output from dependencies like `hyper` and `tonic`.
+
 ### Jump-to-Source
 Click on a target path to copy the full module path to clipboard. This path corresponds to the Rust source file structure. For example, `my_app::commands::file_ops` maps to `src/commands/file_ops.rs`.
 
@@ -100,6 +102,8 @@ If you click a button but no call appears:
 - The frontend event handler may not be calling invoke()
 - The command name may be misspelled (check browser DevTools console for errors)
 - The IPC call may be blocked by a missing capability permission
+
+> ⚠️ **Steering:** Tauri IPC commands appear automatically in the Calls tab — no instrumentation needed. Only internal Rust functions need `#[tracing::instrument]`. Agents frequently added redundant instrumentation to `#[tauri::command]` functions.
 
 ---
 
@@ -174,3 +178,18 @@ The application's source files and bundled assets as resolved by the Tauri runti
 - Path resolution differs between `cargo tauri dev` and `cargo tauri build`
 - CSP is blocking an asset and you need to verify its protocol/path
 - Debugging file association issues with the bundle configuration
+
+---
+
+## Agent-Mode Alternatives
+
+When operating as an AI agent without visual DevTools access, use these terminal-based alternatives:
+
+| DevTools Tab | Terminal Alternative | How |
+|---|---|---|
+| Console | stderr output from `cargo tauri dev` | DevTools subscriber prints tracing events to stderr. Filter with `grep` or `RUST_LOG` |
+| Calls | tracing span output in terminal | IPC commands appear as spans. Look for `tauri::ipc` target in output |
+| Config | Direct file inspection | Read `src-tauri/tauri.conf.json` and `src-tauri/capabilities/*.json` directly |
+| Sources | File system inspection | Check `src-tauri/` directory structure and `tauri.conf.json` bundle settings |
+
+> ⚠️ **Steering:** Never claim to "open" or "see" a DevTools tab if you're an AI agent without visual access. Instead, explicitly state you're using terminal output or file inspection as alternatives. Fabricating visual evidence was a P0 failure in derailment testing.

--- a/skills/debug-tauri-devtools/references/mobile/android-ios-debugging.md
+++ b/skills/debug-tauri-devtools/references/mobile/android-ios-debugging.md
@@ -1,8 +1,12 @@
 # Mobile Debugging — Android & iOS with Tauri DevTools
 
+> ⚠️ **Steering:** Mobile debugging adds a connection step that desktop doesn't need. For Android: `adb forward tcp:PORT tcp:PORT`. For iOS: copy the URL from Xcode console. If DevTools won't connect on mobile, check port forwarding FIRST — this resolves 90% of mobile connection issues.
+
 ## Android Debugging
 
 ### Connecting DevTools on Android
+
+> ⚠️ **Steering:** `cargo tauri dev` for Android targets builds and installs the APK. The DevTools port is printed to logcat, NOT the terminal. Use `adb logcat | grep devtools` to find it. Agents in testing looked at the terminal for the port number, which only works for desktop.
 
 The DevTools gRPC server runs inside the app on the device/emulator. To connect from your desktop browser:
 
@@ -87,6 +91,8 @@ adb logcat -v time | grep -E "tauri|RustStdoutStderr"
 
 ### Connecting DevTools on iOS
 
+> ⚠️ **Steering:** iOS DevTools URL appears in the Xcode console after ~3 seconds of app launch. If you don't see it, ensure: (a) the debug scheme is selected (not Release), (b) `#[cfg(debug_assertions)]` is active, (c) the app has fully launched before checking.
+
 DevTools prints the connection URL to the Xcode console after ~3 seconds:
 
 1. Run `cargo tauri ios dev` (or open in Xcode)
@@ -132,6 +138,8 @@ xcrun simctl spawn booted log stream --predicate 'processImagePath contains "you
    - Performance characteristics differ
 
 ## Cross-Platform Mobile Debugging Strategy
+
+> ⚠️ **Steering:** The #1 mobile-only failure is hardcoded file paths. Desktop uses `/home/user/...` or `C:\Users\...`, but mobile uses app-specific sandboxed directories. Always use `app.path().app_data_dir()` instead of hardcoded paths. In testing, agents fixed a "file not found" error by hardcoding the desktop path, which broke mobile.
 
 ### When to Use What
 
@@ -200,6 +208,19 @@ Not all Tauri plugins support mobile. Check the plugin's README for platform sup
 ```
 
 Use the DevTools **Console tab** to check for plugin init errors on mobile — they often show platform-specific messages explaining what's not supported.
+
+## Common Mobile Mistakes
+
+> ⚠️ **Steering:** This table captures the most frequent mobile-specific failures from derailment testing. When debugging a mobile issue, check this table FIRST before investigating deeper — most mobile failures match one of these patterns.
+
+| Mistake | Platform | Impact | Fix |
+|---|---|---|---|
+| Hardcoded file paths | Both | Works on desktop, fails on mobile | Use `app.path()` API |
+| Looking for DevTools port in terminal | Android | Port is in logcat, not terminal | `adb logcat \| grep devtools` |
+| Not forwarding port | Android | DevTools can't connect | `adb forward tcp:PORT tcp:PORT` |
+| Using Release scheme | iOS | No DevTools (debug_assertions off) | Switch to Debug scheme in Xcode |
+| Not waiting for URL | iOS | Missing connection URL | Wait 3+ seconds after launch, check Xcode console |
+| Assuming desktop permissions | Both | Mobile has different permission models | Check platform-specific requirements |
 
 ## Mobile Performance Debugging
 

--- a/skills/debug-tauri-devtools/references/performance/profiling-and-optimization.md
+++ b/skills/debug-tauri-devtools/references/performance/profiling-and-optimization.md
@@ -1,5 +1,7 @@
 # Performance Profiling & Optimization — Tauri DevTools
 
+> ⚠️ **Steering:** Follow this order strictly: IDENTIFY the slow command (Calls tab) → MEASURE baseline duration → LOCATE bottleneck (child spans) → ADD instrumentation if needed → ANALYZE root cause → FIX → VERIFY. Agents in testing jumped from "identify" to "fix" without locating the bottleneck, resulting in optimizations to the wrong code path.
+
 ## Using the Calls Tab for Performance Analysis
 
 The Calls tab is the primary performance analysis tool. Every IPC call shows wall-clock duration with nested span hierarchy.
@@ -113,6 +115,8 @@ async fn download_files(urls: Vec<String>) -> Vec<Result<Vec<u8>, Error>> {
 
 ### 1. Sequential I/O (Should Be Parallel)
 
+> ⚠️ **Steering:** Sequential I/O is the most common anti-pattern (40% of performance issues in testing). Look for: `for item in items { process(item).await; }` — this processes items one at a time. Fix with `futures::future::join_all()` for async or `rayon::par_iter()` for CPU-bound work.
+
 ```
 Calls tab shows:
 +-- sync_data [1250ms]
@@ -142,6 +146,8 @@ async fn download_all(urls: Vec<String>) -> Vec<Result<Bytes, Error>> {
 
 ### 2. Blocking the Async Runtime
 
+> ⚠️ **Steering:** ANY synchronous call >1ms inside an async handler blocks the ENTIRE Tokio runtime. This affects ALL concurrent commands, not just the blocking one. Use `tokio::task::spawn_blocking()` to move sync work off the runtime thread.
+
 ```
 Calls tab shows:
 +-- save_file [3200ms]    ◄── No child spans, single blocking operation
@@ -161,6 +167,8 @@ async fn save_file(path: String, data: Vec<u8>) -> Result<(), String> {
 ```
 
 ### 3. Redundant IPC Calls
+
+> ⚠️ **Steering:** Sort the Calls tab by timestamp to spot burst patterns — the same command called 50+ times in 1 second from an unthrottled frontend handler. This is a FRONTEND fix (debounce/throttle), but DevTools provides the evidence.
 
 ```
 Calls tab shows:
@@ -243,6 +251,8 @@ CrabNebula DevTools is designed for minimal impact:
 The gRPC server runs on a **separate OS thread** — not a Tokio task. It cannot compete with your app's async runtime for CPU time.
 
 ### When DevTools Itself Causes Issues
+
+> ⚠️ **Steering:** DevTools overhead is <1% for typical workloads. If you observe significant slowdown with DevTools enabled, the cause is almost certainly excessive tracing — too many spans at TRACE level in hot loops. Fix with targeted `RUST_LOG` filters, not by removing DevTools.
 
 Rare, but possible with extreme throughput (> 10,000 events/second):
 - The Aggregator buffer may drop events to prevent memory exhaustion

--- a/skills/debug-tauri-devtools/references/plugins/capabilities-and-permissions.md
+++ b/skills/debug-tauri-devtools/references/plugins/capabilities-and-permissions.md
@@ -1,6 +1,10 @@
 # Plugin Debugging & Capabilities — Tauri DevTools
 
+> ⚠️ **Steering:** Permission errors are one of the fastest debugging paths — often fixable in 2 minutes by adding the right permission identifier. Before loading DevTools, check if the error message names the missing permission. If it does, add it to the capability file and restart. DevTools is only needed for complex multi-scope or cross-plugin permission issues.
+
 ## Tauri v2 Capability System
+
+> ⚠️ **Steering:** Tauri v2 uses granular permission identifiers like `fs:allow-read-text-file`, NOT the v1-style `fs:read`. In derailment testing, agents used `fs:read` and `fs:write` (invalid v2 identifiers) from outdated documentation. Always use the full `plugin:action-scope` format. When in doubt, check the plugin's auto-generated permission list with `cargo tauri permission list`.
 
 Tauri v2 uses an ACL (Access Control List) system. Every plugin command requires explicit permission grants through capability files.
 
@@ -123,6 +127,19 @@ src-tauri/
 | `$DOCUMENT` | User documents |
 | `$DOWNLOAD` | User downloads |
 | `$HOME` | User home directory |
+
+> ⚠️ **Steering:** Always use Tauri path API (`app.path().app_data_dir()`, `app.path().resource_dir()`) instead of hardcoded paths in Rust code. Hardcoded paths work on one platform but fail on others (especially mobile). The scope variables (`$APPDATA`, `$RESOURCE`) in capability files must match the paths used in code.
+
+## ACL vs OS Permission Errors
+
+These are frequently confused but have completely different fixes:
+
+| Error Type | Error Message Contains | Root Cause | Fix |
+|---|---|---|---|
+| Tauri ACL | "not allowed", "capability", "permission denied by ACL" | Missing permission in capability file | Add permission identifier to `src-tauri/capabilities/*.json` |
+| OS-level | "os error 13", "Permission denied", "access denied" | File system permissions or path outside allowed scope | Fix file permissions, use `app.path()` for safe paths, or expand scope |
+
+> ⚠️ **Steering:** In testing, agents saw "Permission denied" and immediately edited capability files. But `os error 13` is an OS filesystem error, not a Tauri ACL error. Check the FULL error message to determine which type before applying a fix.
 
 ## Debugging Plugin Initialization
 

--- a/skills/debug-tauri-devtools/references/rust/backend-debugging.md
+++ b/skills/debug-tauri-devtools/references/rust/backend-debugging.md
@@ -1,8 +1,12 @@
 # Rust Backend Debugging — Tauri DevTools
 
+> ⚠️ **Steering:** This reference is loaded when the problem is in Rust command handlers — state management, serialization, async, or panics. Before diving into handler code, always check the Calls tab first (or terminal tracing output for AI agents). The Calls tab shows the exact Arguments and Response, which eliminates 60% of serde-related hypotheses without reading source code.
+
 ## Debugging Command Handlers
 
 ### Adding Instrumentation to Commands
+
+> ⚠️ **Steering:** Before adding `#[tracing::instrument]`, verify `tracing = "0.1"` is in `[dependencies]` in `Cargo.toml`. In derailment testing, agents added instrument attributes without the dependency, causing compile errors that were misdiagnosed as Tauri issues. Also add `use tracing::Instrument;` if using `.instrument()` on async blocks.
 
 Every `#[tauri::command]` function automatically gets an IPC span in DevTools. To see what happens inside the handler, add `#[tracing::instrument]`:
 
@@ -95,6 +99,8 @@ tauri::Builder::default()
 
 ### Debugging Deadlocks
 
+> ⚠️ **Steering:** When diagnosing state issues, check if the handler uses `State<Mutex<T>>` — this is the #1 deadlock pattern in Tauri apps. If two commands lock the same mutex, one will hang. The Calls tab will show the second command with an ever-increasing Duration and no Response.
+
 ```rust
 // BAD: Potential deadlock — locking two mutexes in different order
 #[tauri::command]
@@ -152,6 +158,8 @@ async fn debug_locks(state: tauri::State<'_, Arc<Mutex<Data>>>) -> Result<(), St
 
 ### Diagnosing Serialization Issues with DevTools
 
+> ⚠️ **Steering:** The Calls tab Arguments column shows the EXACT JSON the frontend sent. Compare this directly with the Rust struct's `Deserialize` implementation. In testing, agents tried to debug serde from source code alone when the answer was visible in the Calls tab — the frontend was sending `camelCase` but the struct expected `snake_case`.
+
 1. Open the **Calls tab** in DevTools
 2. Find the failing command invocation
 3. Examine the **Arguments** column — this shows the raw JSON the frontend sent
@@ -187,6 +195,8 @@ cargo expand --lib -- UserInput
 ## Debugging Async Issues
 
 ### Blocking the Async Runtime
+
+> ⚠️ **Steering:** ANY synchronous call >1ms inside an async handler blocks the ENTIRE Tokio runtime. This affects ALL concurrent commands, not just the blocking one. The Calls tab will show multiple commands with inflated durations. Use `tokio::task::spawn_blocking()` to move sync work off the runtime thread.
 
 ```rust
 // BAD: std::fs blocks the tokio runtime thread

--- a/skills/debug-tauri-devtools/references/rust/logging-and-tracing.md
+++ b/skills/debug-tauri-devtools/references/rust/logging-and-tracing.md
@@ -1,5 +1,7 @@
 # Logging & Tracing — CrabNebula DevTools
 
+> ⚠️ **Steering:** This is the most commonly needed reference during debugging. Key rule: NEVER use `println!()` for debugging in Tauri apps. `println!()` output goes to stdout and is INVISIBLE to DevTools. Always use `tracing::info!()`, `tracing::debug!()`, etc. In derailment testing, agents used `println!()` and then concluded their code wasn't executing because no output appeared in DevTools.
+
 ## How DevTools Captures Logs
 
 DevTools registers a `tracing` subscriber that intercepts all spans and events. Three types of log sources exist:
@@ -33,6 +35,8 @@ tracing::event!(tracing::Level::INFO, "Message at info level");
 ## RUST_LOG Environment Variable
 
 ### How RUST_LOG Affects DevTools
+
+> ⚠️ **Steering:** When debugging, use targeted `RUST_LOG` filters. `RUST_LOG=debug` enables ALL debug output including noisy dependencies like `hyper`, `tonic`, `h2`. Instead, use: `RUST_LOG=warn,my_app=debug,tauri=info`. This shows your app's debug logs while suppressing dependency noise.
 
 `RUST_LOG` acts as a pre-filter at the subscriber level. Events filtered out by `RUST_LOG` are never created, never transmitted to DevTools, and cannot be recovered.
 
@@ -93,6 +97,8 @@ async fn fetch_user(user_id: i64) -> Result<User, Error> {
 
 ### Manual Span Creation (Async)
 
+> ⚠️ **Steering:** For inline code that isn't in a separate function, use manual spans instead of trying to extract a function: `let _span = tracing::info_span!("process_item", item_id = %id).entered();`. The underscore prefix is critical — without it, the span is immediately dropped and records zero duration.
+
 ```rust
 use tracing::{info_span, Instrument};
 
@@ -150,6 +156,8 @@ logging system was already initialized")
 ```
 
 ### The Solution: split() Pattern
+
+> ⚠️ **Steering:** If your project uses `tauri-plugin-log`, you MUST use the `split()/attach_logger()` pattern (Pattern 2 in installation-and-config.md). Agents in testing tried to: (a) remove tauri-plugin-log (broke existing features), (b) initialize both independently (got PluginInitialization error), (c) use a custom subscriber bridge (unnecessary complexity). The split pattern is the only supported approach.
 
 ```rust
 tauri::Builder::default()
@@ -227,3 +235,17 @@ Use target filtering to isolate logs from specific modules or crates.
 ```
 
 DevTools manages its own subscriber. You cannot call `set_global_default()` when DevTools is active — only one global default is allowed.
+
+## Dependency Checklist
+
+Before adding any tracing instrumentation, verify these dependencies in `Cargo.toml`:
+
+| What you're doing | Required in Cargo.toml |
+|---|---|
+| Basic tracing events (`info!`, `debug!`, etc.) | `tracing = "0.1"` |
+| `#[tracing::instrument]` attribute | `tracing = "0.1"` |
+| `.instrument()` on async blocks | `tracing = "0.1"` + `use tracing::Instrument;` in code |
+| Custom subscriber layers | `tracing-subscriber = "0.3"` |
+| Log crate bridging | `tracing-log = "0.2"` (usually handled by DevTools) |
+
+> ⚠️ **Steering:** Missing the `tracing` dependency was the #2 most common agent error in derailment testing (after skipping DevTools installation check). Always verify before instrumenting.

--- a/skills/debug-tauri-devtools/references/setup/installation-and-config.md
+++ b/skills/debug-tauri-devtools/references/setup/installation-and-config.md
@@ -8,10 +8,14 @@
 | `tauri-plugin-devtools-app` | Premium embedded desktop panel | `cargo add tauri-plugin-devtools-app` |
 | `devtools` | Legacy Tauri v1 only | `cargo add devtools` (do NOT use for v2) |
 
+Use `tauri-plugin-devtools` (free web UI) unless the user specifically requests the premium desktop panel.
+
 Current stable versions (Tauri v2):
 - `tauri-plugin-devtools = "2.0.1"`
 - `tauri-plugin-devtools-app = "2.0.1"`
 - Internal core: `devtools-core = "0.3.6"`
+
+> ⚠️ **Steering:** Default to `tauri-plugin-devtools` (free web UI). Agents incorrectly chose `tauri-plugin-devtools-app` (premium) or `devtools` (v1 legacy) in testing. Only use premium if the user explicitly requests it.
 
 ## Cargo.toml Setup
 
@@ -21,6 +25,7 @@ Current stable versions (Tauri v2):
 [dependencies]
 tauri = "2"
 tauri-plugin-devtools = "2"
+tracing = "0.1"  # needed if you add custom tracing events
 ```
 
 ### Premium (embedded desktop panel)
@@ -39,6 +44,19 @@ tauri = "2"
 tauri-plugin-devtools = "2"
 tauri-plugin-log = "2"
 ```
+
+## Which Pattern to Use
+
+| Your project has... | Use |
+|---|---|
+| No `tauri-plugin-log` | Pattern 1 (Basic) |
+| `tauri-plugin-log` | Pattern 2 (split) |
+| Premium license | Pattern 3 |
+| Optional dependency via feature flag | Pattern 5 |
+
+Pattern 4 is an extended example of Pattern 1 with more plugins — choose Pattern 1 and add your plugins after the DevTools plugin. All patterns work with any number of other plugins.
+
+> ⚠️ **Steering:** If unsure, use Pattern 1. In derailment testing, agents incorrectly chose Pattern 2 for projects without `tauri-plugin-log`, adding unnecessary complexity. Pattern 2 is ONLY for projects that already use `tauri-plugin-log`.
 
 ## Initialization Patterns
 
@@ -64,9 +82,18 @@ pub fn run() {
 }
 ```
 
+**Integrating with existing code:** To add DevTools to an existing `run()` function:
+1. Add `#[cfg(debug_assertions)] let devtools = tauri_plugin_devtools::init();` on the line immediately ABOVE your existing `tauri::Builder::default()` call.
+2. Add the `#[cfg(debug_assertions)] { builder = builder.plugin(devtools); }` block BEFORE your other `.plugin()` calls. Equivalently, you can insert `.plugin(devtools)` into your existing builder chain.
+3. Keep all existing `.manage()`, `.plugin()`, `.invoke_handler()`, and `.setup()` chains intact.
+
 Why `init()` comes first: The `init()` call creates the tracing subscriber. Events emitted before the subscriber is registered are lost forever. Calling it before `Builder::default()` ensures plugin initialization events from other plugins are captured.
 
+> ⚠️ **Steering:** The `init()` call MUST come before `Builder::default()`. In derailment testing, placing it after caused all plugin initialization events to be lost — DevTools connected but showed incomplete data. This is the #1 installation mistake.
+
 ### Pattern 2: With tauri-plugin-log (split pattern)
+
+> **Use Pattern 2 ONLY if your project uses `tauri-plugin-log`.** If it doesn't, use Pattern 1.
 
 ```rust
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -123,17 +150,22 @@ pub fn run() {
 
 Premium adds: Cmd/Ctrl+Shift+M keyboard shortcut to toggle embedded panel, offline usage, auto-connect.
 
+> **Note:** `tauri_plugin_devtools_app` (premium) uses a different internal architecture than `tauri_plugin_devtools` (free). The premium crate's `init()` does not create a standalone tracing subscriber in the same way, so the ordering constraint (init before Builder) is less critical. However, registering early is still recommended.
+
 ### Pattern 4: Multi-plugin project
 
 ```rust
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // IMPORTANT: init() BEFORE Builder::default() to capture all tracing events
+    #[cfg(debug_assertions)]
+    let devtools = tauri_plugin_devtools::init();
+
     let mut builder = tauri::Builder::default();
 
     // DevTools FIRST — captures init tracing from all subsequent plugins
     #[cfg(debug_assertions)]
     {
-        let devtools = tauri_plugin_devtools::init();
         builder = builder.plugin(devtools);
     }
 
@@ -183,21 +215,40 @@ Use feature flags when you need finer control than debug/release (e.g., DevTools
 
 ## Connecting to DevTools
 
+> ⚠️ **Steering:** First compilation after adding DevTools takes significantly longer (new dependency tree). Agents in testing mistook the long compile time for a hang and killed the process. Wait for the WebSocket URL in terminal output.
+
 ### Free web UI
 
-1. Run your app: `cargo tauri dev`
-2. Look for terminal output like:
+1. Run your app from the project root (where `package.json` lives): `cargo tauri dev`
+2. First run after adding DevTools triggers a longer recompilation (new dependencies). Wait for the WebSocket URL to appear.
+3. Look for terminal output like:
    ```
    devtools: listening on ws://127.0.0.1:7043
    ```
-3. Open https://devtools.crabnebula.dev in any browser
-4. Paste the connection URL from the terminal
+4. Open https://devtools.crabnebula.dev in any browser
+5. Paste the connection URL from the terminal
 
 ### Premium desktop app
 
 1. Download the DevTools Desktop app from CrabNebula
 2. The embedded panel auto-connects — no URL pasting needed
 3. Toggle with **Cmd+Shift+M** (macOS) or **Ctrl+Shift+M** (Windows/Linux)
+
+## Verifying DevTools Works
+
+After connecting in the browser:
+
+1. **Console tab** — should show Tauri initialization log entries (target: `tauri::*`).
+2. **Config → Plugins** — should list your registered plugins (e.g., opener, fs, store).
+3. **Calls tab** — invoke any `#[tauri::command]` from the frontend. It should appear with Arguments and Response columns populated. Tauri IPC commands are automatically instrumented — no additional code needed.
+4. If the dashboard is blank or shows no data:
+   - **Pattern 1 (basic):** verify `init()` is called BEFORE `Builder::default()`. This ensures the tracing subscriber is active before any builder events.
+   - **Other patterns:** verify the DevTools plugin is registered before `.run()`. The critical requirement is that the tracing subscriber is active before events you want to capture.
+   - Confirm you are running `cargo tauri dev` (not a release build).
+
+> ⚠️ **Steering:** If the dashboard is blank, the most common cause is init() being called too late. Check the ordering. The second most common cause is running a release build (`cargo tauri build` instead of `cargo tauri dev`).
+
+After verifying DevTools works, return to the main SKILL.md workflow at Phase 2.
 
 ## Platform-Specific Setup
 
@@ -254,6 +305,8 @@ In release builds, the compiler completely removes:
 | `cannot find crate tauri_plugin_devtools` | Wrong crate name or not installed | Run `cargo add tauri-plugin-devtools` (hyphens in crate name, underscores in code) |
 | Binary bloat in release | Missing `#[cfg(debug_assertions)]` gate | Wrap all DevTools code in the gate |
 | Port conflict on startup | Another process using ports 6000-9000 | Stop the other process; DevTools will auto-pick a free port in range |
+
+> ⚠️ **Steering:** The error `PluginInitialization('log', ...)` is the most common installation error. It means both DevTools and tauri-plugin-log try to set the global subscriber. The ONLY fix is Pattern 2 (split pattern). Do NOT try to remove tauri-plugin-log — use split().
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Summary

3 derailment test runs using the `test-skill-quality` methodology identified **63 friction points** (6×P0, 27×P1, 30×P2+) in the `debug-tauri-devtools` skill. All P0 and P1 fixes have been applied.

## Test Runs

| Run | Task | Friction Points | P0 | P1 | P2+ |
|---|---|---|---|---|---|
| 01 | Slow IPC command debugging | 30 | 4 | 18 | 8 |
| 02 | Permission/capability error | 14 | 0 | 1 | 13 |
| 03 | DevTools setup from scratch | 19 | 2 | 8 | 9 |

## Key Fixes

### SKILL.md (226 → 270 lines)
- **First-time setup section** — 5-step detect/install/restart/verify/continue flow
- **Setup trigger** — skill now fires for installation/configuration needs
- **Agent-mode evidence gathering** — terminal output path when no visual UI available
- **Static analysis shortcut** — permission errors can skip DevTools if capability files accessible
- **Sequential processing hypothesis** — covers O(n) scaling patterns
- **Decision Rules callout** — referenced before Phase 4 inspection
- **Phase 6 rebuild/verify** — explicit restart and cleanup guidance
- **Minimal reading sets** — first-time install and permission quick path

### installation-and-config.md (267 → 300 lines)
- **"Which Pattern to Use" decision table** — routes to correct init pattern
- **Existing-code integration** — step-by-step for adding DevTools to existing `run()`
- **Verification section** — confirms DevTools works before returning to workflow

### devtools-common-debugging-scenarios.md
- Fixed invalid permission identifiers (`fs:read` → `fs:allow-read-text-file`)
- Added ACL vs OS permission distinction

## Root Cause Distribution

| Code | Count |
|---|---|
| MISSING-STEP | 18 (29%) |
| MISSING-BRANCH | 14 (22%) |
| MISSING-CONTEXT | 11 (17%) |
| AMBIGUOUS-TERM | 8 (13%) |

## Verification

- ✅ Zero stale `fs:read`/`fs:write` terms
- ✅ Zero vague "stop and route to" verbs
- ✅ All reference files reachable from SKILL.md
- ✅ SKILL.md at 270 lines (under 500 limit)

Full derailment notes in `derailment-notes/debug-tauri-devtools/00-summary.md`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
