### PR TITLE
Fix develop-macos-liquid-glass: 20-agent fact-check corrections

### DIFF
--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md
@@ -110,7 +110,7 @@ Informational    → No tint, no prominence           Just glass
 ### macOS-Specific Non-Negotiables
 
 - **`.interactive()` is iOS-only** — use `.onHover {}` on macOS
-- **`.tint(.clear)`** on all macOS glass buttons
+- **`.tint(.clear)`** on macOS glass secondary buttons (practitioner workaround for tint bleed, not official Apple guidance)
 - **`.scrollEdgeEffectStyle(.hard)`** is the macOS default
 - **TabView** uses `.tabViewStyle(.sidebarAdaptable)` on macOS
 - **Settings scene** must exist, bound to Cmd+Comma
@@ -125,7 +125,7 @@ Seeing ANY of these means the code is not native:
 - Hardcoded colors (`Color(red:)`, `Color("#hex")`) on glass
 - Fixed font sizes (`.system(size: 24)`) instead of text styles
 - `NavigationView` instead of `NavigationSplitView`/`NavigationStack`
-- `@StateObject`/`@ObservedObject` instead of `@Observable`
+- `@StateObject`/`@ObservedObject` instead of `@Observable` (superseded, not officially deprecated — but preferred for glass performance)
 - `.toolbarBackground(.visible)` on macOS 26
 - Missing keyboard shortcuts for Cmd+N, S, W, Z, Comma, Q
 - Custom window chrome instead of system toolbar
@@ -158,7 +158,7 @@ Seeing ANY of these means the code is not native:
 - [ ] `GlassEffectContainer` wraps every group of nearby glass elements
 
 ### macOS Native
-- [ ] `.tint(.clear)` on all glass buttons (macOS rendering requirement)
+- [ ] `.tint(.clear)` on secondary glass buttons (practitioner workaround for macOS tint bleed)
 - [ ] No `.interactive()` calls (iOS-only)
 - [ ] `.scrollEdgeEffectStyle` appropriate (macOS defaults `.hard`)
 - [ ] TabView uses `.tabViewStyle(.sidebarAdaptable)`
@@ -170,7 +170,7 @@ Seeing ANY of these means the code is not native:
 
 ### Modern APIs
 - [ ] No `NavigationView` (use `NavigationSplitView` / `NavigationStack`)
-- [ ] No `@StateObject`/`@ObservedObject` (use `@State` + `@Observable`)
+- [ ] No `@StateObject`/`@ObservedObject` (prefer `@State` + `@Observable` — not deprecated but superseded)
 - [ ] No `.foregroundColor()` (use `.foregroundStyle()`)
 - [ ] No `.toolbarBackground()` or `.presentationBackground()` on macOS 26
 - [ ] `#available(macOS 26, *)` gates all Liquid Glass APIs

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/api-reference.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/api-reference.md
@@ -25,7 +25,7 @@ func glassEffect(
 | Preset | Description | Typical use |
 |--------|-------------|-------------|
 | `.regular` | Default translucent glass with standard material and vibrancy | Toolbar items, tab bars, floating controls |
-| `.clear` | Minimal glass — nearly transparent until hovered/active | Secondary or de-emphasized controls |
+| `.clear` | Minimal glass — nearly transparent until hovered/active. **Note:** arrived in Xcode 26 beta 5, not the initial release. On macOS, does not fully replicate Control Center/Dock glass density. | Secondary or de-emphasized controls |
 | `.identity` | No glass effect rendered (opt-out while keeping the modifier in the chain) | Conditional toggling |
 
 #### `.tint(_:)` on Glass
@@ -442,7 +442,9 @@ glass.tintColor = .controlAccentColor // Optional tint applied to the glass
 | `cornerRadius` | `CGFloat` | Corner radius of the glass shape |
 | `tintColor` | `NSColor?` | Optional color tint composited into the glass material |
 
-> **Migration note:** `NSVisualEffectView` continues to work but does not produce the Liquid Glass appearance. To adopt the new design, replace `NSVisualEffectView` instances with `NSGlassEffectView`.
+> **Migration note:** `NSVisualEffectView` continues to work (it is NOT deprecated) but does not produce the Liquid Glass appearance. To adopt the new design, replace `NSVisualEffectView` instances with `NSGlassEffectView`.
+
+> **Critical production constraint:** `NSGlassEffectView` has NO `.state` property equivalent to `NSVisualEffectView.state`. When the hosting `NSWindow` is not the key window, the glass renders significantly more opaque/solid. Unlike `NSVisualEffectView.state = .active`, there is no public API to force active glass rendering on an inactive window. This breaks HUD-style floating windows that intentionally don't take focus. The only known workarounds involve overriding private `NSWindow` methods (`_hasActiveAppearance`, `_hasKeyAppearance`) — which risks App Store rejection. Unresolved as of macOS 26.4.
 
 ---
 
@@ -518,6 +520,8 @@ toolbarItem.isBordered = false // Removes the default glass platter background
 toolbarItem.style = .prominent // Renders with accent color tint (like .glassProminent)
 ```
 
+> **Verification note:** `NSToolbarItem.style = .prominent` could not be independently confirmed in Apple's public API documentation. If this API does not compile, the alternative is to use a custom `NSButton` with `bezelStyle = .glass` and `bezelColor = .controlAccentColor` as the toolbar item's view.
+
 #### Custom background tint
 
 ```swift
@@ -554,20 +558,16 @@ button.bezelStyle = .glass
 button.bezelColor = NSColor.systemGreen   // Optional custom glass tint
 ```
 
-#### `tintProminence`
+#### Tint Control
 
-Controls how strongly the tint color is applied to the glass bezel.
+Control glass button tint via `bezelColor` (confirmed API):
 
 ```swift
-button.tintProminence = .primary // Strong tint — use for primary actions
+button.bezelColor = NSColor.controlAccentColor  // Accent-tinted glass (primary action)
+button.bezelColor = NSColor.clear                // Neutral glass (secondary action)
 ```
 
-| Value | Behavior |
-|-------|----------|
-| `.automatic` | System decides based on context |
-| `.none` | No tint applied (neutral glass) |
-| `.secondary` | Subtle tint |
-| `.primary` | Full tint — visually equivalent to `.glassProminent` in SwiftUI |
+> **Verification note:** Some sources reference a `tintProminence` property with `.automatic`, `.none`, `.secondary`, `.primary` values. This property name could not be independently verified against Apple's public SDK headers. The confirmed path for tint control is `bezelColor` on `NSButton` with `.glass` bezel style. If `tintProminence` exists, it may be from a later Xcode 26 seed — verify against your SDK.
 
 ---
 

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/appkit-bridging.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/appkit-bridging.md
@@ -27,6 +27,8 @@ Stay in pure SwiftUI when:
 
 > **Rule of thumb:** Start in SwiftUI. Bridge only the specific view or subsystem that requires AppKit. Never wrap an entire window in `NSViewRepresentable` when only one control needs it.
 
+> **Critical constraint:** `NSGlassEffectView` has no `.state` property. When the hosting `NSWindow` is not the key window, glass renders significantly more opaque. There is no public API to force active glass on inactive windows (unlike `NSVisualEffectView.state = .active`). This is unresolved as of macOS 26.4 and breaks HUD-style floating windows. See `pitfalls-and-solutions.md` pitfall #30.
+
 ## NSViewRepresentable for NSGlassEffectView
 
 The most common bridge: wrapping `NSGlassEffectView` so you can set corner radius and tint color beyond what the SwiftUI modifier exposes.

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/design-diagnosis.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/design-diagnosis.md
@@ -22,10 +22,12 @@ Each row is a concrete find-and-replace. The "Design Reason" column is what you 
 
 ### State Management (Observation)
 
+> **Important:** `@StateObject`, `@ObservedObject`, `@EnvironmentObject`, and `ObservableObject` are **not officially deprecated** — Apple has not added deprecation annotations to these APIs. However, the `@Observable` macro (iOS 17 / macOS 14) is the preferred modern pattern and offers significant performance advantages. The replacements below are recommendations, not deprecation-driven requirements.
+
 | # | Old API | New API | Since | Design Reason |
 |---|---------|---------|-------|---------------|
 | 6 | `class VM: ObservableObject` | `@Observable class VM` | iOS 17 / macOS 14 | Precise property-level invalidation. Only views reading a changed property re-render. Eliminates phantom redraws that cause glass shimmer artifacts. |
-| 7 | `@StateObject private var vm = VM()` | `@State private var vm = VM()` (with `@Observable`) | iOS 17 / macOS 14 | `@StateObject` is tied to `ObservableObject`. With `@Observable`, `@State` owns the lifecycle. |
+| 7 | `@StateObject private var vm = VM()` | `@State private var vm = VM()` (with `@Observable`) | iOS 17 / macOS 14 | With `@Observable`, `@State` owns the lifecycle. Note: `@StateObject` has unique deferred-initialization semantics that `@State` on `@Observable` does not replicate — verify your use case before migrating. |
 | 8 | `@ObservedObject var vm: VM` | Direct property `var vm: VM` (with `@Observable`) | iOS 17 / macOS 14 | Observation tracking is implicit. No wrapper needed. |
 | 9 | `@EnvironmentObject var store: Store` | `@Environment(Store.self) var store` | iOS 17 / macOS 14 | Type-safe. Compiler error if not injected, instead of runtime crash. |
 | 10 | `@Published var name: String` | Remove (automatic in `@Observable`) | iOS 17 / macOS 14 | Every stored property is observed by default. `@Published` is `ObservableObject`-era boilerplate. |

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/design-principles.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/design-principles.md
@@ -101,14 +101,19 @@ The window's corners establish a baseline radius. Every nested element — toolb
 On macOS 26, the system handles most concentricity automatically. You opt in by using `.rect(cornerRadius: .containerConcentric)` instead of hardcoding a radius value:
 
 ```swift
-// ✅ CORRECT — concentric with the parent container
+// ✅ CORRECT — use the system's concentric shape type
+.glassEffect(.regular, in: ConcentricRectangle())
+
+// ✅ ALSO CORRECT — concentric corner radius token (verify exact API name against Xcode 26 SDK)
 .glassEffect(.regular, in: .rect(cornerRadius: .containerConcentric))
 
 // ❌ WRONG — hardcoded radius breaks concentric alignment
 .glassEffect(.regular, in: .rect(cornerRadius: 12))
 ```
 
-The `.containerConcentric` token tells the system: "make this shape's corners proportional to whatever container I am inside." If your element is inside a toolbar, it becomes concentric with the toolbar. If it is inside a sidebar, it becomes concentric with the sidebar.
+> **API name note:** Official Apple sources reference `ConcentricRectangle` as the SwiftUI shape type for concentricity. The `.containerConcentric` token on `.rect(cornerRadius:)` also appears in practitioner code. Verify the exact spelling against your Xcode 26 SDK — Apple may use `.concentric` or a similar variant.
+
+The concentric system tells the framework: "make this shape's corners proportional to whatever container I am inside." If your element is inside a toolbar, it becomes concentric with the toolbar. If it is inside a sidebar, it becomes concentric with the sidebar.
 
 ### macOS corner radius tiers
 
@@ -116,9 +121,11 @@ The window itself has a corner radius determined by its toolbar style:
 
 | Window Configuration | Approximate Corner Radius | Example |
 |---------------------|--------------------------|---------|
-| No toolbar | ~12pt | Settings panel, utility window |
+| No toolbar (title-bar-only) | ~16pt | Settings panel, utility window |
 | Compact toolbar (icon-only) | ~20pt | Finder, Mail |
 | Standard toolbar (icon+text) | ~26pt | Photos, Keynote |
+
+> **Note:** These values are community-measured from macOS 26 betas, not published by Apple. The no-toolbar tier was previously estimated at ~12pt but multiple independent measurements converge on ~16pt.
 
 Toolbar elements are concentric with the window. Buttons within toolbar glass get smaller concentric radii automatically. You do not need to calculate this — the system does it when you use `.containerConcentric`.
 
@@ -156,6 +163,8 @@ Liquid Glass has a precise hierarchy of visual weight controlled entirely by tin
 
 **One primary action per screen. One. Not two. Not "well, these are both important." One.**
 
+> This rule is consistent with Apple's stated intent ("Apply a single, purposeful tint per screen" — WWDC 2025 Session 219) and mirrors the HIG's long-standing "one default button per view at most" rule for push buttons. While not stated in exactly these words by Apple, violating it produces visual noise.
+
 If your screen has two tinted prominent buttons, neither of them is primary. You have created visual noise, and the user's eye has nowhere to land. Pick the action the user is most likely to perform and make it prominent. Make everything else neutral glass.
 
 ```swift
@@ -189,14 +198,16 @@ If your screen has two tinted prominent buttons, neither of them is primary. You
 
 macOS toolbar buttons are **monochrome by default**. The system renders them in a neutral tone that matches the glass surface. You apply `.tint()` only to the primary action — the one button that needs to stand out.
 
-On macOS, use `.tint(.clear)` on glass buttons to get the correct rendering for secondary actions. This is a macOS-specific requirement — without it, some buttons render with an unexpected tint bleed:
+On macOS, some practitioners report that glass buttons render with unexpected tint bleed from the accent color. A common workaround is `.tint(.clear)` on secondary actions. This is a practitioner-discovered pattern, not official Apple guidance:
 
 ```swift
-// macOS secondary button — explicit clear tint
+// macOS secondary button — practitioner workaround for tint bleed
 Button("Export", systemImage: "square.and.arrow.up") { export() }
     .buttonStyle(.glass)
-    .tint(.clear)
+    .tint(.clear)  // removes accent tint bleed on some macOS configurations
 ```
+
+> **Note:** This `.tint(.clear)` pattern is not documented in any WWDC session or Apple API doc. It addresses a rendering quirk, not a design requirement. Test on your target macOS version before applying universally.
 
 ### What restraint looks like
 
@@ -369,9 +380,11 @@ macOS defaults to `.hard` — a visible dividing line at the scroll edge. iOS de
 
 | Style | Behavior | Use when |
 |-------|---------|----------|
-| `.hard` (macOS default) | Strong dividing line at scroll edge | Document apps, utilities, dense content, any app where clear toolbar/content separation aids comprehension |
-| `.soft` | Gradual fade at scroll edge | Media apps, creative tools, immersive experiences where the toolbar should feel like it floats over content |
-| `.none` | No effect at scroll edge | **Never.** This looks broken — content abruptly clips under the toolbar with no visual treatment |
+| `.hard` (macOS default, ALL edges) | Strong dividing line at scroll edge | Document apps, utilities, dense content, any app where clear toolbar/content separation aids comprehension |
+| `.soft` (iOS default) | Gradual fade at scroll edge | Media apps, creative tools, immersive experiences where the toolbar should feel like it floats over content |
+| `.none` | No effect at scroll edge | Rarely appropriate — content clips under the toolbar with no visual treatment. Exists as a valid API case but use with caution. |
+
+> **Platform defaults:** `.automatic` resolves to `.hard` on macOS for ALL edges (top and bottom). On iOS, `.automatic` resolves to `.soft`. There is no per-edge platform default difference — macOS is `.hard` everywhere.
 
 ```swift
 // Override macOS default for a media-centric app
@@ -543,7 +556,7 @@ These are patterns that immediately mark code as non-native. If a reviewer sees 
 
 6. **`.toolbarBackground(.visible)` on macOS 26.** This forces the old-style opaque toolbar background, which blocks glass rendering entirely. Remove it.
 
-7. **Purple or indigo tint on primary actions.** Apple uses tint colors semantically: blue for standard primary actions, green for positive/confirm, red for destructive. Purple and indigo are not part of this vocabulary. They look out of place.
+7. **Decorative tinting without semantic meaning.** Apple uses tint to communicate function: blue for standard primary actions, green for positive/confirm, red for destructive. Using tint purely for decoration (any color) weakens the signal. If the tint does not convey primary/destructive/selected status, consider removing it.
 
 8. **Fixed font sizes.** `.font(.system(size: 14))` instead of `.font(.body)`. This breaks Dynamic Type and looks wrong at non-default text sizes.
 

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/macos-patterns.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/macos-patterns.md
@@ -35,7 +35,7 @@ Toolbar items on macOS 26 automatically adopt Liquid Glass styling. The system r
 |------|--------|
 | Icons | Monochrome by default. The system tints them to match glass appearance. |
 | `.tint()` | Use only on primary action buttons to draw visual emphasis. |
-| `.confirmationAction` | Automatically receives `.glassProminent` treatment (stronger glass fill). |
+| `.confirmationAction` | Intended for primary confirmation actions. May receive `.glassProminent` treatment automatically (not independently verified — apply explicit `.buttonStyle(.glassProminent)` if needed). |
 | `.toolbar(removing: .title)` | Removes the window title from the toolbar area for a cleaner glass surface. |
 | Grouping | Use `ToolbarItemGroup` to cluster related actions. Glass groups them visually. |
 | Spacers | `ToolbarSpacer(.flexible)` for push-apart layout, `.fixed` for consistent gaps. |
@@ -54,7 +54,7 @@ NavigationSplitView {
         Label(item.name, systemImage: item.icon)
     }
     .backgroundExtensionEffect()
-    .navigationSplitViewColumnWidth(min: 180, ideal: 200)
+    .navigationSplitViewColumnWidth(min: 180, ideal: 200) // Note: unreliable on macOS 26.0–26.1; verify on your target version
 } detail: {
     DetailView(item: selected)
 }
@@ -114,7 +114,7 @@ struct ContentView: View {
 }
 ```
 
-The inspector inherits Liquid Glass from the window chrome. Its content area gets the same ambient tinting as the sidebar.
+The inspector receives an edge-to-edge glass treatment alongside the content (not floating like the sidebar). This is managed by `NSSplitViewController` automatically. Its content area gets ambient tinting similar to (but architecturally distinct from) the sidebar.
 
 ---
 

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/migration-guide.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/migration-guide.md
@@ -294,7 +294,7 @@ For inline replacement across a codebase, the mapping is:
 
 ### Adaptive Glass Modifier
 
-A drop-in `View` extension that uses glass on macOS 26+ and falls back to material on earlier versions:
+A recommended `View` extension that uses glass on macOS 26+ and falls back to material on earlier versions (note: this is a guide-defined pattern, not a widely adopted community convention yet):
 
 ```swift
 extension View {

--- a/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md
+++ b/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md
@@ -1,6 +1,6 @@
 # macOS Liquid Glass — Pitfalls and Solutions
 
-> Verified against macOS 26 Tahoe (26.0–26.2) and Xcode 28 — March 2026
+> Verified against macOS 26 Tahoe (26.0–26.4) and Xcode 26 — April 2026
 > Every issue was reproduced or confirmed via WWDC sessions, Apple documentation, developer forums, or community reports.
 
 ---
@@ -38,6 +38,11 @@
 | 27 | AppKit | `NSGlassEffectContainerView` does NOT propagate cornerRadius | Medium |
 | 28 | AppKit | `NSGlassEffectView` minimal public API | Info |
 | 29 | AppKit | Private `set_variant(_:)` API | Critical |
+| 30 | AppKit | NSGlassEffectView opaque on inactive windows | High |
+| 31 | Migration | No fallback on pre-macOS 26 — crash | Critical |
+| 32 | Accessibility | Focus ring regression — FKA silently enabled | Medium |
+| 33 | Visual | Window resize cursor misalignment (fixed 26.4) | Low |
+| 34 | Visual | Scrollbar clipping under corner radius (partial fix 26.4) | Medium |
 
 ---
 
@@ -285,9 +290,9 @@ GlassEffectContainer {
 
 ### 12. Performance on Intel Macs
 
-GPU-bound shader work is negligible on Apple Silicon but can dip to ~45fps with 5–6 overlapping glass views on older Intel Macs.
+GPU-bound shader work is negligible on Apple Silicon but causes substantial frame rate drops on Intel Macs. Community reports describe Intel integrated GPUs as ~3x slower than Apple Silicon for the Liquid Glass rendering pipeline, with users reporting "20 FPS less in Tahoe" and memory pressure from WindowServer shader calculations.
 
-**Fix**: Reduce overlapping glass elements. Test on target hardware. Consider conditional enhancements for Apple Silicon.
+**Fix**: Reduce overlapping glass elements. Test on target hardware. Profile with Instruments > Core Animation (watch FPS and "Hitches in commit"). Consider conditional enhancements for Apple Silicon.
 
 ```swift
 #if arch(arm64)
@@ -558,9 +563,9 @@ Text("Hello")
 
 ### 25. Reduce Transparency regression
 
-The "Reduce Transparency" accessibility setting stopped working correctly in macOS 26 through 26.2. Glass effects may still render even when the user has enabled the setting.
+The "Reduce Transparency" accessibility setting has been unreliable since macOS 26.0. While macOS 26.1 added explicit user control over Liquid Glass effects, community reports from 26.3 show the toggle itself becoming greyed out and non-functional for some users. **Do not assume this is fixed in any specific version — treat as ongoing.**
 
-**Fix**: File Feedback with Apple. Test with the setting enabled (`System Settings > Accessibility > Display > Reduce Transparency`). Provide additional contrast via semantic colors as a defensive measure.
+**Fix**: Always implement defensive code regardless of OS version. File Feedback with Apple. Test with the setting enabled (`System Settings > Accessibility > Display > Reduce Transparency`).
 
 ```swift
 // Defensive: check accessibility setting
@@ -650,3 +655,51 @@ glassView.tintColor = .clear
 ```
 
 > **Severity: Critical** — Using private API risks App Store rejection and runtime crashes on future macOS versions.
+
+---
+
+### 30. NSGlassEffectView renders opaque on inactive windows — no public workaround
+
+When the hosting `NSWindow` is not the key window, `NSGlassEffectView` becomes significantly more opaque/solid. Unlike `NSVisualEffectView.state = .active`, there is no public API to force active glass rendering.
+
+**Impact**: Breaks HUD-style floating windows, tool palettes, and any non-focus-taking overlay that uses glass.
+
+**Workaround**: The only known approach overrides private `NSWindow` methods (`_hasActiveAppearance`, `_hasKeyAppearance`) via a subclass — this risks App Store rejection.
+
+**Fix**: None available via public API as of macOS 26.4. File Feedback with Apple requesting a `state`-equivalent property on `NSGlassEffectView`.
+
+---
+
+### 31. No automatic fallback on pre-macOS 26 targets — crash
+
+`.buttonStyle(.glass)`, `.glassEffect()`, and all Liquid Glass APIs crash at runtime on macOS versions prior to 26 if called without an `#available` guard. There is no silent degradation.
+
+**Fix**: Always gate with `#available(macOS 26, *)`:
+
+```swift
+if #available(macOS 26, *) {
+    button.glassEffect(.regular, in: .capsule)
+} else {
+    button.background(.ultraThinMaterial)
+}
+```
+
+---
+
+### 32. Focus ring regression — Full Keyboard Access silently enabled
+
+macOS 26 Tahoe implicitly enables Full Keyboard Access for some users after upgrade, causing a blue focus ring to appear around all focusable UI elements — including glass controls. Users are confused by the unexpected focus rings.
+
+**Workaround**: Users can disable via Settings > Accessibility > Motor > Keyboard > Full Keyboard Access (toggle off) or Settings > Keyboard > Keyboard Navigation (toggle off). Developers should not suppress focus rings — they are an accessibility feature — but should be aware this may affect visual testing.
+
+---
+
+### 33. Window resize cursor misalignment (fixed in 26.4)
+
+The resize pointer did not follow the window's large rounded corner shape during drag-resize in macOS 26.0–26.3. Confirmed fixed in macOS 26.4.
+
+---
+
+### 34. Scrollbar clipping under large corner radius (partially fixed in 26.4)
+
+Scrollbars were clipped under the large window corner radius in macOS 26.0–26.3. Fixed in 26.4 for large-radius windows; still present under small-radius windows (e.g., Terminal) as of 26.4. Also affects Finder column view where horizontal scrollbar overlaps resize handles when "always show scrollbars" is enabled.


### PR DESCRIPTION
## Summary

Systematic fact-check of the `develop-macos-liquid-glass` skill using 20 parallel internet-researcher agents, each cross-referencing the skill's 7 reference files against:
- Verified ground truth in `~/dev/macos-hig` (10,761 lines, sourced from Apple HIG/API docs)
- WWDC 2025 Sessions 219, 310, 323, 356
- Apple Developer Documentation (scraped)
- Reddit: r/SwiftUI, r/swift, r/MacOSBeta, r/iOSProgramming
- Stack Overflow, practitioner blogs (juniperphoton, nilcoalescing, troz.net, eclecticlight)

## Critical fixes (verified wrong)

- **Window corner radius**: ~12pt → **16pt** for no-toolbar windows
- **`.tint(.clear)`**: demoted from "macOS requirement" to "practitioner workaround" — no Apple source
- **`@StateObject`/`@ObservedObject`**: changed from "deprecated" to "superseded" — no Xcode deprecation
- **`.containerConcentric`**: added `ConcentricRectangle` as the verified SwiftUI shape type
- **Scroll edge bottom default**: corrected to `.hard` on ALL macOS edges
- **`NSButton.tintProminence`**: marked as unverified, `bezelColor` is the confirmed API

## New pitfalls added (5)

- #30: NSGlassEffectView opaque on inactive windows — no public workaround (High)
- #31: No automatic fallback on pre-macOS 26 — crash (Critical)
- #32: Focus ring regression — Full Keyboard Access silently enabled (Medium)
- #33: Window resize cursor misalignment — fixed in 26.4 (Low)
- #34: Scrollbar clipping under corner radius — partial fix 26.4 (Medium)

## Precision corrections

- Inspector glass framing, .confirmationAction verification, NSToolbarItem.style
- Reduce Transparency regression extended past 26.2, Intel perf figure removed
- adaptiveGlassEffect pattern attribution, Glass.clear availability note

## Test plan

- [ ] All reference files parse correctly (no broken markdown)
- [ ] Pitfall quick-reference table matches numbered entries
- [ ] Version header updated to April 2026 / macOS 26.0–26.4
- [ ] No existing correct content was removed — only corrections and additions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Twenty parallel agents, hundreds of lines reviewed, and the single most self-contradictory paragraph in the entire file walked away untouched — because nobody read the thing they were editing. This PR systematically fact-checks `develop-macos-liquid-glass` across seven reference files using WWDC sessions, Apple HIG/API docs, and community research: the window corner radius gets corrected from ~12pt to ~16pt, `.tint(.clear)` is demoted from "macOS requirement" to "practitioner workaround," the scroll edge default is corrected to `.hard` on all macOS edges, the unverified `tintProminence` property is replaced with the confirmed `bezelColor` API, `@StateObject`/`@ObservedObject` are correctly re-labeled as superseded rather than deprecated, and five new pitfalls (#30–#34) are added covering real production constraints. The factual corrections are accurate and well-sourced. The fatal flaw: pitfall #2 in `pitfalls-and-solutions.md` was never updated — it still declares `.tint(.clear)` mandatory for "proper macOS rendering" and marks code without it as `❌ WRONG`, directly contradicting the demoted framing this same PR introduces in three other locations.

- **Pitfall #2 contradiction** (P1): `pitfalls-and-solutions.md` pitfall #2 still prescribes `.tint(.clear)` as mandatory while SKILL.md, the review checklist, and design-principles.md all describe it as a conditional practitioner workaround — an agent following this skill gets incompatible instructions for the same API
- **Path 3 step 6 inconsistency** (P2): SKILL.md migration workflow still lists `.tint(.clear)` as an unconditional step, defeating the PR's own demotion
- **EOF dumping of new pitfalls** (P2): Pitfalls #30–#34 appended at end-of-file rather than inserted into their respective category sections (AppKit, Migration, Accessibility, Visual), breaking the document's navigational structure
- **Solid factual corrections**: corner radius, `bezelColor` vs `tintProminence`, scroll edge defaults, `ConcentricRectangle`, `@StateObject` deprecation status, `NSGlassEffectView` inactive-window constraint
- **Version header fixed**: "Xcode 28" typo corrected to "Xcode 26"

<h3>Confidence Score: 4/5</h3>

**[Linus Torvalds Mode]** Twenty agents swept the codebase and skipped the paragraph that actively contradicts their own work — this is what peak AI overcoverage looks like. Merge-blocked: pitfall #2 in pitfalls-and-solutions.md gives agents directly opposing instructions for the same API call; fix that before this lands.

This has one actual P1: pitfall #2 still authoritatively declares .tint(.clear) mandatory and marks code without it as wrong, while every other section the PR touched explicitly demotes it to a conditional workaround. That is two directly opposing directives for the same API in the same skill document. The factual corrections across the other six files are accurate and well-sourced. The P2s (Path 3 wording, EOF placement of new pitfalls) are real but don't block merge. One P1 holds this at 4 — fix pitfall #2 and this ships.

pitfalls-and-solutions.md pitfall #2 (untouched contradiction at lines 75–90) and SKILL.md Path 3 step 6 (line 76, still unconditional) — the fact-check army marched straight past both of them.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md | Version header fixed (Xcode 28→26), five new pitfalls added (#30–#34) — but pitfall #2 directly contradicts the PR's own .tint(.clear) demotion, and new entries break the file's category-section structure. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md | .tint(.clear) demoted to workaround in checklist and non-negotiables, but Path 3 step 6 still treats it as a mandatory migration step — residual inconsistency. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/design-principles.md | Corner radius corrected 12pt→16pt, .tint(.clear) demoted, scroll edge default corrected to hard on all edges, ConcentricRectangle added — well-executed factual corrections. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/api-reference.md | Unverified tintProminence replaced with confirmed bezelColor, NSGlassEffectView inactive-window constraint documented, Glass.clear availability note added — accurate corrections. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/design-diagnosis.md | @StateObject/@ObservedObject correctly clarified as not-deprecated but superseded; @StateObject deferred-init caveat added — accurate and useful nuance. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/macos-patterns.md | .confirmationAction marked unverified, inspector framing corrected, navigationSplitViewColumnWidth reliability note added — appropriate hedging of unconfirmed claims. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/migration-guide.md | adaptiveGlassEffect pattern correctly labeled as guide-defined rather than community convention — minimal, accurate change. |
| skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/appkit-bridging.md | Adds inline callout for NSGlassEffectView inactive-window limitation with cross-reference to pitfall #30 — accurate and well-placed. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent reads develop-macos-liquid-glass] --> B{Which path?}
    B -->|Path 3 Migration| C["Step 6: .tint(.clear) on buttons\n(unconditional — SKILL.md line 76)"]
    B -->|Path 4 Review| D[Run review checklist]
    D --> E[".tint(.clear) = practitioner workaround\ntest first — SKILL.md line 161"]
    C --> F["⚡ Contradiction"]
    E --> F
    F --> G[Check pitfalls-and-solutions.md]
    G --> H["Pitfall #2 line 79: .tint(.clear) = mandatory\nfor proper macOS rendering\n— NOT updated by this PR"]
    H --> I["Three incompatible instructions\nfor the same API call"]
    style F fill:#ff6b6b,color:#fff
    style H fill:#ff4444,color:#fff
    style I fill:#cc0000,color:#fff
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md`, line 75-90 ([link](https://github.com/yigitkonur/skills-by-yigitkonur/blob/7bb906dce3e2e3c3c1ff4178d9bfaa578b8bcc13/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md#L75-L90)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Pitfall #2 contradicts the PR's own `.tint(.clear)` demotion**

   This is the intellectual equivalent of fact-checking your essay and then forgetting to re-read the first paragraph. You changed the framing in three places and left the single most authoritative-sounding instance completely untouched.

   Pitfall #2 was not updated by this PR. Its fix statement — "Use `.tint(.clear)` on glass buttons for proper macOS rendering" — directly contradicts the demoted wording now in SKILL.md line 113, the review checklist line 161, and design-principles.md. The `❌ WRONG` label on the example without `.tint(.clear)` is now a flat contradiction by the PR's own logic. An agent reading this skill hits two incompatible instructions for the same API call.

   Update pitfall #2 to align with the PR's intent:

   swift
   // ⚠️ May show accent tint bleed on some macOS 26 configurations
   Button("Action") { }
       .glassEffect()

   // Practitioner workaround — suppresses tint bleed on secondary buttons
   Button("Action") { }
       .glassEffect()
       .tint(.clear)
   ```
   ```

   Twenty agents checked everything else; nobody read the file they were editing.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md
   Line: 75-90

   Comment:
   **Pitfall #2 contradicts the PR's own `.tint(.clear)` demotion**

   This is the intellectual equivalent of fact-checking your essay and then forgetting to re-read the first paragraph. You changed the framing in three places and left the single most authoritative-sounding instance completely untouched.

   Pitfall #2 was not updated by this PR. Its fix statement — "Use `.tint(.clear)` on glass buttons for proper macOS rendering" — directly contradicts the demoted wording now in SKILL.md line 113, the review checklist line 161, and design-principles.md. The `❌ WRONG` label on the example without `.tint(.clear)` is now a flat contradiction by the PR's own logic. An agent reading this skill hits two incompatible instructions for the same API call.

   Update pitfall #2 to align with the PR's intent:

   swift
   // ⚠️ May show accent tint bleed on some macOS 26 configurations
   Button("Action") { }
       .glassEffect()

   // Practitioner workaround — suppresses tint bleed on secondary buttons
   Button("Action") { }
       .glassEffect()
       .tint(.clear)
   ```
   ```

   Twenty agents checked everything else; nobody read the file they were editing.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20skills%2Fdevelop-macos-liquid-glass%2Fskills%2Fdevelop-macos-liquid-glass%2Freferences%2Fpitfalls-and-solutions.md%0ALine%3A%2075-90%0A%0AComment%3A%0A**Pitfall%20%232%20contradicts%20the%20PR's%20own%20%60.tint%28.clear%29%60%20demotion**%0A%0AThis%20is%20the%20intellectual%20equivalent%20of%20fact-checking%20your%20essay%20and%20then%20forgetting%20to%20re-read%20the%20first%20paragraph.%20You%20changed%20the%20framing%20in%20three%20places%20and%20left%20the%20single%20most%20authoritative-sounding%20instance%20completely%20untouched.%0A%0APitfall%20%232%20was%20not%20updated%20by%20this%20PR.%20Its%20fix%20statement%20%E2%80%94%20%22Use%20%60.tint%28.clear%29%60%20on%20glass%20buttons%20for%20proper%20macOS%20rendering%22%20%E2%80%94%20directly%20contradicts%20the%20demoted%20wording%20now%20in%20SKILL.md%20line%20113%2C%20the%20review%20checklist%20line%20161%2C%20and%20design-principles.md.%20The%20%60%E2%9D%8C%20WRONG%60%20label%20on%20the%20example%20without%20%60.tint%28.clear%29%60%20is%20now%20a%20flat%20contradiction%20by%20the%20PR's%20own%20logic.%20An%20agent%20reading%20this%20skill%20hits%20two%20incompatible%20instructions%20for%20the%20same%20API%20call.%0A%0AUpdate%20pitfall%20%232%20to%20align%20with%20the%20PR's%20intent%3A%0A%0A%60%60%60suggestion%0A%23%23%23%202.%20macOS%20button%20tinting%20issue%0A%0AGlass%20buttons%20on%20macOS%20may%20render%20with%20unexpected%20accent%20tint%20bleed%20from%20the%20system%20on%20some%20configurations.%0A%0A**Workaround**%3A%20%60.tint%28.clear%29%60%20on%20secondary%20glass%20buttons%20suppresses%20the%20bleed.%20This%20is%20a%20practitioner-discovered%20pattern%20%E2%80%94%20not%20documented%20in%20WWDC%20sessions%20or%20Apple%20API%20docs.%20Test%20on%20your%20target%20macOS%20version%20before%20applying%20universally.%0A%0A%60%60%60swift%0A%2F%2F%20%E2%9A%A0%EF%B8%8F%20May%20show%20accent%20tint%20bleed%20on%20some%20macOS%2026%20configurations%0AButton%28%22Action%22%29%20%7B%20%7D%0A%20%20%20%20.glassEffect%28%29%0A%0A%2F%2F%20Practitioner%20workaround%20%E2%80%94%20suppresses%20tint%20bleed%20on%20secondary%20buttons%0AButton%28%22Action%22%29%20%7B%20%7D%0A%20%20%20%20.glassEffect%28%29%0A%20%20%20%20.tint%28.clear%29%0A%60%60%60%0A%60%60%60%0A%0ATwenty%20agents%20checked%20everything%20else%3B%20nobody%20read%20the%20file%20they%20were%20editing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=yigitkonur%2Fskills-by-yigitkonur"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>


2. `skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md`, line 76 ([link](https://github.com/yigitkonur/skills-by-yigitkonur/blob/7bb906dce3e2e3c3c1ff4178d9bfaa578b8bcc13/skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md#L76)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Path 3 step 6 still unconditional**

   Congratulations — you demoted `.tint(.clear)` to a workaround in the checklist and forgot the workflow that agents actually follow step-by-step. This is the cargo cult of partial refactoring.

   Path 3 step 6 lists "`.tint(.clear)` on buttons" as a mandatory migration step, contradicting the PR's own demotion to a conditional practitioner workaround. An agent running Path 3 will apply it universally.

   

   Consistency is free.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md
   Line: 76

   Comment:
   **Path 3 step 6 still unconditional**

   Congratulations — you demoted `.tint(.clear)` to a workaround in the checklist and forgot the workflow that agents actually follow step-by-step. This is the cargo cult of partial refactoring.

   Path 3 step 6 lists "`.tint(.clear)` on buttons" as a mandatory migration step, contradicting the PR's own demotion to a conditional practitioner workaround. An agent running Path 3 will apply it universally.

   

   Consistency is free.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20skills%2Fdevelop-macos-liquid-glass%2Fskills%2Fdevelop-macos-liquid-glass%2FSKILL.md%0ALine%3A%2076%0A%0AComment%3A%0A**Path%203%20step%206%20still%20unconditional**%0A%0ACongratulations%20%E2%80%94%20you%20demoted%20%60.tint%28.clear%29%60%20to%20a%20workaround%20in%20the%20checklist%20and%20forgot%20the%20workflow%20that%20agents%20actually%20follow%20step-by-step.%20This%20is%20the%20cargo%20cult%20of%20partial%20refactoring.%0A%0APath%203%20step%206%20lists%20%22%60.tint%28.clear%29%60%20on%20buttons%22%20as%20a%20mandatory%20migration%20step%2C%20contradicting%20the%20PR's%20own%20demotion%20to%20a%20conditional%20practitioner%20workaround.%20An%20agent%20running%20Path%203%20will%20apply%20it%20universally.%0A%0A%60%60%60suggestion%0A6.%20**Refine**%20for%20macOS%3A%20%60.tint%28.clear%29%60%20on%20secondary%20buttons%20only%20if%20tint%20bleed%20is%20observed%20%28practitioner%20workaround%20%E2%80%94%20test%20first%29%2C%20%60scrollEdgeEffectStyle%60%2C%20control%20sizing.%0A%60%60%60%0A%0AConsistency%20is%20free.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=yigitkonur%2Fskills-by-yigitkonur"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Askills%2Fdevelop-macos-liquid-glass%2Fskills%2Fdevelop-macos-liquid-glass%2Freferences%2Fpitfalls-and-solutions.md%3A75-90%0A**Pitfall%20%232%20contradicts%20the%20PR's%20own%20%60.tint%28.clear%29%60%20demotion**%0A%0AThis%20is%20the%20intellectual%20equivalent%20of%20fact-checking%20your%20essay%20and%20then%20forgetting%20to%20re-read%20the%20first%20paragraph.%20You%20changed%20the%20framing%20in%20three%20places%20and%20left%20the%20single%20most%20authoritative-sounding%20instance%20completely%20untouched.%0A%0APitfall%20%232%20was%20not%20updated%20by%20this%20PR.%20Its%20fix%20statement%20%E2%80%94%20%22Use%20%60.tint%28.clear%29%60%20on%20glass%20buttons%20for%20proper%20macOS%20rendering%22%20%E2%80%94%20directly%20contradicts%20the%20demoted%20wording%20now%20in%20SKILL.md%20line%20113%2C%20the%20review%20checklist%20line%20161%2C%20and%20design-principles.md.%20The%20%60%E2%9D%8C%20WRONG%60%20label%20on%20the%20example%20without%20%60.tint%28.clear%29%60%20is%20now%20a%20flat%20contradiction%20by%20the%20PR's%20own%20logic.%20An%20agent%20reading%20this%20skill%20hits%20two%20incompatible%20instructions%20for%20the%20same%20API%20call.%0A%0AUpdate%20pitfall%20%232%20to%20align%20with%20the%20PR's%20intent%3A%0A%0A%60%60%60suggestion%0A%23%23%23%202.%20macOS%20button%20tinting%20issue%0A%0AGlass%20buttons%20on%20macOS%20may%20render%20with%20unexpected%20accent%20tint%20bleed%20from%20the%20system%20on%20some%20configurations.%0A%0A**Workaround**%3A%20%60.tint%28.clear%29%60%20on%20secondary%20glass%20buttons%20suppresses%20the%20bleed.%20This%20is%20a%20practitioner-discovered%20pattern%20%E2%80%94%20not%20documented%20in%20WWDC%20sessions%20or%20Apple%20API%20docs.%20Test%20on%20your%20target%20macOS%20version%20before%20applying%20universally.%0A%0A%60%60%60swift%0A%2F%2F%20%E2%9A%A0%EF%B8%8F%20May%20show%20accent%20tint%20bleed%20on%20some%20macOS%2026%20configurations%0AButton%28%22Action%22%29%20%7B%20%7D%0A%20%20%20%20.glassEffect%28%29%0A%0A%2F%2F%20Practitioner%20workaround%20%E2%80%94%20suppresses%20tint%20bleed%20on%20secondary%20buttons%0AButton%28%22Action%22%29%20%7B%20%7D%0A%20%20%20%20.glassEffect%28%29%0A%20%20%20%20.tint%28.clear%29%0A%60%60%60%0A%60%60%60%0A%0ATwenty%20agents%20checked%20everything%20else%3B%20nobody%20read%20the%20file%20they%20were%20editing.%0A%0A%23%23%23%20Issue%202%20of%203%0Askills%2Fdevelop-macos-liquid-glass%2Fskills%2Fdevelop-macos-liquid-glass%2FSKILL.md%3A76%0A**Path%203%20step%206%20still%20unconditional**%0A%0ACongratulations%20%E2%80%94%20you%20demoted%20%60.tint%28.clear%29%60%20to%20a%20workaround%20in%20the%20checklist%20and%20forgot%20the%20workflow%20that%20agents%20actually%20follow%20step-by-step.%20This%20is%20the%20cargo%20cult%20of%20partial%20refactoring.%0A%0APath%203%20step%206%20lists%20%22%60.tint%28.clear%29%60%20on%20buttons%22%20as%20a%20mandatory%20migration%20step%2C%20contradicting%20the%20PR's%20own%20demotion%20to%20a%20conditional%20practitioner%20workaround.%20An%20agent%20running%20Path%203%20will%20apply%20it%20universally.%0A%0A%60%60%60suggestion%0A6.%20**Refine**%20for%20macOS%3A%20%60.tint%28.clear%29%60%20on%20secondary%20buttons%20only%20if%20tint%20bleed%20is%20observed%20%28practitioner%20workaround%20%E2%80%94%20test%20first%29%2C%20%60scrollEdgeEffectStyle%60%2C%20control%20sizing.%0A%60%60%60%0A%0AConsistency%20is%20free.%0A%0A%23%23%23%20Issue%203%20of%203%0Askills%2Fdevelop-macos-liquid-glass%2Fskills%2Fdevelop-macos-liquid-glass%2Freferences%2Fpitfalls-and-solutions.md%3A656-705%0A**New%20pitfalls%20dumped%20at%20EOF%2C%20bypassing%20category%20sections**%0A%0AThis%20file%20is%20organized%20by%20category%20sections%20and%20you%20appended%20five%20entries%20to%20the%20bottom%20like%20you%20were%20too%20tired%20to%20find%20the%20right%20page.%20An%20agent%20reading%20the%20AppKit%20section%20now%20misses%20pitfall%20%2330%20entirely%20unless%20it%20reads%20the%20whole%20file%20linearly.%0A%0APitfalls%20%2330%E2%80%93%2334%20belong%20in%20their%20respective%20sections%20matching%20the%20quick-reference%20table%3A%20%2330%20under%20%22AppKit%2C%22%20%2331%20under%20%22Migration%2C%22%20%2332%20under%20%22Accessibility%2C%22%20and%20%2333%2F%2334%20under%20%22Visual%20Issues.%22%20Move%20each%20entry%20into%20its%20category%20section%20so%20the%20document%20stays%20navigable.%0A%0AGet%20your%20house%20in%20order.%0A%0A&repo=yigitkonur%2Fskills-by-yigitkonur"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md
Line: 75-90

Comment:
**Pitfall #2 contradicts the PR's own `.tint(.clear)` demotion**

This is the intellectual equivalent of fact-checking your essay and then forgetting to re-read the first paragraph. You changed the framing in three places and left the single most authoritative-sounding instance completely untouched.

Pitfall #2 was not updated by this PR. Its fix statement — "Use `.tint(.clear)` on glass buttons for proper macOS rendering" — directly contradicts the demoted wording now in SKILL.md line 113, the review checklist line 161, and design-principles.md. The `❌ WRONG` label on the example without `.tint(.clear)` is now a flat contradiction by the PR's own logic. An agent reading this skill hits two incompatible instructions for the same API call.

Update pitfall #2 to align with the PR's intent:

```suggestion
### 2. macOS button tinting issue

Glass buttons on macOS may render with unexpected accent tint bleed from the system on some configurations.

**Workaround**: `.tint(.clear)` on secondary glass buttons suppresses the bleed. This is a practitioner-discovered pattern — not documented in WWDC sessions or Apple API docs. Test on your target macOS version before applying universally.

```swift
// ⚠️ May show accent tint bleed on some macOS 26 configurations
Button("Action") { }
    .glassEffect()

// Practitioner workaround — suppresses tint bleed on secondary buttons
Button("Action") { }
    .glassEffect()
    .tint(.clear)
```
```

Twenty agents checked everything else; nobody read the file they were editing.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/SKILL.md
Line: 76

Comment:
**Path 3 step 6 still unconditional**

Congratulations — you demoted `.tint(.clear)` to a workaround in the checklist and forgot the workflow that agents actually follow step-by-step. This is the cargo cult of partial refactoring.

Path 3 step 6 lists "`.tint(.clear)` on buttons" as a mandatory migration step, contradicting the PR's own demotion to a conditional practitioner workaround. An agent running Path 3 will apply it universally.

```suggestion
6. **Refine** for macOS: `.tint(.clear)` on secondary buttons only if tint bleed is observed (practitioner workaround — test first), `scrollEdgeEffectStyle`, control sizing.
```

Consistency is free.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: skills/develop-macos-liquid-glass/skills/develop-macos-liquid-glass/references/pitfalls-and-solutions.md
Line: 656-705

Comment:
**New pitfalls dumped at EOF, bypassing category sections**

This file is organized by category sections and you appended five entries to the bottom like you were too tired to find the right page. An agent reading the AppKit section now misses pitfall #30 entirely unless it reads the whole file linearly.

Pitfalls #30–#34 belong in their respective sections matching the quick-reference table: #30 under "AppKit," #31 under "Migration," #32 under "Accessibility," and #33/#34 under "Visual Issues." Move each entry into its category section so the document stays navigable.

Get your house in order.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix develop-macos-liquid-glass: 20-agent..."](https://github.com/yigitkonur/skills-by-yigitkonur/commit/7bb906dce3e2e3c3c1ff4178d9bfaa578b8bcc13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27430003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->