### PR TITLE
feat: add convert-vue-nextjs skill

### DIFF
--- a/NAMING.md
+++ b/NAMING.md
@@ -59,7 +59,7 @@ Each prefix has a **definition**, a **boundary** (what falls outside it), and **
 - `convert-` vs `build-` — `convert-` requires an existing source artifact; `build-` starts from requirements or a blank slate
 - `convert-` vs `extract-` — `convert-` produces a *buildable project*; `extract-` produces *documentation or structured data*
 
-**Current skills:** `convert-snapshot-nextjs`
+**Current skills:** `convert-snapshot-nextjs`, `convert-vue-nextjs`
 
 ---
 
@@ -346,6 +346,7 @@ When renaming a published skill:
 - `build-skills`
 - `build-supastarter-app`
 - `convert-snapshot-nextjs`
+- `convert-vue-nextjs`
 - `debug-tauri-devtools`
 - `develop-typescript`
 - `extract-saas-design`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-20 skills for AI coding agents — agent configuration, code review, design extraction, browser automation, planning, research, framework guides, SDK guides, language standards, UI component libraries, and CI/CD.
+21 skills for AI coding agents — agent configuration, code review, design extraction, browser automation, planning, research, framework guides, SDK guides, language standards, UI component libraries, and CI/CD.
 
 ## Install the full pack
 
@@ -166,10 +166,12 @@ Deep reference skills for specific frameworks and tools.
 |---|---|
 | **[build-supastarter-app](skills/build-supastarter-app/)** | Comprehensive developer guide for the SupaStarter Next.js SaaS boilerplate — monorepo architecture, App Router layout chains, oRPC API patterns, Better Auth, Prisma, Stripe payments, organizations, mail, i18n, S3 storage, UI conventions, analytics, and deployment. Includes 93 reference docs organized across 20 domains with cheatsheets for commands, env vars, file locations, and imports. |
 | **[debug-tauri-devtools](skills/debug-tauri-devtools/)** | CrabNebula DevTools integration for debugging Tauri v2 apps — gives AI agents visibility into the Rust side with console logs, tracing spans, IPC call timings, live config inspection, and frontend source browsing. Includes 5 reference docs: architecture deep-dive, IPC span anatomy, integration patterns, tab reference, and common debugging scenarios. |
+| **[convert-vue-nextjs](skills/convert-vue-nextjs/)** | Converts Vue 2/3 and Nuxt codebases to Next.js App Router — component mapping (directives, slots, emits, v-model), state migration (Pinia/Vuex to Zustand/Context), routing conversion, SSR/data-fetching patterns, coexistence architectures (proxy/Web Components/micro-frontends), and testing strategy. Includes 12 reference docs: component mapping, state management, routing, SSR/data fetching, advanced patterns, migration workflow, package mapping, migration strategies, assessment checklist, coexistence patterns, testing strategy, and pitfalls. |
 
 ```bash
 npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/build-supastarter-app
 npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/debug-tauri-devtools
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/convert-vue-nextjs
 ```
 
 ---

--- a/skills/convert-vue-nextjs/SKILL.md
+++ b/skills/convert-vue-nextjs/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: convert-vue-nextjs
+description: Use skill if you are converting Vue 2/3 or Nuxt components to Next.js App Router with React, including component mapping, state migration, routing, SSR, or ecosystem packages.
+---
+
+# Vue to Next.js
+
+Convert Vue/Nuxt applications and components to idiomatic Next.js App Router code. Treat the Vue source as the contract: match its public API exactly, then rebuild internals with React patterns.
+
+## Use this skill when
+
+- Converting Vue SFC (`.vue`) files to React/Next.js components
+- Migrating Nuxt pages or layouts to Next.js App Router
+- Converting Vue state management (Pinia/Vuex) to React equivalents
+- Mapping Vue Router config to Next.js file-system routing
+- Replacing Vue ecosystem packages with React equivalents
+- Planning or executing a full Vue-to-Next.js migration
+
+## Do not use this skill when
+
+- Building a new React/Next.js app from scratch (no Vue source)
+- Converting between React frameworks (CRA → Next.js, Remix → Next.js)
+- Converting React to Vue (reverse direction)
+- General React or Next.js questions unrelated to migration
+
+## Start with these decisions
+
+| Situation | Action |
+|---|---|
+| Converting a single Vue SFC | Quick start below — if complex: `references/conversion/component-mapping.md` |
+| Migrating Pinia or Vuex stores | Load `references/conversion/state-management.md` |
+| Converting Vue Router config | Load `references/conversion/routing-conversion.md` |
+| Converting Nuxt SSR or data fetching | Load `references/conversion/ssr-data-fetching.md` |
+| Complex patterns (transitions, teleport, plugins, generics) | Load `references/conversion/advanced-patterns.md` |
+| Need per-component step-by-step workflow | Load `references/conversion/migration-workflow.md` |
+| Choosing React replacements for Vue libraries | Load `references/ecosystem/package-mapping.md` |
+| Planning a full app migration | Load `references/strategy/assessment-checklist.md` then `references/strategy/migration-strategies.md` |
+| Running Vue and Next.js simultaneously | Load `references/strategy/coexistence-patterns.md` |
+| Testing migration parity | Load `references/strategy/testing-strategy.md` |
+| Request is ambiguous | Default to single-component conversion. Do not assume full migration. |
+
+## Non-negotiable rules
+
+1. **Preserve the contract, not the syntax.** Match the component's public API — props, events, slots, DOM output — exactly. Internal implementation will differ.
+2. **Read Vue source before converting.** Identify all patterns (reactivity, state, routing, slots, emits) before writing any React code.
+3. **Immutable state updates only.** Never mutate. Always produce new references with spread, `map`, or `filter`.
+4. **Explicit dependency arrays.** Every `useEffect`, `useMemo`, `useCallback` must list dependencies. Vue auto-tracks; React does not.
+5. **Push `'use client'` as deep as possible.** Default to Server Components. Add `'use client'` only at the leaf components that need interactivity.
+6. **Map emits to callback props.** Vue's `$emit('event', data)` becomes `onEvent(data)` prop calls.
+7. **Convert `<style scoped>` to CSS Modules.** Import as `styles` object, apply via `className={styles.name}`.
+
+## Quick start — Single component conversion
+
+### Conversion algorithm
+
+1. Read the `.vue` file — identify template directives, script setup patterns, style scoping.
+2. Determine Server vs Client — if component uses `ref`, `reactive`, event handlers, or browser APIs → `'use client'`; if data-only display → Server Component.
+3. Convert `<template>` → JSX using the directive map below.
+4. Convert `<script setup>` → function body with hooks.
+5. Convert `<style scoped>` → CSS Module import.
+6. Convert emits → callback props, slots → children/props.
+
+### Template → JSX directive map
+
+| Vue | JSX |
+|---|---|
+| `v-if="show"` | `{show && <El />}` |
+| `v-if` / `v-else` | `{show ? <A /> : <B />}` |
+| `v-show="visible"` | `<div style={{ display: visible ? undefined : 'none' }}>` |
+| `v-for="item in items" :key="item.id"` | `{items.map(item => <El key={item.id} />)}` |
+| `v-model="name"` | `value={name} onChange={e => setName(e.target.value)}` |
+| `:class="{ active: isActive }"` | `className={isActive ? 'active' : ''}` |
+| `:style="{ color }"` | `style={{ color }}` |
+| `@click="handler"` | `onClick={handler}` |
+| `@click.prevent` | `onClick={e => { e.preventDefault(); handler() }}` |
+| `@click.stop` | `onClick={e => { e.stopPropagation(); handler() }}` |
+| `@keyup.enter` | `onKeyUp={e => e.key === 'Enter' && handler()}` |
+| `v-html="raw"` | `dangerouslySetInnerHTML={{ __html: raw }}` |
+| `<slot />` | `{children}` |
+| `<slot name="header" />` | `{header}` (pass as prop) |
+| `<Teleport to="body">` | `createPortal(children, document.body)` |
+
+### Reactivity → Hooks map
+
+| Vue | React | Note |
+|---|---|---|
+| `ref(0)` | `useState(0)` | Replace via setter, never mutate |
+| `reactive({})` | `useState({})` | Spread to update: `setState(p => ({...p, key: val}))` |
+| `computed(() => x)` | `useMemo(() => x, [deps])` | Must list deps manually |
+| `watch(src, cb)` | `useEffect(() => { cb() }, [src])` | Add cleanup return if needed |
+| `watchEffect(cb)` | `useEffect(cb, [deps])` | Must specify deps explicitly |
+| `onMounted(cb)` | `useEffect(cb, [])` | Empty deps = run once |
+| `onUnmounted(cb)` | `useEffect(() => () => cb, [])` | Return cleanup function |
+| `provide/inject` | `createContext` / `useContext` | Wrap tree with Provider |
+| `$emit('name', data)` | `props.onName(data)` | Callback prop pattern |
+| `defineProps<T>()` | Destructure from typed props | `function C({ title }: Props)` |
+
+### Complete example
+
+**Vue SFC (before):**
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+const props = defineProps<{ initialCount?: number }>()
+const emit = defineEmits<{ (e: 'change', value: number): void }>()
+
+const count = ref(props.initialCount ?? 0)
+const doubled = computed(() => count.value * 2)
+
+function increment() {
+  count.value++
+  emit('change', count.value)
+}
+</script>
+
+<template>
+  <div class="counter">
+    <p>Count: {{ count }} (doubled: {{ doubled }})</p>
+    <button @click="increment">+1</button>
+    <slot name="footer" />
+  </div>
+</template>
+
+<style scoped>
+.counter { padding: 1rem; border: 1px solid #ccc; border-radius: 8px; }
+</style>
+```
+
+**Next.js component (after):**
+
+```tsx
+'use client';
+import { useState, useMemo } from 'react';
+import styles from './Counter.module.css';
+
+interface CounterProps {
+  initialCount?: number;
+  onChange?: (value: number) => void;
+  footer?: React.ReactNode;
+}
+
+export default function Counter({ initialCount = 0, onChange, footer }: CounterProps) {
+  const [count, setCount] = useState(initialCount);
+  const doubled = useMemo(() => count * 2, [count]);
+
+  function increment() {
+    const next = count + 1;
+    setCount(next);
+    onChange?.(next);
+  }
+
+  return (
+    <div className={styles.counter}>
+      <p>Count: {count} (doubled: {doubled})</p>
+      <button onClick={increment}>+1</button>
+      {footer}
+    </div>
+  );
+}
+```
+
+**What changed:** `defineProps` → interface + destructured params. `defineEmits` → callback prop. `ref()` → `useState()`. `computed()` → `useMemo()` with explicit deps. `count.value++` → `setCount(next)`. Named slot → `footer` prop. `<style scoped>` → CSS Module.
+
+## Key conversion patterns
+
+### Pinia store → Zustand store
+
+```ts
+// Vue (Pinia)                           // React (Zustand)
+export const useStore = defineStore(      import { create } from 'zustand';
+  'counter', () => {
+  const count = ref(0)                   export const useStore = create((set, get) => ({
+  const doubled = computed(                count: 0,
+    () => count.value * 2)                 doubled: () => get().count * 2,
+  function inc() { count.value++ }         inc: () => set(s => ({ count: s.count + 1 })),
+  return { count, doubled, inc }         }));
+})
+```
+
+### Vue Router → Next.js App Router
+
+| Vue Router | Next.js |
+|---|---|
+| `path: '/users/:id'` | `app/users/[id]/page.tsx` |
+| `children: [...]` | Nested folders + `layout.tsx` |
+| `beforeEach` guard | `middleware.ts` with `config.matcher` |
+| `<router-link>` | `<Link>` from `next/link` |
+| `router.push()` | `useRouter().push()` from `next/navigation` |
+| `<router-view />` | `{children}` in layout |
+
+### Nuxt data fetching → Next.js
+
+| Nuxt | Next.js |
+|---|---|
+| `useFetch('/api/data')` | `async` Server Component + `fetch()` |
+| `useLazyFetch` | Client Component + TanStack Query |
+| `server/api/route.ts` | `app/api/route/route.ts` (Route Handler) |
+| `useRuntimeConfig()` | `process.env` / `NEXT_PUBLIC_*` |
+| `refreshNuxtData()` | `router.refresh()` or `revalidatePath()` |
+
+### Composable → Custom Hook
+
+```ts
+// Vue composable                         // React hook
+export function useToggle(init = false) {  export function useToggle(init = false) {
+  const value = ref(init)                    const [value, setValue] = useState(init);
+  function toggle() {                        const toggle = useCallback(
+    value.value = !value.value                 () => setValue(v => !v), []
+  }                                          );
+  return { value, toggle }                   return { value, toggle };
+}                                          }
+```
+
+## Common mistakes
+
+| # | Mistake | Why it happens | Fix |
+|---|---|---|---|
+| 1 | Mutating state directly | Vue allows `items.push()`; React ignores mutations | Always use setter: `setItems(prev => [...prev, item])` |
+| 2 | Missing dependency arrays | Vue auto-tracks; React needs explicit deps | Add `[dep1, dep2]` to every `useEffect`/`useMemo`/`useCallback` |
+| 3 | Overusing `useEffect` for derived data | Vue `watch` habit; React has simpler path | Compute during render: `const full = first + ' ' + last` |
+| 4 | Forgetting `'use client'` | Vue has no server/client boundary concept | Add `'use client'` to any component using hooks or event handlers |
+| 5 | Placing `'use client'` too high | Marks entire subtree as client-rendered | Push `'use client'` to the smallest interactive leaf component |
+| 6 | No cleanup in `useEffect` | Vue `onUnmounted` is separate; React combines setup+cleanup | Return cleanup function: `return () => ws.close()` |
+| 7 | Creating objects in render | Vue `setup()` runs once; React re-runs every render | Wrap with `useMemo`/`useCallback` or move outside component |
+| 8 | Using `useRef` for reactive state | Confusing Vue `ref` with React `useRef` | Use `useState` for UI state; `useRef` is for non-reactive values |
+| 9 | Expecting reactive prop destructuring | Vue needs `toRefs`; React props are fresh each render | Destructure freely — React gives new values on each render |
+| 10 | Index keys on reorderable lists | Same issue in both frameworks but more visible in React | Use stable unique IDs: `key={item.id}` |
+
+## Do this / not that
+
+| Do this | Not that |
+|---|---|
+| Use `useState` setter with spread/map/filter for updates | Mutate state objects or arrays directly |
+| List all dependencies in `useEffect`, `useMemo`, `useCallback` | Omit dependency arrays or leave them empty when deps exist |
+| Compute derived values inline or with `useMemo` | Use `useEffect` + `setState` to compute derived data |
+| Add `'use client'` only at leaf interactive components | Place `'use client'` at page or layout level |
+| Use `useRef` for DOM refs and non-reactive values | Use `useRef` as a replacement for Vue `ref()` reactive state |
+| Use Framer Motion for enter/exit animations | Convert Vue `<Transition>` to CSS-only animations |
+| Return cleanup functions in `useEffect` for subscriptions/timers | Forget cleanup and cause memory leaks |
+| Destructure React props directly | Wrap props with `toRefs`-style patterns |
+
+## Reference map
+
+| Need | Read |
+|---|---|
+| Full directive/slot/emit mapping | `references/conversion/component-mapping.md` |
+| State migration (Pinia, Vuex, composables) | `references/conversion/state-management.md` |
+| Vue Router → App Router conversion | `references/conversion/routing-conversion.md` |
+| SSR, data fetching, caching | `references/conversion/ssr-data-fetching.md` |
+| Transitions, teleport, plugins, generics | `references/conversion/advanced-patterns.md` |
+| Per-component 10-step workflow | `references/conversion/migration-workflow.md` |
+| React equivalents for Vue libraries | `references/ecosystem/package-mapping.md` |
+| Migration planning and execution order | `references/strategy/migration-strategies.md` |
+| Pre-migration scope assessment | `references/strategy/assessment-checklist.md` |
+| Running Vue and Next.js simultaneously | `references/strategy/coexistence-patterns.md` |
+| Testing parity during migration | `references/strategy/testing-strategy.md` |
+| Expanded pitfall explanations | `references/pitfalls.md` |
+
+Read only the references needed for the current conversion task.

--- a/skills/convert-vue-nextjs/references/conversion/advanced-patterns.md
+++ b/skills/convert-vue-nextjs/references/conversion/advanced-patterns.md
@@ -1,0 +1,369 @@
+# Advanced Patterns: Vue → React/Next.js
+
+Advanced conversion patterns for TypeScript, animations, portals, directives, plugins, and error handling.
+
+---
+
+## TypeScript Migration
+
+### defineProps → Interface Props
+
+```vue
+<!-- Vue -->
+<script setup lang="ts">
+const props = defineProps<{ title: string; count?: number; items: string[] }>()
+</script>
+```
+```tsx
+// React
+interface Props { title: string; count?: number; items: string[] }
+function MyComponent({ title, count, items }: Props) { ... }
+```
+
+### defineEmits → Callback Prop Types
+
+```vue
+<script setup lang="ts">
+const emit = defineEmits<{ change: [id: number]; 'item-click': [item: Item, index: number] }>()
+</script>
+```
+```tsx
+interface Props { onChange: (id: number) => void; onItemClick: (item: Item, index: number) => void }
+```
+
+Rules: Event → `on` prefix + camelCase. Tuple `[arg: T]` → function `(arg: T) => void`.
+
+### withDefaults → Destructuring Defaults
+
+```vue
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ msg?: string; labels?: string[] }>(), {
+  msg: 'hello', labels: () => ['one', 'two'],
+})
+</script>
+```
+```tsx
+const DEFAULT_LABELS = ['one', 'two']; // stable reference for deps
+function MyComponent({ msg = 'hello', labels = DEFAULT_LABELS }: Props) { ... }
+```
+
+### Generic Components
+
+```vue
+<script setup lang="ts" generic="T extends { id: string }">
+defineProps<{ items: T[]; selected?: T }>()
+defineEmits<{ select: [item: T] }>()
+</script>
+```
+```tsx
+interface ListProps<T extends { id: string }> {
+  items: T[]; selected?: T; onSelect: (item: T) => void;
+}
+function GenericList<T extends { id: string }>({ items, selected, onSelect }: ListProps<T>) {
+  return <ul>{items.map(item => (
+    <li key={item.id} onClick={() => onSelect(item)}
+      className={selected?.id === item.id ? 'active' : ''}>
+      {item.id}
+    </li>
+  ))}</ul>;
+}
+// Usage — T inferred: <GenericList items={users} onSelect={handleSelect} />
+```
+
+### Type Mapping Summary
+
+| Concept | Vue | React |
+|---|---|---|
+| State | `Ref<T>` (`.value`) | `T` (direct) |
+| Setter | `ref.value = x` | `Dispatch<SetStateAction<T>>` |
+| Props | `defineProps<T>()` | `(props: T)` param |
+| Events | `defineEmits<T>()` | `onX: (...) => void` props |
+| Context | `InjectionKey<T>` | `Context<T>` |
+| Template ref | `Ref<HTMLElement \| null>` | `RefObject<HTMLElement \| null>` |
+
+---
+
+## Composables → Custom Hooks (Advanced)
+
+### Lifecycle Cleanup
+
+```ts
+// Vue
+export function useEventListener(target: EventTarget, event: string, handler: EventListener) {
+  onMounted(() => target.addEventListener(event, handler))
+  onUnmounted(() => target.removeEventListener(event, handler))
+}
+
+// React
+export function useEventListener(target: EventTarget, event: string, handler: EventListener) {
+  useEffect(() => {
+    target.addEventListener(event, handler);
+    return () => target.removeEventListener(event, handler);
+  }, [target, event, handler]);
+}
+```
+
+### Shared State Composables → Zustand
+
+Vue module-level `ref()` = singleton. React needs external store:
+
+```ts
+// Vue: const notifications = ref<Notification[]>([]) — module singleton
+// React (Zustand):
+export const useNotifications = create<NotificationStore>((set) => ({
+  items: [],
+  add: (msg) => set(s => ({ items: [...s.items, { id: Date.now(), msg }] })),
+  dismiss: (id) => set(s => ({ items: s.items.filter(n => n.id !== id) })),
+}));
+```
+
+### Async Composables → Hooks with Loading/Error
+
+```ts
+// React
+export function useFetchData<T>(url: string) {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch(url).then(r => r.json())
+      .then(d => { if (!cancelled) setData(d); })
+      .catch(e => { if (!cancelled) setError(e); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  return { data, error, loading };
+}
+```
+
+---
+
+## Teleport → createPortal
+
+**Vue:**
+```vue
+<Teleport to="#modal-root">
+  <div class="modal" v-if="show">Content</div>
+</Teleport>
+```
+
+**React:**
+```tsx
+import { createPortal } from 'react-dom';
+
+function Modal({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) {
+  if (!isOpen) return null;
+  return createPortal(
+    <div className="modal">{children}</div>,
+    document.getElementById('modal-root')!
+  );
+}
+```
+
+For Vue's `disabled` prop (render in-place): conditionally return `<>{children}</>` or `createPortal(...)`.
+
+Add portal targets in `app/layout.tsx`:
+```tsx
+<body>{children}<div id="modal-root" /><div id="tooltip-root" /></body>
+```
+
+---
+
+## Transitions & Animation
+
+### `<Transition>` → Framer Motion
+
+**Vue:**
+```vue
+<Transition name="fade"><div v-if="show">Content</div></Transition>
+<style>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.3s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>
+```
+
+**React:**
+```tsx
+'use client';
+import { AnimatePresence, motion } from 'framer-motion';
+
+function FadeContent({ show }: { show: boolean }) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0 }}        // .fade-enter-from
+          animate={{ opacity: 1 }}         // .fade-enter-to
+          exit={{ opacity: 0 }}            // .fade-leave-to
+          transition={{ duration: 0.3 }}
+        >Content</motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+### `<TransitionGroup>` → AnimatePresence + layout
+
+```tsx
+<AnimatePresence>
+  <ul>{items.map(item => (
+    <motion.li key={item.id} layout
+      initial={{ opacity: 0, x: 30 }} animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 30 }} transition={{ duration: 0.3 }}>
+      {item.text}
+    </motion.li>
+  ))}</ul>
+</AnimatePresence>
+```
+
+The `layout` prop enables reorder animations (Vue's `.list-move`).
+
+**CSS-only alternative** (no exit animations): use conditional Tailwind classes like `transition-opacity duration-300 ${show ? 'opacity-100' : 'opacity-0'}`.
+
+---
+
+## KeepAlive
+
+Vue's `<KeepAlive>` caches component state. **No React equivalent.** Workarounds:
+
+1. **Zustand/Context** — persist state externally so it survives unmount
+2. **CSS display toggle** — keep all tabs mounted, toggle `display: none`
+3. **Lift state up** so it persists across tab switches
+
+```tsx
+function TabPanel({ active, children }: { active: boolean; children: React.ReactNode }) {
+  return <div style={{ display: active ? 'block' : 'none' }}>{children}</div>;
+}
+```
+
+---
+
+## Custom Directives → Hooks / Ref Callbacks
+
+### v-focus → useRef + useEffect
+
+```tsx
+function useAutoFocus() {
+  const ref = useRef<HTMLElement>(null);
+  useEffect(() => { ref.current?.focus(); }, []);
+  return ref;
+}
+// Usage: <input ref={useAutoFocus()} />
+```
+
+### v-click-outside → Custom Hook
+
+```tsx
+function useClickOutside(ref: RefObject<HTMLElement | null>, handler: () => void) {
+  useEffect(() => {
+    function listener(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) handler();
+    }
+    document.addEventListener('click', listener);
+    return () => document.removeEventListener('click', listener);
+  }, [ref, handler]);
+}
+```
+
+### v-intersection → Observer Hook
+
+```tsx
+function useIntersection(ref: RefObject<HTMLElement | null>, options?: IntersectionObserverInit) {
+  const [isVisible, setIsVisible] = useState(false);
+  useEffect(() => {
+    if (!ref.current) return;
+    const obs = new IntersectionObserver(([e]) => setIsVisible(e.isIntersecting), options);
+    obs.observe(ref.current);
+    return () => obs.disconnect();
+  }, [ref, options]);
+  return isVisible;
+}
+```
+
+---
+
+## Plugin System → Provider Pattern
+
+| Vue Plugin Feature | React Equivalent |
+|---|---|
+| `app.use(Plugin, options)` | `<Provider options={}>` in layout |
+| `app.provide(key, value)` | `createContext` + `Provider` |
+| `inject(key)` | `useContext(Ctx)` |
+| `app.config.globalProperties.$x` | Context or module export |
+| `app.directive('name', def)` | Custom hook or ref callback |
+| `app.component('Name', Comp)` | Regular import (no global registry) |
+
+```tsx
+const AnalyticsCtx = createContext<Analytics | null>(null);
+
+export function AnalyticsProvider({ children, trackingId }: { children: React.ReactNode; trackingId: string }) {
+  const analytics = useMemo(() => createAnalytics({ trackingId }), [trackingId]);
+  return <AnalyticsCtx.Provider value={analytics}>{children}</AnalyticsCtx.Provider>;
+}
+
+export function useAnalytics() {
+  const ctx = useContext(AnalyticsCtx);
+  if (!ctx) throw new Error('useAnalytics must be within AnalyticsProvider');
+  return ctx;
+}
+```
+
+**ComposeProviders** to avoid nesting:
+```tsx
+function ComposeProviders({ providers, children }: {
+  providers: Array<React.FC<{ children: React.ReactNode }>>; children: React.ReactNode
+}) {
+  return providers.reduceRight((child, Provider) => <Provider>{child}</Provider>, children);
+}
+<ComposeProviders providers={[ThemeProvider, AuthProvider]}><App /></ComposeProviders>
+```
+
+---
+
+## Dynamic Imports
+
+| Vue | React | Next.js |
+|---|---|---|
+| `defineAsyncComponent(loader)` | `lazy(loader)` | `dynamic(loader)` |
+| `loadingComponent` | `<Suspense fallback={}>` | `loading` option |
+| `errorComponent` | `<ErrorBoundary>` | `error.tsx` |
+| N/A | N/A | `ssr: false` (client-only) |
+
+```tsx
+import dynamic from 'next/dynamic';
+const HeavyChart = dynamic(() => import('./HeavyChart'), {
+  loading: () => <ChartSkeleton />,
+  ssr: false,
+});
+```
+
+---
+
+## Error Boundaries
+
+**Vue:** `onErrorCaptured` hook in any component. Return `false` to stop propagation.
+
+**React:** Must be a class component (no hook API):
+```tsx
+'use client';
+class ErrorBoundary extends Component<{ children: ReactNode; fallback?: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+  static getDerivedStateFromError() { return { hasError: true }; }
+  componentDidCatch(error: Error, info: React.ErrorInfo) { console.error(error, info); }
+  render() { return this.state.hasError ? (this.props.fallback ?? <div>Error</div>) : this.props.children; }
+}
+```
+
+**Next.js convention (preferred):**
+```tsx
+// app/dashboard/error.tsx
+'use client';
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <div><h2>Something went wrong</h2><button onClick={reset}>Retry</button></div>;
+}
+```

--- a/skills/convert-vue-nextjs/references/conversion/component-mapping.md
+++ b/skills/convert-vue-nextjs/references/conversion/component-mapping.md
@@ -1,0 +1,390 @@
+# Component Mapping: Vue SFC → React/Next.js
+
+Complete reference for converting Vue 3 Single File Components to React/Next.js components.
+
+---
+
+## Full Mapping Table
+
+| Vue Pattern | React/Next.js Equivalent | Notes |
+|---|---|---|
+| `<template>` block | JSX `return (...)` | `class`→`className`, `for`→`htmlFor` |
+| `<script setup>` | Function component body | Top-level code becomes code before `return` |
+| `<style scoped>` | CSS Modules (`.module.css`) | `className={styles.x}` |
+| `{{ interpolation }}` | `{expression}` | Double-curly → single-curly |
+| `v-if` / `v-else-if` / `v-else` | `&&`, ternary, early return | See examples below |
+| `v-show` | `style={{ display: x ? undefined : 'none' }}` | Element stays in DOM |
+| `v-for` | `.map()` with `key` | `:key` → `key={}` |
+| `v-model` (input) | `value` + `onChange` | Must wire both explicitly |
+| `v-model` (component) | `value` + `onChange` props | Parent owns state |
+| `v-bind:prop` / `:prop` | `prop={value}` | Direct mapping |
+| `v-on:event` / `@event` | `onEvent={handler}` | `@click` → `onClick` |
+| `v-bind:class` | `clsx()` or template literal | `clsx({ [styles.active]: isActive })` |
+| `v-bind:style` | `style={{ prop: value }}` | camelCase CSS properties |
+| Default `<slot>` | `{children}` | `PropsWithChildren<>` in TS |
+| Named `<slot name="x">` | Named JSX props: `header={<X/>}` | Pass JSX as props |
+| Scoped slots | Render props `renderItem={(d) => <X/>}` | Function-as-prop |
+| `$emit('event', data)` | `onEvent(data)` callback prop | Parent passes function |
+| `defineEmits` | TS interface with callbacks | `onSubmit: (d: T) => void` |
+| `defineProps` | Destructured params + interface | `function Comp({ x }: Props)` |
+| Template `ref="el"` | `useRef(null)` + `ref={el}` | `.current` not `.value` |
+| `<component :is="x">` | `const Comp = map[x]; <Comp />` | Dynamic component |
+| `<Teleport to="body">` | `createPortal(children, document.body)` | From `react-dom` |
+| `<Transition>` | Framer Motion `<AnimatePresence>` | No built-in equivalent |
+| `v-html="html"` | `dangerouslySetInnerHTML={{ __html: html }}` | Security warning |
+| `v-text="msg"` | `{msg}` | Direct expression |
+| `v-bind="obj"` | `{...obj}` | Spread operator |
+
+---
+
+## Template → JSX
+
+### v-if / v-else / v-show
+
+**Vue:**
+```vue
+<div v-if="type === 'A'">A</div>
+<div v-else-if="type === 'B'">B</div>
+<div v-else>C</div>
+<span v-show="isVisible">Always in DOM</span>
+```
+
+**React:**
+```tsx
+// Simple: logical AND
+{isLoggedIn && <UserGreeting />}
+
+// Binary: ternary
+{isLoggedIn ? <UserGreeting /> : <LoginPrompt />}
+
+// Multi-branch: early return
+function StatusMessage({ type }: { type: string }) {
+  if (type === 'A') return <div>A</div>;
+  if (type === 'B') return <div>B</div>;
+  return <div>C</div>;
+}
+
+// v-show: toggle CSS display
+<span style={{ display: isVisible ? undefined : 'none' }}>Always in DOM</span>
+```
+
+### v-for
+
+**Vue:**
+```vue
+<li v-for="(item, index) in items" :key="item.id">{{ index }}: {{ item.name }}</li>
+```
+
+**React:**
+```tsx
+{items.map((item, index) => (
+  <li key={item.id}>{index}: {item.name}</li>
+))}
+```
+
+Use `.filter().map()` when Vue combines `v-for` with `v-if`.
+
+### v-bind:class / v-bind:style
+
+**Vue:**
+```vue
+<div :class="{ active: isActive, disabled: isDisabled }">Content</div>
+<div :style="{ color: textColor, fontSize: size + 'px' }">Styled</div>
+```
+
+**React:**
+```tsx
+import clsx from 'clsx';
+<div className={clsx('base', { active: isActive, disabled: isDisabled })}>Content</div>
+<div style={{ color: textColor, fontSize: `${size}px` }}>Styled</div>
+```
+
+**Without a library** — use `filter(Boolean).join(' ')`:
+```tsx
+className={[
+  'base',
+  isActive ? 'active' : '',
+  isDisabled ? 'disabled' : '',
+].filter(Boolean).join(' ')}
+```
+
+> **Tip:** `clsx` or `cn` (tailwind-merge) is idiomatic in most React/Next.js codebases and should be preferred over manual joining.
+
+### v-on / @event + Modifiers
+
+| Vue Modifier | React Equivalent |
+|---|---|
+| `@click.prevent` | `onClick={e => { e.preventDefault(); handler(); }}` |
+| `@click.stop` | `onClick={e => { e.stopPropagation(); handler(); }}` |
+| `@keyup.enter` | `onKeyUp={e => e.key === 'Enter' && handler()}` |
+| `@click.once` | `useEffect` + `addEventListener(..., { once: true })` |
+
+Vue modifiers like `@click.stop.prevent` have no JSX shorthand — must be explicit:
+```tsx
+function handleClick(e: React.MouseEvent) {
+  e.stopPropagation();
+  e.preventDefault();
+  // ... actual logic
+}
+<button onClick={handleClick}>Save</button>
+```
+
+---
+
+## v-model → Controlled Components
+
+**Vue:**
+```vue
+<script setup>
+const name = ref('')
+const agreed = ref(false)
+const color = ref('red')
+</script>
+<template>
+  <input v-model="name" />
+  <input type="checkbox" v-model="agreed" />
+  <select v-model="color"><option value="red">Red</option></select>
+</template>
+```
+
+**React:**
+```tsx
+'use client';
+const [name, setName] = useState('');
+const [agreed, setAgreed] = useState(false);
+const [color, setColor] = useState('red');
+
+<input value={name} onChange={e => setName(e.target.value)} />
+<input type="checkbox" checked={agreed} onChange={e => setAgreed(e.target.checked)} />
+<select value={color} onChange={e => setColor(e.target.value)}>
+  <option value="red">Red</option>
+</select>
+```
+
+**Modifiers:** `.lazy` → `onBlur` | `.number` → `Number(e.target.value)` | `.trim` → `e.target.value.trim()`
+
+> **⚠️ Controlled vs Uncontrolled Warning:**
+> React warns when switching between controlled/uncontrolled inputs. Common cause: `value={undefined}` on first render, then setting state — React interprets this as a mode switch.
+> **Fix:** Always initialize with a concrete value: `useState('')` not `useState()`. For checkboxes: `useState(false)`.
+> Vue doesn't have this concept — `v-model` is always "controlled." Every migrated input must have an explicit initial value.
+
+### Custom Component v-model
+
+**Vue:** `<CustomInput v-model="query" />` uses `defineModel()` internally.
+
+**React:** `<CustomInput value={query} onChange={setQuery} />` — parent owns state, child calls `onChange`.
+
+**Multiple v-models:** `v-model:firstName` + `v-model:lastName` → `firstName` + `onFirstNameChange` + `lastName` + `onLastNameChange` props.
+
+### Form Migration Heuristic
+
+Choose your form strategy based on interactivity requirements:
+
+- **Server-first forms** (simple submission, progressive enhancement): Use Next.js Server Actions (`"use server"` + `<form action={…}>`) with `revalidatePath()`. Works without JS.
+- **Complex client forms** (multi-step wizards, real-time validation, dependent fields): Use React Hook Form + Zod/Yup schema validation. Requires `'use client'`.
+- **Vue VeeValidate / FormKit** → Map to **React Hook Form** (closest mental model: declarative validation, field-level errors, form state).
+
+> **One-liner:** If the form could work without JavaScript, use Server Actions. If it needs client-side orchestration, use React Hook Form.
+
+---
+
+## Slots → Children / Render Props
+
+**Default slot → `children`:**
+```tsx
+function Card({ children }: { children?: React.ReactNode }) {
+  return <div className="card">{children ?? 'Fallback'}</div>;
+}
+```
+
+**Named slots → explicit props:**
+```tsx
+interface LayoutProps { header?: React.ReactNode; footer?: React.ReactNode; children: React.ReactNode }
+function Layout({ header, footer, children }: LayoutProps) {
+  return <><header>{header}</header><main>{children}</main><footer>{footer}</footer></>;
+}
+<Layout header={<h1>Title</h1>} footer={<p>Footer</p>}><p>Main</p></Layout>
+```
+
+**Scoped slots → render props:**
+```tsx
+interface DataListProps<T> { items: T[]; renderItem: (item: T, index: number) => React.ReactNode }
+function DataList<T>({ items, renderItem }: DataListProps<T>) {
+  return <ul>{items.map((item, i) => <li key={i}>{renderItem(item, i)}</li>)}</ul>;
+}
+<DataList items={users} renderItem={(item, i) => <span>{i}: {item.name}</span>} />
+```
+
+---
+
+## Events: $emit → Callback Props
+
+**Vue:** `emit('submit', formData)` / `emit('cancel')`
+
+**React:**
+```tsx
+interface Props { onSubmit: (data: FormData) => void; onCancel: () => void }
+function MyForm({ onSubmit, onCancel }: Props) {
+  return <>
+    <button onClick={() => onSubmit(formData)}>Submit</button>
+    <button onClick={onCancel}>Cancel</button>
+  </>;
+}
+```
+
+Naming: Vue `@item-selected` → React `onItemSelected` (kebab → camelCase with `on` prefix).
+
+---
+
+## Styles: Scoped → CSS Modules
+
+```css
+/* Card.module.css */
+.card { background: white; border-radius: 8px; }
+.title { font-weight: bold; }
+```
+```tsx
+import styles from './Card.module.css';
+<div className={styles.card}><h2 className={styles.title}>Title</h2></div>
+```
+
+- Vue `:deep(.child)` → CSS Modules `:global(.child)` or pass `className` as prop
+- SCSS supported via `.module.scss` (built-in Next.js support)
+
+---
+
+## Refs: Template Refs → useRef
+
+| Aspect | Vue | React |
+|---|---|---|
+| Access | `.value` | `.current` |
+| Reactivity | `ref()` is reactive | `useRef` is NOT reactive |
+| Component ref | `defineExpose()` | `forwardRef` + `useImperativeHandle` |
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null);
+useEffect(() => { inputRef.current?.focus(); }, []);
+return <input ref={inputRef} />;
+```
+
+### defineExpose → useImperativeHandle
+
+Vue's `defineExpose` selectively reveals methods to a parent's template ref. In React, use `forwardRef` + `useImperativeHandle` to expose only the imperative API the parent needs (e.g. `focus`, `scrollIntoView`, `reset`):
+
+**Vue:**
+```vue
+<script setup>
+const inputRef = ref<HTMLInputElement>()
+defineExpose({ focus: () => inputRef.value?.focus() })
+</script>
+<template><input ref="inputRef" /></template>
+```
+
+**React:**
+```tsx
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+
+interface InputHandle { focus: () => void }
+
+const Input = forwardRef<InputHandle, React.InputHTMLAttributes<HTMLInputElement>>(
+  (props, ref) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+    }));
+    return <input ref={inputRef} {...props} />;
+  }
+);
+```
+
+Parent usage: `const ref = useRef<InputHandle>(null)` → `ref.current?.focus()`.
+
+---
+
+## Fallthrough Attributes: $attrs → Rest Props
+
+Vue automatically forwards unrecognized attrs to the root element. React requires explicit forwarding via rest/spread — critical for preserving `data-testid`, `aria-*`, and other passthrough attributes.
+
+```tsx
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary';
+};
+
+function Button({ variant = 'primary', className = '', ...rest }: Props) {
+  return <button className={`btn btn-${variant} ${className}`} {...rest} />;
+}
+```
+
+> **Why this matters:** Without `...rest`, attributes like `aria-label`, `data-testid`, and `disabled` are silently dropped — breaking accessibility and test selectors.
+
+---
+
+## Complete Example: SearchableDropdown
+
+**Vue SFC:**
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+const props = withDefaults(defineProps<{
+  items: { id: string; label: string }[]
+  placeholder?: string
+}>(), { placeholder: 'Search...' })
+const emit = defineEmits<{ select: [item: { id: string; label: string }] }>()
+
+const query = ref('')
+const isOpen = ref(false)
+const filtered = computed(() =>
+  props.items.filter(i => i.label.toLowerCase().includes(query.value.toLowerCase()))
+)
+function select(item: { id: string; label: string }) {
+  query.value = item.label; isOpen.value = false; emit('select', item)
+}
+</script>
+<template>
+  <div class="dropdown">
+    <input v-model="query" :placeholder="placeholder" @focus="isOpen = true" />
+    <ul v-show="isOpen && filtered.length">
+      <li v-for="item in filtered" :key="item.id" @click="select(item)">{{ item.label }}</li>
+    </ul>
+  </div>
+</template>
+<style scoped>
+.dropdown { position: relative; }
+.dropdown ul { position: absolute; width: 100%; list-style: none; padding: 0; }
+.dropdown li { padding: 8px; cursor: pointer; }
+.dropdown li:hover { background: #f0f0f0; }
+</style>
+```
+
+**React/Next.js equivalent:**
+```tsx
+'use client';
+import { useState, useMemo } from 'react';
+import styles from './SearchableDropdown.module.css';
+
+interface Item { id: string; label: string }
+interface Props { items: Item[]; placeholder?: string; onSelect: (item: Item) => void }
+
+export function SearchableDropdown({ items, placeholder = 'Search...', onSelect }: Props) {
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const filtered = useMemo(
+    () => items.filter(i => i.label.toLowerCase().includes(query.toLowerCase())),
+    [items, query]
+  );
+
+  function select(item: Item) { setQuery(item.label); setIsOpen(false); onSelect(item); }
+
+  return (
+    <div className={styles.dropdown}>
+      <input value={query} onChange={e => setQuery(e.target.value)}
+        placeholder={placeholder} onFocus={() => setIsOpen(true)} />
+      {isOpen && filtered.length > 0 && (
+        <ul>{filtered.map(item => (
+          <li key={item.id} onClick={() => select(item)}>{item.label}</li>
+        ))}</ul>
+      )}
+    </div>
+  );
+}
+```

--- a/skills/convert-vue-nextjs/references/conversion/migration-workflow.md
+++ b/skills/convert-vue-nextjs/references/conversion/migration-workflow.md
@@ -1,0 +1,388 @@
+# Vue 3 → Next.js Migration Workflow
+
+Step-by-step operational guide for migrating a Vue 3 application to Next.js, one route and one component at a time.
+
+---
+
+## 1. The Contract Preservation Principle
+
+> Do not rewrite the app in React. Migrate one route and one component boundary at a time, preserving each component's public behavior.
+
+Every Vue component has a **public contract**. Preserve it exactly:
+
+| Contract surface | What to preserve |
+|---|---|
+| **Props** | Names, types, defaults, required vs optional |
+| **Events** | Every `$emit` call → callback prop |
+| **Slots / extensibility** | Default → `children`, named → explicit props, scoped → render props |
+| **DOM structure & classes** | CSS depends on this — change it and styling breaks |
+| **Router / store / data deps** | `useRoute`, Pinia stores, inject/provide |
+| **Imperative behavior** | Focus, scroll, keyboard shortcuts, `defineExpose` refs |
+
+If the React version honors the same contract, tests, CSS, and parent components keep working.
+
+---
+
+## 2. The 6-Phase Migration Order
+
+Migrate **within each route**, from lowest risk to highest:
+
+1. **Presentational leaf components** — `Button`, `Card`, `Avatar`, `Badge`. No state, pure props → markup.
+2. **Input and form field components** — `TextField`, `Select`, `DatePicker`. `v-model` → `value` + `onChange`.
+3. **Overlays and behavior-heavy UI** — Modals, popovers, tooltips. Touch `Teleport`, transitions, focus traps.
+4. **Container components** — Compose children, manage state, connect to stores/routes.
+5. **Route components and layouts** — Vue Router → App Router `page.tsx` / `layout.tsx`.
+6. **Global state and data fetching** — Pinia → Zustand/Context, route guards → middleware.
+
+---
+
+## 3. Per-Component Migration Worksheet
+
+Before migrating **any** component, document every contract surface:
+
+| Category | What to capture |
+|---|---|
+| Props & defaults | `prop: type = defaultValue` |
+| Emitted events | `emit('eventName', payload)` |
+| v-model bindings | `modelValue` / `update:modelValue`, custom `v-model:propName` |
+| Slots | default, named (`header`, `footer`), scoped (`item({ row, index })`) |
+| Fallthrough attrs | `$attrs` — passed to root or inner element? |
+| Refs / exposed methods | `defineExpose`: `focus()`, `open()`, `close()`, `reset()` |
+| Local state | `ref(initial)`, `reactive({ ... })` |
+| Computed values | `computed(() => ...)` |
+| Watchers | `watch(source, handler, options)` |
+| Router usage | `useRoute()`: params, query; `useRouter()`: push, replace |
+| Store usage | `useXxxStore()`: state, getters, actions |
+| Directives | `v-focus`, `v-click-outside`, `v-tooltip` |
+| Teleport / Transition | `Teleport to="body"`, `Transition name="fade"` |
+| CSS dependencies | Class names, scoped styles, CSS modules |
+| Accessibility | `aria-*`, `role`, `tabindex`, test IDs |
+
+> That worksheet is more valuable than blindly translating lines of code.
+
+---
+
+## 4. The 10-Step Per-Component Workflow
+
+### Step 1: Port markup literally
+
+`v-if` → conditional (`&&`, ternary), `v-for` → `.map()`, `:class` → `className`, `v-show` → `style={{ display }}`, `@click` → `onClick`.
+
+```vue
+<!-- Vue -->
+<li v-for="item in items" :key="item.id"
+    :class="{ active: item.id === activeId, disabled: item.disabled }">
+  {{ item.label }}
+</li>
+```
+```tsx
+// React
+{items.map((item) => (
+  <li key={item.id}
+      className={[
+        item.id === activeId ? 'active' : '',
+        item.disabled ? 'disabled' : '',
+      ].filter(Boolean).join(' ')}>
+    {item.label}
+  </li>
+))}
+```
+
+### Step 2: Port props — keep same names, match types and defaults
+
+```vue
+const props = withDefaults(defineProps<{
+  variant?: 'primary' | 'secondary'
+  disabled?: boolean
+}>(), { variant: 'primary', disabled: false })
+```
+```tsx
+function Button({ variant = 'primary', disabled = false }: ButtonProps) {
+```
+
+### Step 3: Translate emits → callback props
+
+Every `$emit('name', payload)` becomes an optional callback:
+
+```vue
+const emit = defineEmits<{ save: [data: FormData]; cancel: [] }>()
+emit('save', formData)
+```
+```tsx
+interface Props { onSave?: (data: FormData) => void; onCancel?: () => void }
+onSave?.(formData)
+```
+
+### Step 4: Translate local state
+
+`ref()` → `useState()`. For `reactive()` where fields change independently, use separate `useState` calls. Only group into one state object when values always change together.
+
+### Step 5: Translate computed correctly
+
+First ask: **"Is this just derived from props/state?"** If yes — compute inline during render, no hook:
+
+```tsx
+function UserList({ users, filter }: Props) {
+  const filtered = users.filter((u) => u.role === filter)
+  return <ul>{filtered.map(/* ... */)}</ul>
+}
+```
+
+Only `useMemo` when genuinely expensive **and** you've measured a problem:
+
+```tsx
+const sorted = useMemo(() => hugeList.slice().sort(expensiveComparator), [hugeList])
+```
+
+### Step 6: Translate watch → useEffect ONLY for true side effects
+
+**Good** (true side effects): localStorage sync, subscriptions, timers, DOM listeners, analytics, network cleanup.
+
+**Bad** (not side effects — derive inline instead): recomputing display values, copying props into state, sorting/filtering for render, transforming data for display.
+
+### Step 7: Translate slots
+
+| Vue slot | React equivalent |
+|---|---|
+| `<slot />` | `children` prop |
+| `<slot name="footer" />` | `footer?: ReactNode` prop |
+| `<slot :item="item" />` | `renderItem?: (item: T) => ReactNode` |
+
+### Step 8: Handle fallthrough attrs
+
+```tsx
+function Button({ variant = 'primary', className = '', ...rest }: ButtonProps) {
+  return <button className={`btn btn-${variant} ${className}`} {...rest} />
+}
+```
+
+### Step 9: Port refs and exposed methods
+
+Convert `defineExpose` to `useImperativeHandle`. Only preserve small imperative APIs:
+
+```tsx
+const TextInput = forwardRef<InputHandle, InputProps>((props, ref) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+    reset: () => { if (inputRef.current) inputRef.current.value = '' },
+  }))
+  return <input ref={inputRef} {...props} />
+})
+```
+
+### Step 10: Port composables → custom hooks
+
+Migrate **before** container components since containers depend on them:
+
+```vue
+<!-- Vue composable -->
+export function useDebounce<T>(value: Ref<T>, delay: number): Ref<T> {
+  const debounced = ref(value.value) as Ref<T>
+  let timeout: ReturnType<typeof setTimeout>
+  watch(value, (v) => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => { debounced.value = v }, delay)
+  })
+  return debounced
+}
+```
+```tsx
+// React hook
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+  return debounced
+}
+```
+
+---
+
+## 5. Full Example: Migrating a Modal Component
+
+### Vue: BaseModal.vue
+
+```vue
+<script setup lang="ts">
+import { watch, onMounted, onBeforeUnmount } from 'vue'
+
+const props = defineProps<{ open: boolean; title: string }>()
+const emit = defineEmits<{ 'update:open': [value: boolean]; close: [] }>()
+
+function handleClose() {
+  emit('update:open', false)
+  emit('close')
+}
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') handleClose()
+}
+watch(() => props.open, (isOpen) => {
+  document.body.style.overflow = isOpen ? 'hidden' : ''
+})
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown)
+  document.body.style.overflow = ''
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="modal-overlay" @click.self="handleClose">
+      <div class="modal-content" role="dialog" aria-modal="true">
+        <h2>{{ title }}</h2>
+        <slot />
+        <div v-if="$slots.footer" class="modal-footer">
+          <slot name="footer" />
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+```
+
+### React: BaseModal.tsx
+
+```tsx
+'use client'
+import { useEffect, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+interface BaseModalProps {
+  open: boolean
+  title: string
+  onOpenChange?: (open: boolean) => void
+  onClose?: () => void
+  children: ReactNode
+  footer?: ReactNode
+}
+
+export default function BaseModal({
+  open, title, onOpenChange, onClose, children, footer,
+}: BaseModalProps) {
+  useEffect(() => {
+    if (!open) return
+    document.body.style.overflow = 'hidden'
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') { onOpenChange?.(false); onClose?.() }
+    }
+    document.addEventListener('keydown', onKeydown)
+    return () => {
+      document.body.style.overflow = ''
+      document.removeEventListener('keydown', onKeydown)
+    }
+  }, [open, onOpenChange, onClose])
+
+  if (!open) return null
+  return createPortal(
+    <div className="modal-overlay"
+         onClick={(e) => { if (e.target === e.currentTarget) { onOpenChange?.(false); onClose?.() } }}>
+      <div className="modal-content" role="dialog" aria-modal="true">
+        <h2>{title}</h2>
+        {children}
+        {footer && <div className="modal-footer">{footer}</div>}
+      </div>
+    </div>,
+    document.body
+  )
+}
+```
+
+### Why each mapping is correct
+
+| Vue concept | React equivalent | Reasoning |
+|---|---|---|
+| `open` prop | `open` prop | Read-only value, same role |
+| `emit('update:open', false)` | `onOpenChange?.(false)` | v-model pattern → controlled callback |
+| `emit('close')` | `onClose?.()` | Semantic event → callback prop |
+| Default `<slot />` | `children` | Standard content projection |
+| Named `<slot name="footer" />` | `footer?: ReactNode` prop | Named slot → explicit prop |
+| `watch` + `onMounted` + `onBeforeUnmount` | Single `useEffect` with cleanup | Consolidate related side effects |
+| `<Teleport to="body">` | `createPortal(jsx, document.body)` | Same DOM escape hatch |
+
+---
+
+## 6. Per-Component Verification Checklist
+
+### Public API
+- [ ] Prop names and defaults preserved?
+- [ ] Every emitted event mapped to a callback prop with same semantics?
+- [ ] Every `v-model` pair now an explicit controlled API?
+
+### Composition & Extensibility
+- [ ] Default slot → `children`? Named slots → explicit props? Scoped → render props?
+- [ ] Fallthrough attributes still reach the intended element?
+
+### State & Reactivity
+- [ ] `ref()` / `reactive()` → sensible local state?
+- [ ] `computed` stayed derived (not redundant state copies)?
+- [ ] `watch` → `useEffect` only for true side effects?
+
+### DOM Behavior
+- [ ] Refs / focus / scroll / portal behavior survived?
+- [ ] Transitions preserve timing and mount/unmount rules?
+- [ ] Click-outside, keyboard shortcuts, and cleanup survived?
+
+### Routing & Data
+- [ ] Route params and search params map correctly?
+- [ ] Navigation calls behave the same?
+- [ ] Data fetching moved to the right layer (server vs client)?
+
+### UI Parity
+- [ ] Class names and DOM structure compatible with existing CSS?
+- [ ] Loading, empty, and error states identical?
+- [ ] ARIA attributes and keyboard behavior preserved?
+
+---
+
+## 7. The Client-Heavy-First Pattern
+
+When migrating a route, start with **everything in a client component** — this mirrors Vue (client-side by default) and guarantees behavioral parity.
+
+**Step 1 — Thin server entry:**
+```tsx
+// app/dashboard/page.tsx — Server Component
+import DashboardPageClient from './DashboardPageClient'
+export default function Page() {
+  return <DashboardPageClient />
+}
+```
+
+**Step 2 — All logic in client component:**
+```tsx
+// app/dashboard/DashboardPageClient.tsx
+'use client'
+import { useState, useEffect } from 'react'
+
+export default function DashboardPageClient() {
+  const [data, setData] = useState(null)
+  useEffect(() => {
+    fetch('/api/dashboard').then((r) => r.json()).then(setData)
+  }, [])
+  if (!data) return <div>Loading...</div>
+  return <div>{/* full dashboard UI */}</div>
+}
+```
+
+**Step 3 — After parity, progressively extract:** static markup → Server Component, data fetching → async server page, non-interactive UI → Server Component children.
+
+```tsx
+// app/dashboard/page.tsx — After optimization
+import { getDashboardData } from '@/lib/data'
+import DashboardCharts from './DashboardCharts' // 'use client'
+
+export default async function Page() {
+  const data = await getDashboardData()
+  return (
+    <main>
+      <h1>Dashboard</h1>              {/* Server-rendered */}
+      <DashboardCharts data={data} />  {/* Client interactive */}
+    </main>
+  )
+}
+```
+
+> Get it working first, then get it optimized. Never both at once.

--- a/skills/convert-vue-nextjs/references/conversion/routing-conversion.md
+++ b/skills/convert-vue-nextjs/references/conversion/routing-conversion.md
@@ -1,0 +1,314 @@
+# Routing Conversion: Vue Router → Next.js App Router
+
+Converting Vue Router's config-based routing to Next.js file-system routing.
+
+---
+
+## File Structure Mapping
+
+Vue Router uses an explicit config object. Next.js uses the `app/` directory tree.
+
+**Vue Router config:**
+```ts
+const routes = [
+  { path: '/', component: Home },
+  { path: '/about', component: About },
+  {
+    path: '/dashboard', component: DashboardLayout,
+    children: [
+      { path: '', component: DashboardHome },
+      { path: 'analytics', component: Analytics },
+      { path: 'settings', component: SettingsLayout, children: [
+        { path: '', component: SettingsGeneral },
+        { path: 'profile', component: Profile },
+      ]},
+    ],
+  },
+  { path: '/users/:id', component: UserDetail },
+  { path: '/docs/:slug+', component: DocsPage },
+  { path: '/:pathMatch(.*)*', component: NotFound },
+]
+```
+
+**Next.js equivalent:**
+```
+app/
+  page.tsx                    ← / (Home)
+  about/page.tsx              ← /about
+  dashboard/
+    layout.tsx                ← DashboardLayout
+    page.tsx                  ← /dashboard
+    analytics/page.tsx        ← /dashboard/analytics
+    settings/
+      layout.tsx              ← SettingsLayout
+      page.tsx                ← /dashboard/settings
+      profile/page.tsx        ← /dashboard/settings/profile
+  users/[id]/page.tsx         ← /users/:id
+  docs/[...slug]/page.tsx     ← /docs/:slug+
+  not-found.tsx               ← 404
+```
+
+**Conversion rules:** Replace `:param` → `[param]`, `:param+` → `[...param]`, `:param*` → `[[...param]]`. Routes with `children` → `layout.tsx` + nested folders. Child `path: ''` → `page.tsx` in parent.
+
+---
+
+## Route Syntax Mapping
+
+| Vue Router | Next.js App Router | Notes |
+|---|---|---|
+| `path: '/'` | `app/page.tsx` | Root page |
+| `path: '/about'` | `app/about/page.tsx` | Static route |
+| `path: '/users/:id'` | `app/users/[id]/page.tsx` | Dynamic segment |
+| `path: '/post/:year/:month'` | `app/post/[year]/[month]/page.tsx` | Multiple params |
+| `path: '/docs/:slug+'` | `app/docs/[...slug]/page.tsx` | Catch-all (1+) |
+| `path: '/docs/:slug*'` | `app/docs/[[...slug]]/page.tsx` | Optional catch-all |
+| `path: '/:pathMatch(.*)*'` | `app/not-found.tsx` | 404 |
+| `children: [...]` | Nested folders + `layout.tsx` | Nested routes |
+| Named views | `@slot` parallel routes | `@sidebar/page.tsx` |
+| `alias` | `next.config.js` `rewrites` | URL aliasing |
+| `redirect` | `next.config.js` `redirects` | Redirect |
+
+### Route Parity Matrix
+
+Track migration progress route-by-route using this template:
+
+| Vue Route | Next Segment | Owner | SSR Needs | Status |
+|---|---|---|---|---|
+| `/user/:id` | `app/users/[id]/page.tsx` | @team | `generateMetadata` + dynamic params | ✅ Done |
+| `/settings` | `app/(app)/settings/page.tsx` | — | Static | 🔲 Todo |
+
+---
+
+## Layouts
+
+**Vue:** `<router-view />` renders child routes.
+**Next.js:** `layout.tsx` with `{children}` renders child pages.
+
+```vue
+<!-- Vue: DashboardLayout.vue -->
+<template>
+  <div class="dashboard">
+    <Sidebar />
+    <main><router-view /></main>
+  </div>
+</template>
+```
+
+```tsx
+// Next.js: app/dashboard/layout.tsx
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dashboard">
+      <Sidebar />
+      <main>{children}</main>
+    </div>
+  );
+}
+```
+
+Layouts persist across navigations within their segment — state is preserved.
+
+> **Client State Persistence:** Components rendered inside a shared `layout.tsx` maintain React state across navigations. Components outside the layout boundary (or in a different layout segment) will remount and lose state. Plan your layout hierarchy to align with state-persistence needs.
+
+---
+
+## Navigation
+
+### `<router-link>` → `<Link>`
+
+```vue
+<!-- Vue -->
+<router-link to="/about">About</router-link>
+<router-link :to="{ name: 'user', params: { id: 1 } }">User</router-link>
+```
+
+```tsx
+// Next.js — uses href, not to. No named routes.
+import Link from 'next/link';
+<Link href="/about">About</Link>
+<Link href={`/users/${id}`}>User</Link>
+```
+
+> **Link Prefetch Behavior:** Next.js `<Link>` automatically prefetches routes when the link enters the viewport (production only). This is a significant performance win over Vue Router, which requires manual `prefetch` hints. Use `prefetch={false}` to disable on low-priority links.
+
+### Programmatic Navigation
+
+```ts
+// Vue
+const router = useRouter()
+router.push('/dashboard')
+router.replace('/login')
+router.go(-1)
+
+// Next.js
+import { useRouter } from 'next/navigation';
+const router = useRouter();
+router.push('/dashboard');
+router.replace('/login');
+router.back();
+```
+
+### Route Params & Query
+
+```ts
+// Vue
+const route = useRoute()
+route.params.id       // dynamic param
+route.query.search    // query string
+route.path            // current path
+
+// Next.js (client components)
+import { useParams, useSearchParams, usePathname } from 'next/navigation';
+useParams().id                    // { id: '123' }
+useSearchParams().get('search')   // query string
+usePathname()                     // '/users/123'
+```
+
+> ⚠️ **useSearchParams / useParams are Client Component hooks only.** They are not available in Server Components. `useSearchParams` can return stale values during partial rendering. **Decision:** prefer reading route params from server page props (`params`, `searchParams`) when possible; fall back to client hooks only for client-interactive features.
+
+### Server-Side Redirect
+
+```tsx
+import { redirect } from 'next/navigation';
+export default async function ProtectedPage() {
+  const session = await getSession();
+  if (!session) redirect('/login');
+  return <Dashboard />;
+}
+```
+
+---
+
+## Navigation Guards → Middleware
+
+| Vue Guard | Next.js Equivalent |
+|---|---|
+| `router.beforeEach` (global) | `middleware.ts` at project root |
+| `router.afterEach` (global) | `useEffect` in root layout |
+| `beforeEnter` (per-route) | `middleware.ts` with pathname matching |
+| `beforeRouteEnter` (component) | Server Component check / middleware |
+| `beforeRouteLeave` (component) | `onbeforeunload` / custom hook |
+| `beforeRouteUpdate` (component) | `useEffect` with params dep |
+
+### Auth Guard Example
+
+**Vue:**
+```ts
+router.beforeEach((to) => {
+  if (to.meta.requiresAuth && !isAuthenticated()) {
+    return { name: 'login', query: { redirect: to.fullPath } }
+  }
+})
+```
+
+**Next.js:**
+```ts
+// middleware.ts
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('auth-token')?.value;
+  if (!token) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('redirect', request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings/:path*', '/admin/:path*'],
+};
+```
+
+| Aspect | Vue Guards | Next.js Middleware |
+|---|---|---|
+| Runs on | Client-side | Edge/server (before page loads) |
+| Access to | Store, component | Request/response only |
+| Cancel | `return false` | `NextResponse.redirect()` |
+| Multiple | Chain guards | Single file, conditionals |
+| Runtime | Full Node.js | Edge Runtime (limited APIs) |
+
+### beforeRouteLeave → Unsaved Changes
+
+```tsx
+'use client';
+export function useUnsavedChanges(isDirty: boolean) {
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); e.returnValue = ''; };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
+}
+```
+
+### proxy.ts (Next 16+)
+
+Next 16+ introduces `proxy.ts` as the explicit network boundary, replacing `middleware.ts` for request-time logic (redirects, rewrites, headers). Codemods are available (`npx @next/codemod@latest middleware-to-proxy`) for migration.
+
+```ts
+// proxy.ts — runs at the network edge
+import { NextProxy } from 'next/proxy';
+
+export default function proxy(request: NextProxy) {
+  if (!request.cookies.get('auth-token')) {
+    return request.redirect('/login');
+  }
+  request.headers.set('x-custom', 'value');
+  return request.next();
+}
+
+export const config = { matcher: ['/dashboard/:path*'] };
+```
+
+> ⚠️ **proxy.ts runs at the network edge** — don't rely on it for full authorization (use server-side checks too). Fetch caching options (`next.revalidate`, `cache`) have no effect inside proxy handlers.
+
+---
+
+## Route Meta
+
+| Vue `meta` Usage | Next.js Equivalent | Location |
+|---|---|---|
+| `meta.title` | `export const metadata` or `generateMetadata()` | `page.tsx` |
+| `meta.requiresAuth` | Pathname matching | `middleware.ts` |
+| `meta.roles` | Token/session check | `middleware.ts` |
+| `meta.layout` | Folder structure | File system |
+| `meta.revalidate` | `export const revalidate = N` | `page.tsx` |
+
+**Dynamic metadata:**
+```tsx
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  return { title: post.title, description: post.excerpt };
+}
+```
+
+---
+
+## Route Groups & Parallel Routes
+
+**Route groups** `(groupName)` organize routes without affecting URLs:
+```
+app/
+  (marketing)/layout.tsx    ← Marketing layout
+  (marketing)/about/page.tsx  ← /about
+  (app)/layout.tsx          ← App layout (with sidebar)
+  (app)/dashboard/page.tsx  ← /dashboard
+```
+
+**Parallel routes** render multiple pages simultaneously using `@slot`:
+```tsx
+// app/layout.tsx — receives named slots as props
+export default function Layout({ children, sidebar }: {
+  children: React.ReactNode; sidebar: React.ReactNode
+}) {
+  return <div className="flex"><aside>{sidebar}</aside><main>{children}</main></div>;
+}
+```
+
+This replaces Vue Router's named views (`<router-view name="sidebar">`).
+
+**Intercepting routes** use `(.)` convention for modal-over-list patterns (e.g., Instagram-style photo modals). Vue has no equivalent.

--- a/skills/convert-vue-nextjs/references/conversion/ssr-data-fetching.md
+++ b/skills/convert-vue-nextjs/references/conversion/ssr-data-fetching.md
@@ -1,0 +1,378 @@
+# SSR & Data Fetching: Nuxt → Next.js
+
+Converting Nuxt data fetching, rendering modes, and server patterns to Next.js App Router.
+
+---
+
+## Pattern Mapping Table
+
+| Nuxt Pattern | Next.js Equivalent | Key Differences |
+|---|---|---|
+| `useFetch('/api/posts')` | `fetch()` in async Server Component | Nuxt: reactive `{data, pending, error}`; Next: plain data |
+| `useAsyncData('key', fn)` | `fetch()` in RSC with cache options | Nuxt: explicit key; Next: auto-dedupes by URL |
+| `$fetch('/api/user')` | Native `fetch()` or direct DB call | Nuxt auto-throws on 4xx/5xx; `fetch` needs `res.ok` check |
+| `useFetch(url, { server: false })` | Client Component with `useEffect`/SWR | Add `'use client'` + client-side library |
+| `useFetch(url, { lazy: true })` | `<Suspense>` boundary + RSC | Streaming |
+| `useFetch(url, { watch: [ref] })` | Client Component with TanStack Query | Reactive refetch needs client lib |
+| `server/api/*.ts` (Nitro) | `app/api/*/route.ts` | `defineEventHandler` → `GET`/`POST` exports |
+| `server/middleware/*.ts` | `middleware.ts` at root | Multiple files → single file with `matcher` |
+| `<ClientOnly>` | `'use client'` directive | Component-level split |
+| `routeRules: { swr: N }` | `export const revalidate = N` | Per-route ISR |
+| `NuxtLink` | `<Link>` from `next/link` | `to` → `href` |
+
+---
+
+## Server-Side Data Fetching
+
+### Nuxt useFetch → Async Server Component
+
+**Nuxt:**
+```vue
+<script setup>
+const { data: posts, pending, error } = await useFetch('/api/posts')
+</script>
+<template>
+  <div v-if="pending">Loading...</div>
+  <div v-else-if="error">Error: {{ error.message }}</div>
+  <ul v-else>
+    <li v-for="post in posts" :key="post.id">{{ post.title }}</li>
+  </ul>
+</template>
+```
+
+**Next.js:**
+```tsx
+// app/posts/page.tsx — Server Component (default)
+export default async function PostsPage() {
+  const res = await fetch('https://api.example.com/posts', {
+    next: { revalidate: 3600 },
+  });
+  if (!res.ok) throw new Error('Failed to fetch');
+  const posts: Post[] = await res.json();
+  return <ul>{posts.map(p => <li key={p.id}>{p.title}</li>)}</ul>;
+}
+
+// app/posts/loading.tsx — replaces v-if="pending"
+export default function Loading() { return <div>Loading...</div>; }
+
+// app/posts/error.tsx — replaces v-else-if="error"
+'use client';
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <div><p>Error: {error.message}</p><button onClick={reset}>Retry</button></div>;
+}
+```
+
+### Key useFetch Option Conversions
+
+| Nuxt Option | Next.js Equivalent |
+|---|---|
+| `{ key: 'x' }` | Auto-deduplication (no key needed) |
+| `{ lazy: true }` | Wrap in `<Suspense>` |
+| `{ server: false }` | `'use client'` + `useEffect`/SWR |
+| `{ cache: true }` | `{ cache: 'force-cache' }` or `{ next: { revalidate: N } }` |
+| `{ watch: [ref] }` | Client Component with TanStack Query |
+| `{ transform: fn }` | Inline after `await res.json()` |
+
+### Client-Side Reactive Fetching
+
+**Nuxt:** `useFetch('/api/search', { query: { q: search }, watch: [search] })`
+
+**Next.js:**
+```tsx
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function SearchPage() {
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useQuery({
+    queryKey: ['search', search],
+    queryFn: () => fetch(`/api/search?q=${search}`).then(r => r.json()),
+    enabled: search.length > 0,
+  });
+  return <>
+    <input value={search} onChange={e => setSearch(e.target.value)} />
+    {isLoading ? <p>Searching...</p> : data?.map((i: Item) => <div key={i.id}>{i.name}</div>)}
+  </>;
+}
+```
+
+### Don't Port onMounted(fetch...) Blindly
+
+A lot of Vue components fetch data in `onMounted` or in watchers reacting to route params. In Next App Router, the better default is to **fetch on the server**.
+
+**Decision framework:**
+
+| Vue Pattern | Next.js Default | When to Deviate |
+|---|---|---|
+| Component **only displays** fetched data | Server Component with `await fetch()` | — |
+| Component **displays data AND has rich interaction** | Fetch in Server Component, pass as props to Client Component | — |
+| Data must be **refreshed from client interactions** | Choose: `router.refresh()`, Server Actions, or client-side fetching | Use client fetch for real-time/polling |
+
+Before reaching for `useEffect` + `fetch`, ask: *"Can this data be fetched before the component renders?"* If yes, use a Server Component.
+
+---
+
+## Server vs Client Components
+
+| Server Component (default) | Client Component (`'use client'`) |
+|---|---|
+| Fetch data, access backend, keep secrets | Interactive UI, browser APIs, state/effects |
+
+### Decision Criteria
+
+Make it a **Client Component** (`'use client'`) if it needs:
+- Local state (`useState`), event handlers (`onClick`, `onChange`)
+- `useEffect`, refs, imperative DOM access
+- Browser APIs (`window`, `localStorage`, `IntersectionObserver`)
+- Client-side router/store hooks (`useRouter`, `useSearchParams`)
+
+Make it a **Server Component** (default) when mostly:
+- Rendering static markup or fetched data
+- Using secrets, env vars, or server-only modules
+- Composing non-interactive content
+
+> **Migration tip:** During migration, bias toward Client Components for parity. Optimize to Server Components later — correctness first, performance second.
+
+### The Donut Pattern
+
+Server wrapper with client interior — data on server, interactivity on client:
+
+```tsx
+// app/products/page.tsx — Server Component
+export default async function ProductsPage() {
+  const products = await db.product.findMany();
+  return <ProductFilter products={products} />; // pass to client
+}
+
+// components/ProductFilter.tsx
+'use client';
+export function ProductFilter({ products }: { products: Product[] }) {
+  const [query, setQuery] = useState('');
+  const filtered = products.filter(p => p.name.toLowerCase().includes(query.toLowerCase()));
+  return <>
+    <input value={query} onChange={e => setQuery(e.target.value)} />
+    {filtered.map(p => <ProductCard key={p.id} product={p} />)}
+  </>;
+}
+```
+
+Push `'use client'` as low in the tree as possible.
+
+### Serialization Boundary Warning
+
+Props passed from a Server Component to a Client Component **must be serializable** — you cannot pass functions, class instances, or Dates across that boundary.
+
+```tsx
+// ❌ BROKEN — function prop crosses the server/client boundary
+export default async function Page() {
+  const handleClick = () => console.log('clicked'); // not serializable
+  return <ClientButton onClick={handleClick} />;
+}
+
+// ✅ CORRECT — keep callbacks inside the client island
+'use client';
+export function ClientButton() {
+  const handleClick = () => console.log('clicked');
+  return <button onClick={handleClick}>Click</button>;
+}
+```
+
+This is why callback-heavy component hierarchies should stay inside a single `'use client'` island at first — split later once the boundary is clear.
+
+---
+
+## Server Actions
+
+**Nuxt mutation:** `await $fetch('/api/posts', { method: 'POST', body: data })`
+
+**Next.js Server Action:**
+```tsx
+// app/posts/actions.ts
+'use server';
+import { revalidatePath } from 'next/cache';
+
+export async function createPost(formData: FormData) {
+  await db.post.create({ data: { title: formData.get('title') as string } });
+  revalidatePath('/posts');
+}
+
+// app/posts/new/page.tsx — no 'use client' needed!
+import { createPost } from '../actions';
+export default function NewPost() {
+  return <form action={createPost}><input name="title" required /><button type="submit">Create</button></form>;
+}
+```
+
+> **Constraint:** `revalidatePath`/`revalidateTag` can only be called from Server Actions or Route Handlers — not from Client Components or proxied imports.
+
+### Optimistic Updates
+
+```tsx
+'use client';
+import { useOptimistic } from 'react';
+
+export function TodoList({ todos }: { todos: Todo[] }) {
+  const [optimistic, addOptimistic] = useOptimistic(todos,
+    (state, newTitle: string) => [...state, { id: 'temp', title: newTitle, pending: true }]
+  );
+  async function handleSubmit(formData: FormData) {
+    addOptimistic(formData.get('title') as string);
+    await addTodo(formData);
+  }
+  return <form action={handleSubmit}>
+    <input name="title" /><button type="submit">Add</button>
+    <ul>{optimistic.map(t => <li key={t.id} style={{ opacity: t.pending ? 0.5 : 1 }}>{t.title}</li>)}</ul>
+  </form>;
+}
+```
+
+---
+
+## SSG / ISR
+
+| Nuxt Config | Next.js Equivalent |
+|---|---|
+| `routeRules: { '/': { prerender: true } }` | `export const dynamic = 'force-static'` |
+| `routeRules: { '/blog/**': { swr: 3600 } }` | `export const revalidate = 3600` |
+| `routeRules: { '/dash/**': { ssr: true } }` | `export const dynamic = 'force-dynamic'` |
+| `nitro: { static: true }` | `next.config: { output: 'export' }` |
+
+**ISR with static params:**
+```tsx
+// app/blog/[slug]/page.tsx
+export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  const posts = await fetch('https://api.example.com/posts').then(r => r.json());
+  return posts.map((p: Post) => ({ slug: p.slug }));
+}
+
+export default async function BlogPost({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = await fetch(`https://api.example.com/posts/${slug}`).then(r => r.json());
+  return <article>{post.content}</article>;
+}
+```
+
+**On-demand revalidation:** `revalidatePath('/posts')` or `revalidateTag('posts')` from Server Actions or Route Handlers.
+
+### ISR via Route Config
+
+Add `export const revalidate = 60` in any `page.tsx`/`layout.tsx` for time-based ISR — stale pages regenerate in the background on next request. For event-driven freshness, tag fetches with `{ next: { tags: ['posts'] } }` and call `revalidateTag('posts')` from a Server Action or Route Handler.
+
+---
+
+## API Routes
+
+**Nuxt:** `server/api/posts/[id].get.ts` with `defineEventHandler`
+**Next.js:** `app/api/posts/[id]/route.ts` with named exports
+
+```ts
+// app/api/posts/[id]/route.ts
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const post = await db.post.findUnique({ where: { id } });
+  if (!post) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(post);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const post = await db.post.create({ data: body });
+  return NextResponse.json(post, { status: 201 });
+}
+```
+
+Prefer direct DB access in Server Components over API routes. Only use Route Handlers for external consumers or Client Component endpoints.
+
+---
+
+## Middleware
+
+**Nuxt:** Multiple files in `server/middleware/`, full Node.js runtime, can access DB.
+**Next.js:** Single `middleware.ts`, Edge Runtime, headers/cookies/redirects only.
+
+```ts
+// middleware.ts
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('auth-token')?.value;
+  if (!token && request.nextUrl.pathname.startsWith('/dashboard')) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+  return NextResponse.next();
+}
+export const config = { matcher: ['/dashboard/:path*'] };
+```
+
+Complex auth requiring DB → move to Route Handlers or Server Actions.
+
+---
+
+## Loading, Error & Streaming
+
+**Loading:** Nuxt `v-if="pending"` → Next.js `loading.tsx` (auto-wraps page in Suspense) or manual `<Suspense fallback={}>`.
+
+**Error:** Nuxt error handling → Next.js `error.tsx` (must be `'use client'`, receives `{ error, reset }`).
+
+**Streaming:** Nest `<Suspense>` boundaries for independent progressive rendering:
+```tsx
+export default function Dashboard() {
+  return <div>
+    <h1>Dashboard</h1>
+    <Suspense fallback={<StatsSkeleton />}><StatsPanel /></Suspense>
+    <Suspense fallback={<ChartSkeleton />}><RevenueChart /></Suspense>
+  </div>;
+}
+```
+
+Each async Server Component streams independently — no waterfall.
+
+---
+
+## Page Migration Pattern
+
+The recommended order for migrating a Vue/Nuxt page component to Next.js App Router:
+
+1. **Move page entry** into `app/.../page.tsx`
+2. **Create a route-local Client Component** (preserves all interactive logic with `'use client'`)
+3. **Pull out leaf child components** — migrate children first, parents last
+4. **Separate data-loading from view logic** (only after parity is achieved)
+5. **Move route-level UX** into `loading.tsx` and `error.tsx`
+
+**Common end state** — server page fetches, client component renders:
+
+```tsx
+// app/users/[id]/page.tsx — Server Component
+import UserPageClient from './UserPageClient';
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  return <UserPageClient initialUser={await getUser((await params).id)} />;
+}
+// app/users/[id]/UserPageClient.tsx — 'use client'
+export default function UserPageClient({ initialUser }: { initialUser: User }) {
+  return <div>{/* All original Vue interactivity lives here */}</div>;
+}
+```
+
+---
+
+## Freshness SLAs
+
+Map each route to a freshness policy: **static** (`dynamic = 'force-static'`), **dynamic** (`dynamic = 'force-dynamic'`), **ISR-N** (`revalidate = N`), or **on-demand** (`revalidateTag()`). Match each Vue data pattern — `useFetch` with caching → ISR, `$fetch` on interaction → dynamic, prerendered → static. Document per-route SLAs to prevent over-fetching or stale data.
+
+---
+
+## Hydration & Conversion Checklist
+
+| Nuxt | Next.js |
+|---|---|
+| Full DOM hydration | Partial — only `'use client'` hydrates |
+| `<ClientOnly>` | `'use client'` directive |
+| `process.server` checks | Server Components (default) vs Client |
+| `refreshNuxtData()` | `router.refresh()` |
+| `clearNuxtData()` | `revalidatePath()` / `revalidateTag()` |

--- a/skills/convert-vue-nextjs/references/conversion/state-management.md
+++ b/skills/convert-vue-nextjs/references/conversion/state-management.md
@@ -1,0 +1,318 @@
+# State Management Conversion: Vue → React
+
+Patterns for converting Vue's reactivity system and state management to React equivalents.
+
+---
+
+## Reactivity Model Differences
+
+Vue uses **Proxy-based automatic tracking** — mutations are direct and dependencies auto-detected. React uses **explicit setState with immutable updates**.
+
+```ts
+// Vue — mutable, auto-tracked
+const count = ref(0)
+count.value++                            // ✅ Vue detects this
+const state = reactive({ items: [] })
+state.items.push('new')                  // ✅ Vue detects nested mutations
+
+// React — immutable, explicit
+const [count, setCount] = useState(0);
+setCount(c => c + 1);                    // ✅ New value via setter
+setState(s => ({ ...s, items: [...s.items, 'new'] })); // ✅ Spread for update
+// state.items.push('new')  ❌ NEVER mutate directly
+```
+
+---
+
+## Primitives Mapping
+
+### ref() → useState()
+
+```ts
+// Vue: const count = ref(0); count.value++
+// React:
+const [count, setCount] = useState(0); // [value, setter] — no .value
+```
+
+### reactive() → useState() with objects
+
+```ts
+// Vue: const form = reactive({ name: '' }); form.name = 'John'
+// React:
+const [form, setForm] = useState({ name: '' });
+setForm(prev => ({ ...prev, name: 'John' })); // must spread
+```
+
+For deeply nested state, consider `useImmer` (from `use-immer`) which allows Vue-like mutations.
+
+### computed() → Render Derivation (not always useMemo)
+
+In React, the first question should be: **is this really state, or just a value derived from props/state during render?**
+
+**Simple derivation — just compute inline:**
+```tsx
+// Vue: const fullName = computed(() => `${first.value} ${last.value}`)
+// React — NO useMemo needed:
+const fullName = `${firstName} ${lastName}`;
+const activeItems = items.filter(i => i.active);
+const sortedList = [...items].sort((a, b) => a.name.localeCompare(b.name));
+```
+
+**Only use useMemo when:**
+- Calculation is genuinely expensive (large lists, complex transforms)
+- Referential stability matters for child props (objects/arrays passed to `React.memo` children)
+
+```ts
+// Vue: const total = computed(() => price.value * (1 + tax.value)) — auto-tracks deps
+// React — expensive or referentially sensitive:
+const total = useMemo(() => price * (1 + tax), [price, tax]); // explicit deps
+```
+
+> Many derived values should simply be computed during render and only memoized when expensive. Over-memoizing is a common migration mistake.
+
+⚠️ Missing deps in `useMemo` = stale values. Vue auto-tracks; React requires explicit arrays.
+
+### watch() → useEffect()
+
+```ts
+// Vue: watch(userId, (newId, oldId) => { ... })
+// React:
+const prevUserId = useRef(userId);
+useEffect(() => {
+  console.log(`Changed from ${prevUserId.current} to ${userId}`);
+  prevUserId.current = userId;
+  fetchUser(userId).then(setUserData);
+}, [userId]);
+```
+
+No `oldValue` in React — use `useRef` to track previous values.
+
+### watchEffect() → useEffect()
+
+```ts
+// Vue: watchEffect(() => { document.title = query.value }) — auto-tracks
+// React:
+useEffect(() => { document.title = query; }, [query]); // must list deps
+```
+
+### Watch Options
+
+| Vue Option | React Equivalent |
+|---|---|
+| `immediate: true` | `useEffect` already runs on mount |
+| `deep: true` | No equivalent; restructure or `JSON.stringify` |
+| `flush: 'post'` | `useEffect` (default) |
+| `flush: 'sync'` | `useLayoutEffect` |
+
+### watch → useEffect: Good vs Bad Migrations
+
+Not every Vue `watch` should become a `useEffect`. Many watches compute derived values — those belong in render, not effects.
+
+**✅ Good watch → useEffect** (true side effects):
+- Syncing to localStorage / sessionStorage
+- Managing subscriptions (WebSocket, EventSource)
+- Timers (`setTimeout`, `setInterval`)
+- DOM event listeners (`resize`, `scroll`)
+- Imperative library integration (chart libs, maps)
+- Analytics / telemetry tracking
+- Network request cancellation / cleanup
+
+**❌ Bad watch → useEffect** (should stay in render):
+- Recomputing display values (→ inline derivation or `useMemo`)
+- Copying props into state (→ derive from props directly)
+- Sorting / filtering data purely for render (→ compute inline)
+- Resetting state when props change (→ use `key` prop to remount)
+
+```ts
+// ❌ BAD — copying prop to state via effect
+const [filtered, setFiltered] = useState(items);
+useEffect(() => { setFiltered(items.filter(i => i.active)); }, [items]);
+
+// ✅ GOOD — derive during render
+const filtered = items.filter(i => i.active);
+```
+
+---
+
+## Composables → Custom Hooks
+
+Nearly identical structure (`useX()` functions), different internals.
+
+### useAuth — Before/After
+
+**Vue composable:**
+```ts
+const user = ref<User | null>(null) // module-level singleton
+const token = ref('')
+
+export function useAuth() {
+  const isLoggedIn = computed(() => !!user.value)
+  async function login(creds: Credentials) {
+    const res = await api.login(creds)
+    user.value = res.user; token.value = res.token
+  }
+  function logout() { user.value = null; token.value = '' }
+  return { user, isLoggedIn, login, logout }
+}
+```
+
+**React hook (Zustand for shared state):**
+```ts
+import { create } from 'zustand';
+
+const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  token: '',
+  login: async (creds) => {
+    const res = await api.login(creds);
+    set({ user: res.user, token: res.token });
+  },
+  logout: () => set({ user: null, token: '' }),
+}));
+
+export function useAuth() {
+  const { user, login, logout } = useAuthStore();
+  return { user, isLoggedIn: !!user, login, logout };
+}
+```
+
+| Aspect | Vue Composable | React Hook |
+|---|---|---|
+| Execution | `setup()` runs once | Function runs every render |
+| Shared state | Module-level `ref()` | Zustand/Context needed |
+| Return values | Reactive refs | Plain values + setters |
+
+---
+
+## Store Conversion
+
+### Pinia Store Migration: 3-Category Decision Framework
+
+Before converting any Pinia store, categorize it first. This distinction is a major source of over-engineering during migrations.
+
+| Category | Examples | React Target |
+|---|---|---|
+| **1. Local UI state** disguised as global | Modal open/closed, current tab, panel collapsed, transient route filters | Local `useState`, `useReducer`, or route-scoped Context |
+| **2. Shared client state** | Auth session, theme preference, cart, multi-step form progress | Context (small), `useReducer` + Context (structured), Zustand (large/complex) |
+| **3. Server state** cached in client | Fetched lists, dashboard metrics, API records, paginated data | Server Component data fetching (preferred), TanStack Query (client cache + background refresh) |
+
+**Migration workflow:**
+1. Audit each Pinia store → assign a category
+2. Category 1 stores often disappear entirely — extract to the component that owns the UI
+3. Category 3 stores should not be Zustand/Redux — use proper data-fetching patterns
+4. Only Category 2 stores map directly to Zustand/Context
+
+### Pinia → Zustand (Recommended)
+
+Closest API match — both use closure-based stores with state + actions.
+
+**Pinia:**
+```ts
+export const useCartStore = defineStore('cart', () => {
+  const items = ref<CartItem[]>([])
+  const total = computed(() => items.value.reduce((s, i) => s + i.price * i.qty, 0))
+  function addItem(p: Product) {
+    const existing = items.value.find(i => i.id === p.id)
+    if (existing) existing.qty++
+    else items.value.push({ ...p, qty: 1 })
+  }
+  function removeItem(id: string) { items.value = items.value.filter(i => i.id !== id) }
+  return { items, total, addItem, removeItem }
+})
+```
+
+**Zustand:**
+```ts
+import { create } from 'zustand';
+
+export const useCartStore = create<CartState>((set) => ({
+  items: [],
+  addItem: (p) => set(s => {
+    const existing = s.items.find(i => i.id === p.id);
+    if (existing) return { items: s.items.map(i => i.id === p.id ? { ...i, qty: i.qty + 1 } : i) };
+    return { items: [...s.items, { ...p, qty: 1 }] };
+  }),
+  removeItem: (id) => set(s => ({ items: s.items.filter(i => i.id !== id) })),
+}));
+
+export const useCartTotal = () => useCartStore(s => s.items.reduce((sum, i) => sum + i.price * i.qty, 0));
+```
+
+**Concept mapping:**
+
+| Pinia | Zustand |
+|---|---|
+| `defineStore('id', () => {...})` | `create((set, get) => ({...}))` |
+| `ref()` for state | Plain properties |
+| `computed()` for getters | Selector functions |
+| Actions (functions) | Functions calling `set()` |
+| `$patch({ ... })` | `set({ ... })` |
+| `$reset()` | `set(initialState)` |
+| `$subscribe(cb)` | `useStore.subscribe(cb)` |
+| `storeToRefs(store)` | `useStore(s => s.prop)` per-property |
+
+### Vuex → Zustand or Redux Toolkit
+
+**Vuex module → Zustand (simpler):**
+```ts
+// Vuex: state + mutations + actions + getters → single Zustand store
+export const useCounterStore = create<CounterState>((set) => ({
+  count: 0,
+  increment: () => set(s => ({ count: s.count + 1 })),
+  fetchCount: async () => { const data = await api.getCount(); set({ count: data }); },
+}));
+export const useDoubleCount = () => useCounterStore(s => s.count * 2);
+```
+
+Use **Redux Toolkit** instead when: 10+ stores, need time-travel debugging, or team prefers Redux patterns. Vuex `mutations` → RTK `reducers` (both use Immer), `actions` → `createAsyncThunk`, `getters` → `createSelector`, `modules` → slices.
+
+---
+
+## provide/inject → React Context
+
+**Vue:**
+```ts
+provide('theme', ref<'light' | 'dark'>('dark'))
+// descendant: const theme = inject('theme')
+```
+
+**React:**
+```tsx
+const ThemeCtx = createContext<{ theme: 'light' | 'dark'; setTheme: (t: 'light' | 'dark') => void } | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+  return <ThemeCtx.Provider value={{ theme, setTheme }}>{children}</ThemeCtx.Provider>;
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeCtx);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}
+```
+
+| Vue | React |
+|---|---|
+| `provide(key, value)` | `<Context.Provider value={...}>` |
+| `inject(key)` | `useContext(Context)` |
+| No wrapper needed | Requires `<Provider>` wrapper |
+
+---
+
+## Decision Tree
+
+```
+What Vue state pattern?
+├─ Local ref/reactive → useState()
+├─ Computed/derived → useMemo() or inline
+├─ Shared across components?
+│  ├─ Parent-child → props + callbacks
+│  ├─ Deep tree → React Context
+│  └─ Global → Zustand store
+├─ Pinia store → Zustand (closest match)
+├─ Vuex store?
+│  ├─ Simple (1-5 modules) → Zustand
+│  └─ Complex (5+, devtools needed) → Redux Toolkit
+└─ provide/inject → React Context
+```

--- a/skills/convert-vue-nextjs/references/ecosystem/package-mapping.md
+++ b/skills/convert-vue-nextjs/references/ecosystem/package-mapping.md
@@ -1,0 +1,350 @@
+# Vue → React/Next.js Package Mapping
+
+> Comprehensive ecosystem mapping for converting Vue applications to React/Next.js, with migration effort ratings and code examples.
+
+---
+
+## Master Package Mapping Table
+
+| Category | Vue Package | React/Next.js Equivalent | Effort | Notes |
+|---|---|---|---|---|
+| **Core Framework** | Vue 3 (Composition API) | React 18/19 (Hooks) | 🔴 High | Fundamentally different reactivity models |
+| **Meta-Framework** | Nuxt 3 | Next.js 14/15 | 🔴 High | Full framework swap; similar concepts, different APIs |
+| **Routing** | Vue Router 4 | Next.js App Router | 🔴 High | Config-based → file-system routing paradigm shift |
+| **State (Simple)** | Pinia | Zustand | 🟡 Medium | Closest API similarity; `defineStore()` → `create()` |
+| **State (Complex)** | Vuex | Redux Toolkit (RTK) | 🟡 Medium | Mutations → reducers, actions → thunks |
+| **State (Atomic)** | Pinia (fine-grained) | Jotai | 🟡 Medium | Each `ref` becomes an `atom` |
+| **DI / Globals** | `provide` / `inject` | React Context + `useContext` | 🟢 Low | Direct conceptual mapping |
+| **Data Fetching** | @tanstack/vue-query | @tanstack/react-query | 🟢 Low | Same library, different framework adapter |
+| **Data Fetching** | Nuxt `useFetch` | Server Components + `fetch()` | 🟡 Medium | Composable → async RSC pattern |
+| **HTTP Client** | Axios | Axios / native `fetch` / ky | 🟢 Low | Axios works identically; consider native `fetch` in RSC |
+| **Forms** | VeeValidate | React Hook Form + Zod | 🟡 Medium | Field-level → register-based; Yup schemas reusable |
+| **Forms** | Vuelidate | React Hook Form + Zod | 🟡 Medium | Declarative rules → Zod schema definitions |
+| **Forms** | FormKit | React Hook Form | 🟡 Medium | Schema-driven → hook-driven |
+| **Validation** | Yup (shared) | Yup or Zod | 🟢 Low | Yup schemas reusable via `@hookform/resolvers/yup` |
+| **i18n** | vue-i18n | next-intl (Next.js) | 🟡 Medium | JSON files reusable; pluralization syntax differs |
+| **i18n** | vue-i18n | react-i18next (generic) | 🟡 Medium | Framework-agnostic alternative; `{{name}}` interpolation |
+| **UI Components** | Vuetify | MUI (Material UI) | 🔴 High | Both Material Design; completely different APIs |
+| **UI Components** | Quasar | Ant Design / MUI | 🔴 High | No single equivalent; cross-platform lost |
+| **UI Components** | PrimeVue | PrimeReact | 🟢 Low | Same vendor, near-identical component API |
+| **UI Components** | Element Plus | Ant Design | 🟡 Medium | Enterprise-focused; similar density |
+| **UI Components** | Naive UI | Mantine | 🟡 Medium | Both TypeScript-first, composable API |
+| **UI (Headless)** | Headless UI (Vue) | Headless UI (React) | 🟢 Low | Same library by Tailwind Labs |
+| **UI (Headless)** | Radix Vue | Radix UI | 🟢 Low | Vue port → React original |
+| **UI (Headless)** | shadcn-vue | shadcn/ui | 🟢 Low | Community port → original; copy-paste model |
+| **Icons** | unplugin-icons | react-icons / lucide-react | 🟢 Low | Direct swap; Lucide icons work in both |
+| **Animation** | `<Transition>` built-in | Framer Motion | 🟡 Medium | No built-in React equivalent |
+| **Animation** | GSAP | GSAP | 🟢 None | Framework-agnostic; works identically |
+| **Auth** | @sidebase/nuxt-auth | NextAuth.js (Auth.js) | 🟡 Medium | Different API; same OAuth concepts |
+| **Meta/SEO** | @unhead/vue / useHead | `generateMetadata()` (Next.js) | 🟡 Medium | Composable → export function in page |
+| **Date/Time** | date-fns / dayjs | date-fns / dayjs | 🟢 None | Framework-agnostic; no changes needed |
+| **CSS Scoping** | `<style scoped>` | CSS Modules (`.module.css`) | 🟢 Low | Rename + import as object |
+| **CSS Utility** | Tailwind CSS | Tailwind CSS | 🟢 None | `class` → `className` only |
+| **CSS Utility** | UnoCSS | Tailwind CSS or UnoCSS | 🟢 Low | UnoCSS works with React; Tailwind has larger ecosystem |
+| **Testing (Runner)** | Vitest | Vitest (same!) or Jest | 🟢 Low | Vitest works natively with React |
+| **Testing (Component)** | Vue Test Utils | React Testing Library | 🟡 Medium | Philosophy shift to accessibility queries |
+| **Testing (E2E)** | Cypress / Playwright | Cypress / Playwright | 🟢 None | Framework-agnostic; same tests work |
+| **Dev Tools** | Vue DevTools | React DevTools | 🟢 N/A | Different browser extension |
+| **Build Tools** | Vite | Next.js (Turbopack) or Vite | 🟡 Medium | Config rewrite; env var prefix change |
+| **Linting** | eslint-plugin-vue | eslint-plugin-react + react-hooks | 🟢 Low | Swap ESLint plugins |
+| **Auto-imports** | unplugin-auto-import | None (explicit imports) | 🟢 Low | React convention: explicit imports |
+| **Storybook** | @storybook/vue3 | @storybook/react | 🟡 Medium | Framework config change; stories need JSX |
+| **Docs** | VitePress | Nextra or Docusaurus | 🟡 Medium | Nextra is Next.js-native |
+
+---
+
+## UI Component Libraries
+
+### Migration Paths
+
+| Current Vue Library | Recommended React Target | Why |
+|---|---|---|
+| Vuetify | MUI or shadcn/ui + Tailwind | MUI for Material Design fidelity; shadcn/ui for modern approach |
+| Quasar | shadcn/ui + Tailwind (web only) | No single React equivalent; cross-platform requires separate projects |
+| PrimeVue | PrimeReact | Lowest effort — same vendor, same component names |
+| Element Plus | Ant Design | Enterprise-focused, similar component density |
+| Naive UI | Mantine | TypeScript-first, composable API |
+| Headless UI (Vue) | Headless UI (React) | Same library, swap import path |
+| Radix Vue | Radix UI | Vue port → original React library |
+| shadcn-vue | shadcn/ui | Community port → better-maintained original |
+
+### Vuetify → MUI Quick Map
+
+| Vuetify | MUI | Notes |
+|---|---|---|
+| `<v-btn>` | `<Button>` | Props differ; `color`, `variant` patterns similar |
+| `<v-card>` | `<Card>` | Subcomponents: `CardContent`, `CardActions` |
+| `<v-dialog>` | `<Dialog>` | Controlled via open/onClose props |
+| `<v-text-field>` | `<TextField>` | Closest mapping |
+| `<v-row>` / `<v-col>` | `<Grid>` or CSS Grid | MUI Grid or use Tailwind grid |
+| `<v-data-table>` | `<DataGrid>` (MUI X) | MUI X is a paid add-on for advanced tables |
+| Vuetify theme | `createTheme()` | Both use Material tokens; different config format |
+
+> **Key gotcha:** Vuetify's directive-based features (`v-ripple`, `v-scroll`) have no MUI equivalent — implement with custom React hooks or CSS.
+
+---
+
+## Form Handling
+
+### VeeValidate → React Hook Form + Zod
+
+**Vue (VeeValidate):**
+```vue
+<script setup>
+import { useForm, useField } from 'vee-validate'
+import * as yup from 'yup'
+
+const schema = yup.object({
+  email: yup.string().required().email(),
+  password: yup.string().required().min(8),
+})
+
+const { handleSubmit } = useForm({ validationSchema: schema })
+const { value: email, errorMessage: emailError } = useField('email')
+const { value: password, errorMessage: passError } = useField('password')
+
+const onSubmit = handleSubmit((values) => {
+  console.log(values)
+})
+</script>
+<template>
+  <form @submit="onSubmit">
+    <input v-model="email" type="email" />
+    <span v-if="emailError">{{ emailError }}</span>
+    <input v-model="password" type="password" />
+    <span v-if="passError">{{ passError }}</span>
+    <button type="submit">Submit</button>
+  </form>
+</template>
+```
+
+**React (React Hook Form + Zod):**
+```tsx
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().min(1, 'Required').email('Invalid email'),
+  password: z.string().min(8, 'Min 8 characters'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = (data: FormData) => console.log(data);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('email')} type="email" />
+      {errors.email && <span>{errors.email.message}</span>}
+      <input {...register('password')} type="password" />
+      {errors.password && <span>{errors.password.message}</span>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+### Key Mapping
+
+| VeeValidate | React Hook Form | Notes |
+|---|---|---|
+| `<Form>` component | `<form onSubmit={handleSubmit(fn)}>` | RHF uses native form + hook |
+| `<Field name="x" />` | `<input {...register('x')} />` | `register()` returns input props |
+| `<ErrorMessage name="x" />` | `{errors.x && <span>{errors.x.message}</span>}` | Manual error rendering |
+| `useField('x')` | `useController({ name: 'x' })` | For custom/controlled components |
+| Yup schemas | Yup or Zod via `@hookform/resolvers` | Yup schemas can be reused directly |
+
+---
+
+## Internationalization (i18n)
+
+### vue-i18n → next-intl (Recommended for Next.js)
+
+**Translation files are mostly reusable!** JSON structure stays the same. Key difference: pluralization syntax.
+
+```json
+// Vue (vue-i18n): src/locales/en.json
+{
+  "greeting": "Hello, {name}!",
+  "items": "no items | one item | {count} items"
+}
+
+// Next.js (next-intl): messages/en.json
+{
+  "greeting": "Hello, {name}!",
+  "items": "{count, plural, =0 {no items} one {one item} other {# items}}"
+}
+```
+
+**Vue component usage:**
+```vue
+<script setup>
+import { useI18n } from 'vue-i18n'
+const { t, locale } = useI18n()
+</script>
+<template>
+  <h1>{{ t('greeting', { name: 'World' }) }}</h1>
+  <p>{{ t('items', { count: 5 }) }}</p>
+  <select v-model="locale">
+    <option value="en">English</option>
+    <option value="fr">Français</option>
+  </select>
+</template>
+```
+
+**Next.js component usage (next-intl):**
+```tsx
+// app/[locale]/page.tsx (Server Component — works without 'use client'!)
+import { useTranslations } from 'next-intl';
+
+export default function Home() {
+  const t = useTranslations();
+  return (
+    <>
+      <h1>{t('greeting', { name: 'World' })}</h1>
+      <p>{t('items', { count: 5 })}</p>
+    </>
+  );
+}
+```
+
+| Feature | vue-i18n | next-intl | react-i18next |
+|---|---|---|---|
+| JSON format | Flat/nested | Same ✅ | Same ✅ |
+| Pluralization | Pipe syntax (`\|`) | ICU format | ICU format |
+| Interpolation | `{name}` | `{name}` ✅ | `{{name}}` (double braces!) |
+| Server rendering | Nuxt SSR | RSC native ✅ | SSR with config |
+| Recommendation | — | **Best for Next.js** | **Best for non-Next.js** |
+
+---
+
+## Testing
+
+### Vue Test Utils → React Testing Library
+
+**Philosophy shift:** VTU queries by component internals (CSS selectors, `wrapper.vm`). RTL queries by what the user sees (roles, text, labels).
+
+| Vue Test Utils | React Testing Library | Notes |
+|---|---|---|
+| `mount(Comp, { props })` | `render(<Comp {...props} />)` | Access rendered output via `screen` |
+| `shallowMount(Comp)` | `render(<Comp />)` (no shallow) | RTL renders fully; mock children if needed |
+| `wrapper.find('.class')` | `screen.getByRole('button')` | Query by role, not CSS selector |
+| `wrapper.find('[data-test]')` | `screen.getByTestId('x')` | Supported but discouraged |
+| `wrapper.text()` | `screen.getByText('text')` | Queries are assertions |
+| `wrapper.trigger('click')` | `fireEvent.click(el)` or `userEvent.click(el)` | Prefer `userEvent` for realistic interaction |
+| `wrapper.setProps({...})` | `rerender(<Comp newProp />)` | Destructure from `render()` return |
+| `wrapper.emitted('event')` | `expect(mockFn).toHaveBeenCalled()` | Test callback props, not emitted events |
+| `wrapper.vm.someRef` | **No equivalent** | Test behavior, not internals |
+| `wrapper.exists()` | `screen.queryByRole(...)` | Returns `null` if not found |
+| `await nextTick()` | `await waitFor(() => ...)` | For async state updates |
+
+**Vue Test (Vitest):**
+```ts
+import { mount } from '@vue/test-utils'
+
+test('submits form', async () => {
+  const wrapper = mount(LoginForm)
+  await wrapper.find('input[type="email"]').setValue('test@example.com')
+  await wrapper.find('input[type="password"]').setValue('password123')
+  await wrapper.find('form').trigger('submit')
+  expect(wrapper.emitted('submit')).toBeTruthy()
+})
+```
+
+**React Test (Vitest + RTL):**
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('submits form', async () => {
+  const handleSubmit = vi.fn()
+  render(<LoginForm onSubmit={handleSubmit} />)
+  await userEvent.type(screen.getByRole('textbox', { name: /email/i }), 'test@example.com')
+  await userEvent.type(screen.getByLabelText(/password/i), 'password123')
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+  expect(handleSubmit).toHaveBeenCalledOnce()
+})
+```
+
+> **Vitest stays!** It works natively with React via `@vitejs/plugin-react`. Keep your test runner — only change the component testing library.
+
+---
+
+## Utility Libraries (VueUse → React Hooks)
+
+VueUse has 200+ composables. No single React library matches it. Use a combination:
+
+| VueUse Composable | React Equivalent | Library |
+|---|---|---|
+| `useStorage` | `useLocalStorage` | usehooks-ts |
+| `useDebounce` | `useDebounce` | usehooks-ts |
+| `useWindowSize` | `useWindowSize` | usehooks-ts |
+| `useMediaQuery` | `useMediaQuery` | usehooks-ts |
+| `useIntersectionObserver` | `useIntersectionObserver` | usehooks-ts |
+| `useMouse` | `useMouse` | @uidotdev/usehooks |
+| `useClipboard` | `useCopyToClipboard` | usehooks-ts |
+| `useDark` | `useTheme` | next-themes (Next.js-optimized) |
+| `useFetch` | `useQuery` | @tanstack/react-query |
+| `useAsyncState` | `useQuery` + `useMutation` | @tanstack/react-query |
+| `useEventListener` | `useEventListener` | usehooks-ts |
+| `useInterval` | `useInterval` | usehooks-ts |
+| `useToggle` | `useToggle` | usehooks-ts |
+| `onClickOutside` | `useOnClickOutside` | usehooks-ts |
+
+**Recommended libraries (in priority order):**
+1. **usehooks-ts** — TypeScript-first, well-maintained, covers most VueUse equivalents
+2. **@tanstack/react-query** — For all data fetching composables (replaces `useFetch`, `useAsyncState`)
+3. **react-use** — Largest single hook library (~200 hooks), closest to VueUse in breadth
+4. **next-themes** — Specifically for dark mode in Next.js (replaces `useDark`)
+
+---
+
+## HTTP & Data Fetching
+
+### Axios — No Migration Needed
+
+Axios works identically in React. In Next.js Server Components, prefer native `fetch` for automatic caching:
+
+```tsx
+// Server Component — native fetch with Next.js caching
+async function getUsers() {
+  const res = await fetch('https://api.example.com/users', {
+    next: { revalidate: 60 },
+  });
+  return res.json();
+}
+```
+
+### @tanstack/vue-query → @tanstack/react-query
+
+Same library, nearly identical API. Change imports and wrap app with `<QueryClientProvider>`:
+
+```tsx
+// app/providers.tsx — required for React Query
+'use client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+const queryClient = new QueryClient();
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+```
+
+---
+
+## Environment Variables
+
+| Vite (Vue) | Next.js | Notes |
+|---|---|---|
+| `VITE_API_URL` | `NEXT_PUBLIC_API_URL` | Client-exposed prefix changes |
+| `import.meta.env.VITE_X` | `process.env.NEXT_PUBLIC_X` | Access pattern changes |
+| `import.meta.env.MODE` | `process.env.NODE_ENV` | Built-in equivalent |
+| `import.meta.env.SSR` | `typeof window === 'undefined'` | Server detection |
+| `.env.local` | `.env.local` | Same file, same behavior ✅ |

--- a/skills/convert-vue-nextjs/references/pitfalls.md
+++ b/skills/convert-vue-nextjs/references/pitfalls.md
@@ -1,0 +1,398 @@
+# Vue → React/Next.js Conversion Pitfalls
+
+> The most common mistakes developers make when converting Vue apps to React/Next.js, with wrong/right code examples and fixes.
+
+---
+
+## Mental Model Shifts
+
+### Mutable → Immutable
+
+Vue wraps data in Proxies that intercept mutations. React requires new references to trigger re-renders.
+
+```js
+// ❌ Vue habit — works in Vue, silent failure in React
+const [user, setUser] = useState({ name: 'Bob', age: 25 });
+user.name = 'Alice';       // Mutates but React won't re-render
+
+// ✅ React way — create a new object
+setUser(prev => ({ ...prev, name: 'Alice' }));
+```
+
+### Template → JSX
+
+Vue templates compile to optimized render functions. JSX is JavaScript — no directives, only expressions.
+
+```vue
+<!-- Vue -->
+<div v-if="show">Visible</div>
+<li v-for="item in items" :key="item.id">{{ item.name }}</li>
+<input v-model="name" />
+```
+```tsx
+// React
+{show && <div>Visible</div>}
+{items.map(item => <li key={item.id}>{item.name}</li>)}
+<input value={name} onChange={e => setName(e.target.value)} />
+```
+
+### Two-Way Binding → One-Way Data Flow
+
+```vue
+<!-- Vue: automatic two-way binding -->
+<ChildInput v-model="username" />
+```
+```tsx
+// React: explicit value + onChange
+<ChildInput value={username} onChange={setUsername} />
+```
+
+### Auto Dependency Tracking → Manual Dependency Arrays
+
+```js
+// Vue: auto-tracked
+const fullName = computed(() => `${firstName.value} ${lastName.value}`)
+// React: must list deps manually
+const fullName = useMemo(() => `${firstName} ${lastName}`, [firstName, lastName])
+```
+
+---
+
+## Top 10 Conversion Mistakes
+
+### 1. Mutating State Directly
+
+```tsx
+// ❌ WRONG
+const [items, setItems] = useState(['a', 'b']);
+items.push('c'); // no re-render
+
+// ✅ RIGHT
+setItems(prev => [...prev, 'c']);               // Append
+setItems(prev => prev.filter(i => i !== 'b'));  // Remove
+```
+
+### 2. Missing useEffect Dependency Arrays
+
+```tsx
+// ❌ WRONG — runs every render, may infinite-loop
+useEffect(() => { fetchData(userId); });
+
+// ❌ WRONG — stale closure, always uses initial userId
+useEffect(() => { fetchData(userId); }, []);
+
+// ✅ RIGHT
+useEffect(() => { fetchData(userId); }, [userId]);
+```
+
+### 3. Stale Closures in Event Handlers
+
+```tsx
+// ❌ WRONG — count captured as 0 forever
+const [count, setCount] = useState(0);
+useEffect(() => {
+  const id = setInterval(() => setCount(count + 1), 1000);
+  return () => clearInterval(id);
+}, []);
+
+// ✅ RIGHT — functional update uses latest value
+useEffect(() => {
+  const id = setInterval(() => setCount(c => c + 1), 1000);
+  return () => clearInterval(id);
+}, []);
+```
+
+### 4. Using useRef Like Vue ref()
+
+Vue's `ref()` triggers re-renders. React's `useRef()` does NOT.
+
+```tsx
+// ❌ WRONG — UI never updates
+const count = useRef(0);
+count.current += 1;
+return <p>{count.current}</p>;
+
+// ✅ RIGHT — useState for UI-affecting values
+const [count, setCount] = useState(0);
+return <p>{count}</p>;
+```
+
+**Rule:** `useRef` = mutable, non-reactive (DOM refs, timers). `useState` = triggers re-render.
+
+### 5. Over-Using useEffect for Derived State
+
+```tsx
+// ❌ WRONG — causes double render
+const [items, setItems] = useState([]);
+const [filtered, setFiltered] = useState([]);
+useEffect(() => { setFiltered(items.filter(i => i.active)); }, [items]);
+
+// ✅ RIGHT — compute during render
+const filtered = useMemo(() => items.filter(i => i.active), [items]);
+// For trivial derivations, skip useMemo entirely:
+const fullName = `${firstName} ${lastName}`;
+```
+
+### 6. Creating Infinite Loops with useEffect + setState
+
+```tsx
+// ❌ WRONG — setState during render → infinite loop
+function Component({ items }) {
+  const [filtered, setFiltered] = useState([]);
+  setFiltered(items.filter(i => i.active)); // triggers re-render → loop
+}
+
+// ✅ RIGHT — derive without state
+function Component({ items }) {
+  const filtered = useMemo(() => items.filter(i => i.active), [items]);
+}
+```
+
+### 7. Forgetting Controlled Component Pattern for Forms
+
+```tsx
+// ❌ WRONG — uncontrolled, can't track value
+let name = '';
+<input onChange={e => { name = e.target.value; }} />
+
+// ✅ RIGHT — controlled component
+const [name, setName] = useState('');
+<input value={name} onChange={e => setName(e.target.value)} />
+```
+
+### 8. Wrong Slot → Children Conversion
+
+Scoped slots pass data back to the parent — plain `children` can't do this.
+
+```tsx
+// ❌ WRONG — children can't receive data from parent component
+<DataList items={users}><span>{/* no item access */}</span></DataList>
+
+// ✅ RIGHT — render prop pattern (scoped slot equivalent)
+<DataList items={users} renderItem={(item, i) => <span>{i}: {item.name}</span>} />
+```
+
+**Mapping:** Default slot → `children`. Named slot → named prop. Scoped slot → render prop.
+
+### 9. Missing Keys in .map() Iterations
+
+```tsx
+// ❌ WRONG — index as key breaks on reorder
+{items.map((item, i) => <li key={i}>{item.name}</li>)}
+
+// ✅ RIGHT — stable unique key
+{items.map(item => <li key={item.id}>{item.name}</li>)}
+```
+
+### 10. Object/Array Reference Equality in Dependencies
+
+```tsx
+// ❌ WRONG — new object every render → effect runs infinitely
+const options = { userId, limit: 10 };
+useEffect(() => { fetchData(options); }, [options]);
+
+// ✅ RIGHT — use primitive values in deps
+useEffect(() => { fetchData({ userId, limit: 10 }); }, [userId]);
+```
+
+---
+
+## Next.js-Specific Gotchas
+
+### Server vs Client Component Boundary
+
+```tsx
+// ❌ WRONG — useState in Server Component (no 'use client')
+export default function Counter() {
+  const [count, setCount] = useState(0); // 💥 Error!
+}
+
+// ✅ RIGHT
+'use client';
+export default function Counter() {
+  const [count, setCount] = useState(0); // Works
+}
+```
+
+### Putting 'use client' Too High
+
+```tsx
+// ❌ WRONG — entire page becomes client-rendered
+'use client';
+export default function ProductPage() { /* loses SSR benefits */ }
+
+// ✅ RIGHT — only interactive leaf is client
+// app/products/page.tsx (Server Component)
+export default async function ProductPage() {
+  const products = await getProducts();
+  return <ProductList products={products} />;
+}
+// components/ProductList.tsx
+'use client';
+export function ProductList({ products }: Props) { /* interactive */ }
+```
+
+### Hydration Pitfalls
+
+Common causes — anything producing different output on server vs client:
+
+```tsx
+// ❌ Reading window/localStorage during render
+const width = window.innerWidth;                    // 💥 SSR crash
+const theme = localStorage.getItem('theme');        // 💥 SSR crash
+
+// ❌ Random IDs that differ server ↔ client
+const id = `input-${Math.random()}`;                // Hydration mismatch
+
+// ❌ Date formatting that differs between environments
+const label = new Date().toLocaleString();          // Server/client locale may differ
+// ❌ Conditional markup based on browser state before hydration
+const isMobile = window.innerWidth < 768;
+return isMobile ? <MobileNav /> : <DesktopNav />;  // Mismatch on first render
+```
+Fixes:
+
+```tsx
+// ✅ Initialize browser-derived state in an Effect
+const [width, setWidth] = useState(0);
+useEffect(() => setWidth(window.innerWidth), []);
+
+// ✅ Render a consistent placeholder until hydrated
+const [mounted, setMounted] = useState(false);
+useEffect(() => setMounted(true), []);
+if (!mounted) return <NavPlaceholder />;            // Same markup server & client
+return width < 768 ? <MobileNav /> : <DesktopNav />;
+
+// ✅ Stable IDs with React.useId()
+const id = useId();                                 // Consistent across server & client
+```
+
+### Browser-Only Libraries in Server Components
+
+Most common migration failure: using browser-only libs (charts, maps, rich-text editors) in Server Components.
+Fix: create thin `'use client'` adapter components — the wrapper imports the browser lib and exports a clean component.
+Parent pages stay Server Components for performance; only the wrapper crosses the client boundary.
+
+### Third-Party Library Wrapping Pattern
+
+```tsx
+// components/ChartWrapper.tsx
+'use client';
+import dynamic from 'next/dynamic';
+const Chart = dynamic(() => import('heavy-chart-lib'), { ssr: false });
+export function ChartWrapper(props) { return <Chart {...props} />; }
+```
+
+Use `dynamic` with `ssr: false` for libs that access `window`/`document` at import time.
+The wrapper is the `'use client'` boundary — parent pages remain Server Components.
+
+### Hydration Mismatch from URL Rewrites
+
+When using Next.js rewrites to proxy Vue routes, client-side pathname can differ from server-side.
+`usePathname` returns unexpected values when rewrites mask the destination URL — causes subtle hydration errors.
+Fix: isolate pathname-dependent UI into dedicated client components.
+Test by comparing SSR output vs client hydration for rewritten routes.
+
+### Making Everything a Server Component Too Early
+
+Start with `'use client'` parity — get it working, verify, then selectively remove `'use client'` where no interactivity is needed. Attempting Server Components first means fighting serialization boundaries.
+
+### Keeping Server Data in Client Global State
+
+> In Next, data that came from API calls often belongs in server fetching, not client-side stores. Don't automatically port Pinia stores that cache API responses into Zustand/Redux.
+
+```tsx
+// ❌ Vue habit — Pinia store ported to Zustand, fetching on client
+const useProductStore = create((set) => ({
+  products: [],
+  fetch: async () => { set({ products: await fetchProducts() }); },
+}));
+// ✅ Next.js — fetch on server, no store needed
+export default async function ProductsPage() {
+  const products = await getProducts();
+  return <ProductGrid products={products} />;
+}
+```
+
+---
+
+## Migration Strategy Pitfalls
+
+### Rewriting Styles + Components Simultaneously
+
+> Do not combine a framework migration with a design-system rewrite unless you absolutely must. That multiplies the risk.
+
+When a visual regression appears, you can't tell whether it came from the framework switch or the design rewrite. Migrate first, then redesign.
+
+### Translating Every watch() into useEffect()
+
+Overlaps with pitfalls #5 and #6. Pure derivation belongs in render, not Effects.
+
+```tsx
+// ❌ Vue watch habit — effect that just derives state
+useEffect(() => { setCount(items.length); }, [items]);
+// ✅ Derive directly
+const count = items.length;
+```
+
+Reserve `useEffect` for **side effects** (API calls, subscriptions, DOM manipulation) — not derivation.
+
+### Replacing Every v-model with Local Child State
+
+> That often breaks coordination. Prefer controlled components.
+
+```tsx
+// ❌ WRONG — child owns state, parent can't coordinate
+function Dropdown() {
+  const [open, setOpen] = useState(false); // Parent has no visibility
+}
+
+// ✅ RIGHT — controlled: parent owns state
+function Dropdown({ open, onOpenChange }: Props) {
+  return <>
+    <button onClick={() => onOpenChange(!open)}>Toggle</button>
+    {open && <ul>...</ul>}
+  </>;
+}
+// Pattern: value/onValueChange, open/onOpenChange, selected/onSelectedChange
+```
+
+---
+
+## Performance Pitfalls
+
+- **Unnecessary re-renders:** Use `React.memo()` for expensive children; Vue does surgical updates, React re-renders subtrees
+- **Giant useEffect:** Split by concern — one effect per responsibility, not one effect with 5 deps
+- **No code-splitting:** Use `next/dynamic` or `React.lazy` — Vue's `defineAsyncComponent` has no auto equivalent
+
+---
+
+## Quick Reference Cheat Sheet
+
+| Vue Concept | React Equivalent | Gotcha |
+|---|---|---|
+| `ref(0)` | `useState(0)` | Never mutate; always use setter |
+| `reactive({})` | `useState({})` | Must spread to create new reference |
+| `computed(() => ...)` | `useMemo(() => ..., [deps])` | Must specify deps manually |
+| `watch(source, cb)` | `useEffect(cb, [source])` | Needs cleanup; beware stale closures |
+| `watchEffect(cb)` | `useEffect(cb)` | Rarely correct — usually needs deps |
+| `onMounted(cb)` | `useEffect(cb, [])` | Runs after paint, not before |
+| `onUnmounted(cb)` | Return cleanup from `useEffect` | `useEffect(() => () => cleanup, [])` |
+| `nextTick()` | `flushSync()` or `useEffect` | Different timing semantics |
+| `$emit('event', data)` | `props.onEvent(data)` | No event system; explicit callbacks |
+| `v-model="x"` | `value={x} onChange={setX}` | Always controlled components |
+| `v-if` / `v-else` | `{cond && <X/>}` or ternary | Falsy values (0, '') can render |
+| `v-show="visible"` | `style={{display: visible ? '' : 'none'}}` | Or className toggle |
+| `v-for` | `{list.map(i => <X key={i.id}/>)}` | Always provide stable key |
+| `<slot />` | `{children}` | Implicit prop |
+| `<slot name="x" />` | Named prop: `{header}` | Pass JSX as prop value |
+| `<slot :data="d" />` | Render prop: `{renderItem(d)}` | Function-as-prop pattern |
+| `provide / inject` | `createContext / useContext` | Context re-renders all consumers |
+| `<Teleport to="#x">` | `createPortal(el, target)` | Import from `react-dom` |
+| `<Transition>` | Framer Motion | No built-in equivalent |
+| `defineProps<T>()` | `function Comp(props: T)` | Props are function arguments |
+| `defineEmits<T>()` | Callback props in interface | No emit type system |
+| `class="x"` | `className="x"` | Reserved word in JS |
+| `@click.prevent` | `e.preventDefault()` in handler | No event modifiers |
+| Scoped CSS | CSS Modules or Tailwind | No built-in scoped styles |
+| `app.use(plugin)` | `<Provider>` component tree | Different plugin model |

--- a/skills/convert-vue-nextjs/references/strategy/assessment-checklist.md
+++ b/skills/convert-vue-nextjs/references/strategy/assessment-checklist.md
@@ -1,0 +1,378 @@
+# Pre-Migration Assessment Checklist
+
+> Evaluate your Vue application's complexity, dependencies, and team readiness before committing to a React/Next.js migration.
+
+---
+
+## App Complexity Assessment
+
+### Component Inventory Matrix
+
+Rate each dimension of your application:
+
+| Dimension | Simple (1 pt) | Moderate (2 pts) | Complex (3 pts) |
+|---|---|---|---|
+| **Component count** | < 30 components | 30–150 components | 150+ components |
+| **Nesting depth** | Max 3 levels | 4–6 levels | 7+ levels or recursive |
+| **Custom directives** | None | 1–5 custom directives | 6+ or heavily used |
+| **Mixins/composables** | < 5 | 5–20 | 20+ shared composables |
+| **Dynamic components** | None | Occasional `<component :is>` | Heavy dynamic rendering |
+| **Renderless components** | None | A few | Core architecture pattern |
+
+### State Management Complexity
+
+| Level | Description | Migration Impact |
+|---|---|---|
+| **Local only** | `ref()` / `reactive()` within components | 🟢 Low — direct `useState` mapping |
+| **Prop drilling** | Props passed 3+ levels deep | 🟡 Medium — consider Context or Zustand |
+| **Single store** | One Pinia/Vuex store | 🟡 Medium — straightforward Zustand conversion |
+| **Multi-store** | Multiple Pinia stores with cross-references | 🟡 Medium — map each store to Zustand slice |
+| **Complex flows** | Vuex modules + actions + plugins + subscriptions | 🔴 High — requires architectural redesign |
+
+### Routing Complexity
+
+| Level | Description | Migration Impact |
+|---|---|---|
+| **Static routes** | Flat list of pages, no params | 🟢 Low — simple file structure |
+| **Dynamic routes** | URL params (`:id`, `:slug`) | 🟢 Low — `[id]`, `[slug]` folders |
+| **Nested routes** | Parent/child layouts with `<router-view>` | 🟡 Medium — nested `layout.tsx` files |
+| **Route guards** | `beforeEach`, per-route guards, meta fields | 🟡 Medium — `middleware.ts` + conventions |
+| **Complex routing** | Programmatic navigation, route-based code splitting, scroll behavior | 🔴 High — significant rearchitecture |
+
+### SSR/SSG Assessment
+
+| Current Setup | Migration Path | Effort |
+|---|---|---|
+| **SPA only** (no SSR) | Client Components with `'use client'` | 🟢 Low |
+| **Nuxt SSR** (universal) | Server Components (default in Next.js) | 🟡 Medium |
+| **Nuxt SSG** (`generate`) | `generateStaticParams()` + static export | 🟡 Medium |
+| **Nuxt ISR** (`routeRules`) | `revalidate` config in route segments | 🟡 Medium |
+| **Nuxt hybrid** (mixed modes) | Per-route rendering config in Next.js | 🔴 High |
+
+---
+
+## Conversion Effort Estimator
+
+Score each factor and multiply by its weight:
+
+| Factor | Low (1×) | Medium (2×) | High (3×) | Weight |
+|---|---|---|---|---|
+| **Component count** | < 30 | 30–150 | 150+ | ×3 |
+| **State complexity** | Local only | Single store | Multi-store + plugins | ×3 |
+| **Routing complexity** | Static | Dynamic + guards | Nested + programmatic | ×2 |
+| **Third-party Vue deps** | 0–3 | 4–10 | 10+ Vue-specific deps | ×3 |
+| **Custom directives** | None | 1–5 | 6+ | ×1 |
+| **Test coverage** | No tests | Some tests | Comprehensive suite | ×2 |
+| **SSR usage** | SPA only | Basic SSR | Hybrid SSR/SSG/ISR | ×2 |
+| **Team React experience** | Strong React skills | Some React knowledge | No React experience | ×2 |
+
+**Scoring guide:**
+- **18–30 points**: Small migration, 2–6 weeks estimated
+- **31–45 points**: Medium migration, 2–4 months estimated
+- **46–54 points**: Large migration, 4–8 months estimated
+
+> Multiply timeline by 1.5× for realistic planning — migrations consistently take longer than estimated.
+
+---
+
+## Dependency Audit Checklist
+
+### Step 1: Inventory All Vue-Specific Dependencies
+
+Run this in your project root:
+
+```bash
+# List all dependencies containing 'vue' in the name
+cat package.json | grep -E '"(vue|@vue|nuxt|@nuxt|vuelidate|vee-validate|pinia|vuex|vuetify|quasar|element-plus|naive-ui|primevue)' 
+```
+
+### Step 2: Categorize Each Dependency
+
+| Category | Action | Example |
+|---|---|---|
+| **Direct equivalent** | Swap package | PrimeVue → PrimeReact |
+| **Alternative available** | Evaluate and choose | Pinia → Zustand |
+| **Framework-agnostic** | Keep as-is | Axios, date-fns, Lodash |
+| **Must rebuild** | Reimplement in React | Custom Vue directives |
+| **Blocker** | No React equivalent; critical feature | Evaluate workarounds |
+
+### Step 3: Identify Blockers
+
+Common blockers (dependencies with no React equivalent):
+- Custom Vue directives used throughout the codebase
+- Vue-specific plugins (`app.use()`) with deep framework integration
+- Quasar cross-platform features (mobile/desktop from single codebase)
+- BootstrapVue components (no maintained React port)
+
+---
+
+## Risk Assessment Matrix
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Timeline overrun** | 🔴 High | 🔴 High | Add 50% buffer; use incremental strategy; track weekly |
+| **Skill gaps** | 🟡 Medium | 🔴 High | Allocate 1–2 weeks for React training before starting |
+| **Feature freeze pressure** | 🔴 High | 🟡 Medium | Use incremental migration; keep shipping features in Vue |
+| **Data loss during migration** | 🟢 Low | 🔴 High | Shared auth/session management; database untouched |
+| **Downtime** | 🟢 Low | 🔴 High | Reverse proxy routing; canary deployment |
+| **Feature parity gaps** | 🟡 Medium | 🟡 Medium | Audit all features before starting; prioritize critical paths |
+| **Performance regression** | 🟡 Medium | 🟡 Medium | Lighthouse baseline before migration; compare after each phase |
+| **Third-party dep incompatibility** | 🟡 Medium | 🔴 High | Full dependency audit before committing; identify blockers early |
+| **Team burnout** | 🟡 Medium | 🟡 Medium | Celebrate milestones; limit migration to 50% of sprint capacity |
+| **Rollback needed** | 🟢 Low | 🟡 Medium | Keep Vue app running; proxy routing enables instant rollback |
+
+---
+
+## Prerequisites Checklist
+
+### Team Readiness
+
+- [ ] At least one team member has React/Next.js production experience
+- [ ] Team has completed React fundamentals training (hooks, JSX, component model)
+- [ ] Team understands key mental model shifts (immutable state, dependency arrays, one-way data flow)
+- [ ] Team has read [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect) (official React docs)
+- [ ] React coding conventions documented (folder structure, naming, state management choice)
+
+### Infrastructure
+
+- [ ] CI/CD pipeline can build both Vue and Next.js apps (if using incremental strategy)
+- [ ] Reverse proxy or routing layer available for parallel deployment
+- [ ] Shared authentication mechanism identified (cookies, JWT, session tokens)
+- [ ] Deployment platform supports Next.js (Vercel, AWS, Docker, etc.)
+- [ ] Monitoring/error tracking works with React (Sentry, Datadog, etc.)
+
+### Testing Infrastructure
+
+- [ ] Decision made: keep Vitest or switch to Jest
+- [ ] React Testing Library configured
+- [ ] E2E tests (Playwright/Cypress) are framework-agnostic and will work post-migration
+- [ ] Performance baseline captured (Lighthouse scores, Core Web Vitals)
+
+### Design System
+
+- [ ] UI component library replacement chosen (see package-mapping.md)
+- [ ] Design tokens (colors, spacing, typography) extracted and documented
+- [ ] Shared component package planned (if running both apps simultaneously)
+
+---
+
+## Decision Framework
+
+### ✅ Migrate to React/Next.js When:
+
+- **Hiring:** React developer pool is 3–5× larger; hiring Vue devs is a bottleneck
+- **Ecosystem:** You need React-only libraries (Framer Motion, Radix, react-aria, React Native)
+- **AI tooling:** AI assistants generate significantly better React code (larger training data)
+- **Team preference:** Your team already knows and prefers React
+- **Major rewrite:** You're rebuilding the architecture anyway — framework switch adds marginal cost
+- **SSR maturity:** Next.js offers ISR, RSC, and streaming that Nuxt can't match yet
+
+### ⛔ Stay on Vue When:
+
+- **Team is productive:** Vue devs are happy, shipping fast, no pain points
+- **Only need Vue 2 → 3:** Upgrading within Vue is significantly less effort than switching frameworks
+- **"Performance" is the reason:** Framework differences are negligible; optimize your code, not your framework
+- **Tight timeline:** Multi-month migration isn't feasible given business constraints
+- **Vue ecosystem suffices:** Radix Vue, shadcn-vue, Pinia, VueUse cover your needs
+- **Laravel backend:** Vue + Laravel ecosystem is mature and well-integrated
+
+### 🔄 Consider Incremental Migration When:
+
+- **Production app with real users:** Can't afford downtime or feature freezes
+- **Clear page boundaries:** App has distinct sections that can be migrated independently
+- **Mixed team skills:** Some devs know React, others know Vue — both can contribute
+- **Risk tolerance is low:** Need the ability to pause or rollback at any point
+- **Large codebase (100+ components):** Full rewrite is too risky; strangler pattern is safer
+
+---
+
+## Migration Order (Recommended)
+
+Once you've decided to migrate, follow this order:
+
+1. **Foundation first:** Auth, routing infrastructure, shared design tokens
+2. **State management:** Convert Pinia/Vuex stores to Zustand
+3. **Leaf components:** Buttons, inputs, cards — isolated, low-risk
+4. **Composite components:** Forms, lists, tables — medium complexity
+5. **Pages:** One at a time, starting with lowest traffic
+6. **Data fetching:** Convert `useFetch`/`useAsyncData` to Server Components or TanStack Query
+7. **Advanced patterns:** Transitions, portals, error boundaries
+8. **Testing:** Migrate test suite alongside each component
+9. **Cleanup:** Remove Vue app, proxy routing, bridge components
+
+> **From u/tengusheath (100K LOC migration):** *"Once the foundational stuff was migrated over, the component to component migration was pretty painless."*
+
+---
+
+## Per-Component Migration Worksheet
+
+> That worksheet is more valuable than blindly translating lines of code.
+
+Before migrating **any** component, copy this template and fill it out completely. It forces you to understand the component's full contract before writing a single line of React.
+
+```markdown
+## Component Migration Worksheet: [ComponentName]
+
+### Public API
+- [ ] Props and defaults: ___
+- [ ] Emitted events: ___
+- [ ] v-model bindings: ___
+
+### Composition
+- [ ] Default slot used: yes/no
+- [ ] Named slots: ___
+- [ ] Scoped slots: ___
+- [ ] Fallthrough attributes ($attrs): ___
+
+### Internal State
+- [ ] Refs / exposed methods (defineExpose): ___
+- [ ] Local reactive state (ref, reactive): ___
+- [ ] Computed values: ___
+- [ ] Watchers: ___
+
+### Dependencies
+- [ ] Router usage (params, query, push): ___
+- [ ] Store usage (which stores, what state): ___
+- [ ] Composables used: ___
+
+### Special Features
+- [ ] Directives used: ___
+- [ ] Teleport: ___
+- [ ] Transition/TransitionGroup: ___
+- [ ] KeepAlive: ___
+
+### UI Contract
+- [ ] CSS dependencies and class names: ___
+- [ ] Accessibility attributes: ___
+- [ ] Test IDs: ___
+```
+
+**How to use this:**
+1. Print or copy for each component before migration
+2. Components with many unknowns (`___`) need investigation first — don't migrate what you don't understand
+3. The "Special Features" section flags patterns that need React-specific solutions (e.g., Teleport → `createPortal`, KeepAlive → custom caching)
+4. Archive completed worksheets — they become documentation for the React version
+
+### TypeScript Component Contract Stubs
+
+Vue components have a "hidden API" — slots and emitted events are often undocumented. Before migrating a component, formalize its contract so both the Vue and React versions satisfy the same interface:
+
+```ts
+// component-contracts/Button.contract.ts
+export type ButtonVariant = "primary" | "secondary" | "danger";
+
+export interface ButtonContract {
+  props: {
+    variant?: ButtonVariant;
+    disabled?: boolean;
+    ariaLabel?: string;
+  };
+  events: {
+    onClick: () => void;
+  };
+  slots: {
+    default: "label content";
+    icon?: "optional icon content";
+  };
+}
+```
+
+**Why contracts matter:**
+- Vue recommends `defineEmits` — but many codebases skip it. Contracts force you to document **all** emitted events before migration.
+- Slots translate to React `children` or render props. Naming them explicitly prevents missed functionality.
+- Both Vue and React implementations must satisfy the same contract interface — it's your behavioral parity guarantee.
+
+**Use contracts as migration gates:** don't deploy the React version of a component until it satisfies every field in the contract. If the contract can't be satisfied, the component isn't ready.
+
+### Contract Validation Tooling
+
+- **Usage graphs:** Scan `.vue` imports with the TypeScript compiler API (AST-based) to generate a dependency graph of who consumes each component and which props/events/slots they use.
+- **Visual parity:** Stand up Storybook for both Vue (`@storybook/vue3`) and React (`@storybook/react`) — write identical stories per contract and compare side-by-side.
+- **Test fixture generation:** Use the contract type to auto-generate test fixtures — every prop combination, every event handler assertion, every slot rendering permutation.
+
+---
+
+## Behavior Freeze Checklist (Pre-Migration per Route)
+
+Before migrating a route, capture its **exact** current behavior. This is your acceptance criteria — the React version must match every item.
+
+### Visual State Capture
+- [ ] Screenshots of all major UI states
+- [ ] Empty state appearance
+- [ ] Loading state appearance
+- [ ] Error state appearance
+- [ ] Responsive breakpoints verified (mobile, tablet, desktop)
+
+### Interaction Behavior
+- [ ] Key interaction flows documented (click paths, form submissions)
+- [ ] Keyboard behavior documented (tab order, shortcuts, escape handling)
+- [ ] Focus management behavior (where focus goes after modals, deletions, navigations)
+- [ ] Route transitions (animations, scroll position restoration)
+
+### Data & State Behavior
+- [ ] Store-driven behavior documented (what state triggers what UI changes)
+- [ ] URL/query-string behavior documented (filters, pagination, deep links)
+- [ ] Optimistic updates or real-time data flows
+
+> **Tip:** Record a short screen capture of each route's key flows. It's faster than writing and catches details you'd miss in a written spec.
+
+---
+
+## Pinia Store Categorization Audit
+
+Not all Pinia stores migrate the same way. Categorize each store **before** you start converting, then choose the right React target.
+
+### Store Category Reference
+
+| Category | What It Holds | React Migration Target |
+|---|---|---|
+| **Local UI state** | Toggles, form state, modals, panel visibility | `useState` / `useReducer` in the consuming component |
+| **Shared client state** | Theme, sidebar state, user preferences | React Context or Zustand (lightweight global) |
+| **Server-cached data** | API responses, lists, entities, pagination | Server Component `fetch` / TanStack Query |
+
+### Store Audit Table
+
+Fill in one row per Pinia store in your application:
+
+| Store | Category | Key State | Subscribers | Migration Target |
+|---|---|---|---|---|
+| ___ | Local UI / Shared / Server | ___ | ___ components | ___ |
+
+### Decision Rules
+
+- **Only 1–2 components read it?** → Inline as `useState`. No global store needed.
+- **Many components read it, rarely writes?** → React Context with `useMemo` provider value.
+- **Frequent reads AND writes across the tree?** → Zustand store (avoids Context re-render issues).
+- **Holds API response data?** → TanStack Query or Server Component fetch — don't put server data in client stores.
+- **Store has actions with side effects (API calls)?** → Those become TanStack Query mutations or Server Actions.
+
+### SSR Sensitivity Audit
+
+Add this column to your component inventory. Components with high SSR sensitivity need `'use client'` directives or conditional imports in Next.js.
+
+| Component | Uses `window`/`document`? | `onMounted` data fetch? | Vue Router coupled? | SSR Sensitivity |
+|---|---|---|---|---|
+| ___ | yes / no | yes / no | params / guards / no | None / Low / High |
+
+**Rating guide:**
+- **None:** Pure presentational, no browser APIs, no lifecycle data fetching
+- **Low:** Uses `onMounted` but only for DOM measurement or animation setup
+- **High:** Calls `window`/`document` at module scope, fetches data in `onMounted`, or reads route params/guards directly — these require `'use client'` or refactoring to Server Components
+
+> **Common mistake:** Migrating every Pinia store to Zustand 1:1. Many stores exist in Vue only because Vue lacks a built-in data-fetching primitive — React Server Components and TanStack Query eliminate the need.
+
+---
+
+## Baseline Metrics to Capture
+
+Before starting migration, record:
+
+| Metric | Tool | Why |
+|---|---|---|
+| Lighthouse scores | Chrome DevTools | Compare performance pre/post |
+| Bundle size | `npx vite-bundle-visualizer` | Ensure React version isn't larger |
+| Core Web Vitals | PageSpeed Insights | Track LCP, FID, CLS |
+| Component count | `find src -name '*.vue' \| wc -l` | Track migration progress |
+| Test count & coverage | `vitest --coverage` | Ensure tests are ported |
+| Build time | CI pipeline logs | Compare build performance |
+| Error rate | Sentry / error tracking | Detect regression post-migration |

--- a/skills/convert-vue-nextjs/references/strategy/coexistence-patterns.md
+++ b/skills/convert-vue-nextjs/references/strategy/coexistence-patterns.md
@@ -1,0 +1,396 @@
+# Coexistence Patterns: Running Vue & Next.js Side-by-Side
+
+> Run both frameworks in production, migrate route-by-route, roll back safely.
+
+---
+
+## 1. Strangler Fig Overview
+
+Next.js becomes the **new frontend edge**; Vue serves unmigrated routes behind proxy/rewrites. Next.js absorbs routes until Vue is fully decommissioned.
+
+### Migration Flow
+
+```mermaid
+graph LR
+  A[Inventory] --> B[Shell]
+  B --> C[Coexistence]
+  C --> D[Feature Parity]
+  D --> E[Leaf Components]
+  E --> F[Stateful Components]
+  F --> G[Route Migration]
+  G --> H[Decommission Vue]
+  style A fill:#e0f2fe
+  style H fill:#bbf7d0
+```
+
+| Phase              | Goal                                                   |
+| ------------------ | ------------------------------------------------------ |
+| **Inventory**      | Catalog every Vue route, component, and shared service  |
+| **Shell**          | Next.js scaffold with layout, auth, and proxy rules     |
+| **Coexistence**    | Both apps serve production traffic via proxy/rewrites   |
+| **Feature Parity** | Migrated routes match Vue behaviour exactly             |
+| **Leaf Components**| Pure presentational components converted first          |
+| **Stateful**       | Complex state-holding components (stores, composables)  |
+| **Route Migration**| Full pages rewritten; Vue routes removed one-by-one     |
+| **Decommission**   | Vue runtime, adapters, and proxy rules removed entirely |
+
+**Key principle:** every phase must be independently deployable and rollback-able. Never batch multiple route migrations into a single deployment.
+
+---
+
+## 2. Coexistence Strategy Decision Table
+
+| Strategy                  | Best For                         | Pros                                       | Cons                                          | When to Use                                     |
+| ------------------------- | -------------------------------- | ------------------------------------------ | --------------------------------------------- | ----------------------------------------------- |
+| **Proxy / Rewrites**      | Route-level strangler            | Zero coupling, simple ops, instant rollback| No shared UI within a single page             | Default choice — start here                     |
+| **Web Components Adapter**| Embedding Vue widgets in Next.js | Framework-agnostic, Shadow DOM isolation   | Prop serialization friction, bundle overhead  | Shared widgets (date-picker, chart) in transition|
+| **Micro-Frontends**       | Large teams, independent deploys | Parallel team velocity, runtime sharing    | Operational complexity, shared state issues   | Multiple teams owning different feature slices  |
+| **Iframe Containment**    | Hard isolation, legacy quarantine| Total CSS/JS isolation                     | Poor SEO, UX seams, no shared state           | Last resort for untouchable legacy modules      |
+
+> **Rule of thumb:** Start with Proxy/Rewrites. Only add Web Components or micro-frontends for within-page coexistence.
+
+---
+
+## 3. Proxy / Rewrites (Route-Level Strangler)
+
+### 3.1 Next.js `rewrites` in `next.config.js`
+
+Forward unmatched routes to Vue. As you add Next.js pages, traffic stops reaching Vue automatically.
+
+```js
+// next.config.js
+const nextConfig = {
+  async rewrites() {
+    return {
+      fallback: [
+        { source: "/:path*", destination: `${process.env.VUE_APP_ORIGIN}/:path*` },
+      ],
+    };
+  },
+};
+module.exports = nextConfig;
+```
+
+Forward a specific prefix explicitly:
+
+```js
+async rewrites() {
+  return [
+    { source: "/legacy/:path*", destination: "http://vue-app.internal:3001/legacy/:path*" },
+  ];
+},
+```
+
+### 3.2 Next 16+ `proxy.ts` Network Boundary
+
+`proxy.ts` replaces many `middleware.ts` uses for routing decisions — runs before the Next.js router.
+
+```ts
+// proxy.ts (project root — Next 16+)
+import type { NextRequest } from "next/server";
+
+const VUE_ORIGIN = process.env.VUE_APP_ORIGIN!;
+const LEGACY_PREFIXES = ["/settings", "/admin", "/reports"];
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (LEGACY_PREFIXES.some((p) => pathname.startsWith(p))) {
+    return fetch(new URL(pathname + request.nextUrl.search, VUE_ORIGIN), {
+      headers: request.headers,
+      method: request.method,
+      body: request.body,
+    });
+  }
+  return undefined; // proceed to Next.js
+}
+```
+
+### 3.3 Pitfalls
+
+| Pitfall                    | Detail                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| **Hydration mismatch**     | If rewritten path differs from what Vue Router expects, hydration breaks. Always preserve the original path. |
+| **Auth in proxy**          | Don't overload `proxy.ts` with auth logic. Share sessions via common cookie domain or JWT. |
+| **Cookie/CORS drift**      | Both apps must share the same top-level domain or set `Domain=.example.com`.    |
+| **Health-check coupling**  | Next.js health checks pass even if Vue is down. Ping both in `/api/health`.     |
+
+---
+
+## 4. Web Components Adapter Layer
+
+Wrap Vue components as Custom Elements to embed them inside Next.js pages.
+
+### 4.1 Vue SFC → Custom Element
+
+**Vue SFC** (`StatusBadge.vue`) with props, emits, and scoped styles becomes a custom element:
+
+```ts
+// register-elements.ts
+import { defineCustomElement } from "vue";
+import StatusBadge from "./StatusBadge.ce.vue"; // rename .vue → .ce.vue
+customElements.define("vue-status-badge", defineCustomElement(StatusBadge));
+```
+
+**Usage in Next.js:**
+
+```tsx
+// app/dashboard/page.tsx
+"use client";
+import { useEffect, useRef } from "react";
+import "@/adapters/register-elements";
+
+export default function Dashboard() {
+  const badgeRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    const el = badgeRef.current;
+    if (!el) return;
+    const handler = () => console.log("badge clicked");
+    el.addEventListener("click", handler);
+    return () => el.removeEventListener("click", handler);
+  }, []);
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      {/* @ts-expect-error — custom element */}
+      <vue-status-badge ref={badgeRef} variant="success">Active</vue-status-badge>
+    </div>
+  );
+}
+```
+
+### 4.2 Prop & Attribute Serialization
+
+HTML attributes are **always strings**. Set complex values as properties on the DOM element:
+
+```tsx
+// ❌ Broken — object coerced to "[object Object]"
+<vue-chart data={chartData} />
+
+// ✅ Correct — set property imperatively
+useEffect(() => {
+  if (chartRef.current) (chartRef.current as any).data = chartData;
+}, [chartData]);
+```
+
+### 4.3 Shadow DOM Styling
+
+`defineCustomElement` uses Shadow DOM by default — global CSS won't penetrate.
+
+1. Bundle styles inside `.ce.vue` files (they are inlined into the shadow root).
+2. Use `::part()` selectors if the component exposes `part` attributes.
+3. Disable Shadow DOM with a wrapper (lose style isolation).
+
+### 4.4 Event Bridging
+
+Custom elements emit `CustomEvent`s. React's synthetic events ignore these — use `addEventListener` via a ref:
+
+```tsx
+useEffect(() => {
+  const el = ref.current;
+  const onSelect = (e: Event) => setSelectedDate((e as CustomEvent).detail.date);
+  el?.addEventListener("date-select", onSelect);
+  return () => el?.removeEventListener("date-select", onSelect);
+}, []);
+```
+
+---
+
+## 5. Micro-Frontends
+
+### 5.1 single-spa
+
+```js
+import { registerApplication, start } from "single-spa";
+registerApplication({
+  name: "@org/vue-settings",
+  app: () => System.import("@org/vue-settings"),
+  activeWhen: ["/settings"],
+});
+registerApplication({
+  name: "@org/react-dashboard",
+  app: () => System.import("@org/react-dashboard"),
+  activeWhen: ["/dashboard"],
+});
+start();
+```
+
+### 5.2 Webpack 5 Module Federation
+
+```js
+// next.config.js (host)
+const { NextFederationPlugin } = require("@module-federation/nextjs-mf");
+module.exports = {
+  webpack(config) {
+    config.plugins.push(
+      new NextFederationPlugin({
+        name: "host",
+        remotes: { vueApp: "vueApp@http://vue-app.internal:3001/remoteEntry.js" },
+        shared: { react: { singleton: true }, "react-dom": { singleton: true } },
+      })
+    );
+    return config;
+  },
+};
+```
+
+### 5.3 When to Use & Complexity Warnings
+
+Use when: multiple teams deploy independently, feature slices justify own build pipelines, or within-page coexistence exceeds Web Components' limits.
+
+| Concern          | Detail                                                                |
+| ---------------- | --------------------------------------------------------------------- |
+| Shared state     | No free lunch — use custom events, a shared store, or URL state.      |
+| Version skew     | Host and remote must agree on shared dependency versions.             |
+| Error isolation  | A crash in one micro-frontend can leak into host if not sandboxed.    |
+| Testing          | Integration tests must boot multiple apps simultaneously.             |
+| Performance      | Each remote adds a network request; use preloading wisely.            |
+
+---
+
+## 6. Iframe Containment
+
+**When:** Hard isolation required (third-party widget, global CSS pollution, untouchable legacy).
+
+**Costs:** weaker SEO (content not indexed), shared state only via `postMessage`, UX seams (scrollbars, focus traps), accessibility issues, poor mobile touch handling.
+
+**Guidance:** Tactical containment tool — not primary strategy. Eliminate all iframes before decommission.
+
+```tsx
+// app/legacy/settings/page.tsx
+export default function LegacySettings() {
+  return (
+    <iframe
+      src={`${process.env.VUE_APP_ORIGIN}/settings`}
+      className="w-full h-[calc(100vh-64px)] border-0"
+      title="Legacy Settings"
+      sandbox="allow-scripts allow-same-origin allow-forms"
+    />
+  );
+}
+```
+
+---
+
+## 7. Component Contracts
+
+### 7.1 TypeScript Contract Stub
+
+Define an interface both Vue and React implementations must satisfy:
+
+```ts
+// contracts/button.contract.ts
+export interface ButtonContract {
+  props: {
+    variant?: "primary" | "secondary";
+    size?: "sm" | "md" | "lg";
+    disabled?: boolean;
+  };
+  events: {
+    onClick: () => void;
+  };
+  slots: {
+    default: "label content";
+    icon?: "optional leading icon";
+  };
+}
+```
+
+### 7.2 Using Contracts to Gate Migration
+
+1. **Extract** contract from Vue component's props, emits, and slots.
+2. **Implement** React component to same contract.
+3. **Verify** via shared Storybook story that both render identically.
+4. **Swap** behind a feature flag (see §8).
+
+```ts
+import type { ButtonContract } from "@/contracts/button.contract";
+type AssertVueProps = ButtonContract["props"];   // used in Vue defineProps<>
+type AssertReactProps = ButtonContract["props"]; // used in React component
+```
+
+### 7.3 Generating Usage Graphs
+
+Before migrating, understand the component's blast radius:
+
+```bash
+rg "import.*StatusBadge" --type vue --type ts -l    # direct importers
+rg "StatusBadge" src/ --type vue -c | sort -t: -k2 -rn | head -20  # usage count
+```
+
+Use `madge` to visualize dependency order — leaf components with zero consumers migrate first.
+
+---
+
+## 8. Rollback Strategies
+
+Every migration step must be reversible. Three levels cover the full spectrum.
+
+### 8.1 Route-Level Rollback
+
+Add the route back to `LEGACY_PREFIXES` to redirect traffic to Vue:
+
+```ts
+// proxy.ts — rollback: add "/dashboard" back
+const LEGACY_PREFIXES = ["/settings", "/dashboard"];
+```
+
+**Recovery time:** seconds (deploy config change or env-var toggle).
+
+### 8.2 Component-Level Rollback
+
+Feature flag swaps between Vue custom element and React component:
+
+```tsx
+import { useFeatureFlag } from "@/lib/feature-flags";
+
+export function StatusBadge(props: StatusBadgeProps) {
+  const useReact = useFeatureFlag("react-status-badge");
+  if (!useReact) {
+    // @ts-expect-error custom element
+    return <vue-status-badge variant={props.variant}>{props.children}</vue-status-badge>;
+  }
+  return <span className={`badge badge--${props.variant}`}>{props.children}</span>;
+}
+```
+
+**Recovery time:** milliseconds (flip the flag).
+
+### 8.3 Request-Boundary Rollback
+
+`proxy.ts` is a **single-file convention** for instant rollback at the network edge:
+
+```ts
+// Rollback in one file:
+//   1. Add route to LEGACY_PREFIXES
+//   2. Deploy (or toggle env var)
+//   3. All traffic for that route returns to Vue
+```
+
+### Rollback Decision Matrix
+
+| Signal                             | Level            | Action                               |
+| ---------------------------------- | ---------------- | ------------------------------------ |
+| Spike in 5xx on migrated route     | Route-level      | Add prefix back to `LEGACY_PREFIXES` |
+| Visual regression on one component | Component-level  | Flip feature flag to Vue adapter     |
+| Auth / session issues              | Request-boundary | Route all traffic through Vue        |
+| Performance regression             | Route-level      | Roll back route, profile, re-migrate |
+
+---
+
+## 9. Decommission Checklist
+
+Once every route is migrated and validated, remove coexistence scaffolding:
+
+- [ ] **Remove Vue runtime** — delete `vue`, `@vue/*` from `package.json`
+- [ ] **Remove adapter layer** — delete `register-elements.ts`, `.ce.vue` files
+- [ ] **Remove proxy rules** — delete `proxy.ts` legacy forwarding, clean `rewrites()`
+- [ ] **Remove feature flags** — delete migration-specific flags and dead code paths
+- [ ] **Simplify build pipeline** — remove Module Federation / single-spa config
+- [ ] **Remove Vue dev tooling** — Vite config, Vue ESLint plugin, Vue test utils
+- [ ] **Clean shared deps** — audit `node_modules` for orphaned Vue packages
+- [ ] **DNS / infra cleanup** — decommission Vue deployment, remove DNS entries
+- [ ] **Final performance audit** — Lighthouse, Core Web Vitals vs pre-migration baseline
+- [ ] **Update documentation** — remove all coexistence references
+
+> **Celebrate.** The strangler fig has consumed the host. Ship it. 🎉

--- a/skills/convert-vue-nextjs/references/strategy/migration-strategies.md
+++ b/skills/convert-vue-nextjs/references/strategy/migration-strategies.md
@@ -1,0 +1,373 @@
+# Migration Strategy Patterns
+
+> Battle-tested strategies for migrating Vue applications to React/Next.js, drawn from 8 real-world case studies and community consensus.
+
+---
+
+## Strategy Comparison
+
+| Strategy | Best For | Timeline | Risk | Team Size |
+|---|---|---|---|---|
+| **Big Bang Rewrite** | Small apps, strong React team, clean break | 2–8 weeks | 🔴 High | 2–5 devs |
+| **Incremental / Strangler Fig** | Production apps, continuous delivery needed | 3–12 months | 🟢 Low | 2–10 devs |
+| **Micro-Frontend** | Very large apps, multiple independent teams | 6–18 months | 🟡 Medium | 5+ devs |
+| **Page-by-Page** | Clear page boundaries, Nuxt → Next.js | 2–6 months | 🟢 Low | 2–5 devs |
+
+---
+
+## Big Bang Rewrite
+
+### When It Works
+
+- **Small apps** (< 30 components, < 20 pages)
+- **Strong React team** that can rebuild quickly
+- **Major redesign** planned anyway (new UI, new architecture)
+- **No active users** (internal tools, pre-launch apps)
+
+### When It Fails
+
+- **Large apps** (100+ components) — scope creep is inevitable
+- **Active users** expecting continuous feature delivery
+- **Evolving requirements** — new features get blocked during rewrite
+
+> **u/domdommdommmm:** *"I've tried on 3 separate occasions to migrate a large application to no success."*
+
+### Execution Steps
+
+1. Set up new Next.js project with TypeScript, Tailwind, Zustand
+2. Recreate routing structure (`app/` directory mirrors Vue Router config)
+3. Convert state management (Pinia → Zustand)
+4. Rebuild components bottom-up (leaf → composite → pages)
+5. Migrate tests (VTU → RTL), deploy, decommission Vue app
+
+### Risk Mitigations
+
+- Keep the old app running as a fallback
+- Set a hard deadline — migrations without timelines never finish
+- Deploy incrementally using feature flags or canary releases
+
+---
+
+## Incremental / Strangler Fig (Recommended)
+
+Gradually replace the old system while keeping it running. Used in the most successful case studies.
+
+### Architecture
+
+```
+                    ┌─────────────────┐
+    User traffic →  │  Reverse Proxy  │
+                    │  (nginx/Vercel) │
+                    └──┬──────────┬───┘
+                       │          │
+              ┌────────▼──┐  ┌───▼────────┐
+              │  Next.js  │  │  Vue/Nuxt  │
+              │  (new)    │  │  (legacy)  │
+              └───────────┘  └────────────┘
+                    │              │
+                    └──────┬───────┘
+                    ┌──────▼──────┐
+                    │ Shared Auth │
+                    │ Shared API  │
+                    └─────────────┘
+```
+
+### Step-by-Step Process
+
+**Phase 1: Foundation (Week 1–2)**
+- Set up Next.js project alongside Vue app
+- Configure reverse proxy (all traffic → Vue by default)
+- Implement shared authentication (same-domain cookies or JWT)
+- Create shared design token package
+
+**Phase 2: First Page (Week 3–4)**
+- Pick the **simplest, lowest-traffic page** for first migration
+- Rebuild in Next.js, update proxy to route that path to Next.js
+- Validate: auth works, styles match, functionality identical
+
+**Phase 3: Accelerate (Ongoing)**
+- Migrate pages one at a time, increasing complexity
+- Convert shared components into a common package
+- Update proxy routing after each page
+
+**Phase 4: Cleanup**
+- All traffic routed to Next.js; remove Vue app and proxy
+
+### Proxy Routing Config
+
+**Nginx:**
+```nginx
+upstream vue_app  { server localhost:3000; }
+upstream next_app { server localhost:3001; }
+
+server {
+  # Migrated pages → Next.js
+  location /dashboard { proxy_pass http://next_app; }
+  location /profile   { proxy_pass http://next_app; }
+  # Everything else → Vue (legacy)
+  location / { proxy_pass http://vue_app; }
+}
+```
+
+### Shared Auth
+
+Both apps must share authentication. Same-domain cookies work automatically. For JWT:
+
+```ts
+// packages/shared-auth/index.ts
+export function getAuthToken(): string | null {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith('auth-token='))
+    ?.split('=')[1] ?? null;
+}
+
+export function isAuthenticated(): boolean {
+  const token = getAuthToken();
+  if (!token) return false;
+  const payload = JSON.parse(atob(token.split('.')[1]));
+  return payload.exp * 1000 > Date.now();
+}
+```
+
+### Real-World Results
+
+| Case Study | Scale | Timeline | Downtime |
+|---|---|---|---|
+| Navid Barsalari (SaaS dashboard) | 4 zones | 3 months | **0 hours** |
+| Hakan Aktaş (internal app) | Company-wide | 8 months | **0 hours** |
+| Better Programming (large app) | Major tech debt | 15+ months | **0 hours** |
+
+---
+
+## Micro-Frontend Approach
+
+### When to Use
+
+- **Very large apps** with 200+ components and multiple independent teams
+- **Long-term coexistence** of both frameworks is acceptable
+
+### Implementation Options
+
+| Tool | Approach | Complexity |
+|---|---|---|
+| **Module Federation** | Share modules at runtime | 🟡 Medium |
+| **single-spa** | Framework-agnostic orchestrator | 🔴 High |
+| **Astro.js** | Container for both Vue and React | 🟡 Medium |
+
+> **Warning:** *"Deploying Module Federation without version-locking shared deps → runtime conflicts."* Always pin shared dependency versions.
+
+- Adds infrastructure complexity — only justified for large organizations
+- Shared state between micro-frontends is challenging
+- Bundle size increases (two framework runtimes)
+
+---
+
+## Page-by-Page Migration
+
+Use subdomain or path-based routing to serve different pages from different apps. Start with **least complex, lowest-risk pages**:
+
+1. Static pages (about, terms, FAQ) — simplest
+2. Auth pages (login, register) — isolated
+3. Settings pages — usually CRUD
+4. Dashboard pages — data-heavy
+5. Core feature pages — highest complexity, migrate last
+
+### Shared Components via Package
+
+```
+packages/shared-ui/     # npm package with shared design tokens
+apps/next-app/           # Imports React components
+apps/nuxt-app/           # Imports Vue components
+```
+
+---
+
+## ReactWrapper Bridge Component
+
+For component-level coexistence — mount React components inside Vue:
+
+```vue
+<!-- ReactWrapper.vue -->
+<template>
+  <div ref="reactRoot" />
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount, watch, toRaw } from 'vue'
+import { createRoot } from 'react-dom/client'
+import React from 'react'
+
+const props = defineProps({
+  component: { type: [Object, Function], required: true },
+  componentProps: { type: Object, default: () => ({}) }
+})
+
+const reactRoot = ref(null)
+let root = null
+
+function render() {
+  if (!root || !reactRoot.value) return
+  root.render(React.createElement(toRaw(props.component), toRaw(props.componentProps)))
+}
+
+onMounted(() => { root = createRoot(reactRoot.value); render() })
+watch(() => props.componentProps, render, { deep: true })
+onBeforeUnmount(() => { root?.unmount(); root = null })
+</script>
+```
+
+**Usage:**
+```vue
+<ReactWrapper :component="ReactChart" :componentProps="{ data: chartData }" />
+```
+
+**Use when:** Migrating individual components within a Vue page, testing React components before full page migration. **Remove** once the entire page is migrated.
+
+**Limitations:** Two runtimes in bundle, no shared reactive context, prop-drilling at scale.
+
+---
+
+## Component Migration Order (6 Phases per Route)
+
+Within each route, migrate components in this order — it minimizes the number of moving parts you have to reason about at the same time:
+
+| Phase | What to Migrate | Why This Order |
+|---|---|---|
+| 1 | **Presentational leaf components** (Button, Card, Avatar, Badge, Icon) | Pure props-in/render-out — no state, no side effects |
+| 2 | **Input & form field components** (TextField, Select, DatePicker) | Introduces `v-model` → controlled component conversion |
+| 3 | **Overlays & behavior-heavy UI** (modals, popovers, tooltips, drawers) | Portals, focus traps, animation — complex but self-contained |
+| 4 | **Container components** (compose children, manage state, store/route access) | Depend on layers 1–3 being stable |
+| 5 | **Route components & layouts** (Vue Router → App Router structure) | Structural migration — reshapes the page boundary |
+| 6 | **Global state & data fetching** (Pinia, route guards, API layer) | Cross-cutting — touch last to avoid cascading changes |
+
+---
+
+## 12-Step Practical Project Order
+
+For a medium-to-large Vue 3 app, follow this end-to-end sequence:
+
+1. Create the Next.js app shell and root layout
+2. Pick one **non-critical route** (settings, profile, about)
+3. Create the route in `app/` — keep it `"use client"` heavy at first
+4. Port the route's leaf UI components (Phase 1 above)
+5. Port form controls and `v-model` contracts (Phase 2)
+6. Port overlays — modals, dropdowns, tooltips (Phase 3)
+7. Port composables into custom hooks
+8. Port route/container logic (Phase 4–5)
+9. Move fetches to the server where appropriate
+10. Move persistent shells (sidebar, navbar) into layouts
+11. Migrate Pinia stores by category: local UI → shared client → server state
+12. **Only then** optimize `"use client"` boundaries into more Server Components
+
+> Steps 1–8 are about **parity**. Steps 9–12 are about **leverage**.
+
+---
+
+## Behavior Freeze Before Migration
+
+Before migrating any route, capture its current behavior as a baseline:
+
+- **Screenshots** of major states (populated, empty, loading, error)
+- **Key interaction flows** (click paths, form submissions, drag/drop)
+- **Keyboard & focus behavior** (tab order, focus traps, shortcuts)
+- **Route transitions** and URL/query-string behavior
+- **Responsive breakpoints** (mobile, tablet, desktop renders)
+- **Store-driven behavior** (how Pinia state affects the UI)
+
+> *"This is not ceremony. It is how you avoid the classic migration problem where 'the component renders' but no longer behaves the same."*
+
+---
+
+## The Two-Phase Mindset
+
+Every migrated route goes through two distinct phases:
+
+**Phase 1 — Contract Preservation (ship this):**
+- Does it still look the same?
+- Do interactions behave identically?
+- Does state sync correctly?
+- Does navigation work?
+
+**Phase 2 — Architectural Refinement (optimize after):**
+- Which components should stay client-side?
+- Which can become Server Components?
+- Which Pinia store responsibilities should move to layouts, Context, or server fetching?
+
+> *"That two-phase mindset is why component-by-component migration works."* Never combine both phases — ship parity first, refine second.
+
+---
+
+## CSS / UI Parity Rule
+
+For the first pass of every component, preserve:
+
+- Same HTML structure and wrapper elements
+- Same CSS classes and breakpoint logic
+- Same portal/teleport targets
+- Same animation timing and transitions
+
+> *"Do not combine a framework migration with a design-system rewrite."* Visual changes introduce ambiguity — you can't tell if a bug is from the migration or the redesign. Redesign **after** parity is proven.
+
+---
+
+## Testing During Migration
+
+- **Keep both test suites running:** `test:vue` and `test:react` scripts
+- **E2E tests are framework-agnostic:** Playwright/Cypress tests work regardless of framework
+- **Smoke test each migrated page** before moving to the next
+
+```ts
+// Playwright smoke test for migrated pages
+const migratedPages = ['/dashboard', '/profile', '/settings'];
+for (const page of migratedPages) {
+  test(`${page} loads`, async ({ page: p }) => {
+    await p.goto(page);
+    await expect(p.locator('body')).not.toBeEmpty();
+  });
+}
+```
+
+---
+
+## Real-World Lessons
+
+### Timeline Reality
+
+| Estimate | Actual | Why |
+|---|---|---|
+| "2 months" | 4–6 months | Third-party deps take 2–3× longer |
+| "Same as Vue 2→3" | 3–5× more | Framework switch ≠ version upgrade |
+
+> **u/budd222:** *"Half the team thinks it will be the same amount of time... Half the team doesn't know what they are talking about."*
+
+### What Works
+
+- **Dedicated migration team** (2–3 devs) for fast timelines
+- **Rotation** (1 week/month per dev) for sustainability
+- **New features go in React** — build forward, fix backward
+- **Never pause feature delivery** — every successful migration kept shipping
+
+> **Hakan Aktaş:** *"Avoid long isolated rewrites — keep shipping."*
+
+### When to Stop and Reassess
+
+- ⚠️ At 50% done but 80% of estimated time used
+- ⚠️ Critical deps have no React equivalent
+- ⚠️ Team morale dropping; migration feels like a death march
+
+**Recovery:** Scale down scope, switch to micro-frontend, or pause and revisit.
+
+---
+
+## Migration Checklist
+
+- [ ] Next.js project initialized with TypeScript + Tailwind
+- [ ] Reverse proxy or routing layer configured
+- [ ] Shared auth working across both apps
+- [ ] State management converted (Pinia → Zustand)
+- [ ] Leaf components migrated and tested
+- [ ] Pages migrated in priority order
+- [ ] All proxy routes point to Next.js
+- [ ] Vue app decommissioned; bridge components removed
+- [ ] Final performance audit completed

--- a/skills/convert-vue-nextjs/references/strategy/testing-strategy.md
+++ b/skills/convert-vue-nextjs/references/strategy/testing-strategy.md
@@ -1,0 +1,296 @@
+# Testing Strategy: Vue-to-Next.js Migration
+
+> Ensuring behavioral parity at every phase of migration — test the contract, not the framework.
+
+---
+
+## 1. Migration Testing Philosophy
+
+Migration testing exists to answer one question: **does the migrated component behave identically to the original?**
+
+**Core principles:**
+
+- **Test behavioral parity, not implementation details.** A Vue component using `v-model` and a React component using `useState` + `onChange` are equivalent if they produce the same DOM and respond to the same interactions.
+- **Test the contract, not the framework internals.** Never assert on Vue reactivity internals or React fiber nodes. Assert on what the user sees and what the network receives.
+- **Dual-framework period requires both test libraries.** During coexistence, Vue Test Utils validates the legacy baseline, React Testing Library validates the migrated version. Both must pass for the same behavioral spec.
+- **Tests are the migration's safety net, not its deliverable.** Write the minimum tests that catch regressions. Over-testing slows migration velocity without reducing risk.
+
+---
+
+## 2. Testing Ladder
+
+Four levels, ordered from most granular (fastest feedback) to broadest (highest confidence):
+
+| Level | Tool | What It Validates | When to Use |
+|---|---|---|---|
+| Component parity | React Testing Library + Vue Test Utils | Same DOM output, same interaction results | Every migrated component |
+| Visual regression | Chromatic / Percy / Playwright screenshots | CSS drift between Vue `scoped` styles and React CSS Modules | Every styling change |
+| Route-level E2E | Playwright / Cypress | Navigation, auth redirects, data freshness across Vue↔Next boundary | Every migrated route |
+| Performance baseline | Lighthouse CI / Web Vitals | TTFB, LCP, CLS not regressed | After shell setup + each phase |
+
+**Rule of thumb:** if a component parity test catches it, don't write an E2E for it. Push failures down the ladder.
+
+---
+
+## 3. Component Parity Testing
+
+### Side-by-Side Pattern
+
+The core technique: render the Vue component and the React component with **identical props/state**, then assert **identical DOM output and interaction behavior**.
+
+#### Vue baseline (Vue Test Utils)
+
+```js
+// tests/vue/Button.spec.js
+import { mount } from '@vue/test-utils';
+import Button from '@/components/Button.vue';
+
+describe('Button (Vue baseline)', () => {
+  it('renders label and fires click', async () => {
+    const onClick = vi.fn();
+    const wrapper = mount(Button, {
+      props: { label: 'Submit', disabled: false },
+      attrs: { onClick },
+    });
+
+    expect(wrapper.text()).toBe('Submit');
+    expect(wrapper.find('button').attributes('disabled')).toBeUndefined();
+
+    await wrapper.find('button').trigger('click');
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+#### React migrated (React Testing Library)
+
+```tsx
+// tests/react/Button.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '@/components/Button';
+
+describe('Button (React migrated)', () => {
+  it('renders label and fires click', async () => {
+    const onClick = vi.fn();
+    render(<Button label="Submit" disabled={false} onClick={onClick} />);
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+### Key Mapping Patterns to Test
+
+| Vue Pattern | React Equivalent | What to Assert |
+|---|---|---|
+| `<slot>` / `<slot name="x">` | `children` / named props | Same rendered content in same position |
+| `$emit('change', value)` | `onChange(value)` callback | Callback called with identical arguments |
+| `v-model` | Controlled input (`value` + `onChange`) | Typing produces same value, caret position preserved |
+| `v-if` / `v-show` | Conditional render / `style.display` | Element present/absent or visible/hidden identically |
+| `provide` / `inject` | React Context | Descendant components receive same values |
+
+---
+
+## 4. Visual Regression Testing
+
+### Why It Matters
+
+CSS scoped styles → CSS Modules drift is the **#1 silent regression** in Vue-to-React migrations. The component passes all behavioral tests but looks subtly wrong because:
+
+- Class name specificity changed
+- CSS property order shifted
+- A global style leak was accidentally relied upon
+
+### Tool Options
+
+| Tool | Strength | Tradeoff |
+|---|---|---|
+| Chromatic | Tight Storybook integration, free for OSS | Requires Storybook for both frameworks |
+| Percy | Framework-agnostic snapshot service | Per-snapshot pricing |
+| Playwright screenshots | Free, runs in CI, no vendor lock | Manual threshold tuning, no visual diffing UI |
+
+### Setup Pattern: Dual Storybook
+
+Maintain Storybook for both Vue and React with identical stories during migration. Run visual comparison between Vue and React story screenshots — any pixel diff beyond threshold is a regression.
+
+### CSS Ordering Warning
+
+Next.js dev mode and production builds can load CSS in **different orders**. Always verify visual regression against `next build && next start`, not `next dev`. Add this to CI:
+
+```yaml
+- run: npm run build
+- run: npx start-server-and-test 'npm start' 3000 'npx playwright test --project=visual'
+```
+
+---
+
+## 5. Verification Checklist Per Migrated Unit
+
+Run this checklist for **every** migrated component before marking it done:
+
+### Rendering
+- [ ] DOM structure matches (same semantic elements, same nesting)
+- [ ] Empty state renders identically
+- [ ] Loading state renders identically
+- [ ] Error state renders identically
+- [ ] List rendering with 0, 1, and many items
+
+### Interactions
+- [ ] Click handlers fire with correct arguments
+- [ ] Keyboard input produces correct state changes
+- [ ] Focus management (tab order, focus traps) preserved
+- [ ] Hover/active states visually consistent
+
+### Accessibility
+- [ ] Label associations (`for`/`id`, `aria-labelledby`) preserved
+- [ ] ARIA attributes (`aria-expanded`, `aria-selected`, etc.) identical
+- [ ] Keyboard navigation works (Enter, Escape, Arrow keys)
+- [ ] Screen reader announcements unchanged (live regions)
+
+### Network
+- [ ] Correct number of API requests (no duplicate fetches)
+- [ ] Request timing matches (on mount, on interaction, on interval)
+- [ ] Cache behavior preserved (stale-while-revalidate, dedup)
+- [ ] Error/retry handling produces same UX
+
+### SSR
+- [ ] No `window`/`document` usage in Server Components
+- [ ] Hydration completes without mismatch warnings
+- [ ] `'use client'` boundary placed at correct level
+- [ ] Meta tags and SEO output identical (check `view-source:`)
+
+### State
+- [ ] Controlled input parity: caret position, selection range
+- [ ] IME composition (CJK input) handled correctly
+- [ ] Debounced/throttled values fire at same intervals
+- [ ] Form submission produces identical payloads
+
+---
+
+## 6. E2E Cross-Boundary Testing
+
+### The Vue↔Next Boundary Problem
+
+During coexistence, users navigate between Next.js pages and proxied Vue pages. The boundary must be invisible. Test it explicitly.
+
+### Playwright Example: Cross-Boundary Navigation
+
+```ts
+// e2e/cross-boundary.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('navigate from Next route to Vue route and back', async ({ page }) => {
+  // Start on a migrated Next.js page
+  await page.goto('/dashboard');
+  await expect(page.locator('h1')).toHaveText('Dashboard');
+
+  // Navigate to a not-yet-migrated Vue page (proxied)
+  await page.click('a[href="/settings/billing"]');
+  await expect(page).toHaveURL('/settings/billing');
+  await expect(page.locator('.billing-header')).toBeVisible();
+
+  // Navigate back to Next.js
+  await page.click('a[href="/dashboard"]');
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.locator('h1')).toHaveText('Dashboard');
+});
+
+test('auth redirect parity: expired session redirects to login', async ({ page }) => {
+  // Clear auth state
+  await page.context().clearCookies();
+
+  // Next.js protected route should redirect
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL(/\/login/);
+
+  // Vue protected route should redirect identically
+  await page.goto('/settings/billing');
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test('deep link parity: direct navigation to nested route', async ({ page }) => {
+  await page.goto('/settings/billing/invoices/2024');
+  await expect(page.locator('[data-testid="invoice-year"]')).toHaveText('2024');
+});
+```
+
+### What to Test at the Boundary
+
+| Scenario | Assertion |
+|---|---|
+| Forward navigation (Next → Vue) | URL correct, content loads, no flash of wrong layout |
+| Back navigation (Vue → Next) | Browser back button works, no full page reload |
+| Auth redirects | Both frameworks redirect to same login URL with same `returnTo` param |
+| Deep links | Direct URL entry resolves correctly on both sides |
+| Shared state | Auth token, theme preference, locale survive boundary crossing |
+
+---
+
+## 7. CI Pipeline for Dual-Framework Testing
+
+```yaml
+# .github/workflows/migration-tests.yml
+jobs:
+  vue-tests:
+    runs-on: ubuntu-latest
+    steps: [checkout, npm ci, npm run test:vue]
+
+  react-tests:
+    runs-on: ubuntu-latest
+    steps: [checkout, npm ci, npm run test:react]
+
+  e2e-cross-boundary:
+    needs: [vue-tests, react-tests]
+    steps: [checkout, npm ci, playwright install, npm run build, playwright test]
+
+  performance:
+    needs: [e2e-cross-boundary]
+    steps: [checkout, npm ci, npm run build, lighthouse-ci-action]
+
+  visual-regression:
+    needs: [vue-tests, react-tests]
+    steps: [checkout, npm ci, playwright test --project=visual-regression]
+```
+
+### Pipeline Gates
+
+| Gate | Threshold | Action on Failure |
+|---|---|---|
+| Vue tests | 100% pass | Block merge |
+| React tests | 100% pass | Block merge |
+| E2E cross-boundary | 100% pass | Block merge |
+| LCP regression | > 200ms increase | Warn, require justification |
+| CLS regression | > 0.05 increase | Block merge |
+| Visual diff | > 0.1% pixel change | Require manual approval |
+
+---
+
+## 8. Testing Phases Aligned to Migration
+
+| Migration Phase | Testing Focus | Key Risks |
+|---|---|---|
+| **Shell setup** | URL parity (every route resolves), SEO parity (`view-source:` comparison), performance baseline capture | Proxy misconfiguration, missing meta tags |
+| **Leaf components** | Component parity tests, visual regression snapshots | CSS drift, slot→children mapping errors |
+| **Stateful components** | Effect parity (no duplicate API calls in Strict Mode), controlled input parity, timer/interval cleanup | `useEffect` double-fire, stale closures |
+| **Routes/pages** | Deep link parity, route guard parity, cache invalidation on navigation | Auth redirect loops, layout shift on transition |
+| **Decommission** | Full E2E suite (no more cross-boundary), comprehensive performance audit, remove Vue test infrastructure | Orphaned Vue dependencies, missed proxy routes |
+
+### Phase Transition Criteria
+
+A phase is complete when all parity tests pass, visual regression shows zero unintended diffs, E2E covers all migrated routes, performance gates pass, and no `TODO(migration)` comments remain.
+
+---
+
+## Quick Reference: Test Commands
+
+```bash
+npm run test:vue                # Vue baseline tests
+npm run test:react              # React migrated tests
+npm run test:vue & npm run test:react & wait  # Both in parallel
+npm run build && npx start-server-and-test 'npm start' 3000 'npx playwright test'  # E2E
+npm run build && npx lhci autorun  # Performance audit
+```


### PR DESCRIPTION
## New Skill: `convert-vue-nextjs`

Adds a comprehensive Vue/Nuxt → Next.js App Router conversion skill (skill #21).

### What it does
Converts Vue 2/3 SFCs and Nuxt applications to idiomatic Next.js App Router code with React. Covers the full conversion surface: template directives → JSX, reactivity → hooks, Pinia/Vuex → Zustand/Context, Vue Router → file-system routing, Nuxt data fetching → Server Components, and ecosystem package mapping.

### Structure
- **SKILL.md** (261 lines) — Decision routing table, 7 non-negotiable rules, directive/hook maps, complete before/after example, common mistakes table, do-this/not-that, reference map
- **12 reference docs** organized in 3 subdirectories:
  - `conversion/` — component mapping, state management, routing, SSR/data fetching, advanced patterns, migration workflow
  - `ecosystem/` — 30+ Vue→React package equivalents
  - `strategy/` — assessment checklist, migration strategies, coexistence patterns (Strangler Fig, Web Components, MFE), testing strategy
  - `pitfalls.md` — 20+ anti-patterns with fixes

### Quality checklist
- [x] Directory name is canonical kebab-case with verb prefix (`convert-vue-nextjs`)
- [x] Frontmatter `name` matches directory exactly
- [x] Description starts with "Use skill if you are" (27 words)
- [x] SKILL.md body under 500 lines (261)
- [x] All 12 reference files explicitly routed from SKILL.md
- [x] No orphaned files, junk files, or eval content
- [x] README.md updated (Framework Guides category, skill count → 21)
- [x] NAMING.md canonical list updated
- [x] No trigger collision with `convert-snapshot-nextjs` (Vue source code vs HTML snapshots)
- [x] Directive, operational tone matching repo family
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
