### PR TITLE
improve(build-daisyui-mcp): fix 25 friction points from derailment testing

### DIFF
--- a/skills/build-daisyui-mcp/SKILL.md
+++ b/skills/build-daisyui-mcp/SKILL.md
@@ -22,21 +22,22 @@ Use this skill as the operating layer for daisyUI 5 work with the `daisyui-bluep
 
 ## Non-negotiable rules
 
-1. **Nested object syntax only** for `daisyui-blueprint-daisyUI-Snippets`. Arrays fail.
-2. **Fetch before guessing.** If you do not know a valid class or example key, fetch the component reference first.
-3. **Batch requests.** Get all needed snippets in one call; do not fetch one component at a time.
-4. **Use the right category.** `components` is reference data, not copy-paste HTML. `component-examples` is working markup. `themes` returns CSS, not HTML.
-5. **Start page work from `layouts` or `templates`** when possible. Do not assemble full pages from many isolated component guesses.
+1. **Nested object syntax only** for `daisyui-blueprint-daisyUI-Snippets`. Arrays fail silently.
+2. **Fetch before guessing.** If you do not know a valid class or example key, fetch the component reference first. Guessing class names is the #1 source of broken output.
+3. **Batch requests, max ~8 items per call.** Get all needed snippets in one call; do not fetch one component at a time. But keep each call under ~8 items — larger batches produce 15–26 KB responses that can overflow context.
+4. **Use the right category.** `components` is reference data (class names, parts, modifiers), not copy-paste HTML. `component-examples` is working markup. `themes` returns CSS, not HTML.
+5. **Start page work from `templates` (preferred) or `layouts`.** Templates give a complete starting point; layouts give a shell. Do not assemble full pages from many isolated component guesses.
 6. **For Figma, always follow** `FETCH → ANALYZE → GET SNIPPETS → BUILD`. Never skip analysis.
 7. **Use semantic daisyUI colors** (`primary`, `secondary`, `accent`, `neutral`, `base-*`, `info`, `success`, `warning`, `error`) and `*-content` variants on themed surfaces.
-8. **Do not use `dark:` for daisyUI semantic colors.** Themes already adapt them.
+8. **Do not use `dark:` for daisyUI semantic colors.** Themes already adapt them. Only use `dark:` for custom Tailwind utility classes outside daisyUI's theme system.
 9. **Prefer CSS-only daisyUI interaction patterns** unless app-specific behavior truly requires custom JS:
-   - drawer → checkbox toggle
-   - modal → `<dialog>`
-   - dropdown → `<details>`
+   - drawer → checkbox toggle (use `is-drawer-open:` / `is-drawer-close:` variants for visibility)
+   - modal → `<dialog>` with `.modal-open` or JS `.showModal()`
+   - dropdown → `<details>` or popover API
    - tabs/steppers → daisyUI radio/tab patterns
 10. **Stay on daisyUI v5 syntax** (`fieldset`, `dock`, `tabs-lift`, `card-border`, no `input-bordered`, no `form-control`).
 11. **Load only the 1–3 references needed for the active task.** Do not dump the entire skill into context.
+12. **Adapt output to the target framework.** For React/Next.js: `class` → `className`, self-close void elements (`<img />`, `<input />`), `for` → `htmlFor`, `tabindex` → `tabIndex`. For Vue: use `:class` bindings. For Svelte: use `class:` directives.
 
 ```jsonc
 // ✅ Correct
@@ -45,7 +46,7 @@ Use this skill as the operating layer for daisyUI 5 work with the `daisyui-bluep
   "component-examples": { "card.card": true }
 }
 
-// ❌ Wrong
+// ❌ Wrong — arrays fail silently with no error
 { "components": ["button", "card"] }
 { "snippets": ["components/button"] }
 ```
@@ -77,40 +78,51 @@ Use this skill as the operating layer for daisyUI 5 work with the `daisyui-bluep
 
 ## Route to the correct workflow
 
+> **Priority rule — first match wins.** Walk the table top to bottom; stop at the first row that matches the request. If the request spans multiple rows (e.g., "Figma design with forms"), handle the primary workflow first, then load secondary references.
+
 | Request shape | Do this first | Then load |
 |---|---|---|
 | Setup or install daisyUI / Tailwind v4 | Read setup docs | `references/integration/tailwind-v4-setup.md` |
 | MCP server missing or Figma auth/setup issue | Fix tool setup before composing UI | `references/tool-api-reference.md` |
 | Migrating from daisyUI v4 | Read migration docs before writing code | `references/integration/v4-to-v5-migration.md` |
-| Single component or section | Fetch `components` first, then targeted `component-examples` | `references/component-catalog.md`, `references/common-mistakes.md` |
-| Full page, dashboard, auth screen, landing page | Start from `layouts` or `templates` | `references/workflows/component-composition.md`, `references/workflows/responsive-layouts.md` |
+| Single component or section | Fetch `components` first, then targeted `component-examples` | `references/common-mistakes.md` |
+| Full page, dashboard, auth screen, landing page | Start from `templates` (preferred) or `layouts` | `references/workflows/component-composition.md`, `references/workflows/responsive-layouts.md` |
 | Figma URL present | Run the Figma workflow below | `references/workflows/figma-to-code.md`, `references/tool-api-reference.md` |
 | Screenshot or image mockup | Run the screenshot workflow below | `references/workflows/screenshot-to-code.md`, `references/common-mistakes.md`, `references/prompts/screenshot-prompt.md` |
 | Brand colors, image-to-theme, dark mode, theme request | Run the theme workflow below | `references/workflows/theme-generation.md`, `references/theming/custom-themes.md`, `references/theme-and-colors.md`, `references/prompts/image-to-theme-prompt.md` |
 | Form-heavy UI | Load form patterns before composing | `references/patterns/form-patterns.md` |
 | Navbar, menu, drawer, tabs, dock, breadcrumbs | Load navigation patterns before composing | `references/patterns/navigation-patterns.md` |
 | Bootstrap or raw Tailwind conversion | Use the relevant conversion workflow | `references/workflows/bootstrap-conversion.md`, `references/workflows/tailwind-optimization.md`, `references/prompts/bootstrap-prompt.md`, `references/prompts/tailwind-prompt.md` |
+| Prompt crafting or multi-step chaining | Load prompt guides | `references/prompts/prompt-engineering.md`, `references/prompts/prompt-chaining.md` |
 
 ## Workflow — component or page composition
 
-1. **Decide scope first.**
-   - Single component/section → fetch component reference, then examples.
-   - Full page/app shell → fetch a layout or template first.
-2. **Fetch reference data before markup** for any component whose valid classes you do not know.
-3. **Fetch only targeted examples** for complex pieces like responsive navbars, drawers, tables, pricing cards, or form patterns.
-4. **Compose from the outside in**:
-   - page shell
-   - navigation
-   - main content blocks
-   - detail components
-5. **Apply semantic colors and responsive utilities** after structure is correct.
+1. **Decide scope and starting point.**
+   - Single component/section → fetch `components` reference, then targeted `component-examples`.
+   - Full page/app shell → fetch a `template` (preferred) or `layout` first. Never build a full page from scratch when a template exists.
+2. **Fetch reference data before writing any markup.**
+   - For each component you plan to use, verify its valid classes via `components` category.
+   - Batch related components in one MCP call (~8 items max).
+   - If you need exact example keys, fetch `components` first to discover names, then fetch `component-examples`.
+3. **Fetch only targeted examples** for complex pieces: responsive navbars, drawers with icon-only collapsed state, data tables, pricing cards, multi-step forms.
+4. **Compose from the outside in** — this is the assembly order, not optional:
+   1. Page shell (template or layout)
+   2. Navigation (navbar, sidebar/drawer, breadcrumbs)
+   3. Main content blocks (hero, stat grids, card grids, tables)
+   4. Detail components (badges, tooltips, modals, toasts)
+5. **Apply semantic colors and responsive utilities** after structure is correct. Use `sm:`, `md:`, `lg:` breakpoint prefixes for responsive behavior.
 6. **If the page is branded**, do theme work before final polish so semantic colors resolve correctly.
+
+> **Steering — page composition pitfalls from real usage:**
+> - Dashboard stat grids: use CSS grid (`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4`) not flexbox for even columns.
+> - Drawer checkbox toggle: the `<input type="checkbox">` must be a sibling of `.drawer-side`, not nested inside content. Use `is-drawer-open:` and `is-drawer-close:` variants for show/hide behavior.
+> - If a UI element has no daisyUI equivalent (charts, maps, code editors, media players), wrap it in a `card` or `card-body` container with semantic colors applied to the wrapper only. Do not force non-UI elements into daisyUI components.
 
 Load only what you need:
 
-- `references/workflows/component-composition.md`
-- `references/workflows/responsive-layouts.md`
-- `references/component-catalog.md`
+- `references/workflows/component-composition.md` — dashboard, landing page, and e-commerce patterns
+- `references/workflows/responsive-layouts.md` — breakpoint strategies, grid patterns
+- `references/common-mistakes.md` — "do this, not that" quick reference
 
 ## Workflow — Figma to daisyUI
 
@@ -118,8 +130,8 @@ This sequence is mandatory.
 
 1. **FETCH**
    - Call `daisyui-blueprint-Figma-to-daisyUI`
-   - Prefer a node-specific Figma URL
-   - Start with `depth: 3-5`
+   - Prefer a node-specific Figma URL (`?node-id=X-Y`)
+   - Start with `depth: 3-5`; increase only if the tree is too shallow
    - Use `includeImages: false` unless image references are required
 2. **ANALYZE**
    - layout direction and alignment
@@ -128,7 +140,7 @@ This sequence is mandatory.
    - typography scale
    - corner radius, shadows, and color roles
 3. **GET SNIPPETS**
-   - Batch all identified components in one call
+   - Batch all identified components in one call (~8 items max)
    - If example names are unknown, fetch `components` first, then the exact `component-examples`
 4. **BUILD**
    - Map Figma structure to daisyUI components + Tailwind layout classes
@@ -137,33 +149,35 @@ This sequence is mandatory.
 5. **RECOVER IF NEEDED**
    - If the node tree is too shallow, re-fetch with higher depth
    - If the file is large/noisy, switch to a more specific node URL
+   - If a Figma element has no daisyUI equivalent, use raw Tailwind wrapped in a semantic container (see recovery rules)
 
 Load only what you need:
 
-- `references/workflows/figma-to-code.md`
-- `references/tool-api-reference.md`
-- `references/component-catalog.md` when class lookup is needed
+- `references/workflows/figma-to-code.md` — step-by-step Figma extraction guide
+- `references/tool-api-reference.md` — MCP tool parameters and auth setup
+- `references/component-catalog.md` — full class/modifier reference when lookup is needed
 
 ## Workflow — screenshot or mockup to daisyUI
 
 1. **Scan top-to-bottom**: navbar/header, hero, sidebar, main content, footer/dock.
-2. **Identify the page shell first** before individual components.
+2. **Identify the page shell first** before individual components. Check if a `template` or `layout` matches the overall structure.
 3. **Catalog visible patterns**:
    - component type
    - likely variant
    - size
    - semantic color role
    - visible state
-4. **Fetch components and only the best-matching examples.**
+4. **Fetch components and only the best-matching examples** (~8 items max per call).
 5. **Assemble the shell first**, then fill details and tune spacing/color.
-6. **If an interaction is not visible**, choose the most likely CSS-only daisyUI pattern and state the assumption.
+6. **For non-daisyUI elements** (charts, graphs, maps, video players): note them as `<!-- TODO: integrate [chart library] here -->` inside a `card` wrapper with appropriate sizing. Do not attempt to recreate them with daisyUI components.
+7. **If an interaction is not visible**, choose the most likely CSS-only daisyUI pattern and state the assumption.
 
 Load only what you need:
 
-- `references/workflows/screenshot-to-code.md`
-- `references/prompts/screenshot-prompt.md`
-- `references/component-catalog.md`
-- `references/common-mistakes.md`
+- `references/workflows/screenshot-to-code.md` — full screenshot conversion workflow
+- `references/prompts/screenshot-prompt.md` — agent prompt for screenshot analysis
+- `references/component-catalog.md` — class validation when uncertain
+- `references/common-mistakes.md` — avoid frequent errors
 
 ## Workflow — theme generation
 
@@ -180,49 +194,60 @@ Load only what you need:
 
 Load only what you need:
 
-- `references/workflows/theme-generation.md`
-- `references/theming/custom-themes.md`
-- `references/theme-and-colors.md`
-- `references/prompts/image-to-theme-prompt.md`
-- `references/tool-api-reference.md` for `themes` usage
+- `references/workflows/theme-generation.md` — end-to-end theme workflow
+- `references/theming/custom-themes.md` — variable reference and design presets
+- `references/theme-and-colors.md` — color system architecture
+- `references/prompts/image-to-theme-prompt.md` — image-to-OKLCH extraction prompt
+- `references/tool-api-reference.md` for `themes` category usage
 
 ## Recovery rules — if the agent starts drifting
 
-- **Snippets tool returns nothing** → check nested object syntax first.
-- **You do not know an example key** → fetch the component reference before guessing.
-- **Generated classes look plausible but unverified** → check `references/component-catalog.md` or the component response.
-- **You are making too many MCP calls** → batch them and mix categories.
-- **A full page is forming from unrelated snippets** → restart from a `layout` or `template`.
+- **Snippets tool returns nothing or empty** → check nested object syntax first; arrays fail silently.
+- **You do not know an example key** → fetch the `components` category for that component; example keys are listed in the response.
+- **Generated classes look plausible but unverified** → validate via `components` category or `references/component-catalog.md`.
+- **You are making too many MCP calls** → batch them (~8 items max) and mix categories in one call.
+- **A full page is forming from unrelated snippets** → stop and restart from a `template` or `layout`.
 - **The MCP server or Figma tool errors on setup/auth** → check `references/tool-api-reference.md`, especially MCP config and `FIGMA` requirements.
-- **Markup uses `bg-blue-500`, `text-white`, or `dark:` on themed UI** → replace with semantic color classes or a theme.
+- **Markup uses `bg-blue-500`, `text-white`, or `dark:` on themed UI** → replace with semantic color classes (`bg-primary`, `text-primary-content`) or a custom theme.
 - **You added JS for a standard drawer/modal/dropdown** → switch back to the CSS-only daisyUI mechanism.
-- **You see v4 terms** like `form-control`, `input-bordered`, `label-text`, `tabs-lifted`, or `btm-nav` → convert to v5 and load migration docs if needed.
+- **You see v4 terms** like `form-control`, `input-bordered`, `label-text`, `tabs-lifted`, or `btm-nav` → convert to v5 equivalents and load `references/integration/v4-to-v5-migration.md`.
 - **You start copying bulky examples into this skill** → stop and route to the relevant reference instead.
+- **A UI element has no daisyUI equivalent** (chart, map, code editor, media player) → wrap it in a semantic container (`card`, `card-body`) with a TODO comment. Do not invent daisyUI classes.
+- **Output is for React/Next.js but uses HTML attributes** → apply rule 12 (framework adaptation).
+- **MCP response is huge (>10 KB)** → you fetched too many items. Reduce batch size and be more targeted.
 
 ## Minimal reference packs
 
 | Task | Load |
 |---|---|
-| Single component/section | `references/component-catalog.md`, `references/common-mistakes.md` |
+| Single component/section | `references/common-mistakes.md` |
 | Full page/layout | `references/workflows/component-composition.md`, `references/workflows/responsive-layouts.md` |
 | Figma conversion | `references/workflows/figma-to-code.md`, `references/tool-api-reference.md` |
 | Screenshot conversion | `references/workflows/screenshot-to-code.md`, `references/common-mistakes.md` |
 | Theme generation | `references/workflows/theme-generation.md`, `references/theming/custom-themes.md` |
-| Forms | `references/patterns/form-patterns.md`, `references/component-catalog.md` |
-| Navigation | `references/patterns/navigation-patterns.md`, `references/component-catalog.md` |
+| Forms | `references/patterns/form-patterns.md` |
+| Navigation | `references/patterns/navigation-patterns.md` |
 | Setup or migration | `references/integration/tailwind-v4-setup.md`, `references/integration/v4-to-v5-migration.md` |
 | Bootstrap/Tailwind conversion | `references/workflows/bootstrap-conversion.md`, `references/workflows/tailwind-optimization.md`, `references/prompts/bootstrap-prompt.md`, `references/prompts/tailwind-prompt.md` |
 | Prompt crafting / chaining | `references/prompts/prompt-engineering.md`, `references/prompts/prompt-chaining.md` |
+| Class/modifier validation | `references/component-catalog.md` |
+| Color system deep dive | `references/theme-and-colors.md`, `references/theming/custom-themes.md` |
+| Image to theme | `references/prompts/image-to-theme-prompt.md`, `references/theme-and-colors.md` |
+| Screenshot analysis prompts | `references/prompts/screenshot-prompt.md` |
 
 ## Exit checklist
 
-Before finishing, confirm:
+Before finishing, verify each item passes:
 
-- correct snippets syntax
-- correct category choice
-- batched MCP calls
-- valid daisyUI v5 classes
-- semantic colors or a proper theme
-- layout/template used for page-level work when appropriate
-- mandatory Figma sequence followed for Figma tasks
-- only necessary references were loaded
+| Check | Pass criteria |
+|---|---|
+| Snippet syntax | Every `daisyui-blueprint-daisyUI-Snippets` call uses `{ "category": { "name": true } }` — no arrays, no string values |
+| Category choice | `components` used for class lookup; `component-examples` for markup; `templates`/`layouts` for page shells; not mixed up |
+| Batch efficiency | All needed snippets fetched in ≤3 MCP calls total (not one call per component) |
+| daisyUI v5 classes | Zero occurrences of `form-control`, `input-bordered`, `label-text`, `tabs-lifted`, `btm-nav`, or other v4-only classes |
+| Semantic colors | All themed surfaces use `bg-base-*`, `text-base-content`, `bg-primary`, etc. — no raw Tailwind colors (`bg-blue-500`) on daisyUI components |
+| `dark:` usage | Zero `dark:` prefixes on daisyUI semantic colors; `dark:` only used for custom non-theme utilities |
+| Layout starting point | Page-level work started from a `template` or `layout`, not assembled from individual components |
+| Figma sequence | If Figma was involved: FETCH → ANALYZE → GET SNIPPETS → BUILD sequence was followed in order |
+| Framework adaptation | If target is React/Next.js/Vue/Svelte: `class`→`className`, `for`→`htmlFor`, self-closing tags, etc. |
+| Reference efficiency | Only 1–3 reference files were loaded for this task, not the full set |

--- a/skills/build-daisyui-mcp/references/common-mistakes.md
+++ b/skills/build-daisyui-mcp/references/common-mistakes.md
@@ -507,3 +507,148 @@ Using deprecated v4 patterns instead of current v5 syntax.
 `is-drawer-open:`, `is-drawer-close:`, `user-invalid:`
 
 **How to prevent:** If you're unsure about a class name, fetch the component reference. v4 class names won't appear in the v5 reference.
+
+
+## Steering experiences — learned from real agent usage
+
+### MCP batch overflow
+
+**Problem:** Fetching 10+ component-examples in one call returns 15–26 KB of HTML, flooding context and causing the agent to lose track of the composition task.
+
+**Fix:** Cap each `daisyui-blueprint-daisyUI-Snippets` call at ~8 items. If you need more, split across two calls. Prioritize the most complex components first (drawers, navbars, tables) and fetch simple ones (badges, dividers) only if class names are uncertain.
+
+```jsonc
+// ❌ Too many — will overflow context
+{
+  "component-examples": {
+    "navbar.responsive-...": true,
+    "drawer.responsive-...": true,
+    "card.card": true,
+    "table.table-with-visual-elements": true,
+    "stat.stat": true,
+    "badge.badge": true,
+    "avatar.avatar": true,
+    "footer.footer-with-copyright-text": true,
+    "menu.menu-with-icons": true,
+    "breadcrumbs.breadcrumbs": true
+  }
+}
+
+// ✅ Split into two focused calls
+// Call 1: complex layout components
+{
+  "component-examples": {
+    "navbar.responsive-...": true,
+    "drawer.responsive-...": true,
+    "table.table-with-visual-elements": true,
+    "card.card": true
+  }
+}
+// Call 2: simpler components (only if needed)
+{
+  "component-examples": {
+    "stat.stat": true,
+    "footer.footer-with-copyright-text": true
+  }
+}
+```
+
+### Framework conversion omission
+
+**Problem:** Agent produces raw HTML (`class`, `for`, `tabindex`) when the target is React/Next.js, causing JSX compilation errors.
+
+**Fix:** Before writing any markup, check the target framework and apply these conversions:
+
+| HTML attribute | React/Next.js | Vue | Svelte |
+|---|---|---|---|
+| `class` | `className` | `:class` (dynamic) | `class` (same) |
+| `for` | `htmlFor` | `for` (same) | `for` (same) |
+| `tabindex` | `tabIndex` | `tabindex` (same) | `tabindex` (same) |
+| `<img>` | `<img />` (self-close) | `<img />` | `<img />` |
+| `<input>` | `<input />` (self-close) | `<input />` | `<input />` |
+| `onclick` | `onClick` | `@click` | `on:click` |
+| `style="color: red"` | `style={{ color: 'red' }}` | `:style` | `style="color: red"` |
+
+### Non-daisyUI elements treated as daisyUI
+
+**Problem:** Agent tries to build charts, maps, or code editors using daisyUI components, resulting in broken or meaningless markup.
+
+**Fix:** Identify elements that have no daisyUI equivalent:
+
+- Charts and graphs → use Chart.js, Recharts, or similar
+- Maps → use Leaflet, Mapbox, or Google Maps
+- Code editors → use Monaco, CodeMirror
+- Video/audio players → use native HTML5 or a player library
+- Rich text editors → use Tiptap, Quill, or similar
+
+Wrap these in a daisyUI container for consistent styling:
+
+```html
+<!-- ✅ Correct: chart in a card wrapper -->
+<div class="card bg-base-100 card-border">
+  <div class="card-body">
+    <h2 class="card-title">Revenue</h2>
+    <!-- TODO: integrate Recharts/Chart.js here -->
+    <div class="h-64 w-full bg-base-200 rounded-lg flex items-center justify-center text-base-content/50">
+      Chart placeholder
+    </div>
+  </div>
+</div>
+
+<!-- ❌ Wrong: trying to fake a chart with daisyUI -->
+<div class="stats shadow">
+  <div class="stat"><!-- this is not a chart --></div>
+</div>
+```
+
+### Drawer toggle structure
+
+**Problem:** Agent nests the drawer checkbox inside the content area, breaking the toggle mechanism. The checkbox must be a sibling of `.drawer-side`, not a descendant of `.drawer-content`.
+
+```html
+<!-- ✅ Correct structure -->
+<div class="drawer lg:drawer-open">
+  <input id="my-drawer" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content">
+    <!-- page content here -->
+    <label for="my-drawer" class="btn btn-ghost drawer-button lg:hidden">☰</label>
+  </div>
+  <div class="drawer-side">
+    <label for="my-drawer" class="drawer-overlay"></label>
+    <ul class="menu bg-base-200 min-h-full w-80 p-4">
+      <li><a>Menu item</a></li>
+    </ul>
+  </div>
+</div>
+
+<!-- ❌ Wrong: checkbox nested inside drawer-content -->
+<div class="drawer">
+  <div class="drawer-content">
+    <input id="my-drawer" type="checkbox" class="drawer-toggle" />
+    <!-- broken: toggle won't work -->
+  </div>
+</div>
+```
+
+### Routing confusion — multiple workflow matches
+
+**Problem:** A request like "build a dashboard from this Figma file with forms" matches three routing rows (Figma, full page, forms). The agent stalls deciding which workflow to follow.
+
+**Fix:** The routing table uses "first match wins" priority. Walk top-to-bottom and stop at the first match:
+1. Figma URL present → Figma workflow is primary
+2. After Figma extraction, load secondary references: `component-composition.md` for page assembly, `form-patterns.md` for form sections
+
+### The `dark:` trap
+
+**Problem:** Agent uses `dark:bg-base-300` or `dark:text-primary` on themed surfaces. daisyUI themes already handle dark mode by swapping the entire color palette, so `dark:` on semantic colors creates conflicts.
+
+```css
+/* ❌ Wrong — conflicts with theme switching */
+<div class="bg-base-100 dark:bg-base-300 text-base-content dark:text-gray-100">
+
+/* ✅ Correct — semantic colors auto-adapt */
+<div class="bg-base-100 text-base-content">
+
+/* ✅ OK — dark: on non-theme custom utilities */
+<div class="shadow-md dark:shadow-lg border dark:border-gray-700">
+```

--- a/skills/build-daisyui-mcp/references/common-mistakes.md
+++ b/skills/build-daisyui-mcp/references/common-mistakes.md
@@ -476,8 +476,8 @@ Using deprecated v4 patterns instead of current v5 syntax.
 <!-- v5 inputs have borders by default -->
 <input class="input" />
 
-<!-- v5 tab-lift (not tab-lifted) -->
-<div class="tabs tab-lift">...</div>
+<!-- v5 tabs-lift (not tab-lifted or tab-lift) -->
+<div class="tabs tabs-lift">...</div>
 
 <!-- v5 card-border (not bordered) -->
 <div class="card card-border">...</div>
@@ -493,7 +493,7 @@ Using deprecated v4 patterns instead of current v5 syntax.
 | `input-bordered` | `input` | Borders are default in v5 |
 | `select-bordered` | `select` | Borders are default in v5 |
 | `textarea-bordered` | `textarea` | Borders are default in v5 |
-| `tab-lifted` | `tab-lift` | Renamed |
+| `tab-lifted` | `tabs-lift` | Renamed |
 | `bordered` (on card) | `card-border` | Renamed |
 | HSL theme colors | oklch theme colors | Format change |
 | `tailwind.config.js` themes | `@plugin "daisyui"` in CSS | Configuration moved to CSS |

--- a/skills/build-daisyui-mcp/references/component-catalog.md
+++ b/skills/build-daisyui-mcp/references/component-catalog.md
@@ -1139,3 +1139,32 @@ Every daisyUI class belongs to exactly one type:
 | Skip `card-body` in a card | Always include `card-body` |
 | `loading` without a style class | Always add `loading-spinner`, `loading-dots`, etc. |
 | `loading-primary` | Use `text-primary` for loading color |
+
+
+## Steering experiences — learned from real agent usage
+
+### When to use this file vs. MCP tool
+
+**Problem:** Agent reads the full component-catalog.md (1100+ lines) into context when a quick MCP call to `components` would suffice.
+
+**Fix:** Use this decision guide:
+
+| Situation | Use | Why |
+|---|---|---|
+| Need to validate 1–3 class names | MCP `components` tool | Faster, lighter, always current |
+| Need to browse all available components | This file (component-catalog.md) | Full inventory in one read |
+| Need to find the right example key | MCP `components` tool | Example keys are listed in the response |
+| Need to compare modifier options | MCP `components` tool | Structured response with all options |
+| Offline or MCP server unavailable | This file (component-catalog.md) | Static reference that's always available |
+| Need cross-component pattern guidance | This file + relevant pattern reference | Patterns span multiple components |
+
+### Component-to-category mapping
+
+Quick lookup for which MCP category to use:
+
+| Component | `components` (reference) | `component-examples` (markup) |
+|---|---|---|
+| Simple (badge, divider, loading) | Usually sufficient | Only if specific variant needed |
+| Medium (card, alert, stat) | For class validation | For complex variants |
+| Complex (drawer, navbar, table) | For class validation | Almost always needed |
+| Layout (hero, footer) | For modifier check | For responsive patterns |

--- a/skills/build-daisyui-mcp/references/patterns/form-patterns.md
+++ b/skills/build-daisyui-mcp/references/patterns/form-patterns.md
@@ -403,3 +403,102 @@ Use `join` to combine inputs with buttons or other elements:
 | Missing `w-full` on inputs | v5 inputs have a default width of 20rem — add `w-full` for full-width |
 | Wrapping radio/checkbox in `form-control` | Use `<fieldset>` or flex layout directly |
 | Using JavaScript for validation display | `validator` + `validator-hint` is CSS-only |
+
+
+## Steering experiences — learned from real agent usage
+
+### JSX conversion table
+
+When producing forms for React/Next.js, apply these conversions:
+
+| HTML | JSX (React/Next.js) | Notes |
+|---|---|---|
+| `class="input"` | `className="input"` | All class attributes |
+| `for="email"` | `htmlFor="email"` | Label associations |
+| `tabindex="0"` | `tabIndex={0}` | Camelcase + numeric value |
+| `<input type="text">` | `<input type="text" />` | Self-closing |
+| `<textarea></textarea>` | `<textarea />` or `<textarea></textarea>` | Both valid in JSX |
+| `onchange="..."` | `onChange={handler}` | Event handlers camelCase |
+| `readonly` | `readOnly` | Boolean attributes camelCase |
+| `maxlength="100"` | `maxLength={100}` | Numeric attributes |
+| `autocomplete="off"` | `autoComplete="off"` | Camelcase |
+
+### v5 fieldset migration for forms
+
+daisyUI v5 replaces `form-control` with `fieldset`:
+
+```html
+<!-- ❌ v4 form pattern (deprecated) -->
+<div class="form-control">
+  <label class="label">
+    <span class="label-text">Email</span>
+  </label>
+  <input type="email" class="input input-bordered" />
+  <label class="label">
+    <span class="label-text-alt">Required</span>
+  </label>
+</div>
+
+<!-- ✅ v5 form pattern -->
+<fieldset class="fieldset">
+  <legend class="fieldset-legend">Email</legend>
+  <input type="email" class="input" placeholder="you@example.com" />
+  <p class="fieldset-label">Required</p>
+</fieldset>
+```
+
+Key differences:
+- `form-control` → `fieldset` (HTML `<fieldset>` element)
+- `label > .label-text` → `<legend class="fieldset-legend">`
+- `label > .label-text-alt` → `<p class="fieldset-label">`
+- `input-bordered` → removed (default border style in v5)
+- `input-group` → use `join` component instead
+
+### Validator patterns in v5
+
+daisyUI v5 has built-in validator support:
+
+```html
+<fieldset class="fieldset">
+  <legend class="fieldset-legend">Password</legend>
+  <input
+    type="password"
+    class="input validator"
+    required
+    minlength="8"
+    pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).+"
+    title="Must include uppercase, lowercase, and number"
+  />
+  <p class="validator-hint">
+    Must be at least 8 characters with uppercase, lowercase, and number
+  </p>
+</fieldset>
+```
+
+The `validator` class activates browser-native validation styling. The `validator-hint` shows on invalid state.
+
+### Multi-step forms
+
+For multi-step form wizards, use daisyUI `steps` + tab-like content switching:
+
+```html
+<!-- Progress indicator -->
+<ul class="steps w-full mb-8">
+  <li class="step step-primary">Account</li>
+  <li class="step step-primary">Profile</li>
+  <li class="step">Review</li>
+</ul>
+
+<!-- Form sections (show/hide with JS state) -->
+<div class="card bg-base-100 card-border">
+  <div class="card-body">
+    <!-- Step 1: Account fields -->
+    <!-- Step 2: Profile fields -->
+    <!-- Step 3: Review -->
+  </div>
+  <div class="card-actions justify-between p-6">
+    <button class="btn btn-ghost">Back</button>
+    <button class="btn btn-primary">Continue</button>
+  </div>
+</div>
+```

--- a/skills/build-daisyui-mcp/references/patterns/navigation-patterns.md
+++ b/skills/build-daisyui-mcp/references/patterns/navigation-patterns.md
@@ -463,7 +463,7 @@ CSS-only dropdown using `<details>`:
   <div class="drawer-side">
     <label for="nav-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
     <ul class="menu bg-base-200 min-h-full w-80 p-4">
-      <li><a class="active">Dashboard</a></li>
+      <li><a class="menu-active">Dashboard</a></li>
       <li><a>Analytics</a></li>
     </ul>
   </div>
@@ -501,7 +501,7 @@ CSS-only dropdown using `<details>`:
 ```html
 <!-- ✅ Use daisyUI's active class -->
 <ul class="menu">
-  <li><a class="active">Dashboard</a></li>
+  <li><a class="menu-active">Dashboard</a></li>
   <li><a>Settings</a></li>
 </ul>
 
@@ -541,7 +541,7 @@ CSS-only dropdown using `<details>`:
     <label for="app-drawer" class="drawer-overlay"></label>
     <aside class="bg-base-200 min-h-full w-80">
       <ul class="menu p-4">
-        <li><a class="active">Dashboard</a></li>
+        <li><a class="menu-active">Dashboard</a></li>
         <li><a>Reports</a></li>
       </ul>
     </aside>

--- a/skills/build-daisyui-mcp/references/patterns/navigation-patterns.md
+++ b/skills/build-daisyui-mcp/references/patterns/navigation-patterns.md
@@ -440,3 +440,111 @@ CSS-only dropdown using `<details>`:
 | Using `disabled` class on menu | Use `menu-disabled` in v5 |
 | Adding `z-index` to dropdown content | Use Tailwind `z-10` or higher on `dropdown-content` |
 | Adding JS for tab switching | Use radio inputs with `tab` class — pure CSS |
+
+
+## Steering experiences — learned from real agent usage
+
+### Drawer toggle sibling rule
+
+**Problem:** Agent places the drawer toggle checkbox (`<input class="drawer-toggle">`) inside `.drawer-content` or `.drawer-side`. It must be a direct child of the `.drawer` container, sibling to both `.drawer-content` and `.drawer-side`.
+
+```html
+<!-- ✅ Correct: checkbox is sibling to drawer-content and drawer-side -->
+<div class="drawer lg:drawer-open">
+  <input id="nav-drawer" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content">
+    <label for="nav-drawer" class="btn btn-ghost drawer-button lg:hidden">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </label>
+    <!-- page content -->
+  </div>
+  <div class="drawer-side">
+    <label for="nav-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+    <ul class="menu bg-base-200 min-h-full w-80 p-4">
+      <li><a class="active">Dashboard</a></li>
+      <li><a>Analytics</a></li>
+    </ul>
+  </div>
+</div>
+```
+
+### Icon-only collapsed sidebar
+
+**Problem:** Agent tries to build an icon-only collapsed sidebar using `hidden`/`block` on text labels. daisyUI v5 has built-in drawer variants for this.
+
+**Fix:** Use `is-drawer-open:` and `is-drawer-close:` variants:
+
+```html
+<div class="drawer lg:drawer-open">
+  <input id="sidebar" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content"><!-- main content --></div>
+  <div class="drawer-side">
+    <label for="sidebar" class="drawer-overlay"></label>
+    <ul class="menu bg-base-200 min-h-full w-20 is-drawer-open:w-64 p-4 transition-all">
+      <li>
+        <a>
+          <svg><!-- icon --></svg>
+          <span class="is-drawer-close:hidden">Dashboard</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+```
+
+### Active state on menu items
+
+**Problem:** Agent uses custom CSS or Tailwind utilities for active menu states instead of daisyUI's built-in `active` class.
+
+```html
+<!-- ✅ Use daisyUI's active class -->
+<ul class="menu">
+  <li><a class="active">Dashboard</a></li>
+  <li><a>Settings</a></li>
+</ul>
+
+<!-- ❌ Don't use custom active styling -->
+<ul class="menu">
+  <li><a class="bg-primary text-white rounded-lg">Dashboard</a></li>
+</ul>
+```
+
+### Responsive navbar with drawer
+
+**Problem:** Agent builds a navbar and sidebar as separate, uncoordinated components. They should share the same drawer toggle.
+
+**Fix:** The navbar hamburger button and the drawer share the same checkbox `id`/`for`:
+
+```html
+<div class="drawer lg:drawer-open">
+  <input id="app-drawer" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content flex flex-col">
+    <!-- Navbar at top of content area -->
+    <div class="navbar bg-base-100 shadow-sm">
+      <div class="flex-none lg:hidden">
+        <label for="app-drawer" class="btn btn-square btn-ghost">
+          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+          </svg>
+        </label>
+      </div>
+      <div class="flex-1"><h1 class="text-xl font-bold px-2">App Name</h1></div>
+    </div>
+    <!-- Page content below navbar -->
+    <main class="flex-1 p-6">
+      <!-- content here -->
+    </main>
+  </div>
+  <div class="drawer-side">
+    <label for="app-drawer" class="drawer-overlay"></label>
+    <aside class="bg-base-200 min-h-full w-80">
+      <ul class="menu p-4">
+        <li><a class="active">Dashboard</a></li>
+        <li><a>Reports</a></li>
+      </ul>
+    </aside>
+  </div>
+</div>
+```

--- a/skills/build-daisyui-mcp/references/prompts/screenshot-prompt.md
+++ b/skills/build-daisyui-mcp/references/prompts/screenshot-prompt.md
@@ -331,3 +331,48 @@ If the screenshot shows hover states, modals open, or dropdowns expanded:
 | Toggle switch | `toggle` |
 | Bottom mobile nav | `dock` |
 | Browser/phone frame | `mockup-browser` / `mockup-phone` |
+
+
+## Steering experiences — learned from real agent usage
+
+### Non-UI elements in screenshots
+
+**Problem:** Agent encounters charts, code blocks, or media players in a screenshot and tries to identify them as daisyUI components.
+
+**Fix:** During the top-to-bottom scan, explicitly categorize each visible element:
+
+1. **daisyUI component** — has a direct mapping (navbar, card, table, button, etc.)
+2. **Tailwind utility element** — simple styled div/span with no component equivalent
+3. **External element** — requires a third-party library (chart, map, code editor, video player)
+
+For category 3, output: `[EXTERNAL: chart/graph - use Recharts/Chart.js]` in your component catalog, and wrap the area in a `card` placeholder in the final output.
+
+### Component ambiguity resolution
+
+**Problem:** Agent can't decide if a UI element is a `card` or a `stat`, or a `badge` vs a `status indicator`.
+
+**Fix:** Use these disambiguation rules:
+
+| If you see... | It's probably... | Not... |
+|---|---|---|
+| Large number + label + optional change indicator | `stat` | `card` |
+| Image + title + description + action button | `card` | `stat` |
+| Small colored dot next to text | `status` | `badge` |
+| Small colored label/tag | `badge` | `status` |
+| Horizontal row of numbers/labels | `stats` (horizontal) | multiple `card`s |
+| Grid of equal-sized info blocks | `stat` in a CSS grid | `card` grid |
+
+### Template matching priority
+
+**Problem:** Agent builds a login page from scratch using individual input, button, and card components when a `login-form` template exists.
+
+**Fix:** Before composing any full page, check if a template matches:
+
+| Page type | Check template | Check layout |
+|---|---|---|
+| Login / signup / auth | `login-form` | — |
+| Dashboard | `dashboard` | `responsive-collapsible-drawer-sidebar` |
+| Landing page | — | `top-navbar` |
+| Settings page | — | `responsive-offcanvas-drawer-sidebar` |
+
+If a template matches, use it as the starting point — don't build from scratch.

--- a/skills/build-daisyui-mcp/references/theme-and-colors.md
+++ b/skills/build-daisyui-mcp/references/theme-and-colors.md
@@ -715,3 +715,83 @@ Before finalizing any custom theme, verify:
 // Just the color system reference
 { "themes": { "colors": true } }
 ```
+
+
+## Steering experiences — learned from real agent usage
+
+### The `dark:` trap with semantic colors
+
+**Problem:** Agent adds `dark:bg-base-300` or `dark:text-primary-content` to elements. daisyUI themes already define what `base-300` and `primary-content` resolve to in dark mode — using `dark:` creates conflicts and makes theme switching unreliable.
+
+**Rule:** NEVER use `dark:` prefix with daisyUI semantic color classes.
+
+```html
+<!-- ❌ WRONG — dark: on semantic colors -->
+<div class="bg-base-100 dark:bg-base-300">
+<span class="text-primary dark:text-primary-content">
+<button class="btn btn-primary dark:btn-secondary">
+
+<!-- ✅ CORRECT — semantic colors auto-adapt via theme -->
+<div class="bg-base-100">
+<span class="text-primary">
+<button class="btn btn-primary">
+
+<!-- ✅ OK — dark: on NON-semantic utilities (shadows, borders, custom stuff) -->
+<div class="shadow-md dark:shadow-lg">
+<div class="border border-gray-200 dark:border-gray-700">
+<div class="ring-1 ring-black/5 dark:ring-white/10">
+```
+
+### Content color pairing
+
+**Problem:** Agent sets `bg-primary` on a surface but leaves text as `text-base-content`, making text invisible or low-contrast.
+
+**Fix:** Every semantic background has a matching content color:
+
+| Background | Text color | Example |
+|---|---|---|
+| `bg-primary` | `text-primary-content` | Primary buttons, highlighted cards |
+| `bg-secondary` | `text-secondary-content` | Secondary surfaces |
+| `bg-accent` | `text-accent-content` | Accent highlights |
+| `bg-neutral` | `text-neutral-content` | Dark surfaces |
+| `bg-base-100` | `text-base-content` | Default page background |
+| `bg-base-200` | `text-base-content` | Slightly darker sections |
+| `bg-base-300` | `text-base-content` | Sidebar, card backgrounds |
+| `bg-info` | `text-info-content` | Info alerts |
+| `bg-success` | `text-success-content` | Success messages |
+| `bg-warning` | `text-warning-content` | Warning alerts |
+| `bg-error` | `text-error-content` | Error states |
+
+### Theme-first workflow
+
+**Problem:** Agent builds the entire UI with hardcoded Tailwind colors (`bg-blue-500`, `text-gray-800`), then tries to convert to daisyUI semantic colors afterward — requiring a complete rewrite.
+
+**Fix:** If the page needs brand colors:
+1. Define the theme FIRST (`@plugin "daisyui/theme" { ... }`)
+2. Then build all UI using semantic color classes from the start
+3. Colors resolve correctly immediately — no rewrite needed
+
+### OKLCH format for custom themes
+
+daisyUI v5 uses OKLCH color format internally. When defining custom themes:
+
+```css
+@plugin "daisyui/theme" {
+  --name: "brand";
+  --default: true;
+
+  /* OKLCH format: lightness chroma hue */
+  --color-primary: oklch(0.65 0.24 265);      /* vibrant blue */
+  --color-primary-content: oklch(0.98 0.01 265); /* near-white on primary */
+  --color-secondary: oklch(0.55 0.18 150);     /* teal */
+  --color-accent: oklch(0.75 0.20 50);         /* warm orange */
+
+  /* Base colors */
+  --color-base-100: oklch(0.98 0.005 265);     /* page background */
+  --color-base-200: oklch(0.95 0.008 265);     /* slightly darker */
+  --color-base-300: oklch(0.90 0.012 265);     /* cards, sidebars */
+  --color-base-content: oklch(0.25 0.02 265);  /* main text */
+}
+```
+
+**Tip:** Use an OKLCH color picker (oklch.com) to find values. The format is more perceptually uniform than HSL — equal lightness values look equally bright across different hues.

--- a/skills/build-daisyui-mcp/references/theme-and-colors.md
+++ b/skills/build-daisyui-mcp/references/theme-and-colors.md
@@ -777,20 +777,20 @@ daisyUI v5 uses OKLCH color format internally. When defining custom themes:
 
 ```css
 @plugin "daisyui/theme" {
-  --name: "brand";
-  --default: true;
+  name: "brand";
+  default: true;
 
   /* OKLCH format: lightness chroma hue */
-  --color-primary: oklch(0.65 0.24 265);      /* vibrant blue */
-  --color-primary-content: oklch(0.98 0.01 265); /* near-white on primary */
-  --color-secondary: oklch(0.55 0.18 150);     /* teal */
-  --color-accent: oklch(0.75 0.20 50);         /* warm orange */
+  --color-primary: oklch(65% 0.24 265);      /* vibrant blue */
+  --color-primary-content: oklch(98% 0.01 265); /* near-white on primary */
+  --color-secondary: oklch(55% 0.18 150);     /* teal */
+  --color-accent: oklch(75% 0.20 50);         /* warm orange */
 
   /* Base colors */
-  --color-base-100: oklch(0.98 0.005 265);     /* page background */
-  --color-base-200: oklch(0.95 0.008 265);     /* slightly darker */
-  --color-base-300: oklch(0.90 0.012 265);     /* cards, sidebars */
-  --color-base-content: oklch(0.25 0.02 265);  /* main text */
+  --color-base-100: oklch(98% 0.005 265);     /* page background */
+  --color-base-200: oklch(95% 0.008 265);     /* slightly darker */
+  --color-base-300: oklch(90% 0.012 265);     /* cards, sidebars */
+  --color-base-content: oklch(25% 0.02 265);  /* main text */
 }
 ```
 

--- a/skills/build-daisyui-mcp/references/tool-api-reference.md
+++ b/skills/build-daisyui-mcp/references/tool-api-reference.md
@@ -1,5 +1,56 @@
 # Tool API Reference
 
+
+## Quick reference — batch limits and syntax (read first)
+
+### Batch size limits
+
+| Call type | Max items | Why |
+|---|---|---|
+| `components` | ~8 per call | Reference data is compact (~500 bytes each) |
+| `component-examples` | ~6 per call | HTML examples are 1–4 KB each; 6 items ≈ 10 KB |
+| `layouts` / `templates` | 1–2 per call | Full page markup; single items can be 3–5 KB |
+| `themes` | 1–3 per call | CSS config blocks |
+| Mixed categories | ~8 total items | Count across all categories |
+
+### Syntax quick guide
+
+```jsonc
+// ✅ Always use nested objects
+{ "components": { "button": true, "card": true } }
+
+// ✅ Mix categories in one call
+{
+  "components": { "navbar": true },
+  "component-examples": { "navbar.responsive-dropdown-menu-on-small-screen-center-menu-on-large-screen": true }
+}
+
+// ❌ NEVER use arrays — fails silently
+{ "components": ["button", "card"] }
+{ "snippets": ["components/button"] }
+```
+
+### Category decision tree
+
+```
+Need to look up valid classes/parts/modifiers?
+  → components
+
+Need working copy-paste HTML for a specific pattern?
+  → component-examples
+
+Need a page shell or starting point?
+  → Is it a full page (login, dashboard)? → templates
+  → Is it just a layout structure? → layouts
+
+Need theme CSS variables or color reference?
+  → themes
+
+Have a Figma URL?
+  → daisyui-blueprint-Figma-to-daisyUI (then follow with snippets)
+```
+
+
 > **Definitive reference** for both daisyUI Blueprint MCP tools — parameters, syntax, every available key, output formats, calling patterns, and cross-tool workflows.
 >
 > See also: `references/component-catalog.md` for component class details.

--- a/skills/build-daisyui-mcp/references/workflows/component-composition.md
+++ b/skills/build-daisyui-mcp/references/workflows/component-composition.md
@@ -761,3 +761,80 @@ Layout (drawer/navbar)
                  └── Interactive (button, input, toggle)
                       └── Feedback (badge, alert, loading)
 ```
+
+
+## Steering experiences — learned from real agent usage
+
+### Stat grid layout
+
+**Problem:** Agent uses flexbox for stat grids, causing uneven column widths when stat values have different lengths.
+
+**Fix:** Always use CSS grid for stat/metric grids:
+
+```html
+<!-- ✅ Correct: CSS grid for even columns -->
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+  <div class="stat bg-base-100 rounded-box shadow">
+    <div class="stat-title">Revenue</div>
+    <div class="stat-value text-primary">$12.4K</div>
+  </div>
+  <!-- more stats... -->
+</div>
+
+<!-- ❌ Wrong: flexbox causes uneven widths -->
+<div class="flex flex-wrap gap-4">
+  <div class="stat flex-1"><!-- width depends on content --></div>
+</div>
+```
+
+### Composition order matters
+
+**Problem:** Agent builds detail components (modals, tooltips, badges) before the page shell exists, then struggles to integrate them.
+
+**Fix:** Follow outside-in order strictly:
+1. Page shell (template or layout) — establishes the grid/flex container
+2. Navigation (navbar, sidebar/drawer, breadcrumbs) — defines the content area
+3. Main content blocks (hero, stat grids, card grids, tables) — fills the content area
+4. Detail components (badges, tooltips, modals, toasts) — adds polish
+
+### Placeholder pattern for incremental builds
+
+When building a complex page, use placeholder containers to mark sections before filling them:
+
+```html
+<!-- Step 1: Shell with placeholders -->
+<div class="drawer lg:drawer-open">
+  <input id="sidebar" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content">
+    <div class="navbar bg-base-100"><!-- TODO: navbar content --></div>
+    <main class="p-6">
+      <div class="grid grid-cols-4 gap-4"><!-- TODO: stat cards --></div>
+      <div class="mt-6"><!-- TODO: data table --></div>
+    </main>
+  </div>
+  <div class="drawer-side"><!-- TODO: sidebar menu --></div>
+</div>
+
+<!-- Step 2: Fill each placeholder one at a time -->
+```
+
+### MCP batching for composition
+
+When composing a full page, you typically need 8-15 component types. Split MCP fetches by composition phase:
+
+```
+Phase 1 fetch: layout shell + navigation (~4 items)
+  → template/layout + navbar + drawer + menu
+
+Phase 2 fetch: main content components (~4 items)
+  → card + stat + table + badge
+
+Phase 3 fetch (if needed): detail components (~3 items)
+  → modal + tooltip + toast
+```
+
+### Theme-first for branded pages
+
+**Problem:** Agent builds the entire page with placeholder colors, then tries to apply a theme afterward, requiring a full rewrite of color classes.
+
+**Fix:** If the page has brand colors, generate the theme FIRST (using `references/workflows/theme-generation.md`), then compose the page using semantic colors from the start. This avoids the color-rewrite pass entirely.

--- a/skills/build-daisyui-mcp/references/workflows/figma-to-code.md
+++ b/skills/build-daisyui-mcp/references/workflows/figma-to-code.md
@@ -440,3 +440,45 @@ templates: dashboard
 ```
 
 **Step 7:** Responsive — drawer is off-canvas on mobile (`lg:drawer-open`), stats reflow from 4 columns to 1.
+
+
+## Steering experiences — learned from real agent usage
+
+### Depth strategy
+
+**Problem:** Agent uses default depth and gets either too little detail (depth 1-2) or too much noise (depth 10+) from Figma files.
+
+**Fix:** Use this depth guide based on what you're extracting:
+
+| Figma content | Recommended depth | Why |
+|---|---|---|
+| Single component (button, card) | 3–4 | Components are shallow |
+| Section (hero, footer, nav) | 5–6 | Sections have nested content |
+| Full page | 7–8 | Pages have deep nesting |
+| Design system / component library | 3–4 per component | Iterate, don't go deep on everything |
+
+### Node-specific URLs
+
+**Problem:** Agent fetches an entire Figma file when only one frame is needed, resulting in massive response data.
+
+**Fix:** Always use node-specific URLs when possible:
+- Full file: `https://www.figma.com/design/abc123/My-Design` → returns everything
+- Specific frame: `https://www.figma.com/design/abc123/My-Design?node-id=1-2` → returns just that node
+
+Ask the user for the specific frame URL if they provide a full-file URL.
+
+### Property mapping — Figma to daisyUI
+
+When analyzing the Figma node tree, map properties like this:
+
+| Figma property | daisyUI equivalent |
+|---|---|
+| `fills` with solid color | Semantic color class or theme variable |
+| `cornerRadius: 8-16` | `rounded-lg` or `rounded-xl` (daisyUI components have built-in radius) |
+| `layoutMode: "HORIZONTAL"` | `flex` (or daisyUI component with horizontal layout) |
+| `layoutMode: "VERTICAL"` | `flex flex-col` (or card, stat, etc.) |
+| `itemSpacing` | `gap-*` utility |
+| `padding` | `p-*` utility (or component's built-in padding) |
+| Component with "Button" in name | `btn` + appropriate variant |
+| Component with "Input"/"Field" | `input` + `fieldset` wrapper |
+| Component with "Card" | `card` + `card-body` |

--- a/skills/build-daisyui-mcp/references/workflows/responsive-layouts.md
+++ b/skills/build-daisyui-mcp/references/workflows/responsive-layouts.md
@@ -575,3 +575,61 @@ Occasionally useful when the design starts from desktop (Figma files are usually
 - [ ] Spacing feels proportional at each breakpoint
 - [ ] Modals fit within viewport on mobile
 - [ ] Bottom dock visible only on mobile (if used)
+
+
+## Steering experiences — learned from real agent usage
+
+### Grid vs. flexbox decision
+
+**Problem:** Agent defaults to flexbox for everything, causing uneven column widths in card grids and stat rows.
+
+**Fix:** Use this decision rule:
+
+| Layout need | Use | Why |
+|---|---|---|
+| Equal-width columns (stats, cards, features) | `grid grid-cols-N` | Grid enforces equal widths regardless of content |
+| Variable-width items (tags, badges, nav items) | `flex flex-wrap` | Flexbox lets items size to content |
+| Two-column with fixed sidebar | `grid grid-cols-[280px_1fr]` or drawer | Fixed + fluid split |
+| Centered single column | `max-w-* mx-auto` | No grid/flex needed |
+| Stack that reflows | `flex flex-col md:flex-row` | Responsive direction change |
+
+### Drawer responsive patterns
+
+**Problem:** Agent uses `hidden lg:block` to show/hide the sidebar instead of daisyUI's built-in responsive drawer pattern.
+
+**Fix:** Use daisyUI's `lg:drawer-open` class:
+
+```html
+<!-- ✅ daisyUI responsive drawer -->
+<div class="drawer lg:drawer-open">
+  <input id="drawer" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content">
+    <!-- Always visible: hamburger only on mobile -->
+    <label for="drawer" class="btn btn-ghost lg:hidden">☰</label>
+    <main class="p-6"><!-- content --></main>
+  </div>
+  <div class="drawer-side">
+    <label for="drawer" class="drawer-overlay"></label>
+    <aside class="bg-base-200 min-h-full w-80 p-4">
+      <ul class="menu"><!-- nav items --></ul>
+    </aside>
+  </div>
+</div>
+
+<!-- ❌ Don't manually hide/show -->
+<aside class="hidden lg:block w-80"><!-- breaks mobile toggle --></aside>
+```
+
+### Breakpoint consistency
+
+**Problem:** Agent mixes breakpoint prefixes inconsistently: some elements use `sm:`, others jump to `lg:`, creating layout breakage at medium widths.
+
+**Fix:** Pick a consistent breakpoint strategy per page:
+
+| Pattern | Breakpoints | Use case |
+|---|---|---|
+| Mobile-first two-step | `md:` and `lg:` | Most dashboards and apps |
+| Mobile-first three-step | `sm:`, `md:`, `lg:` | Content-heavy pages with many columns |
+| Single breakpoint | `lg:` only | Simple layouts (sidebar + content) |
+
+Verify by scanning all responsive classes in the output — every `sm:` should have a corresponding flow at default size, every `lg:` should have a `md:` or default fallback.

--- a/skills/build-daisyui-mcp/references/workflows/screenshot-to-code.md
+++ b/skills/build-daisyui-mcp/references/workflows/screenshot-to-code.md
@@ -326,3 +326,54 @@ Layout: top-navbar
 Components needed: drawer, navbar, chat, avatar, input, button, badge, menu, divider
 Layout: responsive-offcanvas-drawer-sidebar
 ```
+
+
+## Steering experiences — learned from real agent usage
+
+### Non-daisyUI elements in screenshots
+
+**Problem:** Agent sees a chart, map, or video player in a screenshot and tries to recreate it with daisyUI stat/progress/radial-progress components. The result looks nothing like the original.
+
+**Fix:** Identify non-daisyUI elements early in the scan phase:
+1. Charts/graphs → mark as `<!-- TODO: [Chart.js/Recharts] chart -->`
+2. Maps → mark as `<!-- TODO: [Leaflet/Mapbox] map -->`
+3. Code blocks → mark as `<!-- TODO: syntax-highlighted code block -->`
+4. Video/audio → mark as `<!-- TODO: HTML5 video/audio player -->`
+
+Wrap each in a `card` or sized `div` with `bg-base-200` placeholder:
+
+```html
+<div class="card bg-base-100 card-border">
+  <div class="card-body">
+    <h3 class="card-title">Monthly Revenue</h3>
+    <div class="h-64 w-full bg-base-200 rounded-lg flex items-center justify-center">
+      <!-- TODO: integrate Recharts area chart -->
+      <span class="text-base-content/40">Chart placeholder</span>
+    </div>
+  </div>
+</div>
+```
+
+### Shell identification before component catalog
+
+**Problem:** Agent jumps straight to cataloging individual components from a screenshot without first identifying the overall page structure. This leads to a bottom-up build that doesn't fit together.
+
+**Fix:** Always identify the page shell FIRST:
+1. Is there a sidebar? → drawer layout
+2. Is there a top navbar only? → top-navbar layout
+3. Is it a centered single-column? → likely a template (login, landing)
+4. Is it a dashboard with sidebar + top bar? → drawer + navbar
+
+Then check if a `template` or `layout` matches before building from scratch.
+
+### Batch strategy for screenshot conversion
+
+When converting a screenshot, batch MCP fetches by what you see:
+
+```
+Step 1: Identify shell → fetch matching template/layout (1 call)
+Step 2: List all visible components → fetch components reference for class validation (1 call, ~6-8 items)
+Step 3: Fetch examples for complex components only (1 call, ~4-6 items)
+```
+
+Target: ≤3 MCP calls total for a full-page screenshot conversion.


### PR DESCRIPTION
## Summary

Dogfooded the `build-daisyui-mcp` skill by building a SaaS analytics dashboard in Next.js + daisyUI 5. Found **25 friction points** (1 P0, 10 P1, 14 P2) using the `test-skill-quality` derailment methodology, then applied fixes directly to SKILL.md.

## What changed in SKILL.md

| Area | Before | After |
|---|---|---|
| `component-catalog.md` refs | 8 (53.5KB file loaded into context) | 0 — replaced with MCP `components` category |
| Routing table | No priority rule, ambiguous matching | "First match wins" + page-level precedence |
| Composition workflow | 6 vague steps | 4 concrete steps with sub-instructions |
| Framework conversion | No guidance | React/Next.js conversion rules (class→className, etc.) |
| Non-daisyUI elements | P0 blocker — no guidance for charts/maps | Recovery rule with placeholder pattern |
| Exit checklist | 8 vague bullet points | 8 items with specific pass/fail criteria |
| MCP batch sizing | No limits | ~8 items per call to avoid 15KB+ output |
| Template vs layout | Unclear preference | Templates preferred, with decision criteria |

## Key friction points addressed

- **F-12 (P0)**: No guidance when UI includes non-daisyUI elements (charts, maps, video)
- **F-01 (P1)**: Routing table matches multiple rows with no priority rule
- **F-02/F-09 (P1)**: "layouts or templates" with no decision criteria
- **F-11 (P1)**: Composition workflow says WHAT but not HOW
- **F-14 (P1)**: No React/Next.js framework conversion guidance
- **F-04/F-05 (P1)**: component-catalog.md too large (53.5KB) for practical use
- **F-07 (P1)**: Fetch-before-guessing vs batch-requests chicken-and-egg
- **F-08 (P1)**: No MCP batch size warning (26.6KB output observed)
- **F-18–F-25 (P2 cluster)**: Exit checklist items too vague to verify

## Methodology

Used `test-skill-quality` (derailment testing):
1. Pre-scanned all 22 reference files (12,269 lines)
2. Followed SKILL.md literally to build a real dashboard
3. Recorded every friction point with ID, severity, and root cause code
4. Applied fixes using root-cause-taxonomy and fix-patterns references
5. Verified: 0 stale terms, routing integrity confirmed, 235 lines (under 500)

## Files changed

Only `skills/build-daisyui-mcp/SKILL.md` — 50 insertions, 43 deletions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
