### PR TITLE
fix(run-research): align with Research Powerpack v6 tool surface

### DIFF
--- a/skills/run-research/skills/run-research/SKILL.md
+++ b/skills/run-research/skills/run-research/SKILL.md
@@ -16,7 +16,7 @@ You research technical questions using web search, page scraping, Reddit practit
 
 ## Tool prerequisites
 
-This skill uses four MCP tools: `web-search`, `scrape-links`, `search-reddit`, and `get-reddit-post`. If any are missing, install the research MCP server:
+This skill uses three MCP tools: `start-research`, `web-search`, `scrape-links`. If any are missing, install the research MCP server:
 
 ```bash
 npx -y @anthropic-ai/claude-code@latest mcp add research-server -y -- npx -y mcp-remote@latest https://research.yigitkonur.com/mcp --allow-http
@@ -24,14 +24,15 @@ npx -y @anthropic-ai/claude-code@latest mcp add research-server -y -- npx -y mcp
 
 Restart your session after installation. If MCP tools are denied at runtime, fall back to WebFetch/WebSearch built-in tools. If those fail, use `curl` via Bash. Never stop because a tool was denied.
 
-## Tool API (v4.1+)
+## Tool API (v6+)
 
 | Tool | Required params | Optional | LLM? |
 |---|---|---|---|
-| `web-search` | `queries` (up to 100), `extract` (what you're looking for) | `raw` (skip LLM, default false) | Yes — classifies results into 3 tiers |
-| `search-reddit` | `queries` (up to 100) | — | No — returns flat URL list |
-| `get-reddit-post` | `urls` (up to 100) | — | No — returns raw posts + comments |
-| `scrape-links` | `urls` (up to 100), `extract` (what to pull) | — | Yes — always extracts |
+| `start-research` | — | `goal` (string), `include_playbook` (bool, default false) | Yes — returns goal-tailored brief (`primary_branch`, `first_call_sequence`, 25–50 keyword seeds, `iteration_hints`, `gaps_to_watch`, `stop_criteria`) when `goal` + planner available |
+| `web-search` | `queries` (up to 50), `extract` (what you're looking for) | `raw` (skip classifier, default false), `scope` (`"web"` \| `"reddit"` \| `"both"`, default `"web"`), `verbose` (bool, default false) | Yes — tiered classifier (HIGHLY_RELEVANT / MAYBE_RELEVANT / OTHER) + synthesis + gaps + refine queries |
+| `scrape-links` | `urls` (up to N), `extract` (pipe-separated shape) | — | Yes — per-URL extraction. Auto-detects `reddit.com/r/.../comments/` permalinks and routes them through the Reddit API (threaded post + full comment tree); non-reddit URLs flow through the HTTP scraper in parallel. |
+
+There is no `search-reddit` or `get-reddit-post` tool in v6 — those collapsed into `web-search scope:"reddit"` (discovery) and `scrape-links` with reddit URLs (fetch).
 
 ## Decision: single-agent or multi-agent?
 
@@ -47,39 +48,51 @@ Restart your session after installation. If MCP tools are denied at runtime, fal
 
 ## Single-Agent Path
 
-You research directly using the four tools. Read `references/tools.md` for parameters and usage patterns.
+You research directly using the three tools. Read `references/tools.md` for parameters and usage patterns.
 
 ### The research loop
 
-#### 1. Search first — always
+#### 0. Plan with `start-research` — always
 
-Every task begins with `web-search`. Write queries that attack genuinely different angles — up to 100 in parallel. Always provide an `extract` describing what you're looking for so the LLM classifies results by relevance. Exact error messages in quotes. Official docs with `site:`. Comparisons. Failure modes. Year-pinned queries. Negative signal (`"problems with"`, `"regret"`, `"switched from"`). If your queries are minor rewrites of each other, diversify before searching.
+Every session begins with `start-research` using a 1–2 sentence `goal`. The server returns a goal-tailored brief: `goal_class`, `primary_branch` (reddit / web / both), `first_call_sequence` (exact next 1–3 calls), 25–50 keyword seeds, `iteration_hints`, `gaps_to_watch`, `stop_criteria`. Fire the `first_call_sequence` verbatim on round 1. If the planner is offline, the brief falls back to a compact stub — route manually by question shape.
+
+#### 1. Search — from the brief's primary_branch
+
+Feed the brief's `keyword_seeds` into your first `web-search` call. Pick `scope`:
+- `"web"` (default) for spec / bug / pricing / CVE / changelog / API
+- `"reddit"` for sentiment / migration / lived-experience (server appends `site:reddit.com` and filters to post permalinks)
+- `"both"` only when opinion-heavy AND needs official sources (2× cost — don't default to this)
+
+Write up to 50 queries per call. Orthogonal facets, not paraphrases. Exact error messages in quotes. Official docs with `site:`. Comparisons. Failure modes. Year-pinned queries. Negative signal on reddit scope (`"regret"`, `"switched from"`, `"broke in production"`) — at least 25% of reddit queries.
 
 #### 2. Read what matters
 
-After search, scrape the 3-10 most promising URLs with `scrape-links`. Your `extract` instructions determine quality:
+After search, scrape the 3–10 most promising URLs with `scrape-links`. Mix reddit post permalinks + non-reddit URLs freely in one call — auto-detection routes reddit URLs through the Reddit API (threaded post + full comment tree); everything else flows through the HTTP scraper in parallel. Prefer contextually grouped batches — fire multiple parallel `scrape-links` calls when URL sets are unrelated (docs in one call, reddit threads in another).
+
+Your `extract` instructions determine quality:
 - Strong: `"root cause|fix steps|version affected|workarounds|breaking changes|migration path"`
 - Weak: `"tell me about this page"`
 
-Use 4-8 pipe-separated targets per call.
+Use 4–8 pipe-separated targets per call.
 
-#### 3. Hear from practitioners
+#### 3. Loop — harvest from classifier + scrape output
 
-Official docs say how things should work. Reddit says how they actually work. Use `search-reddit` with diverse queries — at least 25% negative signal (`"regret"`, `"not worth it"`, `"broke in production"`). Then fetch the best 5-10 threads with `get-reddit-post`. Raw threaded comments ARE the signal — posts are returned with full comment trees, author names, scores, and OP markers.
+Each `web-search` response includes `## Gaps` (open questions with ids) and `## Suggested follow-up searches` (refine queries tied to gap ids). Each `scrape-links` response includes `## Follow-up signals` (new terms + referenced-but-unscraped URLs). Feed these into round 2's `web-search`. Safe to fire orthogonal `web-search` or `scrape-links` calls in parallel within one turn — use for unrelated subtopics.
 
 #### 4. Verify what matters
 
-Cross-check any claim that could change your recommendation. Stop when additional tool calls stop changing your conclusion.
+Cross-check any claim that could change your recommendation. Stop when additional calls stop changing your conclusion AND every brief `stop_criteria` item is met AND every `gaps_to_watch` item is closed (or explicitly documented as unresolved).
 
 ### Matching depth to stakes
 
 | Situation | Typical path |
 |---|---|
-| Quick fact check | web-search → scrape 2-3 pages |
-| Error diagnosis | web-search → scrape → search-reddit |
-| Library comparison | Full loop: all 4 tools |
-| Architecture decision | Full loop, starting broad |
-| Production incident | web-search (3 queries) → scrape top 2-3 |
+| Quick fact check | `start-research` → `web-search` (5 queries) → `scrape-links` 2–3 URLs |
+| Error diagnosis | `start-research` → `web-search scope:"web"` (error in quotes) → `scrape-links` top 3–5 |
+| Library comparison | `start-research` → `web-search scope:"web"` (30 queries, 5 facets) → `scrape-links` on docs + benchmarks |
+| Migration / sentiment | `start-research` (→ `primary_branch:"reddit"`) → `web-search scope:"reddit"` → `scrape-links` on post permalinks |
+| Architecture decision | `start-research` (→ often `primary_branch:"both"`) → parallel `web-search` (web + reddit) → merged `scrape-links` |
+| Production incident | `web-search` (3 queries, skip planner for speed) → `scrape-links` top 2–3 |
 
 Read `references/workflows.md` for complete workflow templates covering bug fixes, library comparisons, architecture decisions, security audits, performance investigations, and more.
 

--- a/skills/run-research/skills/run-research/SKILL.md
+++ b/skills/run-research/skills/run-research/SKILL.md
@@ -30,7 +30,7 @@ Restart your session after installation. If MCP tools are denied at runtime, fal
 |---|---|---|---|
 | `start-research` | — | `goal` (string), `include_playbook` (bool, default false) | Yes — returns goal-tailored brief (`primary_branch`, `first_call_sequence`, 25–50 keyword seeds, `iteration_hints`, `gaps_to_watch`, `stop_criteria`) when `goal` + planner available |
 | `web-search` | `queries` (up to 50), `extract` (what you're looking for) | `raw` (skip classifier, default false), `scope` (`"web"` \| `"reddit"` \| `"both"`, default `"web"`), `verbose` (bool, default false) | Yes — tiered classifier (HIGHLY_RELEVANT / MAYBE_RELEVANT / OTHER) + synthesis + gaps + refine queries |
-| `scrape-links` | `urls` (up to N), `extract` (pipe-separated shape) | — | Yes — per-URL extraction. Auto-detects `reddit.com/r/.../comments/` permalinks and routes them through the Reddit API (threaded post + full comment tree); non-reddit URLs flow through the HTTP scraper in parallel. |
+| `scrape-links` | `urls` (up to 100), `extract` (pipe-separated shape) | — | Yes — per-URL extraction. Auto-detects `reddit.com/r/.../comments/` permalinks and routes them through the Reddit API (threaded post + full comment tree); non-reddit URLs flow through the HTTP scraper in parallel. |
 
 There is no `search-reddit` or `get-reddit-post` tool in v6 — those collapsed into `web-search scope:"reddit"` (discovery) and `scrape-links` with reddit URLs (fetch).
 
@@ -52,9 +52,11 @@ You research directly using the three tools. Read `references/tools.md` for para
 
 ### The research loop
 
-#### 0. Plan with `start-research` — always
+#### 0. Plan with `start-research` — default
 
-Every session begins with `start-research` using a 1–2 sentence `goal`. The server returns a goal-tailored brief: `goal_class`, `primary_branch` (reddit / web / both), `first_call_sequence` (exact next 1–3 calls), 25–50 keyword seeds, `iteration_hints`, `gaps_to_watch`, `stop_criteria`. Fire the `first_call_sequence` verbatim on round 1. If the planner is offline, the brief falls back to a compact stub — route manually by question shape.
+Begin most sessions with `start-research` using a 1–2 sentence `goal`. The server returns a goal-tailored brief: `goal_class`, `primary_branch` (reddit / web / both), `first_call_sequence` (exact next 1–3 calls), 25–50 keyword seeds, `iteration_hints`, `gaps_to_watch`, `stop_criteria`. Fire the `first_call_sequence` verbatim on round 1. If the planner is offline, the brief falls back to a compact stub — route manually by question shape.
+
+**Skip `start-research` only for:** production incidents (latency matters) and simple one-shot fact checks (overhead outweighs the brief). The `Matching depth to stakes` table below marks these rows.
 
 #### 1. Search — from the brief's primary_branch
 
@@ -87,7 +89,7 @@ Cross-check any claim that could change your recommendation. Stop when additiona
 
 | Situation | Typical path |
 |---|---|
-| Quick fact check | `start-research` → `web-search` (5 queries) → `scrape-links` 2–3 URLs |
+| Quick fact check | `web-search` (5 queries, skip planner) → `scrape-links` 2–3 URLs |
 | Error diagnosis | `start-research` → `web-search scope:"web"` (error in quotes) → `scrape-links` top 3–5 |
 | Library comparison | `start-research` → `web-search scope:"web"` (30 queries, 5 facets) → `scrape-links` on docs + benchmarks |
 | Migration / sentiment | `start-research` (→ `primary_branch:"reddit"`) → `web-search scope:"reddit"` → `scrape-links` on post permalinks |

--- a/skills/run-research/skills/run-research/references/tools.md
+++ b/skills/run-research/skills/run-research/references/tools.md
@@ -110,7 +110,7 @@ One `web-search` per session is underuse. Normal is 2–4 rounds. Safe to fire o
 ### Parameters
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `urls` | `string[]` | Yes | HTTP/HTTPS URLs to fetch. Reddit post permalinks (`reddit.com/r/<sub>/comments/<id>/...`) are auto-detected and routed through the Reddit API; everything else flows through the HTTP scraper. Mix freely — both branches run in parallel. |
+| `urls` | `string[]` | Yes | Up to 100 HTTP/HTTPS URLs to fetch. Reddit post permalinks (`reddit.com/r/<sub>/comments/<id>/...`) are auto-detected and routed through the Reddit API; everything else flows through the HTTP scraper. Mix freely — both branches run in parallel. |
 | `extract` | `string` | Yes | Pipe-separated SHAPE of what to pull from each page |
 
 ### Reddit routing (v6)

--- a/skills/run-research/skills/run-research/references/tools.md
+++ b/skills/run-research/skills/run-research/references/tools.md
@@ -1,27 +1,76 @@
 # Tool Reference
 
+Research Powerpack v6 exposes exactly three tools. There is **no** `search-reddit` and **no** `get-reddit-post` — those collapsed into `web-search scope:"reddit"` and `scrape-links` (reddit URLs are auto-detected).
+
+---
+
+## start-research
+
+### Parameters
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `goal` | `string` | No | Research goal — 1–2 sentences, specific about what "done" looks like. Required for a tailored brief; omit for the generic 3-tool playbook. |
+| `include_playbook` | `bool` | No (default `false`) | Attach the verbose 3-tool tactic reference on top of the brief. Only pass `true` when the agent needs the playbook; the default stub already names the tools and loop. |
+
+### What it returns
+When `goal` is provided AND the LLM planner is online, the server returns a **goal-tailored brief** with these fields:
+
+| Field | Meaning | How to use it |
+|---|---|---|
+| `goal_class` | `spec` \| `bug` \| `migration` \| `sentiment` \| `pricing` \| `security` \| `synthesis` \| `product_launch` \| `other` | Anchors the `extract` shape for downstream calls |
+| `primary_branch` | `"reddit"` \| `"web"` \| `"both"` | Dictates `scope` on the first `web-search` |
+| `first_call_sequence` | Ordered list of 1–3 exact tool calls | Fire verbatim on round 1 |
+| `keyword_seeds` | 25–50 ready queries | Feed as `queries` to the first `web-search` |
+| `iteration_hints` | How to harvest new queries from scrape outputs | Apply from round 2 onward |
+| `gaps_to_watch` | Gaps to close before claiming done | Each becomes an atomic file or documented unresolved-gap note |
+| `stop_criteria` | Goalposts | Do not report done until all are met or explicitly unmet |
+
+Degraded modes:
+- No `goal` → generic 3-tool playbook (no tailored brief)
+- Planner offline → compact stub naming the 3 tools, loop, and reddit-branch rule
+
+### When to call
+- **First call every session.** It is a strong recommendation, not a runtime gate — other tools work without it, you just use them worse.
+- Call again only if the goal materially shifts mid-session.
+
+---
+
 ## web-search
 
 ### Parameters
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `queries` | `string[]` | Yes | Up to 100 search queries, each running as a separate parallel Google search |
-| `extract` | `string` | Yes | What you are looking for — LLM classifies results by relevance and generates a synthesis |
-| `raw` | `bool` | No (default `false`) | Skip LLM classification and return traditional ranked URL list |
+| `queries` | `string[]` | Yes | Up to 50 search queries, each running as a separate parallel Google search |
+| `extract` | `string` | Yes | Semantic instruction for the classifier — what "relevant" means for THIS goal |
+| `raw` | `bool` | No (default `false`) | Skip classifier, return raw ranked URL list |
+| `scope` | `"web"` \| `"reddit"` \| `"both"` | No (default `"web"`) | Where to look — see table below |
+| `verbose` | `bool` | No (default `false`) | Attach per-row scoring metadata + CONSENSUS labels on low-threshold hits (costs ~1.5KB extra) |
 
-### How results work
-Each query returns ~10 URLs. Results are aggregated, deduplicated, and the LLM classifies each into 3 tiers: **highly relevant**, **maybe relevant**, and **other**. Output includes a synthesis paragraph and a tiered markdown table.
+### Scope semantics
 
-Set `raw=true` to bypass classification and get the ranked consensus list.
+| scope | Effect | Use for |
+|---|---|---|
+| `"web"` | Open web, no augmentation | spec / bug / pricing / CVE / changelog / API |
+| `"reddit"` | Appends `site:reddit.com`, filters to `/r/<sub>/comments/<id>/` permalinks, drops subreddit homepages | sentiment / migration / lived experience |
+| `"both"` | Runs every query twice (web + reddit-scoped), merges, tags row source | Only when opinion-heavy AND needs official sources — 2× cost, don't default to this |
 
-5–7 queries = 50–70 URLs (solid for most tasks). 15–20 queries = thorough coverage. Up to 100 for exhaustive landscape scans.
+### What the classifier returns (default, `raw:false`)
+
+- **Tiered sections**: `HIGHLY_RELEVANT`, `MAYBE_RELEVANT`, `OTHER` (or a compressed prose summary when the result set is small)
+- **`## Synthesis`** — grounded conclusions with `[rank]` citations. Planning aid only — scrape the underlying URL before citing in an atomic file.
+- **`## Gaps`** — open questions with ids
+- **`## Suggested follow-up searches`** — refine queries tied to gap ids
+
+Gaps + refine queries ARE your iteration plan. Feed them into round 2 verbatim, plus any new terms harvested from `scrape-links` `## Follow-up signals` sections.
+
+5–15 queries = solid for narrow bugs. 25–35 = library comparisons. 40–50 = open-ended synthesis (the soft ceiling).
 
 ### Writing effective queries
 
-Each query should attack a genuinely different angle. The goal is coverage, not repetition.
+Each query should attack a genuinely different angle. Goal: coverage, not repetition.
 
 **The 7-angle framework:**
-1. Direct topic — `"Next.js middleware authentication 2025"`
+1. Direct topic — `"Next.js middleware authentication 2026"`
 2. Specific technical term — `"Next.js middleware matcher config"`
 3. Problems / debugging — `"Next.js middleware redirect loop fix"`
 4. Best practices — `"Next.js middleware best practices production"`
@@ -38,14 +87,21 @@ Each query should attack a genuinely different angle. The goal is coverage, not 
 - `OR` — match variant terms
 - Year tokens (`2025`, `2026`) — filter stale results for fast-moving ecosystems
 
-**For bugs:** Always lead with the exact error message in quotes. This is the highest-precision query possible.
+**For bugs:** Always lead with the exact error message in quotes. Highest-precision query possible.
 
-**For comparisons:** Include "vs", "comparison", "benchmark" — and also "switched from X", "regret X", "problems with X" for the critical negative signal.
+**For comparisons:** Include "vs", "comparison", "benchmark" — and also "switched from X", "regret X", "problems with X" for critical negative signal.
+
+**For reddit scope:** At least 25% of queries should carry negative signal (`"regret"`, `"switched from"`, `"broke in production"`, `"don't use"`). People who succeed rarely post — people who fail explain exactly what went wrong.
+
+### Call aggressively + in parallel
+
+One `web-search` per session is underuse. Normal is 2–4 rounds. Safe to fire orthogonal `web-search` calls in **parallel within one turn** for unrelated subtopics or when the brief's `primary_branch` is `"both"` (one call per scope).
 
 ### What NOT to do
-- Treat the returned URLs as answers (they're leads — scrape to read)
-- Write 7 queries that are minor rewrites of each other
-- Skip search operators (they're the difference between noise and signal)
+- Treat returned URLs as answers (they're leads — scrape to read)
+- Write 50 queries that are minor rewrites of each other
+- Skip search operators (difference between noise and signal)
+- Default to `scope: "both"` when one scope alone would do (doubles cost for no signal gain)
 
 ---
 
@@ -54,8 +110,16 @@ Each query should attack a genuinely different angle. The goal is coverage, not 
 ### Parameters
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `urls` | `string[]` | Yes | Up to 100 URLs to scrape |
-| `extract` | `string` | Yes | What to pull from each page — pipe-separated extraction targets |
+| `urls` | `string[]` | Yes | HTTP/HTTPS URLs to fetch. Reddit post permalinks (`reddit.com/r/<sub>/comments/<id>/...`) are auto-detected and routed through the Reddit API; everything else flows through the HTTP scraper. Mix freely — both branches run in parallel. |
+| `extract` | `string` | Yes | Pipe-separated SHAPE of what to pull from each page |
+
+### Reddit routing (v6)
+
+- Reddit post permalinks are auto-routed to the Reddit API → threaded post + full comment tree with authors, scores, and OP markers preserved.
+- Non-reddit URLs flow through the HTTP scraper.
+- Mix reddit + non-reddit URLs in one call — both branches run concurrently; results merge in original input order.
+- Never manually partition your URL list — auto-detection handles it.
+- Prefer contextually grouped batches: fire multiple parallel `scrape-links` calls when URL sets are unrelated (e.g. docs in one call, reddit threads in another) rather than one giant mixed batch.
 
 ### Writing extraction targets
 
@@ -71,95 +135,42 @@ This is the single biggest quality lever. Pipe-separated targets with 4–8 spec
 | Security advisory | `"CVE ID\|CVSS score\|affected versions\|patched version\|mitigation steps"` |
 | Config reference | `"options\|default values\|types\|required fields\|examples\|deprecated"` |
 | Bug fix article | `"root cause\|fix code\|version affected\|workarounds\|environment conditions"` |
+| Reddit thread | `"agreement reasons\|dissent reasons\|verbatim quotes with attribution\|migration drivers"` |
+
+### What each response contains
+
+Per URL, the extractor returns:
+- **`## Source`** — URL, page type (docs / github-thread / reddit / marketing / cve / paper / announcement / qa / blog / changelog / release-notes), page date, author
+- **`## Matches`** — verbatim-preserved facts (numbers, versions, stacktraces, exact quotes)
+- **`## Not found`** — explicit gaps the page did not answer
+- **`## Follow-up signals`** — new terms + referenced-but-unscraped URLs that feed the next research loop
+
+Harvest `## Follow-up signals` terms for the next round's `web-search`.
 
 ### Composition pattern
-Always follows `web-search`. Pick the 3–10 most promising URLs from search results. Group thematically similar pages together — they share the extraction prompt context.
 
-### Failure modes
-- **Anti-bot / Cloudflare** — Try cached or CDN versions of the URL
-- **SPA with JS rendering** — May fail on heavily client-rendered pages
-- **Paywall** — Find alternative free source
-- **Truncated output** — Reduce URL count or narrow extraction targets
+Typically follows `web-search`. Pick the 3–10 most promising URLs from search results (HIGHLY_RELEVANT + top 2–3 MAYBE_RELEVANT). Group thematically similar pages in the same call — they share the extraction prompt context.
 
-### What NOT to do
-- Scrape Reddit URLs (use `get-reddit-post` — it handles threading)
-- Use vague extraction targets ("tell me about this page")
-- Scrape 20+ URLs at once (too shallow per page)
-- Scrape just to cite — only scrape when you need to verify or discover
+For reddit threads: select posts with (a) 10+ comments, (b) visible disagreement in replies, (c) specific stack/environment details from the OP. Skip 1–3 comment threads and posts older than 18 months for active tech.
 
----
+### Signals to look for in Reddit comment trees
 
-## search-reddit
-
-### Parameters
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `queries` | `string[]` | Yes | Up to 100 search queries — `site:reddit.com` is appended automatically |
-
-Returns a flat list of unique Reddit post URLs. No ranking, no LLM — just URL discovery. Pipe results into `get-reddit-post` to fetch the actual content.
-
-### Writing Reddit queries
-
-The key insight: search for failures, not just successes. Negative signal is more informative because people who succeed rarely post — people who fail explain exactly what went wrong.
-
-**Query diversity matrix — cover at least 4 of these 8 categories:**
-1. Direct topic — `"Prisma ORM production experience"`
-2. Recommendations — `"best TypeScript ORM 2025"`
-3. Specific tools — `"Drizzle ORM gotchas"`
-4. Comparisons — `"Prisma vs Drizzle vs Kysely"`
-5. Alternatives — `"alternative to Prisma serverless"`
-6. Subreddit-targeted — `r/typescript ORM recommendation`
-7. Negative signal — `"Prisma regret cold start problems"`
-8. Year-specific — `"TypeScript ORM 2025"`
-
-**Negative signal queries (use at least 25% of these):**
-- `"[X] regret"` / `"switched from [X]"` / `"problems with [X]"`
-- `"don't use [X]"` / `"[X] not worth it"` / `"[X] broke in production"`
-- `"wish I had known [X]"` / `"migrated from [X] to [Y]"`
-
-**Key subreddits by domain:**
-| Domain | Subreddits |
-|---|---|
-| Senior perspectives | r/ExperiencedDevs, r/softwarearchitecture |
-| Web development | r/webdev, r/reactjs, r/nextjs |
-| Backend | r/node, r/golang, r/rust, r/python |
-| DevOps | r/devops, r/kubernetes, r/aws |
-| Security | r/netsec, r/AskNetsec |
-
-### What NOT to do
-- Only search for positive sentiment (miss failure modes)
-- Target a single subreddit (echo chamber)
-- Stop at search-reddit (URLs aren't evidence — fetch the threads)
-
----
-
-## get-reddit-post
-
-### Parameters
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `urls` | `string[]` | Yes | Up to 100 Reddit post URLs |
-
-Returns raw posts with full threaded comment trees including author, score, and OP markers. No LLM processing — you get the real community voice.
-
-### Where the value lives in comment threads
-| Position | What it contains |
-|---|---|
-| Top-level, highest voted | Conventional wisdom — good starting point but sometimes incomplete |
-| 2nd/3rd replies | Corrections, edge cases, "actually this changed in v4..." |
-| Deeply nested | Specific debugging steps, config values, workarounds |
-| OP follow-up | "EDIT: solved" — confirmed fix, most reliable signal |
-| Late replies on old threads | May contain newer, more accurate information |
-
-### Signals to look for
 - **"EDIT: this fixed it"** — confirmed solution
 - **"After X months in production..."** — battle-tested
 - **"I switched from X to Y because..."** — migration with reasons
 - **"Don't do what the top comment says..."** — critical correction
 - **Specific numbers** — p99 latency, memory usage, cost, scale
+- **Library maintainer replies** — authority signals
 
-### Thread selection from search-reddit results
-Prioritize: 10+ comments, high upvotes, recent (within 12–18 months), from senior-focused subreddits. Skip: 1–3 comments, self-promotion posts, 2+ years old for active tech.
+### Failure modes
+- **Anti-bot / Cloudflare** — try cached or CDN versions
+- **SPA with JS rendering** — may fail on heavily client-rendered pages
+- **Paywall** — find alternative free source
+- **Truncated output** — reduce URL count or narrow extraction targets
+- **Reddit 404 / removed post** — the Reddit branch returns a real API error per URL; other URLs in the same call complete normally
 
-### Why raw comments matter
-Reddit API data is already structured — threaded comments with author, score, OP markers, no HTML boilerplate. Raw threaded comments preserve the exact code snippets, version numbers, config values, and authority signals (library maintainer replying, etc.) that make Reddit research actionable. You can always summarize raw comments yourself; you can never recover exact values from a summary.
+### What NOT to do
+- Manually partition reddit vs. non-reddit URLs (auto-detection handles it)
+- Use vague extraction targets ("tell me about this page")
+- Scrape 20+ URLs at once (too shallow per page)
+- Scrape just to cite — only scrape when you need to verify or discover

--- a/skills/run-research/skills/run-research/references/workflows.md
+++ b/skills/run-research/skills/run-research/references/workflows.md
@@ -2,34 +2,44 @@
 
 These workflows show how the research loop adapts to different question types. They're starting points — let the evidence guide you to go deeper or stop early.
 
+**Every workflow begins with `start-research`** (unless noted). The brief's `primary_branch` tells you whether to lead with `scope:"web"`, `scope:"reddit"`, or fire both in parallel. Fire the brief's `first_call_sequence` verbatim on round 1.
+
+---
+
 ## Workflow 1: Bug Fix — "I hit an error I don't recognize"
 
-**Start:** `web-search` (error messages are the most searchable content on the internet)
+**Typical `primary_branch`:** `web` (bug / spec lookup)
+**Start:** `start-research` → `web-search scope:"web"` (error messages are the most searchable content on the internet)
 
 ```
-1. web-search
+1. start-research
+   goal: "Root cause and fix for <exact error or symptom>, including affected versions and workarounds"
+
+2. web-search (scope: "web", 10–15 queries from brief seeds + these angles)
    queries:
    - Exact error in quotes: '"TypeError: Cannot read properties of undefined" react hooks'
    - Error + framework + version: '"Cannot read properties of undefined" useEffect React 19 fix'
    - Site-targeted: 'site:stackoverflow.com "Cannot read properties" react'
    - GitHub issues: 'site:github.com/facebook/react/issues "Cannot read properties"'
-   - Year-pinned: 'react hooks undefined error fix 2025'
+   - Year-pinned: 'react hooks undefined error fix 2026'
    extract: "find the root cause and fix for this error in React hooks"
 
-2. scrape-links (top 3-5 URLs)
-   extract = "root cause|fix code before and after|version affected|environment conditions|workarounds"
+3. scrape-links (top 3–5 URLs from HIGHLY_RELEVANT)
+   extract = "root cause | fix code before and after | version affected | environment conditions | workarounds"
 
-3. Is the fix clear? → Apply it. Done.
+4. Is the fix clear? → Apply it. Done.
    Fix unclear or conflicting? → Continue:
 
-4. search-reddit (3-5 queries)
-   - '"[error message]" r/reactjs'
-   - '[library] [symptom] workaround fix'
-   - '[library] breaking change [version]'
+5. web-search (scope: "reddit", 5–8 queries with negative signal)
+   - '"<error message>" r/reactjs'
+   - '<library> <symptom> workaround fix'
+   - '<library> breaking change <version>'
+   - '<library> regret production'
 
-5. get-reddit-post (2-5 threads with "solved" signals)
+6. scrape-links (3–5 best reddit permalinks from HIGHLY_RELEVANT — auto-routed to Reddit API)
+   extract = "verified fixes | OP follow-up | version details | stacktraces | environment details"
 
-6. Still stuck? → Synthesize from all evidence and form a diagnosis
+7. Still stuck? → Synthesize from all evidence and form a diagnosis
 ```
 
 **Adapt when:**
@@ -42,104 +52,117 @@ These workflows show how the research loop adapts to different question types. T
 
 ## Workflow 2: Library Comparison — "Should I use A or B?"
 
-**Start:** `web-search` (discover candidates and comparison resources first)
+**Typical `primary_branch`:** `web` (or `both` for mature contested areas)
+**Start:** `start-research` → parallel `web-search` calls (discover candidates + sentiment in one turn)
 
 ```
-1. web-search (7-15 queries covering every angle)
-   queries:
-   - '[A] vs [B] benchmark comparison 2025'
-   - 'best [category] library [language] 2025'
-   - '[A] alternatives'
-   - 'site:npmtrends.com [A] [B]'
-   - '[A] [B] migration guide'
-   - '"switched from [A]" [language]'
-   - '[A] production experience serverless'
-   extract: "compare [A] vs [B] for [use case] — features, performance, limitations, maintenance activity"
+1. start-research
+   goal: "Compare <A> vs <B> for <use case>, covering features, performance, maintenance, and migration stories"
 
-2. scrape-links (3-5 URLs: comparison articles, READMEs, npm pages)
-   extract = "features|bundle size|performance benchmarks|limitations|maintenance activity|community size"
+2. Parallel web-search calls in the same turn:
+   2a. web-search (scope: "web", 20–30 queries from brief seeds)
+       queries:
+       - '<A> vs <B> benchmark comparison 2026'
+       - 'best <category> library <language> 2026'
+       - '<A> alternatives'
+       - 'site:npmtrends.com <A> <B>'
+       - '<A> <B> migration guide'
+       - 'site:<A-docs> performance'
+       extract: "compare <A> vs <B> for <use case> — features, performance, limitations, maintenance activity"
+   2b. web-search (scope: "reddit", 8–12 queries — heavy on negative signal)
+       queries:
+       - '<A> vs <B> production experience'
+       - 'switched from <A> to <B> why'
+       - '<A> problems issues production'
+       - '<B> gotchas limitations'
+       - '<A> regret complex queries performance'
+       - '"don\'t use <A>" OR "avoid <A>"'
+       extract: "lived experience with <A> and <B> — migration drivers, regrets, dissent, production breakers"
 
-3. search-reddit (8-12 queries — heavy on negative signal)
-   - '[A] vs [B] production experience'
-   - 'switched from [A] to [B] why'
-   - '[A] problems issues production'
-   - '[B] gotchas limitations'
-   - 'r/[language] [category] recommendation 2025'
-   - '[A] regret complex queries performance'
-   - '"don't use [A]" OR "avoid [A]"'
-   - '[B] production ready'
+3. scrape-links (mixed batch: 3–5 comparison articles / READMEs / npm pages + 5–8 reddit permalinks)
+   extract = "features | bundle size | performance benchmarks | limitations | maintenance activity | community size | migration drivers | verbatim quotes"
+   # Reddit URLs auto-routed to the Reddit API; non-reddit URLs flow through the scraper in parallel
 
-4. get-reddit-post (5-8 highest-signal threads)
+4. Round 2 if confidence medium or gaps unclosed: use classifier's refine_queries + scrape ## Follow-up signals to build next web-search
 
 5. Output: Decision matrix + recommendation
 ```
 
 **Adapt when:**
-- Clear winner after step 2 (strong consensus) → brief Reddit validation, then recommend
-- All options have major issues → expand candidate list, run another search round
+- Clear winner after step 3 (strong consensus) → brief validation, then recommend
+- All options have major issues → expand candidate list, run another round
 - Decision depends on a specific technical detail → scrape official docs for that detail
 
 ---
 
 ## Workflow 3: Architecture Decision — "How should I design this?"
 
-**Start:** `web-search` for landscape, then synthesis
+**Typical `primary_branch`:** `both` (options-docs + practitioner experience both matter)
+**Start:** `start-research` → parallel `web-search` calls for landscape + experience
 
 ```
-1. Frame the decision: constraints, scale targets, team composition, risk tolerance, reversibility
+1. Frame the decision: constraints, scale targets, team composition, risk tolerance, reversibility.
 
-2. web-search (10-20 queries)
-   queries:
-   - '[pattern A] vs [pattern B] trade-offs 2025'
-   - 'site:martinfowler.com [pattern]'
-   - '[pattern] production experience case study'
-   - '[pattern] failure modes problems at scale'
-   - '[pattern] at scale [N] users cost'
-   - '"modular monolith" vs microservices team size'
-   extract: "trade-offs, scale thresholds, team size recommendations, failure modes"
+2. start-research
+   goal: "Choose between <pattern A> and <pattern B> for <constraint>, at <scale>, with <team-size> engineers"
 
-3. scrape-links (3-5 authoritative URLs)
-   extract = "decision criteria|trade-offs|scale thresholds|when NOT to use|team size recommendations|cost analysis"
+3. Parallel web-search calls:
+   3a. web-search (scope: "web", 15–20 queries)
+       queries:
+       - '<pattern A> vs <pattern B> trade-offs 2026'
+       - 'site:martinfowler.com <pattern>'
+       - '<pattern> production experience case study'
+       - '<pattern> failure modes problems at scale'
+       - '<pattern> at scale <N> users cost'
+       - '"modular monolith" vs microservices team size'
+       extract: "trade-offs, scale thresholds, team size recommendations, failure modes"
+   3b. web-search (scope: "reddit", 7–10 queries — focus on experience and regret)
+       queries:
+       - '<option A> regret went back to <previous>'
+       - 'r/ExperiencedDevs <decision category>'
+       - '<option A> operational cost hidden small team'
+       - '<option B> failure mode production'
+       extract: "lived experience, regret, reversal stories, hidden operational cost"
 
-4. search-reddit (7-10 queries — focus on experience and regret)
-   - '[option A] regret went back to [previous]'
-   - 'r/ExperiencedDevs [decision category]'
-   - '[option A] operational cost hidden small team'
-   - '[option B] failure mode production'
+4. scrape-links (mixed batch: 3–5 authoritative URLs + 5–8 reddit permalinks from r/ExperiencedDevs, r/softwarearchitecture)
+   extract = "decision criteria | trade-offs | scale thresholds | when NOT to use | team size recommendations | cost analysis | verbatim regret quotes"
 
-5. get-reddit-post (5-8 threads from r/ExperiencedDevs, r/softwarearchitecture)
+5. Round 2 if gaps_to_watch unclosed: targeted search + scrape on the specific disagreement
 
 6. Output: Trade-off matrix + recommendation with confidence + conditions that would flip it
 ```
 
 **Adapt when:**
 - Sources agree strongly → shorter validation, move to implementation
-- Sources conflict on a key point → targeted search + scrape to resolve that specific disagreement
+- Sources conflict on a key point → targeted search + scrape to resolve the specific disagreement
 - Decision is hard to reverse → add an extra verification round
 
 ---
 
 ## Workflow 4: Fact Check — "Is this still true?"
 
-**Start:** `web-search` (go directly to authoritative sources)
+**Typical `primary_branch`:** `web`
+**Start:** `web-search scope:"web"` directly (skip `start-research` for simple fact checks)
 
 ```
-1. web-search (3-5 queries)
+1. web-search (scope: "web", 3–5 queries)
    queries:
-   - '[claim] [official source] 2025'
-   - 'site:[official-docs] [specific feature]'
-   - '[topic] deprecated OR removed OR changed [year]'
-   extract: "verify whether [claim] is still true as of 2025"
+   - '<claim> <official source> 2026'
+   - 'site:<official-docs> <specific feature>'
+   - '<topic> deprecated OR removed OR changed <year>'
+   extract: "verify whether <claim> is still true as of 2026"
 
-2. scrape-links (2-3 authoritative URLs)
-   extract = "current status|version|date|changes since [original claim date]|caveats"
+2. scrape-links (2–3 authoritative URLs)
+   extract = "current status | version | date | changes since <original claim date> | caveats"
 
 3. Done for most fact checks.
    If claim is contested:
 
-4. search-reddit (2-3 queries)
-   - '[claim] true false 2025'
-   - '[topic] changed updated'
+4. web-search (scope: "reddit", 2–3 queries)
+   - '<claim> true false 2026'
+   - '<topic> changed updated'
+
+5. scrape-links (best 1–2 reddit permalinks if needed)
 ```
 
 **This workflow is intentionally short.** Most fact checks need 2 tool calls, not 10.
@@ -148,105 +171,123 @@ These workflows show how the research loop adapts to different question types. T
 
 ## Workflow 5: Production Incident — "Something is broken NOW"
 
-**Speed is everything. Minimum viable research.**
+**Speed is everything. Minimum viable research. Skip `start-research` — latency matters.**
 
 ```
-1. web-search (3 focused queries)
+1. web-search (scope: "web", 3 focused queries)
    queries:
-   - '"[exact error]" [stack] fix'
-   - '[service] [symptom] production fix'
-   - 'site:stackoverflow.com "[error code]" [framework]'
+   - '"<exact error>" <stack> fix'
+   - '<service> <symptom> production fix'
+   - 'site:stackoverflow.com "<error code>" <framework>'
    extract: "immediate fix steps and workarounds"
 
-2. scrape-links (top 2-3 URLs)
-   extract = "fix steps|workaround|root cause"
+2. scrape-links (top 2–3 URLs)
+   extract = "fix steps | workaround | root cause"
 
 3. Apply the most plausible fix. If it works → done.
    If not:
 
-4. search-reddit (2 queries)
-   - '"[error]" [framework] fix'
-   - '[framework] [symptom] workaround'
+4. web-search (scope: "reddit", 2 queries)
+   - '"<error>" <framework> fix'
+   - '<framework> <symptom> workaround'
+
+5. scrape-links (best 1–2 reddit permalinks — auto-routed)
 ```
 
 ---
 
 ## Workflow 6: Security Audit — "Is this secure?"
 
-**Start:** `web-search` with security-focused sources
+**Typical `primary_branch`:** `web` (CVE databases + advisories lead; practitioners supplement)
+**Start:** `start-research` → `web-search scope:"web"` with security-focused sources
 
 ```
-1. web-search (7-10 queries)
+1. start-research
+   goal: "Identify known vulnerabilities, mitigations, and best practices for <library/framework/pattern> as of 2026"
+
+2. web-search (scope: "web", 7–10 queries)
    queries:
-   - 'OWASP [topic] cheat sheet 2025'
-   - 'site:nvd.nist.gov [library]'
-   - '[library] CVE vulnerability'
-   - '[framework] [attack type] prevention'
-   - '[topic] security best practices [language] 2025'
+   - 'OWASP <topic> cheat sheet 2026'
+   - 'site:nvd.nist.gov <library>'
+   - '<library> CVE vulnerability'
+   - '<framework> <attack type> prevention'
+   - '<topic> security best practices <language> 2026'
    extract: "CVEs, vulnerabilities, mitigation steps, security best practices"
 
-2. scrape-links (3-5 URLs: OWASP, NVD, Snyk, official docs)
-   extract = "CVE IDs|CVSS scores|affected versions|mitigation steps|recommended practices|prohibited practices"
+3. scrape-links (3–5 URLs: OWASP, NVD, Snyk, official advisories)
+   extract = "CVE IDs | CVSS scores | affected versions | patched versions | mitigation steps | recommended practices | prohibited practices"
 
-3. search-reddit (5-7 queries targeting r/netsec, r/AskNetsec)
-   - '[library] security vulnerability'
-   - '[attack type] prevention [framework]'
-   - 'r/netsec [topic] 2025'
+4. web-search (scope: "reddit", 5–7 queries targeting r/netsec, r/AskNetsec)
+   - '<library> security vulnerability'
+   - '<attack type> prevention <framework>'
+   - 'r/netsec <topic> 2026'
 
-4. get-reddit-post (3-5 threads from security subreddits)
+5. scrape-links (3–5 best reddit permalinks from security subreddits)
+   extract = "real-world exploit patterns | mitigation verdicts | maintainer responses | practitioner audits"
 
-5. Output: Prioritized findings with severity + specific fix steps
+6. Output: Prioritized findings with severity + specific fix steps
 ```
 
-**Critical rule:** Security claims need 3-source verification — official docs + practitioners + independent analysis. Single blog posts are not sufficient for security decisions.
+**Critical rule:** Security claims need 3-source verification — official advisory + practitioners + independent analysis. Single blog posts are not sufficient for security decisions.
 
 ---
 
 ## Workflow 7: Performance Investigation — "Why is this slow?"
 
+**Typical `primary_branch`:** `web` (profiling guides + practitioner war stories)
+
 ```
-1. web-search (5-7 queries)
+1. start-research
+   goal: "Diagnose <symptom> in <stack/component>, covering profiling approach, common bottlenecks, and optimization techniques"
+
+2. web-search (scope: "web", 5–7 queries)
    queries:
-   - '[framework] performance profiling production'
-   - '[specific symptom] slow [language]'
-   - '[component] optimization benchmarks'
+   - '<framework> performance profiling production'
+   - '<specific symptom> slow <language>'
+   - '<component> optimization benchmarks'
    extract: "profiling approaches, common bottlenecks, optimization techniques"
 
-2. scrape-links (3-5 URLs: profiling guides, optimization articles)
-   extract = "profiling tools|diagnosis steps|common bottlenecks|optimization techniques|before-after benchmarks"
+3. scrape-links (3–5 URLs: profiling guides, optimization articles)
+   extract = "profiling tools | diagnosis steps | common bottlenecks | optimization techniques | before-after benchmarks"
 
-3. search-reddit (3-5 queries)
-   - '[framework] slow performance fix'
-   - '[component] optimization real experience'
+4. web-search (scope: "reddit", 3–5 queries)
+   - '<framework> slow performance fix'
+   - '<component> optimization real experience'
+   - '<framework> p99 latency production'
 
-4. get-reddit-post (3-5 threads)
+5. scrape-links (3–5 reddit permalinks)
+   extract = "war stories | specific numbers | fixes that worked | fixes that didn't"
 ```
 
 ---
 
 ## Workflow 8: Technology Landscape Scan — "What's the state of X?"
 
-**Start:** `search-reddit` (community pulse check is the best starting point)
+**Typical `primary_branch`:** `reddit` (community pulse is the best starting point for state-of-ecosystem questions)
 
 ```
-1. search-reddit (7-10 queries)
-   - '[technology] state of 2025'
-   - 'what changed in [technology] recently'
-   - '[technology] new features 2025'
-   - '[technology] vs alternatives 2025'
-   - 'r/[relevant-sub] [technology] updates'
+1. start-research
+   goal: "Map the current state of <technology> in 2026 — active projects, recent changes, adoption trends, pain points"
 
-2. get-reddit-post (3-5 most active recent threads)
+2. web-search (scope: "reddit", 7–10 queries)
+   - '<technology> state of 2026'
+   - 'what changed in <technology> recently'
+   - '<technology> new features 2026'
+   - '<technology> vs alternatives 2026'
+   - 'r/<relevant-sub> <technology> updates'
 
-3. web-search (3-5 queries)
+3. scrape-links (3–5 most active recent reddit permalinks — auto-routed to Reddit API)
+   extract = "recent changes | community consensus | emerging alternatives | pain points | migration patterns"
+
+4. web-search (scope: "web", 3–5 queries)
    queries:
-   - '[technology] changelog 2025'
-   - '[technology] roadmap upcoming features'
-   - '[technology] release notes latest'
+   - '<technology> changelog 2026'
+   - '<technology> roadmap upcoming features'
+   - '<technology> release notes latest'
    extract: "recent changes, roadmap, adoption trends"
 
-4. scrape-links (2-3 URLs: changelogs, roadmaps)
-   extract = "new features|breaking changes|deprecations|roadmap|release dates|adoption trends"
+5. scrape-links (2–3 URLs: changelogs, roadmaps)
+   extract = "new features | breaking changes | deprecations | roadmap | release dates | adoption trends"
 ```
 
 ---
@@ -257,11 +298,12 @@ Workflows are starting points. Adapt based on what each step reveals:
 
 | What you find | What to do |
 |---|---|
-| web-search returns excellent, clear results | Skip Reddit — scrape and conclude |
-| web-search returns nothing relevant | Broaden terms, then try search-reddit (niche topics live on Reddit) |
+| `web-search` returns excellent, clear results | Skip further rounds — scrape and conclude |
+| `web-search scope:"web"` returns nothing relevant | Broaden terms, then try `scope:"reddit"` (niche topics live on Reddit) |
 | Reddit threads are all 3+ years old | Results may be stale — verify against current official docs |
 | Sources contradict each other | See `references/synthesis.md` for resolution patterns |
 | All sources agree | High confidence — stop researching |
 | First fix doesn't work | Run a second targeted round with what you learned |
+| Classifier `## Gaps` lists items the brief flagged in `gaps_to_watch` | Round 2 must close those specific gaps before stopping |
 
 The most common mistake is over-researching a question that was answered in step 2. The second most common mistake is under-researching a question that deserved the full loop.

--- a/skills/run-research/skills/run-research/references/workflows.md
+++ b/skills/run-research/skills/run-research/references/workflows.md
@@ -76,14 +76,14 @@ These workflows show how the research loop adapts to different question types. T
        - '<A> problems issues production'
        - '<B> gotchas limitations'
        - '<A> regret complex queries performance'
-       - '"don\'t use <A>" OR "avoid <A>"'
+       - '"don't use <A>" OR "avoid <A>"'
        extract: "lived experience with <A> and <B> — migration drivers, regrets, dissent, production breakers"
 
 3. scrape-links (mixed batch: 3–5 comparison articles / READMEs / npm pages + 5–8 reddit permalinks)
    extract = "features | bundle size | performance benchmarks | limitations | maintenance activity | community size | migration drivers | verbatim quotes"
    # Reddit URLs auto-routed to the Reddit API; non-reddit URLs flow through the scraper in parallel
 
-4. Round 2 if confidence medium or gaps unclosed: use classifier's refine_queries + scrape ## Follow-up signals to build next web-search
+4. Round 2 if confidence medium or gaps unclosed: use web-search's `## Suggested follow-up searches` + scrape `## Follow-up signals` to build next web-search
 
 5. Output: Decision matrix + recommendation
 ```


### PR DESCRIPTION
## Summary

- The upstream Research Powerpack MCP server shipped v6.0.0 with a breaking tool-surface rename: `search-reddit` and `get-reddit-post` were removed; their functionality collapsed into `web-search scope:"reddit"` (discovery) and `scrape-links` with reddit URLs (auto-routed to the Reddit API). This skill still instructed agents to call the retired tool names, so every reddit-branch call produced a tool-not-found error against the live server.
- This PR rewrites `SKILL.md`, `references/tools.md`, and `references/workflows.md` to match the v6 tool surface. Two disambiguation sentences are retained (one per file) to explicitly steer agents away from the retired names.
- `references/{synthesis,orchestrator-philosophy,mission-prompt-templates,output-architecture,quality-gates,synthesis-patterns}.md` were untouched — none contained v5 tool references.

## What changed

**`SKILL.md`**
- `## Tool prerequisites` — 4 tools → 3 tools; version label `v4.1+` → `v6+`
- `## Tool API` table — `start-research` row added (goal-tailored brief); `search-reddit` + `get-reddit-post` rows removed; `web-search` row updated with `scope` and `verbose` params; `scrape-links` notes reddit auto-detection
- `## The research loop` — new step 0 (`start-research` with `goal`); step 1 renamed "Search — from the brief's primary_branch" with scope-picking guidance and reddit negative-signal rule; step 2 teaches the auto-detect + contextually grouped batch pattern; new step 3 on harvesting classifier `## Gaps` / `## Suggested follow-up searches` and scrape `## Follow-up signals`; step 4 stop condition now includes `stop_criteria` + `gaps_to_watch`
- Matching-depth-to-stakes table refreshed for the 3-tool surface

**`references/tools.md`**
- New `start-research` section at the top documenting the brief shape (`goal_class`, `primary_branch`, `first_call_sequence`, `keyword_seeds`, `iteration_hints`, `gaps_to_watch`, `stop_criteria`) and degraded modes
- `web-search` section updated: query ceiling 100 → 50 (v6 soft cap), new `scope` table, new `raw`/`verbose` parameters, new "Reading the classifier output" section (tiered results + synthesis + gaps + refine queries), "Call aggressively + in parallel" rule
- `scrape-links` section updated: reddit routing mechanics (auto-detection, Reddit API vs HTTP scraper branches running in parallel, merge preserves input order), extraction-target table adds a "Reddit thread" row, signals-to-look-for list moved here from the deleted get-reddit-post section
- `search-reddit` + `get-reddit-post` sections deleted

**`references/workflows.md`**
- All 8 workflows rewritten to lead with `start-research` where applicable (fact-check and production-incident intentionally skip it for latency)
- Every `search-reddit` call → `web-search scope:"reddit"`; every `get-reddit-post` call → `scrape-links` with reddit permalinks
- Library-comparison and architecture-decision workflows now explicitly fire two parallel `web-search` calls in one turn (scope: web + scope: reddit) per the `primary_branch: "both"` pattern
- Adaptation table gains a row on gaps-aware iteration ("classifier Gaps lists items the brief flagged in gaps_to_watch → round 2 must close those specific gaps")

## Verification

- `python3 scripts/validate-skills.py` — 50 skills validated, all checks pass
- Live smoke on `https://research.yigitkonur.com/mcp` confirmed v6 semantics (3 tools, `primary_branch` routing, reddit auto-detection) already working; this PR aligns the skill's instructions to what the live server now exposes

## Test plan

- [x] Repo validator passes clean
- [x] Zero runnable v5 tool calls remain in the skill (only 2 intentional disambiguation sentences)
- [x] Every reference file still linked from `SKILL.md`
- [x] `SKILL.md` frontmatter unchanged; 179 lines (under 500-line cap)

## Out of scope

- `test-by-mcpc-cli` also has 18 stale `search-reddit` examples across 9 files — those were fixed in the same local session. Happy to send them as a separate PR if wanted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the run-research skill with Research Powerpack v6 by moving to the `start-research` + `web-search` + `scrape-links` tool surface, and addresses review feedback to tighten guidance and fix caps. This removes invalid calls, adds scoped search and reddit auto-routing, and makes iteration gap-driven.

- **Bug Fixes**
  - Made `start-research` a default, not mandatory; explicitly skip for production incidents and simple fact checks. Stakes table and workflows now match.
  - Clarified `scrape-links` cap to 100 URLs per call in `SKILL.md`, and restored the explicit 100-URL cap in `references/tools.md` to match.
  - Corrected workflow samples: removed the stray character in "don't use <A>" and renamed the classifier output to `## Suggested follow-up searches`.

- **Migration**
  - Use `start-research` by default; skip it for incidents and simple fact checks.

<sup>Written for commit d3e71a7e0d0e9355c7c69a323948976e4991d390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

