### PR TITLE
feat(do-brainstorm): framework-aware brainstorming with Cynefin-first routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-49 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+51 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 
@@ -20,6 +20,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 
 | Skill | Category | Description |
 |---|---|---|
+| [do-brainstorm](skills/do-brainstorm/) | productivity | Framework-aware, user-in-the-loop brainstorming; Cynefin-first classifier routes across 25 mental models |
 | [optimize-cli-for-agents](skills/optimize-cli-for-agents/) | development | Audit or design agent-ready CLIs with iterative feedback loops |
 | [build-chrome-extension](skills/build-chrome-extension/) | development | Chrome extensions with Manifest V3 |
 | [build-convex-clerk-swiftui](skills/build-convex-clerk-swiftui/) | development | Convex + Clerk backends for SwiftUI iOS/macOS apps |

--- a/skills/do-brainstorm/README.md
+++ b/skills/do-brainstorm/README.md
@@ -1,0 +1,19 @@
+# do-brainstorm
+
+A framework-aware, user-in-the-loop brainstorming session. Classifies the problem first (Cynefin), then routes to the right mental-model frameworks, pausing at forks to bring the user along.
+
+**Category:** productivity
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/do-brainstorm
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/do-brainstorm/skills/do-brainstorm/SKILL.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when the task is to:
 Prefer another skill when:
 
 - a specific design is already agreed → go implement (`build-*`, `develop-*`)
-- a PR exists to evaluate → `review-pr` / `evaluate-code-review`
+- a PR exists to evaluate → `review-pr` (or the companion `evaluate-code-review` skill if installed)
 - the task is narrowly "design this feature before coding it" with no exploration needed → direct design + skip this skill
 - the agent is reasoning alone with no user in the loop → `think-deeper`
 - the work is executing pre-decided tasks at scale → `run-issue-tree`
@@ -134,7 +134,7 @@ Produce the full output (see `references/output-format.md`). Minto-style: conclu
 Every session ends with:
 
 - A **ranked summary** table
-- A **recommended next step** with the right next-skill pointer (`build-skills` / `request-code-review` / `run-issue-tree` / direct implementation / further research)
+- A **recommended next step** with the right next-skill or action pointer (e.g., `build-skills` to implement, `run-issue-tree` to plan, `run-research` to gather more evidence, direct implementation, or the companion `request-code-review` skill if installed)
 - An **explicit user question** naming the next fork — not "let me know what you think"
 
 ## Output contract

--- a/skills/do-brainstorm/skills/do-brainstorm/SKILL.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: do-brainstorm
+description: Use skill if you are brainstorming before committing — architecture decisions, debugging direction, scoping research, prioritization, or exploring a solution space with the user in the loop.
+---
+
+# Do Brainstorm
+
+A framework-aware, user-in-the-loop brainstorming session. Not a feature-design linear flow (see obra/brainstorming) and not solo reasoning (see the repo's `think-deeper` skill). This skill classifies the problem first (Cynefin), then routes to the right combination of 25 mental-model frameworks, pausing at forks to bring the user along.
+
+## Trigger boundary
+
+Use this skill when the task is to:
+
+- **architect a decision** — two or more plausible designs; tradeoffs matter
+- **find a direction in a stuck debug** — the next step isn't obvious
+- **scope an ambiguous task** — unclear where to start, what's in/out
+- **prioritize under constraint** — more options than bandwidth
+- **explore a solution space** before committing to implementation
+- **root-cause a recurring problem** — one-off fixes haven't worked
+
+Prefer another skill when:
+
+- a specific design is already agreed → go implement (`build-*`, `develop-*`)
+- a PR exists to evaluate → `review-pr` / `evaluate-code-review`
+- the task is narrowly "design this feature before coding it" with no exploration needed → direct design + skip this skill
+- the agent is reasoning alone with no user in the loop → `think-deeper`
+- the work is executing pre-decided tasks at scale → `run-issue-tree`
+
+## Non-negotiable rules
+
+1. **HARD GATE** — do not skip to implementation before the session produces its output contract. Even "simple" brainstorms surface assumptions that change the plan.
+2. **Classify before routing.** Step 1 (Cynefin) runs first, always. Frameworks selected in Steps 2-5 depend on the classification.
+3. **Pause at every fork.** Five fork points total (end of Steps 1-5). User approves or redirects at each. Do not silently resolve forks unilaterally.
+4. **One question at a time** when asking open-ended. Bundle multiple-choice questions via the runtime's ask-user tool (see `references/cross-runtime.md`) — up to 4 per call, 2-4 options each, `(Recommended)` first.
+5. **Deep passes run internally; structured output surfaces.** Apply frameworks inside each step; show the user the artifacts (tree, options, evaluation table, pre-mortem) — not your internal monologue.
+6. **YAGNI ruthlessly.** Every option, weight, or constraint must earn its place. If you cannot justify why something is in the session, drop it.
+7. **Surface assumptions, blind spots, second-order effects.** These are required sections in the output contract — not optional flourishes.
+8. **Every session ends with a concrete next step + an explicit user question.** Not "let me know what you think" — name the fork.
+
+## The two output modes
+
+| Mode | Trigger phrasing | Produces |
+|---|---|---|
+| **Interactive** (default) | "Let's brainstorm X", "Help me think through Y" | Full 6-step session with pauses; output emitted progressively |
+| **One-shot** | "Give me a brainstorm doc on X", "Run the full brainstorm and hand me the result" | Runs Steps 1-6 without pauses; produces the full output contract as a single markdown deliverable; user reviews at the end instead of at each fork |
+
+Default to interactive. Switch to one-shot only when the user explicitly asks for a deliverable without mid-session involvement.
+
+## Required workflow
+
+### 1. Classify the problem (Cynefin first)
+
+Before picking tools, classify. Dispatch **one** ask-user-tool call with up to 3 questions:
+
+- "What shape is this problem?" — options: design decision / root-cause hunt / prioritization / novel exploration / stabilizing a crisis
+- "How clear is cause-effect here?" — options: fully understood / multiple plausible paths / unknown unknowns / genuinely chaotic
+- "How reversible is the outcome?" — options: fully reversible / adjustable / costly to reverse / one-shot
+
+Map answers to Cynefin domain. See `references/classify-problem.md` for the full decision table.
+
+| Domain | Routes to |
+|---|---|
+| **Clear** — known best practice applies | Decline politely: "This has a standard answer — recommend X. Brainstorm not needed." |
+| **Complicated** — multiple known-unknowns, analysis will resolve | Step 2 (decompose → analyze) |
+| **Complex** — unknown unknowns, probe to learn | Steps 2 lite + 3 (explore → iterate) |
+| **Chaotic** — in crisis, stabilize first | Step 2 lite + Step 4 (triage with Hard Choice Model) |
+| **Disorder** — you can't tell which domain | Run Abstraction Laddering first, then re-classify |
+
+**FORK 1:** Show the user the classification + proposed route. Ask: "Does this read right? Anything that changes the shape?"
+
+### 2. Decompose (surface the real problem)
+
+Pick the decomposition tool based on the Cynefin domain + problem symptoms. See `references/decompose.md`.
+
+| Symptom | Tool |
+|---|---|
+| Problem is a why/how chain | **Issue Trees** (MECE; ask why for problem, ask how for solutions) |
+| Multi-factor root cause across categories | **Ishikawa** (fishbone; people/methods/tools/environment) |
+| Recurring issue, surface fixes failed | **Iceberg Model** (events → patterns → structures → mental models) |
+| Problem statement feels wrong | **Abstraction Laddering** (climb up with "why", down with "how") |
+
+Surface the decomposition inline as markdown (tree, table, or bulleted hierarchy).
+
+**FORK 2:** "Does this decomposition capture the problem? Missing branches? Wrong level of abstraction?"
+
+### 3. Explore (generate options)
+
+Pick generative tools based on what the session needs. See `references/explore.md` (and `references/systems.md` for systems-specific problems).
+
+| Need | Tool |
+|---|---|
+| Perspective diversity | **Six Thinking Hats** (White/Red/Black/Yellow/Green/Blue — use Blue to orchestrate, Green to generate, Black to attack) |
+| Reason from foundations, escape analogy traps | **First Principles** + Socratic questioning |
+| Novel combinations across multiple dimensions | **Zwicky Box** (morphological analysis — dimensions × values → combinations) |
+| System / feedback-loop dynamics | **Connection Circles** + **Reinforcing/Balancing Feedback** (see `systems.md`) |
+
+Generate **≥3 options**. Each option gets: one-line label, 2-3 sentence rationale, key tradeoff, and which Cynefin domain it suits best.
+
+**FORK 3:** "Which of these resonates? Should I expand one, drop one, add a new one, or widen the search?"
+
+### 4. Evaluate (score + filter)
+
+Use `references/evaluate.md`. First classify the decision shape with the Hard Choice Model:
+
+| Impact | Comparability | Approach |
+|---|---|---|
+| Low | Easy | Just pick — optimizing wastes time |
+| Low | Hard | Pick by current priorities; don't overthink |
+| High | Easy | **Decision Matrix** — factors + weights + scores |
+| High | Hard | **Decision Matrix** + run a cheap experiment; accept there is no "right" answer |
+
+For prioritization across many options: **Impact-Effort Matrix** (quick wins → major projects → fill-ins → thankless); **Eisenhower Matrix** for time-allocation subsets.
+
+Emit an evaluation table. Scores explicit. Weights explicit. Confidence flagged.
+
+**FORK 4:** "Are the factors + weights right? Anything I'm undervaluing or overvaluing?"
+
+### 5. Stress-test (blind spots + second-order)
+
+Always run all three. See `references/stress-test.md`.
+
+- **Inversion** (pre-mortem): "If this fails in 6 months, what went wrong?" List the plausible failures, then propose mitigations.
+- **Ladder of Inference**: climb down from the recommendation to the raw observations, then back up. What data was selected? What was interpreted? What was assumed?
+- **Second-Order Thinking**: 10-minute / 10-month / 10-year timeline. What happens *after* the first-order win?
+
+Surface: **Assumptions**, **Blind spots**, **Second-order effects** as explicit sections — required in the output contract.
+
+**FORK 5:** "Any of these change the pick? Should we revisit an earlier step?"
+
+### 6. Communicate + commit (Minto structure)
+
+Produce the full output (see `references/output-format.md`). Minto-style: conclusion + ranking near the end AFTER the full thinking, but **Approach** section at the top gives the fast skim.
+
+Every session ends with:
+
+- A **ranked summary** table
+- A **recommended next step** with the right next-skill pointer (`build-skills` / `request-code-review` / `run-issue-tree` / direct implementation / further research)
+- An **explicit user question** naming the next fork — not "let me know what you think"
+
+## Output contract
+
+Every session produces this structure. In interactive mode, sections emit progressively (after their step). In one-shot mode, all at once.
+
+```markdown
+# <Brainstorm topic>
+
+## Approach
+Chosen frameworks: <list>. Why: <one-sentence rationale per>.
+
+## Problem shape (Cynefin)
+Domain: <Clear / Complicated / Complex / Chaotic / Disorder>
+Evidence: <what the user said in Step 1>.
+
+## Decomposition
+<tree / table / hierarchy from Step 2>
+
+## Options explored
+<list of ≥3 options with rationale and tradeoffs from Step 3>
+
+## Evaluation
+<table with factors, weights, scores, confidence from Step 4>
+
+## Assumptions
+- <explicit, load-bearing>
+- ...
+
+## Blind spots
+- <what the process likely missed>
+- ...
+
+## Second-order effects
+- 10 minutes: <...>
+- 10 months: <...>
+- 10 years: <...>
+
+## Ranked summary
+| # | Option | Score / Rationale | Confidence | Notes |
+
+## Recommended next step
+<Concrete action + which skill or tool to use next>.
+**Your input needed on:** <specific question at the next fork>.
+```
+
+## Do this, not that
+
+| Do this | Not that |
+|---|---|
+| classify with Cynefin first, always | pick a framework because it's your favorite |
+| pause at the 5 forks, show the user the output of each step | silently resolve forks and present the conclusion |
+| generate ≥3 options before converging | propose one option and ask if it's good |
+| always run Inversion + Ladder of Inference + Second-Order | skip stress-testing because the recommendation "looks obvious" |
+| surface assumptions explicitly as a section | bury assumptions in prose |
+| point to the right follow-on skill at the end | end with "let me know what you think" |
+| bundle clarifying questions via the ask-user tool, ≤4 per call | fire 10 open-ended questions in one message |
+| scale section detail to complexity | 500 words on a 2-line decision |
+| deep-pass frameworks internally, surface structured output | narrate your internal monologue as the output |
+
+## Guardrails and recovery
+
+- Do not pick frameworks before the Cynefin classification is confirmed at Fork 1.
+- Do not compress the 5 forks into fewer. If the user explicitly asks for one-shot, honor it — otherwise pause at each.
+- Do not skip Step 5 (stress-test). Every session runs Inversion + Ladder of Inference + Second-Order.
+- Do not terminate without a named next-step skill or action.
+- Do not propose `do-brainstorm` again as the next step — that's infinite regress. If more brainstorming is truly needed, name the sub-topic and explicitly hand off.
+
+Recovery moves:
+
+- **User's Step 1 answers don't fit Cynefin cleanly** — run Abstraction Laddering first to reframe, then re-classify. Say so explicitly.
+- **Fork 3 reveals the decomposition was wrong** — loop back to Step 2 with the new understanding, don't paper over.
+- **Evaluation reveals no option is acceptable** — revisit Step 3 with a different generative tool (if Six Hats was used, try Zwicky Box), or expand the constraints.
+- **User pushes for implementation mid-session** — hold the gate; offer to compress remaining steps but not skip them. If they insist, comply but explicitly state which sections were skipped.
+- **Session crosses 60+ minutes or becomes unwieldy** — stop, produce a partial output contract covering what ran, flag incomplete sections, point at the next skill or a follow-up session.
+
+## Reference routing
+
+| File | Read when |
+|---|---|
+| `references/classify-problem.md` | Running Step 1 — Cynefin classification questions + decision table + Disorder → Abstraction-Laddering escape |
+| `references/decompose.md` | Running Step 2 — Issue Trees / Ishikawa / Iceberg / Abstraction Laddering; picking the right tool for the problem's shape |
+| `references/explore.md` | Running Step 3 — Six Thinking Hats / First Principles / Zwicky Box; generating ≥3 options |
+| `references/systems.md` | Step 2 or 3 when the problem has feedback dynamics — Connection Circles + Reinforcing/Balancing Feedback + Concept Map |
+| `references/evaluate.md` | Running Step 4 — Hard Choice Model classifier + Decision Matrix + Impact-Effort + Eisenhower |
+| `references/stress-test.md` | Running Step 5 — Inversion (pre-mortem) + Ladder of Inference + Second-Order Thinking |
+| `references/communicate.md` | Running Step 6 — Minto Pyramid output structure + Situation-Behavior-Impact for feedback situations + Conflict Resolution Diagram for stakeholder conflicts |
+| `references/meta.md` | When the session itself needs adjustment — OODA Loop for pacing + Productive Thinking Model for innovation tasks + Confidence-determines-Speed/Quality for speed-vs-quality calls |
+| `references/interaction-patterns.md` | Unsure when to pause, how to phrase a question, or whether to push back when the user wants to skip a fork — includes the "one question at a time" discipline |
+| `references/output-format.md` | Writing the final deliverable — exact section templates, Minto ordering, ranked-summary column rules |
+| `references/cross-runtime.md` | Running on a non-Claude runtime — compact ask-user-tool table, portability notes, and prose fallback; mirrors the lookup convention from the sibling `enhance-prompt` skill |
+
+## Final checks
+
+Before declaring the session done, confirm:
+
+- [ ] Cynefin classification confirmed at Fork 1
+- [ ] Decomposition approved at Fork 2
+- [ ] ≥3 options presented at Fork 3
+- [ ] Evaluation factors + weights approved at Fork 4
+- [ ] Inversion + Ladder of Inference + Second-Order all run at Step 5; user responded at Fork 5
+- [ ] Output contract includes Approach / Problem shape / Decomposition / Options / Evaluation / Assumptions / Blind spots / Second-order / Ranked summary / Recommended next step
+- [ ] Recommended next step names a specific follow-on skill or concrete action
+- [ ] Explicit user question at the end — not "let me know"
+- [ ] No infinite-regress recommendation (don't recommend `do-brainstorm` as the next step)

--- a/skills/do-brainstorm/skills/do-brainstorm/references/classify-problem.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/classify-problem.md
@@ -51,7 +51,7 @@ Dispatch ONE ask-user-tool call with these 3 questions (see `cross-runtime.md` f
 | Fully reversible, low-stakes | Favor quicker routes (Big Choice or No-brainer in Hard Choice Model) |
 | Adjustable with effort | Normal routing |
 | Costly to reverse | Extra weight on Step 5 (stress-test) |
-| One-shot (migration, irreversible deploy) | Extra weight on Step 5; also surface this in the output contract's Risks section |
+| One-shot (migration, irreversible deploy) | Extra weight on Step 5; surface one-shot nature in the **Assumptions** section of the output contract and fold mitigations into the ranked summary |
 
 Reversibility doesn't change Cynefin domain but does change how much time to spend in Step 5 (stress-test) — irreversible calls get more Inversion + Second-Order Thinking.
 

--- a/skills/do-brainstorm/skills/do-brainstorm/references/classify-problem.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/classify-problem.md
@@ -1,0 +1,141 @@
+# Classify the Problem (Step 1 — Cynefin First)
+
+Every session starts here. Before choosing frameworks, classify the problem's domain. The Cynefin framework (pronounced "ku-NEV-in") is the router: each domain calls for different action sequences and different downstream tools.
+
+## The five domains
+
+| Domain | Signature | Action sequence | Routes to |
+|---|---|---|---|
+| **Clear** (Obvious / Simple) | Familiar problem, clear cause-effect, stable conditions. "Known knowns." | Sense → categorize → respond | **Decline brainstorm**: recommend the established best practice |
+| **Complicated** | Multiple plausible answers exist, but aren't immediately obvious. "Known unknowns." Clear questions needing investigation. | Sense → analyze → respond | Step 2 (decompose) using **Issue Trees** or **Ishikawa** |
+| **Complex** | "Unknown unknowns." Situation can't be understood by analysis. Unclear what questions to ask first. | Probe → sense → respond | Step 2 lite + Step 3 (**Six Thinking Hats**, **Connection Circles**, **Zwicky Box**) |
+| **Chaotic** | Out of control. No clear cause-effect. Immediate action required to stabilize. | Act → sense → respond | Step 2 lite + Step 4 (**Hard Choice Model** for triage) |
+| **Disorder** | You can't tell which domain applies. | Identify the domain first | Run **Abstraction Laddering**, then re-classify |
+
+**Key principle:** different kinds of situations require different kinds of responses. Treating a Complex problem with Complicated-domain tools (pure analysis) fails — because analysis assumes the answer is discoverable, which it isn't. Treating a Complicated problem as Complex (experiment-first) wastes time — because analysis would have resolved it.
+
+## The 3-question classifier
+
+Dispatch ONE ask-user-tool call with these 3 questions (see `cross-runtime.md` for tool names per runtime):
+
+### Question 1: problem shape
+
+> "What shape is this problem?"
+
+| Option | Signal |
+|---|---|
+| Design decision (architecture, framework choice, API shape) | Usually **Complicated** or **Complex** |
+| Root-cause hunt (recurring bug, unclear failure) | Usually **Complicated** (decompose) or **Complex** (probe) |
+| Prioritization under constraint | Usually **Complicated** (evaluate known options) |
+| Novel exploration (no clear precedent) | Usually **Complex** or **Chaotic** |
+| Stabilizing a crisis (production down, data at risk) | **Chaotic** |
+| I'm not sure what shape this is | **Disorder** → run Abstraction Laddering |
+
+### Question 2: cause-effect clarity
+
+> "How clear is cause-effect here?"
+
+| Option | Signal |
+|---|---|
+| Fully understood | **Clear** — decline |
+| Multiple plausible paths, analysis will resolve | **Complicated** |
+| Unknown unknowns, not sure what to even measure | **Complex** |
+| Genuinely chaotic, no stable pattern | **Chaotic** |
+
+### Question 3: reversibility
+
+> "How reversible is the outcome?"
+
+| Option | Signal |
+|---|---|
+| Fully reversible, low-stakes | Favor quicker routes (Big Choice or No-brainer in Hard Choice Model) |
+| Adjustable with effort | Normal routing |
+| Costly to reverse | Extra weight on Step 5 (stress-test) |
+| One-shot (migration, irreversible deploy) | Extra weight on Step 5; also surface this in the output contract's Risks section |
+
+Reversibility doesn't change Cynefin domain but does change how much time to spend in Step 5 (stress-test) — irreversible calls get more Inversion + Second-Order Thinking.
+
+## Combining the answers
+
+Take the modal answer across the three questions:
+
+| Combination | Domain |
+|---|---|
+| Q1=Design, Q2=Plausible paths, Q3=Adjustable | **Complicated** |
+| Q1=Root-cause, Q2=Unknown unknowns, Q3=Any | **Complex** |
+| Q1=Stabilizing, Q2=Chaotic, Q3=One-shot | **Chaotic** |
+| Q1=Novel, Q2=Unknown unknowns, Q3=Any | **Complex** |
+| Q1=Prioritization, Q2=Fully understood options, Q3=Any | **Complicated** |
+| Any question answered "I'm not sure" | **Disorder** |
+
+If answers straddle two domains (e.g. Complicated + Complex), **prefer the more exploratory one** (Complex). The cost of over-exploring is small; the cost of analyzing a problem that can't be analyzed is "lots of pretty diagrams that don't help."
+
+## The Disorder path — Abstraction Laddering
+
+If classified as **Disorder**, run Abstraction Laddering before anything else.
+
+Steps:
+
+1. Write the current problem statement as the user stated it.
+2. Ask **"Why?"** to climb one rung up — produces a more abstract statement. (e.g., "Make the login page faster" → why → "Reduce friction in the first-touch user experience")
+3. Ask **"How?"** from the original to climb one rung down — produces a more concrete statement or solution. (e.g., "Make the login page faster" → how → "Reduce the bundle size of the login route")
+4. Offer the user 3 problem statements: original + one rung up + one rung down.
+5. Ask: "Which of these is the actual problem you're trying to solve?"
+
+Once the user picks, re-run the 3-question classifier on the chosen framing.
+
+## What "Clear" looks like — when to decline
+
+If classification returns **Clear**, do not run the brainstorm. Respond with:
+
+> "This has a standard answer: <the best practice>. Recommending that directly. If you'd like to deviate from the standard, let me know why — we can brainstorm the custom path then."
+
+Examples of Clear-domain asks:
+
+- "How should I structure a PR title?" → follow Conventional Commits; no brainstorm needed
+- "What file-naming convention should I use?" → check the repo's existing convention; no brainstorm needed
+- "Should I write tests for this one-line typo fix?" → no; write the fix
+
+Declining is respectful of the user's time. Running a 6-step brainstorm on a Clear-domain problem signals the skill can't distinguish shapes.
+
+## Chaotic — the "act first, stabilize, then brainstorm" path
+
+If classified as **Chaotic** (production down, data at risk, financial emergency), the brainstorm is not what the user needs first. Respond:
+
+> "This reads as a Chaotic-domain problem — act first to stabilize, then we brainstorm once the immediate fire is out. Right now: <the most conservative stabilizing action>. Do you want me to help with that first, or is the immediate action already handled and we're here to think about what's next?"
+
+Only run the full brainstorm if the user confirms the chaos is already under control. Otherwise the brainstorm is the wrong tool.
+
+## Fork 1 output (what to surface)
+
+After classification, show the user:
+
+```
+## Classification
+
+Problem shape: <from Q1>
+Cause-effect clarity: <from Q2>
+Reversibility: <from Q3>
+
+Cynefin domain: <domain>
+
+Proposed route:
+- Step 2 decomposition tool: <Issue Trees / Ishikawa / Iceberg / Abstraction Laddering>
+- Step 3 generative tools: <Six Thinking Hats / First Principles / Zwicky Box / Connection Circles>
+- Step 4 evaluation: <Decision Matrix / Impact-Effort / Hard Choice>
+- Step 5 stress-test (always): Inversion + Ladder of Inference + Second-Order
+
+Does this read right? Anything that changes the shape?
+```
+
+Wait for approval or redirect. Do not proceed to Step 2 until confirmed.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Skipping Cynefin because "it's obviously Complicated" | Run the 3-question classifier anyway; assumptions about domain are commonly wrong |
+| Treating Complex as Complicated | The symptom: diagrams multiply, no action emerges. Switch to probe-based tools (Zwicky Box, Six Hats) |
+| Treating Disorder as any specific domain | Run Abstraction Laddering first; disorder means you don't know what problem you're solving |
+| Running the full 6-step brainstorm on a Clear-domain question | Decline. Recommend the best practice. |
+| Missing the Chaotic signal | "Production down", "user data at risk", "paying customer blocked right now" are chaotic markers. Stabilize first. |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/communicate.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/communicate.md
@@ -1,0 +1,170 @@
+# Communicate (Step 6 — Present and Commit)
+
+The brainstorm ends by producing structured output. This file covers how to present it — Minto Pyramid for the structure, Situation-Behavior-Impact for any feedback-shaped content, and Conflict Resolution Diagram when the brainstorm revealed stakeholder tension.
+
+The required section order is in `output-format.md`. This file covers the voice, framing, and communication patterns.
+
+## Minto Pyramid — conclusion first
+
+**When**: always, for the final output contract. Busy readers skip the middle; the headline must land in the first section.
+
+**Principle**: lead with the conclusion. Then the reasons. Then the supporting detail. BLUF ("bottom line up front").
+
+**Mechanics**:
+
+1. **Start with the conclusion** — what is the recommendation? (Top of the pyramid.)
+2. **Key arguments** — 2-4 short summaries of *why* the recommendation holds. (Middle of the pyramid.)
+3. **Supporting detail** — the evaluation matrix, decomposition tree, stress-test findings. (Bottom of the pyramid; skimmable.)
+
+**Applied to this skill's output**:
+
+The output-format (in `output-format.md`) is technically "approach → problem shape → decomposition → options → evaluation → assumptions → blind spots → second-order → ranked summary → recommended next step." That ORDER looks bottom-up. But Minto still applies inside each section and in the skim experience:
+
+- **Approach section** is Minto's top layer — reads first, named chosen frameworks + why in ONE paragraph
+- **Ranked summary** is the Minto conclusion — restated at the end because the journey matters too
+- **Recommended next step** is the call to action — the reader's "what do I do now?"
+
+A reader who skips everything between Approach and Ranked summary should still get the right answer.
+
+## When to use Minto for sub-sections
+
+For each step's output:
+
+- **Step 1 (Classify)**: Lead with the domain. Then the evidence. Not "user said X, Y, Z, therefore Complex" — "Complex domain, because the user said X."
+- **Step 2 (Decomposition)**: Lead with the priority branches. Then the full tree as supporting detail.
+- **Step 3 (Options)**: Lead with the option labels + one-liner. Then the rationale per option.
+- **Step 4 (Evaluation)**: Lead with the winner + total score. Then the matrix as supporting detail.
+- **Step 5 (Stress-test)**: Lead with whether the pick changed. Then the artifacts.
+
+Bury no conclusions in prose. Every section has a headline sentence at the top.
+
+## Situation-Behavior-Impact (SBI)
+
+**When**: the brainstorm involves feedback — on a teammate's work, on a past decision, on a process. Common when the "root cause" (Step 2 decomposition) surfaced "this team ships without QA" and the next step is a conversation.
+
+**Structure**:
+
+1. **Situation** — the specific context. Concrete: when, where, what meeting.
+2. **Behavior** — what was observed. Observable, not inferred. "Missed three of the last four deadlines" not "doesn't care about deadlines."
+3. **Impact** — what the behavior caused. On you, on the team, on downstream stakeholders. "Which made me worry…" or "Which caused the on-call team to absorb…"
+
+**Optional extension — Intent**:
+
+4. **Intent** — ask what their intention was. Often there's a legitimate reason you haven't seen.
+
+**Output example** (for a brainstorm that ends with "give feedback to the release manager"):
+
+```
+## Feedback framing (SBI)
+
+Situation: In the last four Wednesday standups (Oct-Nov 2024)...
+Behavior: ...release timelines were marked green while bugs found in prod counted as post-release issues in the changelog...
+Impact: ...which caused on-call pages every release night and burned 8+ engineering-hours per cycle reacting to what could have been a pre-release decision.
+Intent (ask): What was the intent in marking those timelines green? Were there pressures outside the standup visibility?
+```
+
+**What it reveals**: the gap between the giver's interpretation and the actor's intent. Avoids character-based feedback; stays actionable.
+
+**Interactions**: Pairs with Ladder of Inference (Step 5) — SBI forces you to separate observations (available data) from interpretations. If your SBI "behavior" is actually an interpretation, Ladder of Inference would have caught it.
+
+## Conflict Resolution Diagram (Evaporating Cloud)
+
+**When**: the brainstorm surfaced a conflict between stakeholders — "engineering wants X, product wants Y, and they're mutually exclusive." Common in architecture brainstorms where two teams have incompatible demands.
+
+**Principle**: conflicts dissolve when you find the shared higher-level goal and the underlying needs behind each position.
+
+**Structure**:
+
+```
+          Shared goal
+         /           \
+    Need A             Need B
+       |                 |
+  Proposal A       Proposal B (mutually exclusive)
+```
+
+**Mechanics** (right-to-left in the diagram, top-to-bottom in the conversation):
+
+1. **Proposals** — what does each side want to do? Write both. Confirm they seem mutually exclusive.
+2. **Needs** — what needs does each proposal satisfy? Underlying, not surface.
+3. **Shared goal** — what higher-level objective do both need sides pursue? Both sides need to agree on this.
+4. **Assumptions** — why do the two sides believe the proposals are mutually exclusive? The assumptions usually turn out to be negotiable.
+5. **Reframed solution** — a new proposal that meets both underlying needs and serves the shared goal.
+
+**Output example**:
+
+```
+## Conflict resolution (if surfaced)
+
+Parties: engineering (X), product (Y)
+
+Proposals:
+  X: Freeze new feature work for 6 weeks; pay down debt.
+  Y: Ship the holiday campaign feature on time.
+
+Needs:
+  X: Prevent cascading incidents; sustainable velocity.
+  Y: Meet a customer commitment; hit quarterly revenue target.
+
+Shared goal: Sustainable, profitable growth over the next 12 months.
+
+Assumptions (examining):
+  - X assumes all incidents trace to debt. Actually 2 of the last 4 traced to config drift.
+  - Y assumes the full feature must ship on Dec 1. Minimum viable = login + 1 banner variant.
+
+Reframed: Ship MVP version of the feature by Dec 1 (meets Y's commitment). In parallel, dedicate 30% capacity to the top 3 debt items (meets X's need). Full feature lands by Dec 20.
+```
+
+**What it reveals**: assumptions that manufactured the conflict. Most "mutually exclusive" positions aren't — they're mutually exclusive given a specific set of constraints that were never examined.
+
+**Interactions**: Pairs with Six Thinking Hats (Step 3) — specifically Yellow (what both sides want) and Black (why the current framing fails). Also with First Principles — conflicts often dissolve when the assumed constraints aren't first principles.
+
+## Voice rules
+
+The output is a technical artifact. Voice rules:
+
+| Do | Don't |
+|---|---|
+| Lead sections with the conclusion | Bury the conclusion in paragraph 4 |
+| Cite evidence per claim | "It seems like…" |
+| Flag confidence where low | Uniform confidence across all claims |
+| Name the next step concretely | "Consider next steps" |
+| Ask an explicit question at the end | "Let me know what you think" |
+| Use tables for scoring / ranking | Prose for what's really a table |
+| Keep prose dense — one idea per paragraph | Multi-paragraph rambles |
+
+Forbidden phrases (borrowed from `evaluate-code-review/voice.md`):
+
+- "Thanks for the great discussion"
+- "Hope this helps"
+- "Please feel free to"
+- "You're absolutely right" (even when they are)
+
+## Framing the "Recommended next step"
+
+Every session ends with a next-step pointer. Make it concrete — a skill, a command, or a specific decision fork.
+
+Good next-step formats:
+
+- "Run `build-skills` to implement the chosen architecture as a draft."
+- "Create a GitHub Issue via `run-issue-tree` with the plan and assign."
+- "Open a PR for the migration with the Phase 1 changes; use `request-code-review` to generate the self-review body."
+- "Schedule a 30-minute decision meeting with <stakeholders> using the Conflict Resolution Diagram above as the discussion document."
+- "Raise confidence on the low-confidence scores in Step 4 by running a cheap benchmark; re-evaluate if the scores move."
+
+Bad next-step formats:
+
+- "Think about it and decide." (not concrete)
+- "Implement it." (which skill? what's the artifact?)
+- "Let me know." (not actionable)
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Conclusion buried in paragraph 6 of the output | Move to top; Minto structure |
+| Next step is "consider" or "think about" | Make concrete: a command, a skill, a specific conversation |
+| Final question is "let me know what you think" | Name the explicit fork: "Should we proceed with Option A or run the cheap experiment first?" |
+| Feedback content in the output without SBI structure | SBI it; character-based feedback triggers defensiveness |
+| Conflict surfaced but diagnosed at the proposal level | Use Conflict Resolution Diagram to go to needs + shared goal |
+| Output prose reads like internal monologue | Keep internal monologue internal; surface structured artifacts |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/communicate.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/communicate.md
@@ -133,7 +133,7 @@ The output is a technical artifact. Voice rules:
 | Use tables for scoring / ranking | Prose for what's really a table |
 | Keep prose dense — one idea per paragraph | Multi-paragraph rambles |
 
-Forbidden phrases (borrowed from `evaluate-code-review/voice.md`):
+Forbidden phrases (shared convention across the code-review-related skills in this pack):
 
 - "Thanks for the great discussion"
 - "Hope this helps"
@@ -148,7 +148,7 @@ Good next-step formats:
 
 - "Run `build-skills` to implement the chosen architecture as a draft."
 - "Create a GitHub Issue via `run-issue-tree` with the plan and assign."
-- "Open a PR for the migration with the Phase 1 changes; use `request-code-review` to generate the self-review body."
+- "Open a PR for the migration with the Phase 1 changes; include a self-review body (if you have the `request-code-review` skill installed, use it; otherwise follow the PR-body convention in the `review-pr` skill)."
 - "Schedule a 30-minute decision meeting with <stakeholders> using the Conflict Resolution Diagram above as the discussion document."
 - "Raise confidence on the low-confidence scores in Step 4 by running a cheap benchmark; re-evaluate if the scores move."
 

--- a/skills/do-brainstorm/skills/do-brainstorm/references/cross-runtime.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/cross-runtime.md
@@ -2,7 +2,7 @@
 
 This skill is written natively for Claude Code but is designed to work on any runtime that supports an ask-user tool. This file covers runtime compatibility, the compact runtime lookup table, and the prose fallback for runtimes without structured tools.
 
-For the fullest runtime-to-tool mapping and the payload-shape details, see `skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md` — this skill mirrors that convention deliberately.
+The table below is self-contained. If the `enhance-prompt` skill is also installed in this pack, its `ask-user-tools.md` reference uses the same convention — the two are intentionally kept in sync.
 
 ## Runtime compatibility matrix
 
@@ -154,11 +154,11 @@ A few runtimes are text-completion only (no tool calls). In that case:
 
 This works but is friction-heavy. If the user is on such a runtime, suggest they switch to a tool-capable runtime for this particular skill. The skill still works; it's just less fluid.
 
-## Mirroring enhance-prompt
+## Mirroring the enhance-prompt convention
 
-The table above is a snapshot of `skills/enhance-prompt/.../references/ask-user-tools.md`, intentionally. Both skills face the same problem: dispatching user questions across runtimes. Duplicating the table here means this skill is usable standalone (one-level-deep rule); updating either should eventually propagate to both via a shared-state convention.
+If the `enhance-prompt` skill is installed in this pack, its ask-user-tool reference uses the same convention and the two files contain equivalent runtime mappings. Duplicating the table locally means this skill is usable standalone (one-level-deep rule).
 
-If the upstream `enhance-prompt/ask-user-tools.md` gains a new runtime, this file should be updated too. The tables are small enough that propagation is cheap.
+When a new runtime emerges with its own ask-user tool, update both files. The tables are small enough that manual propagation is cheap; single-source coupling across skills would break the one-level-deep rule.
 
 ## Common mistakes
 

--- a/skills/do-brainstorm/skills/do-brainstorm/references/cross-runtime.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/cross-runtime.md
@@ -1,0 +1,171 @@
+# Cross-Runtime — Portability Notes
+
+This skill is written natively for Claude Code but is designed to work on any runtime that supports an ask-user tool. This file covers runtime compatibility, the compact runtime lookup table, and the prose fallback for runtimes without structured tools.
+
+For the fullest runtime-to-tool mapping and the payload-shape details, see `skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md` — this skill mirrors that convention deliberately.
+
+## Runtime compatibility matrix
+
+This skill requires ONE capability: the ability to ask the user a structured question mid-workflow. The tool's name and signature vary by runtime; the workflow logic is identical.
+
+### Full runtime → tool lookup
+
+| Runtime | Tool name | Style |
+|---|---|---|
+| **claude-code** (Anthropic SDK) | `AskUserQuestion` | PascalCase |
+| **codex** (OpenAI) | `ask_user_question` | snake_case |
+| **gemini-cli** | `ask_user` | snake_case |
+| **deepagents** | `ask_user` | snake_case |
+| **kimi-cli** | `AskUserQuestion` | PascalCase |
+| **cline** | `ask_followup_question` | snake_case |
+| **droid** (Factory) | `AskUser` | PascalCase |
+| **cursor** | `AskQuestion` | PascalCase |
+| **github-copilot** | `ask_user` | snake_case |
+| **roo** | `ask_followup_question` | snake_case |
+| **opencode** | `question` | plain |
+| **continue** | `AskQuestion` | PascalCase |
+| **antigravity** | `suggested_responses` | snake_case |
+| **pi** | `ask_user` | snake_case |
+| **qwen-code** | `ask_user_question` | snake_case |
+| **mistral-vibe** | `ask_user_question` | snake_case |
+| **unknown / other** | — | use prose fallback (see below) |
+
+Casing matters. Lookup is exact-match.
+
+### Picking at runtime
+
+1. Look up the runtime in the table.
+2. If the runtime isn't listed → try `AskUserQuestion` once; if the tool is unknown, try `ask_user` once; otherwise prose fallback.
+3. Never silently skip a fork. If no tool works, fall back to prose. Do not proceed without the user's answer.
+
+## Portable payload shape
+
+The runtimes above share a payload shape. Code your calls to this shape and they'll work across nearly all of them:
+
+```
+questions: [
+  {
+    question: "<user-facing question text, ending with a question mark>",
+    header: "<short chip label, max 12 chars>",
+    multiSelect: true | false,
+    options: [
+      { label: "<short label, 1-5 words>", description: "<one-line description>" },
+      ...
+    ]
+  },
+  ...
+]
+```
+
+**Portability constraints** (tightest across runtimes):
+
+- 1-4 questions per call (Claude Code's cap)
+- 2-4 options per question
+- First option marked `(Recommended)` in the label, based on your analysis — not static
+- Do NOT manually add "Other" — Claude Code auto-adds it; other runtimes may differ, but mimicking keeps the prompt clean
+- Use `multiSelect: true` only when choices are genuinely orthogonal (e.g., "which failure modes to block")
+
+## The five forks mapped to the ask-user tool
+
+Each fork in the workflow dispatches one tool call:
+
+| Fork | Typical question count | multiSelect? |
+|---|---|---|
+| Fork 1 (Classify) | 3 questions (Cynefin classifier) | No |
+| Fork 2 (Decompose) | 1-2 questions (approve + optional missing branches) | No |
+| Fork 3 (Explore) | 1 question (which options resonate, multiSelect if "add more") | Mixed |
+| Fork 4 (Evaluate) | 1-2 questions (approve matrix + optional weight change) | No |
+| Fork 5 (Stress-test) | 1 question (any of these change the pick?) | No |
+
+Total across the session: 7-9 tool calls. Well within runtime limits.
+
+## Prose fallback — when no tool is available
+
+Some runtimes don't expose a structured ask-user tool. Fall back to markdown prose with the same decision surface:
+
+### Prose template for Fork 1 (Classify)
+
+```markdown
+Before I pick the tools for this brainstorm, I need to classify the problem's shape. Three questions:
+
+**1. What shape is this problem?**
+- (Recommended) Design decision (architecture, framework, API)
+- Root-cause hunt (recurring bug, unclear failure)
+- Prioritization under constraint
+- Novel exploration (no clear precedent)
+- Stabilizing a crisis
+- I'm not sure
+
+**2. How clear is cause-effect here?**
+- Fully understood
+- (Recommended) Multiple plausible paths, analysis will resolve
+- Unknown unknowns, not sure what to even measure
+- Genuinely chaotic
+
+**3. How reversible is the outcome?**
+- Fully reversible, low-stakes
+- (Recommended) Adjustable with effort
+- Costly to reverse
+- One-shot
+
+Reply with your picks (e.g., "1-design, 2-plausible, 3-adjustable") or "other: <free text>".
+```
+
+### Prose template for Fork 3 (Options)
+
+```markdown
+Three options emerged from the exploration:
+
+**Option A: <label>** — <1-sentence rationale + tradeoff>
+**Option B: <label>** — <1-sentence rationale + tradeoff>
+**Option C: <label>** — <1-sentence rationale + tradeoff>
+
+Which of these resonates? Pick A, B, C, combo (e.g. "A+B"), "expand X", or "widen search with different tool".
+```
+
+Other forks follow the same pattern: same question content, same option set, rendered as markdown instead of a structured tool call.
+
+## Claude-native affordances
+
+When running on Claude Code specifically, a few things work extra well:
+
+- **Markdown tables** render cleanly in the user's terminal — use them freely for the Evaluation matrix and Ranked summary
+- **Code blocks** render with syntax highlighting — use for ASCII decomposition trees and Concept Maps
+- **The `(Recommended)` suffix** is a rendering convention — highlighted in Claude Code's UI
+- **`multiSelect: true`** is first-class in AskUserQuestion
+
+Other runtimes may render differently. Keep the content portable; Claude-specific rendering is a nice-to-have, not a requirement.
+
+## Formatting portability
+
+- Markdown renders consistently across Claude Code, Codex, Gemini CLI, Cursor
+- Some runtimes (terminal-based agents) may not render tables well — prefer bulleted hierarchies as a fallback for lists >4 items
+- ASCII diagrams in code blocks are the most portable visual; mermaid / dot / flowcharts are not universally supported
+
+When in doubt, prefer plain markdown over rich formatting. The brainstorm's value is in the content, not the rendering.
+
+## When a runtime truly can't support the workflow
+
+A few runtimes are text-completion only (no tool calls). In that case:
+
+- Use prose fallback for every fork
+- Collapse fork messages into single-response blocks
+- The user replies in prose; you parse and proceed
+
+This works but is friction-heavy. If the user is on such a runtime, suggest they switch to a tool-capable runtime for this particular skill. The skill still works; it's just less fluid.
+
+## Mirroring enhance-prompt
+
+The table above is a snapshot of `skills/enhance-prompt/.../references/ask-user-tools.md`, intentionally. Both skills face the same problem: dispatching user questions across runtimes. Duplicating the table here means this skill is usable standalone (one-level-deep rule); updating either should eventually propagate to both via a shared-state convention.
+
+If the upstream `enhance-prompt/ask-user-tools.md` gains a new runtime, this file should be updated too. The tables are small enough that propagation is cheap.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Hard-coding `AskUserQuestion` in the skill's examples | Use the table; fall back to prose if the runtime isn't in it |
+| Casing mistakes (e.g., `askuserquestion` instead of `AskUserQuestion`) | Exact-match lookup; casing matters |
+| Skipping a fork because the tool call failed | Never skip — fall back to prose; a fork missed is a fork failed |
+| Proliferating 5+ questions in a single tool call | Cap at 4 — Claude Code's limit and most portable |
+| Manually adding "Other" to the options list | Most runtimes auto-add it; mimicking keeps prompts clean |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/decompose.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/decompose.md
@@ -1,0 +1,183 @@
+# Decompose (Step 2 — Surface the Real Problem)
+
+Once classified (Step 1), decompose. This step surfaces the structure the session will work with. Four tools; pick based on the problem's signature. Do NOT run all four — one, maybe two if the first reveals a framing issue.
+
+## Pick one
+
+| Symptom | Tool |
+|---|---|
+| Why-chain problem: "why is X happening?" or "how do we solve Y?" | **Issue Trees** |
+| Multi-factor root cause, suspect several interacting causes | **Ishikawa (Fishbone)** |
+| Recurring issue, one-off fixes have failed, suspect structural or cultural cause | **Iceberg Model** |
+| The problem statement itself feels wrong or too narrow | **Abstraction Laddering** |
+
+## Issue Trees
+
+**When**: A problem that decomposes naturally into sub-causes or sub-solutions via repeated "why" or "how" questions.
+
+**Mechanics**:
+
+1. Write the top-level problem as the tree root. Keep it neutral — not a hypothesized cause.
+2. Ask **"Why?"** for a problem tree (root causes) or **"How?"** for a solution tree (remedies). Generate 3-5 branches per level.
+3. Enforce **MECE** at each level:
+   - **Mutually Exclusive**: no branch overlaps another
+   - **Collectively Exhaustive**: branches together cover the problem
+4. Stay at one abstraction level per tier. Don't mix "not enough users" with "missing OAuth redirect" at the same tier.
+5. Apply the **80/20 rule**: mark the 1-2 branches most likely to carry the bulk of the cause, based on data or informed judgment.
+6. Recurse on the marked branches. 2-3 levels deep is usually enough.
+
+**Output** (inline markdown tree):
+
+```
+Problem: Users aren't adopting the new feature
+├── They don't know about it
+│   ├── ► Not in release notes
+│   ├── No in-product promotion
+│   └── No marketing email
+├── They know but can't find it
+│   ├── Buried in 3rd-level menu
+│   └── No discoverability cue
+└── They know + find it but don't use it
+    ├── ► Onboarding friction
+    ├── Doesn't solve their problem
+    └── Existing workflow is good enough
+
+(► = 80/20 priority branches)
+```
+
+**What it reveals**: the branches most worth investigating — the 1-2 high-leverage sub-problems.
+
+**Interactions**: Pair with **First Principles** (Step 3) on the priority branches — "why" deep dives into foundational truths. Feeds **Decision Matrix** (Step 4) when evaluating solutions across branches.
+
+## Ishikawa (Fishbone) Diagram
+
+**When**: A problem where multiple categories of cause plausibly contribute. "Why is sign-ups dropping?" — could be landing page, competition, marketing, onboarding, product change.
+
+**Mechanics**:
+
+1. Problem on the right; draw a spine toward the left.
+2. Pick 4-6 category bones. Defaults: **People / Methods / Tools / Materials / Measurement / Environment**. Customize for software: **People / Process / Code / Infrastructure / Data / External**.
+3. For each category, brainstorm 2-4 specific candidate causes under the bone.
+4. Per candidate, ask "why is this happening?" once to get one level deeper.
+5. Analysis: identify the 2-3 most likely candidates (by evidence or team judgment); plan the test that discriminates among them.
+
+**Output**:
+
+```
+                           People                  Process
+                             │                        │
+               Not enough reviewers      Retrospective never happens
+                             │                        │
+                             │                        │
+                    ─────────┴────────────────────────┴──────────>  Shipping broken features
+                             │                        │
+               Test infrastructure flaky         Deploy bot silences errors
+                             │                        │
+                            Code              Infrastructure
+```
+
+**What it reveals**: a map of plausible causes across disjoint categories — prevents tunnel vision on one category.
+
+**Interactions**: Complements **Iceberg Model** (Ishikawa enumerates siblings at the same level; Iceberg descends levels of abstraction). Feeds **Inversion** (Step 5) when stress-testing the picked cause.
+
+## Iceberg Model
+
+**When**: A recurring problem where point fixes haven't worked. "We keep shipping bugs even though we fix them." "Deploys keep breaking even though we audit after each one."
+
+**Mechanics**: Four levels, top to bottom. Each deeper level gives more leverage.
+
+1. **Events** — "What's happening right now?" (concrete, observable: "bug in the release yesterday")
+2. **Patterns** — "What's been happening over time? What are the trends?" ("every release ships with bugs")
+3. **Structures** — "What's influencing these patterns? What connections exist?" ("no dedicated QA phase; deadlines drive cuts from testing budget")
+4. **Mental models** — "What values, beliefs, or assumptions shape the system?" ("we value shipping on time over quality; team lead believes QA is blocking")
+
+**Output**:
+
+```
+Level 1 — Events: release 2024-11-02 shipped with 3 P1 bugs
+Level 2 — Patterns: 4 of last 5 releases have ≥2 P1 bugs
+Level 3 — Structures:
+  - No pre-release QA gate
+  - Testing treated as "if time permits"
+  - On-call absorbs the impact (no feedback to engineering)
+Level 4 — Mental models:
+  - "Velocity = shipping more features"
+  - "QA slows us down"
+  - "Bugs are an on-call problem, not an engineering-quality problem"
+```
+
+Intervene at the deepest level you can afford. Event-level fixes (patch the bug) have lowest leverage; mental-model fixes (re-align the team's definition of "done") have highest.
+
+**Interactions**: Sits deeper than Ishikawa — Ishikawa enumerates siblings at the Structures level; Iceberg descends. Pair with **Connection Circles** (`systems.md`) to map the feedback loops at the Structures level explicitly.
+
+## Abstraction Laddering
+
+**When**: The problem statement feels wrong, too narrow, too vague, or solution-shaped. Classic signal: "this is a solution pretending to be a problem."
+
+**Mechanics**:
+
+1. Write the current problem statement.
+2. Ask **"Why?"** to climb UP one rung — produces a more abstract statement.
+3. Ask **"How?"** to climb DOWN one rung — produces a more concrete statement or a solution.
+4. Offer 3 rungs: original + 1 up + 1 down.
+5. Ask the user which rung is the actual problem.
+
+**Output**:
+
+```
+Up rung (why):     Make users trust the product
+   ↑
+Original:          Add a trust badge to the homepage
+   ↓
+Down rung (how):   Integrate SSL-certificate-issuer logo in the hero
+```
+
+"Add a trust badge" is a solution statement — the real problem is building trust, and the trust badge is one of many possible approaches. Going up reveals other candidates (social proof, case studies, SOC2 compliance).
+
+**What it reveals**: alternative framings. Commonly, climbing UP unlocks better solutions; climbing DOWN validates that the user has a concrete need.
+
+**Interactions**: Operates on problem **statements** (framing). Iceberg operates on problem **causation**. Use Laddering BEFORE decomposing — it resets what you're decomposing. Pairs with **Disorder → Classify** loop in `classify-problem.md`.
+
+## Deciding "deep enough"
+
+Stop decomposing when one of these holds:
+
+- You can point at 1-2 branches/causes/rungs where an action would change the outcome
+- The next level of depth isn't actionable (philosophical rather than operational)
+- Budget: 2-3 levels deep is usually enough; 4+ is almost always over-decomposing
+
+Do NOT decompose until exhaustion. The goal is insight, not completeness.
+
+## Fork 2 output
+
+After decomposition, surface:
+
+```
+## Decomposition
+
+Tool used: <Issue Trees / Ishikawa / Iceberg / Abstraction Laddering>
+Rationale: <one sentence why this tool>
+
+<The tree / fishbone / iceberg / ladder inline>
+
+Priority branches (80/20): <the 1-2 marked for Step 3 focus>
+
+Does this decomposition capture the problem? Missing branches? Wrong level of abstraction?
+```
+
+Wait for approval. Common redirects:
+
+- User adds a branch you missed → update the tree + re-identify priorities
+- User says the priorities are wrong → re-apply 80/20 with their context
+- User says the level is off → re-run Abstraction Laddering, then redo the tree
+- User says the tool was wrong → switch tools (rare but legitimate)
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Issue Tree with overlapping branches | Enforce MECE; if you can't, the categorization is off — redo |
+| Ishikawa that's really an Issue Tree | Ishikawa is for multi-category; if all causes cluster in one category, use Issue Trees |
+| Iceberg that stops at "Patterns" | The leverage is at Structures + Mental Models; push deeper |
+| Abstraction Laddering that climbs 4+ rungs | Usually 1-2 is enough; 4+ means the real problem is well away from the stated one (legitimate, but rare) |
+| Decomposing before classifying (skipping Step 1) | Decomposition choice depends on Cynefin domain; run Step 1 first |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/evaluate.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/evaluate.md
@@ -1,0 +1,183 @@
+# Evaluate (Step 4 — Score and Filter)
+
+After generating ≥3 options (Step 3), pick the right evaluation tool based on the decision's **shape**. Use the Hard Choice Model as the classifier; it routes to Decision Matrix, Impact-Effort, Eisenhower, or "just pick."
+
+## Start with the Hard Choice Model
+
+Two dimensions: **impact** (how significant is the outcome?) × **comparability** (how easy to compare options?).
+
+| Impact | Comparability | Quadrant | Approach |
+|---|---|---|---|
+| Low | Easy | **No-brainer** | Pick quickly. Optimizing wastes time. |
+| Low | Hard | **Apples & Oranges** | Pick by current priorities; don't overthink. |
+| High | Easy | **Big Choice** | **Decision Matrix** — factors + weights + scores. |
+| High | Hard | **Hard Choice** | **Decision Matrix** + accept there is no "right" answer; run a cheap experiment if possible. |
+
+**Heuristic**: the bigger the impact, the more carefully you proceed. Use the time and ceremony that the stakes deserve — no more, no less.
+
+## Decision Matrix
+
+**When**: Big Choice or Hard Choice quadrant. Multiple options, multiple factors, factors have different weights.
+
+**Mechanics**:
+
+1. List the options (rows) — from Step 3, usually 3-5.
+2. List the factors (columns) — the things that matter. 3-6 factors.
+3. Assign **weights** to each factor (1-5 or 1-10). Explicit — not gut weighting.
+4. Score each option on each factor (same scale).
+5. Multiply score × weight per cell. Sum rows.
+6. Highest total wins. But also: check confidence per score (see below).
+
+**Output**:
+
+```
+## Decision Matrix
+
+Factors (weights):
+  - Latency (weight 5)
+  - Operational complexity (weight 4, inverted — lower is better)
+  - Cost at current scale (weight 3)
+  - Migration risk (weight 4, inverted)
+
+| Option                    | Latency (5) | OpComplex (4) | Cost (3) | MigRisk (4) | Total |
+|---------------------------|-------------|---------------|----------|-------------|-------|
+| Keep Postgres, tune       | 3 × 5 = 15  | 5 × 4 = 20    | 5 × 3 = 15 | 5 × 4 = 20 | 70 ◄ |
+| Add read-replica          | 4 × 5 = 20  | 3 × 4 = 12    | 4 × 3 = 12 | 4 × 4 = 16 | 60   |
+| Switch to Redis/Dynamo    | 5 × 5 = 25  | 2 × 4 = 8     | 3 × 3 = 9  | 2 × 4 = 8  | 50   |
+
+Confidence notes:
+- Latency scores based on benchmark X (medium confidence — benchmark is 3 months old)
+- MigRisk for Dynamo scored low; unfamiliar with team's DynamoDB experience
+```
+
+**What it reveals**: the option that wins when all factors are made explicit at their true weights. The act of writing weights often changes the pick — "I thought latency was top priority, but when I weighted it I realized migration risk matters more."
+
+**Gotcha**: the first Decision Matrix pass is often wrong. Common fixes:
+
+- **Wrong factors** — revisit; sometimes "team familiarity" or "reversibility" should be a factor
+- **Wrong weights** — commonly the weights were gut-set rather than evidence-set; revisit
+- **Missing factor** — a factor that doesn't differentiate the options is worth including only if it constrains scoring ("must not violate SOC2")
+
+## Impact-Effort Matrix
+
+**When**: prioritization across many items (not picking between 3 options for one decision). Common in sprint planning, backlog grooming, deciding which items in a long list to tackle.
+
+**Axes**: impact (high/low) × effort (high/low). Four quadrants:
+
+| Quadrant | Label | Action |
+|---|---|---|
+| High impact, Low effort | **Quick Wins** | Tackle first. Best ROI. |
+| High impact, High effort | **Major Projects** | Plan and execute after Quick Wins. |
+| Low impact, Low effort | **Fill-ins** | Do in spare time; optional. |
+| Low impact, High effort | **Thankless Tasks** | Avoid. |
+
+**Mechanics**:
+
+1. List candidates.
+2. Per candidate: estimate impact (concretely — what metric moves, by how much?) and effort (developer-days, or relative t-shirt size).
+3. Plot on a 2×2.
+4. Execute in order: Quick Wins → Major Projects → Fill-ins. Never Thankless.
+
+**Output**:
+
+```
+## Impact-Effort Matrix
+
+Quick Wins (do first):
+  - Add retry on 503 → stops a recurring customer complaint (impact H, effort L)
+  - Fix the N+1 in /users/:id → 60ms avg latency drop (impact H, effort L)
+
+Major Projects (plan):
+  - Session-store migration to Redis (impact H, effort H)
+
+Fill-ins (if spare time):
+  - Clean up stale feature flags (impact L, effort L)
+
+Thankless (avoid):
+  - Rewrite the logging module end-to-end (impact L, effort H)
+```
+
+**What it reveals**: where effort turns into return; what to drop.
+
+**Interactions**: Pair with **Eisenhower** for scheduling — Impact-Effort tells you *what* to do; Eisenhower tells you *when*.
+
+## Eisenhower Matrix
+
+**When**: scheduling subsets of the already-prioritized list. Orthogonal to Impact-Effort (which is about what to do); Eisenhower is about when / by whom.
+
+**Axes**: urgency × importance.
+
+| Urgent | Important | Label | Action |
+|---|---|---|---|
+| Yes | Yes | Q1 | **Do it now.** Crises, deadlines. |
+| No | Yes | Q2 | **Schedule it.** Strategic, deep-work. |
+| Yes | No | Q3 | **Delegate it** (if possible). Admin, other-people's-fires. |
+| No | No | Q4 | **Don't do it.** |
+
+**Priority order**: Q1 > Q2 > Q3 > Q4. Q2 is the classic trap — important but not urgent, gets dropped in favor of Q3 urgent-but-not-important noise.
+
+**Mechanics**: same 2×2 assessment per candidate. Then allocate calendar time (or assign owners).
+
+**Output** usually terse — just quadrant per item.
+
+## Second-Order Thinking during evaluation
+
+Decision Matrix captures first-order impact per factor. Second-order effects don't fit neatly into factor weights — they're better surfaced separately during Step 5 (stress-test). BUT: if a factor exists ("long-term maintenance cost"), weight it meaningfully — at least 25% of the total weight. Otherwise, long-term gets drowned out by short-term factors.
+
+Rule of thumb: if you're picking between options with similar short-term scores, the second-order effects (Step 5) will be the tiebreaker.
+
+## Confidence flagging
+
+Every score in a Decision Matrix carries a confidence level. Classify each score as:
+
+- **High confidence** — backed by data, measurement, or direct experience
+- **Medium confidence** — informed judgment; plausible but could be wrong
+- **Low confidence** — guess; worth doing research or a small experiment to raise it
+
+If the winning option's total depends on low-confidence scores, that's a signal to:
+
+1. Spend 30-60 minutes raising the confidence (quick benchmark, lookup, ask someone)
+2. Run a cheap experiment (Hard Choice quadrant exit-ramp)
+3. OR: acknowledge the uncertainty in the Step 6 output contract and pick the option most robust to being wrong on those factors
+
+## Fork 4 output
+
+After evaluation, surface:
+
+```
+## Evaluation
+
+Decision shape (Hard Choice Model): <No-brainer / Apples & Oranges / Big Choice / Hard Choice>
+Tool used: <Decision Matrix / Impact-Effort / Eisenhower / just-pick>
+
+<The matrix inline>
+
+Winner: <option X, total score>
+Runner-up: <option Y, total score>
+Gap: <meaningful / marginal / rounding-error>
+
+Low-confidence scores worth raising:
+- <score with low confidence + what would raise it>
+
+Are the factors + weights right? Anything I'm undervaluing or overvaluing?
+```
+
+Wait for approval or redirect. Common redirects:
+
+- User adjusts a weight → recompute; re-rank; winner may change
+- User adds a factor → recompute
+- User challenges a score → re-evaluate that score with the user's evidence
+- User says "gap is marginal, let's run an experiment" → exit to Hard Choice experiment path (cheap test; define success criteria)
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Running Decision Matrix when Hard Choice is "No-brainer" | Just pick; save the ceremony for High-impact decisions |
+| Decision Matrix with weights all equal to 1 | Weights are the whole point; differentiate them |
+| Factors that don't differentiate options (all get same score) | Drop those factors; they're noise |
+| Scoring as gut feel without confidence flagging | Every score gets a confidence level; low-confidence scores are the ones to improve |
+| Skipping Impact-Effort in favor of Decision Matrix for a backlog | Different tools: Decision Matrix = one decision among options; Impact-Effort = prioritizing many items |
+| Treating Eisenhower's Q3 (delegate) as "skip" | Delegation is a real outcome — name the delegatee, define the handoff |
+| Ignoring the gap size between winner and runner-up | Marginal gap = the Decision Matrix didn't really discriminate; widen the factors or run an experiment |
+| Low-confidence winning score with no plan to raise confidence | Either raise it, run an experiment, or flag in Step 6 output and pick the robust option |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/explore.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/explore.md
@@ -1,0 +1,208 @@
+# Explore (Step 3 — Generate Options)
+
+After decomposition, generate options. The goal is divergent thinking: ≥3 options with rationale, tradeoffs, and each option's Cynefin-fit. Premature convergence is the biggest failure mode here — if the first good-looking option gets selected without alternatives, the session hasn't brainstormed, it's rationalized.
+
+## Pick the generative tool
+
+| Need | Tool |
+|---|---|
+| Perspective diversity — want to see the decision from multiple angles | **Six Thinking Hats** |
+| Reason from foundations — analogy isn't working, problem is novel | **First Principles** |
+| Novel combinations — many dimensions, want to find non-obvious mixes | **Zwicky Box** |
+| System with feedback loops — dynamics matter more than snapshots | See `systems.md` (Connection Circles + Feedback Loops) |
+
+Use ONE primary tool. If the first pass produces <3 meaningful options, switch tools — don't force more options from a tool that's dry.
+
+## Six Thinking Hats
+
+**When**: decisions with stakeholders, tradeoffs, or emotional stakes; need structured perspective-taking before converging.
+
+**Mechanics**: Rotate through six "hats" — each a distinct mental stance. Per hat, generate ideas or observations from that stance only.
+
+| Hat | Stance | Ask |
+|---|---|---|
+| **Blue** | Process | What's our goal here? Are we on track? (Start + end with Blue.) |
+| **White** | Data | What do we actually know? What data is missing? |
+| **Red** | Emotions | Gut reaction? What do I feel about this without justification? |
+| **Yellow** | Positivity | What are the benefits? Best-case scenarios? |
+| **Black** | Downside | What could go wrong? Worst-case scenarios? |
+| **Green** | Creativity | What wild ideas haven't been considered? Let it run free. |
+
+**Order**: Blue → White → Yellow → Black → Green → Red → Blue. Start and end with Blue (orchestration); generate (Green) after risks (Black) so creativity isn't pre-filtered; Red last so emotions don't anchor analysis.
+
+**Time-box**: 1-3 minutes per hat for a compact brainstorm; longer for deeper sessions.
+
+**Output** (what to surface):
+
+```
+## Six Hats pass
+
+Blue: Goal is X. Constraint is Y.
+White: Data says A, B, C. We don't know D.
+Yellow: If it works, we get <benefits>.
+Black: Risks: <fail modes>.
+Green: Wild options: <unfiltered>.
+Red: Gut: feels <honest reaction>.
+Blue: Close. The options that survive are <list>.
+```
+
+**What it reveals**: blind spots a single-perspective analysis misses. Yellow hat particularly catches "this option has upside we underweighted"; Black hat catches "this option has a risk we glossed over."
+
+**Interactions**: Pair Green with **Zwicky Box** when Green gets stuck. Pair Black with **Inversion** (Step 5) — both are downside-focused, but Black is mid-brainstorm, Inversion is post-decision.
+
+## First Principles
+
+**When**: the problem is novel, analogies from past work are failing, you suspect you're carrying assumptions you haven't examined.
+
+**Mechanics**:
+
+1. State the problem.
+2. Recursively ask **"Why?"** or **"What's beneath this?"** until you hit a truth that can't be broken down further — a "first principle".
+3. Separate: what do we *actually know* is true (physics, math, constraints, hard data) from what we *assume* is true (convention, analogy, inherited belief).
+4. Rebuild the solution from the first principles only. What does the evidence plus the hard constraints force?
+
+**Socratic questions** to push down the ladder:
+
+- Clarification: "What do you mean by X?"
+- Probing assumptions: "What could we assume instead?"
+- Probing reasons: "Why do you think this is true?"
+- Implications: "What effect would that have?"
+- Alternative viewpoints: "Is there another way to see this?"
+- Questioning the question: "What was the point of asking this?"
+
+**Output**:
+
+```
+## First Principles breakdown
+
+Problem: <the stated problem>
+
+Layer 1 (why): <immediate cause/reason>
+Layer 2 (why): <upstream cause>
+Layer 3 (why): <foundational constraint>
+Layer 4 (why): <physical/mathematical/hard truth>  ← first principle
+
+Assumptions we carried (not first principles):
+- <assumption 1> — actually a convention from <source>
+- <assumption 2> — actually an inherited belief
+
+Rebuild:
+Given only the first principles and the hard constraints, the solution space is:
+<list of options, including ones the assumptions would have ruled out>
+```
+
+**What it reveals**: assumptions masquerading as constraints. Classic outcome: an option the team "couldn't do" turns out to be ruled out only by convention.
+
+**Interactions**: Use on a priority branch from the decomposition (Step 2) — not the whole problem, which is too broad. Pairs with **Ladder of Inference** (Step 5) — both audit the reasoning chain, but First Principles generates, Ladder of Inference stress-tests.
+
+## Zwicky Box (Morphological Analysis)
+
+**When**: a problem with multiple independent dimensions; want to generate novel whole-system solutions, not just tweaks.
+
+**Mechanics**:
+
+1. Name 3-5 **dimensions** — logically independent attributes of the solution. (For an app: target audience, main function, unique feature, delivery method, revenue model.)
+2. Per dimension, list 3-6 **values**. Don't filter — include implausible ones; they combine usefully.
+3. Build the matrix (dimensions × values).
+4. Generate **combinations**: pick one value per column. Try 3-5 systematic combinations + 2-3 random combinations.
+5. Evaluate each combination as a whole solution; discard the ones that clearly don't work, keep the surprising ones.
+
+**Output**:
+
+```
+## Zwicky Box
+
+Problem: <problem>
+
+Dimensions:
+| Target audience | Delivery | Timing | Incentive | Format |
+|---|---|---|---|---|
+| Free users | Email | Weekly | None | Text |
+| Paid users | In-app banner | Monthly | Discount | Video |
+| Enterprise | Push notification | On event | Early access | Live workshop |
+| Churned users | Sales call | One-shot | Credits | Mixed |
+
+Combinations:
+1. Churned users + Email + On event + Credits + Video
+   → Personalized win-back with usage-credit for the re-engagement.
+
+2. Enterprise + In-app banner + Weekly + Early access + Text
+   → Power-user feature announcement stream.
+
+3. Free users + Sales call + One-shot + Early access + Live workshop
+   → Freemium-to-paid conversion via white-glove workshop; unusual but might work.
+
+[3-5 more combinations]
+```
+
+**What it reveals**: non-obvious whole-system combinations. Great for breaking out of "we've always done it this way" defaults.
+
+**Interactions**: Downstream of **First Principles** — Zwicky Box explores the solution space that First Principles opens up. Pair with **Decision Matrix** (Step 4) to score combinations.
+
+## What "≥3 options" means
+
+Not 3 minor variations on the same theme. Each option:
+
+- **Labeled** (1-5 words)
+- **Grounded** in a different framework or different priority branch
+- **Distinguishable** in at least one meaningful dimension (risk profile, reversibility, time cost, team fit)
+- **Fits a Cynefin domain** — note which option suits which domain
+
+Example of bad options (all same):
+
+```
+1. Use Postgres with connection pooling
+2. Use Postgres with a different connection pool size
+3. Use Postgres with tuned connection timeouts
+```
+
+Example of good options (distinct):
+
+```
+1. Keep Postgres; tune the connection pool + add a retry layer (Complicated — known-unknown)
+2. Introduce a read-replica for the hot-read path (Complicated — different architecture decision)
+3. Switch to a session-store that matches the access pattern (Redis/DynamoDB) (Complex — probe first with shadow traffic)
+```
+
+## Fork 3 output
+
+After explore, surface:
+
+```
+## Options explored
+
+Tool(s) used: <Six Hats / First Principles / Zwicky Box / Connection Circles>
+
+Option A: <label>
+  Rationale: <2-3 sentences>
+  Tradeoff: <key tension>
+  Suits: <Cynefin domain>
+
+Option B: <label>
+  ...
+
+Option C: <label>
+  ...
+
+[Optional: Option D, E if the generative tool produced them]
+
+Which of these resonates? Should I expand one, drop one, add a new one, or widen the search with a different tool?
+```
+
+Wait for approval or redirect. Common redirects:
+
+- User wants to add a new option → generate it + add to the list
+- User wants to kill an option as non-starter → remove + rebalance (need to get back to ≥3)
+- User wants to expand one option into sub-options → recurse into that option with the same or a different generative tool
+- User wants a wider search → switch generative tool (e.g. from Six Hats to Zwicky Box)
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Three options that are minor variations of the same idea | Switch generative tool; the current tool is dry |
+| Presenting one strong option + two weak ones for illusion of choice | Hold yourself to ≥3 meaningfully different options; weak straw-men defeat the session |
+| Skipping Six Hats because "we already know the tradeoffs" | Run it anyway for 3 minutes. Yellow/Black/Green commonly surface something missed |
+| First Principles that never hits a hard constraint | Keep asking "why?" — if 4 layers in, you're still at assumptions, you haven't reached first principles |
+| Zwicky Box with 8+ dimensions | Combinatorial explosion; cap at 5 dimensions. Merge or drop dimensions that aren't actually independent |
+| Forgetting to tag each option's Cynefin-fit | The fit informs Step 4 (evaluation); missing it makes scoring harder |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/interaction-patterns.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/interaction-patterns.md
@@ -1,0 +1,187 @@
+# Interaction Patterns — How to Bring the User Along
+
+The skill's whole premise is "user in the loop." This file is the how-to: when to pause, how to phrase questions, when to push back on a user who wants to shortcut a fork, and the "one question at a time" discipline.
+
+## The five forks (recap)
+
+Every interactive session pauses five times, one per step:
+
+| Fork | After | User answers |
+|---|---|---|
+| Fork 1 | Step 1 (Classify) | Cynefin domain correct? Route right? |
+| Fork 2 | Step 2 (Decompose) | Decomposition captures the problem? Branches missing? |
+| Fork 3 | Step 3 (Explore) | Options resonate? Add / drop / expand? |
+| Fork 4 | Step 4 (Evaluate) | Factors + weights right? Anything over- or under-weighted? |
+| Fork 5 | Step 5 (Stress-test) | Blind spots change the pick? Loop back? |
+
+No more, no fewer. Combining forks reduces user control; splitting them into more produces friction.
+
+## One question at a time
+
+When asking **open-ended** questions in a session, bundle only when the questions are truly parallel (choices along different dimensions). If a topic needs more exploration, split into multiple questions across messages.
+
+**Good** (one per message):
+
+```
+Before I propose options, I want to make sure I have the right problem.
+You mentioned "users aren't adopting the feature." Is the measure:
+  (a) zero-use since release, OR
+  (b) initial use but no return?
+```
+
+**Bad** (multi-topic in one message):
+
+```
+Before I propose options, I want to understand: what's the user
+segment? What's your success metric? What's the timeline? What
+competitors have tried? What's the budget?
+```
+
+The user picks one to answer and ignores the rest. Four of five questions go unanswered; session loses depth.
+
+## Multiple-choice via the ask-user tool
+
+When the question has **discrete choices**, use the runtime's ask-user tool (see `cross-runtime.md`). Rules:
+
+- **Up to 4 questions per call** — AskUserQuestion's cap; keep portable
+- **2-4 options per question** — structured; more is noise
+- **First option marked `(Recommended)`** based on your analysis (not always the same option)
+- **"Other" auto-provided** — don't add manually
+
+Multiple-choice is faster for the user to answer and more accurate to capture — they pick rather than type. Use it for:
+
+- Cynefin classification questions (Step 1)
+- Decomposition-tool selection ("This looks like a root-cause problem — Issue Tree or Ishikawa?")
+- Option-prioritization questions ("Which of these three resonates?")
+- Evaluation-factor weighting ("Is latency or operational-simplicity more important?")
+
+Don't use multiple-choice for questions where the answer is prose:
+
+- "Tell me about the current architecture" — open-ended
+- "What's the history of this problem?" — open-ended
+- "What would failure look like to you?" — open-ended
+
+Rule of thumb: if options A/B/C/D cover the answer space, use the tool. If the user needs to explain something, use a direct prompt.
+
+## Phrasing questions
+
+**Good** question framing:
+
+- Names the decision explicitly: "Before I move to Step 3, I need to confirm the decomposition."
+- Names what would make the answer useful: "The option labels below are drafts — I want to know which resonate so I can expand those."
+- Names the consequence of the answer: "If we pick Option A, we lock into Postgres; if Option C, we're exploring a switch."
+
+**Bad** question framing:
+
+- Vague: "Thoughts?"
+- Leading: "Option A is clearly the best, right?" (pre-filters the user's judgment)
+- Multi-layer: "I'm thinking X because Y given Z unless you think W, so what do you want to do?"
+
+## Pausing vs. surfacing
+
+Pause at forks. Surface the rest of the time.
+
+**Surfacing** = you produce output continuously — the decomposition tree, the options list, the evaluation matrix. The user sees what you're doing without being asked.
+
+**Pausing** = you stop and wait for the user at fork points. The fork message explicitly names the decision.
+
+Do NOT surface silently (no output until final) — the user can't redirect.
+Do NOT pause continuously (one question per minor choice) — the user gets fatigued.
+
+## When the user wants to skip a fork
+
+Common: the user says "just pick Option B, move on." Or: "skip the stress-test, I'm fine with it."
+
+**The response** depends on which fork:
+
+| Fork | Skip-request response |
+|---|---|
+| Fork 1 (Classify) | **Refuse skip**. The classification is load-bearing; picking frameworks without it is operating blind. Say: "Let me get 30 seconds of classification; it changes which tools we use." |
+| Fork 2 (Decompose) | **Compress, don't skip**. Present decomposition as 3 bullets, ask for y/n to move on. |
+| Fork 3 (Explore) | **Compress, don't skip**. Show options as 1-liner each; ask "any missing?" in one message. |
+| Fork 4 (Evaluate) | **Compress, don't skip**. Show the matrix; ask "any weights wrong?" |
+| Fork 5 (Stress-test) | **Refuse skip** if the decision has reversibility-cost > "fully reversible." Skipping stress-test on irreversible decisions is the skill failing. |
+
+If the user pushes hard after a refuse-skip: comply, but explicitly flag in the output contract that the fork was skipped. "Note: Step 5 was skipped at user request; this recommendation has not been pre-mortemed."
+
+## The compression discipline
+
+Sometimes the user is time-pressed. Each fork has a compressed form:
+
+**Compressed Fork 1** (Classify):
+```
+Reading this as <domain> because <short rationale>. OK to proceed? (y/n)
+```
+
+**Compressed Fork 2** (Decompose):
+```
+Decomp: <3-bullet summary>. Priority: <1-2 branches>. Anything missing? (yes/no)
+```
+
+**Compressed Fork 3** (Options):
+```
+Options: A <label>, B <label>, C <label>. Which to focus on? (A/B/C/expand X/widen search)
+```
+
+**Compressed Fork 4** (Evaluate):
+```
+Matrix winner: <Option X, score>. Confidence: <H/M/L>. Want to challenge a weight? (y/n)
+```
+
+**Compressed Fork 5** (Stress-test):
+```
+Inversion + Ladder + Second-Order: pick <unchanged / changed to X>. Concerns: <list>. Proceed? (y/n)
+```
+
+Use compressed forms when:
+- The user explicitly asks for compression
+- The session has been running long and pacing needs to pick up
+- The decision is low-impact (No-brainer or Apples-&-Oranges in Hard Choice terms)
+
+## YAGNI discipline — cut what doesn't serve
+
+Borrowed from obra/brainstorming: **YAGNI ruthlessly**. Every option, every weight, every factor, every branch in the decomposition — if you can't defend its presence, drop it.
+
+Signs of YAGNI violation:
+
+- Option that's listed because "it could be considered" — no active proponent
+- Factor in the Decision Matrix that doesn't discriminate (all options score the same) — drop it
+- Branch in the Issue Tree that's there because MECE required it but has no priority — note it exists, don't recurse into it
+- Second-order effect that's purely speculative — drop it; every listed effect needs a chain of "and then what"
+
+YAGNI makes the output shorter. Shorter output is easier for the user to evaluate at each fork.
+
+## Pushback patterns
+
+When the user says something that's operationally wrong:
+
+- Wrong framework for the problem → push back with the right framework's name + one-line rationale
+- Wrong classification → re-run the 3-question classifier with the user's new information
+- Picking an option the evaluation ruled out → ask what evidence they're weighting that the matrix missed; revisit the matrix
+- Skipping a fork on an irreversible decision → refuse politely (see above)
+
+Pushback is technical, not oppositional. Frame: "The evaluation has Option A at 70, Option B at 68 — a 2-point gap is inside the rounding error. We can ship Option B if you prefer; I want to flag the Decision Matrix didn't really discriminate."
+
+## When the user is silent
+
+If the user doesn't answer a fork (tool timeout, conversation paused for a long time, etc.):
+
+- Do NOT silently pick an answer
+- Do NOT loop asking the same question
+- Resume by surfacing a **compressed, one-message** version of the fork: "Still waiting on the <fork N> decision. Compressed: <options>. <specific question in one sentence>."
+- If no answer after that, state you'll hold the fork open and offer to resume when the user is back
+
+Never fabricate an answer.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Asking 5 questions in one message | One question per message for open-ended; bundle only multiple-choice via the ask-user tool |
+| Leading questions ("Option A is best, right?") | Neutral framing; let the user answer without anchor |
+| Silently resolving a fork | Always pause at forks; compressed if pressed, never skipped if irreversible |
+| Not using the ask-user tool for discrete choices | Tool is faster + more accurate for structured questions |
+| Over-pausing (question per minor choice) | 5 forks total; micro-forks inside steps are unnecessary |
+| Forbidden phrases ("you're absolutely right", "thanks for the great question") | Delete; actions speak. Technical correctness > social softening |
+| Refusing to compress when the user is time-pressed | Compress the surfacing; keep the fork itself |
+| Stopping at the final output without an explicit user question | Every session ends with a named question at a concrete fork |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/meta.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/meta.md
@@ -1,0 +1,102 @@
+# Meta — When the Session Itself Needs Adjustment
+
+Three frameworks for meta-level decisions about the brainstorm session itself — pacing (OODA), structuring ideation with execution plan (Productive Thinking Model), and deciding whether to prioritize speed or quality in the output (Confidence-determines-Speed-vs-Quality).
+
+Most sessions won't touch this file. Reach for it when:
+
+- The session is dragging and decisions aren't emerging fast enough (OODA)
+- You need an end-to-end path from ideation to execution plan, not just a recommendation (Productive Thinking Model)
+- You're brainstorming how to BUILD something and need to decide MVP-vs-v1 (Confidence framework)
+
+## OODA Loop
+
+**When**: the session is in a rapidly changing environment, or decisions need to happen faster than analysis can complete. Competitor just shipped; incident is unfolding; user feedback is coming in faster than you can parse.
+
+**The four steps** (cycled continuously, not once):
+
+1. **Observe** — gather available information. Situational context, external data, feedback from previous cycles. Speed matters because data can become obsolete.
+2. **Orient** — analyze and synthesize. Consider options. Leverage experience. Challenge the status quo. Consider others' perspectives.
+3. **Decide** — select a course of action. Treat it as a **hypothesis you'll test by acting**, not a final commitment.
+4. **Act** — implement to test whether the observations and decision were accurate. Feedback feeds the next Observe.
+
+**Key principle**: the advantage is the **tempo of the loop**, not any single decision. Running OODA faster than the environment changes gives you unpredictability — your next move is hard for adversaries / competitors / complexity to anticipate.
+
+**Application to the brainstorm**:
+
+- If the session keeps looping back to Step 2 because new info keeps arriving, use OODA: acknowledge it's a Complex-domain problem, commit to faster cycles, ship smaller decisions and learn
+- If the session is exploring something where the "market" shifts weekly (e.g., LLM tooling), plan for OODA cycles explicitly in the recommended next step — "decide on first version, ship, observe for 2 weeks, re-brainstorm"
+
+**Interactions**: OODA complements Cynefin — Cynefin classifies the domain, OODA is the cadence for Complex domain decisions. OODA is NOT a decision method (for that, see `evaluate.md`); it's the tempo structure around the method.
+
+## Productive Thinking Model (Tim Hurson)
+
+**When**: the brainstorm needs to produce a full **execution plan** with success criteria, catalytic questions, and resource allocation — not just a recommendation.
+
+**The six steps**:
+
+1. **What's going on?** Explore the problem's nature: impact, knowledge, parties involved, target future state.
+2. **What's success?** Define success via the **DRIVE** framework:
+   - **D** — what the solution must **D**o
+   - **R** — **R**estrictions
+   - **I** — **I**nvestable resources (time, money, people)
+   - **V** — **V**alues that must be upheld
+   - **E** — **E**ssential outcomes
+3. **What's the question?** Generate "catalytic questions" phrased as **"How might we…?"** These frame the solution space.
+4. **Generate answers.** Brainstorm potential solutions to the HMW questions. This is where Steps 3-4 of our skill's workflow (Explore + Evaluate) would normally fire.
+5. **Forge the solution.** Evaluate candidates against the DRIVE criteria. Use Decision Matrix for scoring.
+6. **Align resources.** Document necessary actions, resources, and responsibility assignments for execution.
+
+**Application to the brainstorm**:
+
+- Use Productive Thinking when the session's end-state is a plan, not just a decision
+- DRIVE (Step 2 above) is a stronger success-criteria frame than generic "what does success look like?" — use it when stakes are high or stakeholders are multiple
+- "How might we…?" questions from Step 3 above feed directly into Step 3 (Explore) of our workflow — use HMW phrasing when generating options
+
+**Interactions**: Productive Thinking wraps around our workflow — its Step 1-2 precede our Step 1 (Cynefin); its Step 6 (align resources) extends our Step 6 (Communicate). If the user asks for "the full plan, not just the decision," adopt Productive Thinking's frame.
+
+## Confidence-Determines-Speed-vs-Quality
+
+**When**: brainstorming what to BUILD (product, feature, system) and the decision "ship the MVP or build the right thing first" needs to be explicit.
+
+**The two axes**:
+
+1. **Confidence in problem importance** — do you genuinely understand the problem's significance? How many users feel it? How much pain?
+2. **Confidence in solution correctness** — does your proposed solution actually solve the problem? Is there a better one you haven't found?
+
+**Decision matrix**:
+
+| Problem confidence | Solution confidence | Posture |
+|---|---|---|
+| Low | Any | **Focus on speed.** Ship the cheapest possible experiment; learn fast. |
+| High | Low | **Balance speed + quality.** Iterate, but with rigor. |
+| High | High | **Focus on quality.** Invest in the build. The certainty earns the time. |
+
+**Key note**: confidence is a scale, not binary. Outcomes are graded. "Moderately high problem, low solution" → lean toward speed.
+
+**Application to the brainstorm**:
+
+- When the recommendation involves building something, add a "posture" section: speed-first, balanced, or quality-first
+- If posture is "speed-first," the recommended next step should be a cheap experiment (hours-to-days), not a full build
+- If posture is "quality-first," name the evidence that justifies the certainty — future-you will want to verify the confidence was earned
+
+**Interactions**: Plays with Hard Choice Model (`evaluate.md`) — Hard Choice's "High impact, hard compare, run a cheap experiment" aligns with Confidence's "Low solution confidence → speed-focused experiment." The frameworks converge on: when in doubt, experiment cheaply before investing.
+
+## When to consult this file
+
+Most sessions don't need this file. Signals to reach for it:
+
+| Signal | Framework |
+|---|---|
+| Session pacing feels wrong — dragging or shallow | OODA — check if the cycle time is mismatched to the environment |
+| User wants a full plan, not a decision | Productive Thinking Model — wrap our workflow with DRIVE + resource alignment |
+| Deciding what to build at what depth | Confidence-Speed-Quality — surface the posture explicitly |
+| Session covered a week-to-ship vs. month-to-ship argument | Confidence framework + Hard Choice Model — make the experiment vs. commit call |
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Using OODA as a decision method | OODA is a cadence, not a method; use it around methods in `evaluate.md` |
+| Productive Thinking's DRIVE not applied because "success is obvious" | Run it anyway; surfaces resource and value constraints that get missed |
+| Skipping Confidence framework on build decisions | Build decisions always benefit from the posture call; surface it even if briefly |
+| Treating Confidence as binary (shipped vs. not) | It's graded; name the confidence level (Low/Med/High) with evidence |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/output-format.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/output-format.md
@@ -324,8 +324,8 @@ Above 3,000 words, the brainstorm is probably too large — re-scope to a sub-pr
 - **Bulleted lists** for assumptions, blind spots, options
 - **Bold** for section headlines (`**Option A:**`)
 - **Italic** for emphasis within prose
-- Backticks for framework names on first reference (``` `Six Thinking Hats` ```)
-- Backticks for skill names (``` `build-skills` ```)
+- Backticks for framework names on first reference — use a single pair of backticks (for example, `Six Thinking Hats`)
+- Backticks for skill names (for example, `build-skills`)
 - Inline citations use `file:line` format when referencing code
 
 ## Anti-patterns

--- a/skills/do-brainstorm/skills/do-brainstorm/references/output-format.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/output-format.md
@@ -1,0 +1,342 @@
+# Output Format — The Required Structure
+
+Every session produces this exact section order. Missing any section means the brainstorm is incomplete. This file is the template; `communicate.md` covers the voice.
+
+## Contents
+- [Section order (required)](#section-order-required)
+- [Per-section rules](#per-section-rules) — templates for all 10 sections
+- [Mode differences](#mode-differences) — Interactive vs. One-shot
+- [Length budgets](#length-budgets) — target word count by problem size
+- [Formatting conventions](#formatting-conventions) — tables, code blocks, emphasis
+- [Anti-patterns](#anti-patterns) — common failure modes and fixes
+
+## Section order (required)
+
+```markdown
+# <Brainstorm topic>
+
+## Approach
+## Problem shape (Cynefin)
+## Decomposition
+## Options explored
+## Evaluation
+## Assumptions
+## Blind spots
+## Second-order effects
+## Ranked summary
+## Recommended next step
+```
+
+Ten sections. In this order. For interactive mode, sections emit progressively (after each workflow step). For one-shot mode, the full document emits at the end.
+
+## Per-section rules
+
+### 1. Approach
+
+**Length**: 2-4 sentences. Never more than 80 words.
+
+**Content**: chosen frameworks + one-sentence rationale per. The Minto headline — a reader skimming only this and the Ranked summary should still get the right answer.
+
+**Template**:
+
+```markdown
+## Approach
+
+Chosen frameworks: <framework 1>, <framework 2>, <framework 3>.
+Why: <framework 1> for <reason>, <framework 2> for <reason>, <framework 3> for <reason>.
+Cynefin domain: <domain>. Output mode: <Interactive | One-shot>.
+```
+
+**Example**:
+
+```markdown
+## Approach
+
+Chosen frameworks: Cynefin (for classification), Issue Trees (to decompose the root-cause chain), Six Thinking Hats (for perspective diversity on options), Decision Matrix (to compare three architectural paths). Cynefin domain: Complicated. Output mode: Interactive.
+```
+
+### 2. Problem shape (Cynefin)
+
+**Length**: 3-5 lines.
+
+**Content**: the domain + the evidence from Step 1's classifier answers.
+
+**Template**:
+
+```markdown
+## Problem shape (Cynefin)
+
+Domain: <Clear | Complicated | Complex | Chaotic | Disorder>
+Q1 (shape): <user's answer>
+Q2 (cause-effect): <user's answer>
+Q3 (reversibility): <user's answer>
+
+Rationale: <one-sentence why this domain>
+```
+
+### 3. Decomposition
+
+**Length**: scale to complexity. 10-30 lines for most problems; up to 60 for genuinely complex ones.
+
+**Content**: the tree / fishbone / iceberg / ladder from Step 2, with priority markers.
+
+**Template**:
+
+```markdown
+## Decomposition
+
+Tool: <Issue Trees | Ishikawa | Iceberg Model | Abstraction Laddering | Connection Circles | Concept Map>
+
+<The tool's output inline — tree, fishbone, iceberg levels, ladder, or circle>
+
+Priority branches / levels: <the 1-2 marked for focus>
+```
+
+Use markdown lists for trees, markdown tables for matrices, or fenced code blocks for ASCII diagrams. Keep text — no external image files.
+
+### 4. Options explored
+
+**Length**: 1 paragraph per option + label. Minimum 3 options.
+
+**Content**: each option has a label, rationale, tradeoff, and Cynefin-fit.
+
+**Template**:
+
+```markdown
+## Options explored
+
+Tool used: <Six Thinking Hats | First Principles | Zwicky Box | Connection Circles>
+
+**Option A: <label>**
+- Rationale: <2-3 sentences>
+- Key tradeoff: <what is given up>
+- Cynefin-fit: <domain this option suits best>
+
+**Option B: <label>**
+- Rationale: <...>
+- Key tradeoff: <...>
+- Cynefin-fit: <...>
+
+**Option C: <label>**
+- Rationale: <...>
+- Key tradeoff: <...>
+- Cynefin-fit: <...>
+
+[Optional: D, E if the generative tool produced them]
+```
+
+### 5. Evaluation
+
+**Length**: the matrix + rationale — usually 15-30 lines.
+
+**Content**: Decision Matrix (or Impact-Effort / Eisenhower / No-brainer note) with scores, weights, and confidence flags.
+
+**Template** (Decision Matrix case):
+
+```markdown
+## Evaluation
+
+Decision shape (Hard Choice Model): <quadrant>
+Tool: <Decision Matrix | Impact-Effort | Eisenhower | just-pick>
+
+Factors (weights):
+| Factor | Weight | Rationale for weight |
+|---|---|---|
+
+Scoring:
+| Option | Factor 1 | Factor 2 | Factor 3 | Total |
+|---|---|---|---|---|
+
+Winner: <Option X, total>
+Runner-up: <Option Y, total>
+Gap: <meaningful | marginal | rounding-error>
+
+Low-confidence scores:
+- <score + what would raise confidence>
+```
+
+### 6. Assumptions
+
+**Length**: bulleted list, 3-8 items typically.
+
+**Content**: load-bearing assumptions the recommendation depends on. Surface the ones that, if wrong, would change the pick.
+
+**Template**:
+
+```markdown
+## Assumptions
+
+- <assumption 1 — what is taken as true>
+- <assumption 2>
+- <assumption 3>
+```
+
+Rules:
+- One assumption per bullet
+- Each assumption is checkable (specific, not vague)
+- Flag which assumptions are highest-risk (asterisk or "high-risk:" prefix)
+
+**Example**:
+
+```markdown
+## Assumptions
+
+- Team has one engineer with Dynamo experience
+- Current Postgres instance will scale to 3x traffic without hardware upgrade
+- Latency regression of >200ms on hot paths is unacceptable  *
+- * high-risk: user threshold for latency not empirically validated
+```
+
+### 7. Blind spots
+
+**Length**: bulleted list, 2-5 items typically.
+
+**Content**: what the process likely missed. What a different framework or perspective would have surfaced.
+
+**Template**:
+
+```markdown
+## Blind spots
+
+- <what the process likely missed>
+- <what a different tool would have caught>
+- <bias in the option generation>
+```
+
+**Rules**:
+- Be specific about the missed thing, not generic "we might have missed something"
+- Name the alternative framework that would have caught it, if known
+
+**Example**:
+
+```markdown
+## Blind spots
+
+- No option considered a hybrid (read-replica + cache). Zwicky Box would have surfaced it; we used Six Thinking Hats which stayed on clean alternatives.
+- Operational cost at scale unknown beyond current traffic; no factor captures scaling cost over 12 months.
+- Vendor lock-in risk for option C mentioned in Black hat but not scored in Decision Matrix.
+```
+
+### 8. Second-order effects
+
+**Length**: 6-12 lines.
+
+**Content**: both the consequence chain AND the timeline analysis from Step 5.
+
+**Template**:
+
+```markdown
+## Second-order effects
+
+Consequence chain:
+  Immediate: <first-order>
+  → Next: <second-order>
+  → Next: <third-order — often diminishing clarity>
+
+Timeline:
+  - 10 minutes: <operational effect>
+  - 10 months: <quarter-level impact>
+  - 10 years: <strategic consequence>
+
+Surprising effects:
+- <effect that changes the pick or requires mitigation>
+```
+
+### 9. Ranked summary
+
+**Length**: the table + optional notes.
+
+**Content**: options ranked by total score with confidence. This is the Minto conclusion restated near the end of the document.
+
+**Template**:
+
+```markdown
+## Ranked summary
+
+| # | Option | Score / Rationale | Confidence | Notes |
+|---|---|---|---|---|
+| 1 | <Option X> | <score + 1-line rationale> | <H/M/L> | <caveat or mitigation> |
+| 2 | <Option Y> | <score + 1-line> | <H/M/L> | <caveat> |
+| 3 | <Option Z> | <score + 1-line> | <H/M/L> | <caveat> |
+
+Confidence flags: <any scores that warrant follow-up>
+```
+
+### 10. Recommended next step
+
+**Length**: 2-4 sentences + an explicit question.
+
+**Content**: concrete action (a skill to invoke, a command to run, a decision to make) + the explicit user question at the next fork.
+
+**Template**:
+
+```markdown
+## Recommended next step
+
+<Concrete next action — a skill to invoke, a command, a specific decision>.
+
+**Your input needed on:** <specific question at the next fork>.
+```
+
+**Example**:
+
+```markdown
+## Recommended next step
+
+Proceed with Option A (keep Postgres + tune pool + add retry layer). Use `build-skills` to draft the implementation plan, or create a GitHub Issue via `run-issue-tree` with the three sub-tasks (pool tuning, retry module, monitoring). Budget: ~5 engineer-days.
+
+**Your input needed on:** Should I open the issue tree now, or do you want to raise confidence on the latency-regression threshold first with a 2-hour benchmark?
+```
+
+## Mode differences
+
+### Interactive mode
+
+Sections emit **progressively**, each after its workflow step:
+
+- After Step 1 → Approach + Problem shape
+- After Step 2 → Decomposition
+- After Step 3 → Options explored
+- After Step 4 → Evaluation
+- After Step 5 → Assumptions + Blind spots + Second-order effects
+- After Step 6 → Ranked summary + Recommended next step
+
+Each fork gives the user a chance to redirect. The final output is reassembled into the full 10-section document.
+
+### One-shot mode
+
+All 10 sections emit as **one document**, post-Step 5, no interim pauses. The user reviews the full document and responds once. Use this mode only when the user explicitly asks for a deliverable without mid-session involvement.
+
+## Length budgets
+
+| Problem size | SKILL.md output total |
+|---|---|
+| Small (No-brainer, Apples & Oranges) | 300-600 words |
+| Medium (Big Choice) | 600-1,500 words |
+| Large (Hard Choice, Complex domain) | 1,500-3,000 words |
+
+Above 3,000 words, the brainstorm is probably too large — re-scope to a sub-problem.
+
+## Formatting conventions
+
+- **Tables** for matrices, ranked lists, and scoring
+- **Code blocks** for ASCII diagrams, trees, iceberg levels
+- **Bulleted lists** for assumptions, blind spots, options
+- **Bold** for section headlines (`**Option A:**`)
+- **Italic** for emphasis within prose
+- Backticks for framework names on first reference (``` `Six Thinking Hats` ```)
+- Backticks for skill names (``` `build-skills` ```)
+- Inline citations use `file:line` format when referencing code
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Sections out of order | Follow the 10-section order exactly; it's Minto-structured for skimmability |
+| Combined sections ("Assumptions and blind spots") | Keep separate; they catch different failure modes |
+| Missing "Second-order effects" section | Required — Step 5 always runs; always surface results |
+| "Recommended next step" that says "consider..." | Concrete action only — a skill, a command, or a specific decision |
+| Ranked summary without confidence column | Confidence is required for prioritizing which scores to raise |
+| Options section with <3 options | Minimum 3; if Step 3 produced fewer, go back and widen the generative tool |
+| Vague assumptions ("the team is capable") | Checkable: "team has ≥1 engineer with Dynamo experience" |
+| Blind spots section that reads "we might have missed things" | Name the specific thing missed and the tool that would have caught it |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/stress-test.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/stress-test.md
@@ -1,0 +1,229 @@
+# Stress-Test (Step 5 — Blind Spots and Second-Order)
+
+Step 5 is not optional. Every session runs all three tools: Inversion, Ladder of Inference, Second-Order Thinking. Skipping it converts the brainstorm from "rigorous exploration" to "prettier rationalization of the first plausible option." The whole point of the skill is that Step 5 sometimes changes the pick.
+
+## Always run all three
+
+Each tool catches a different failure mode:
+
+| Tool | Catches |
+|---|---|
+| **Inversion** (pre-mortem) | Failure paths the Yellow/Green hat optimism hid |
+| **Ladder of Inference** | Jumped reasoning, skipped evidence, treated interpretation as fact |
+| **Second-Order Thinking** | Long-term consequences hidden by short-term optimization |
+
+## Inversion — Pre-mortem
+
+**Core idea**: imagine the chosen option failed badly in 6-12 months. Work backward to find why.
+
+**Mechanics**:
+
+1. Assume the winning option shipped. Assume it's 6-12 months later.
+2. Premise: "The project failed. What went wrong?"
+3. Generate 5-10 plausible failure modes. Don't self-censor — weird ones count.
+4. For each failure mode: rate likelihood (H/M/L) and severity (H/M/L).
+5. For High likelihood × High severity: surface a **mitigation** baked into the plan.
+6. For the rest: name as watch-items, not mitigations. (Spending on every risk is over-insurance.)
+
+**Diagnostic prompts**:
+
+- "How could this go wrong?"
+- "What would the opposite approach look like?"
+- "What characterizes a poor solution in this space?"
+- "What assumptions is this option betting on? Which of those are false?"
+
+**Output**:
+
+```
+## Inversion (Pre-mortem)
+
+Imagine: 9 months from now, <winning option> has failed. What went wrong?
+
+Failure modes (likelihood × severity):
+1. Team lost the one engineer who understood the new stack          (M × H) — mitigate: onboard 2 engineers during Phase 1
+2. Latency regression under 10x load not caught pre-prod            (M × H) — mitigate: load test in staging, not prod
+3. Vendor lock-in on the managed service became painful at scale    (L × M) — watch-item, not mitigate
+4. Migration ran longer than estimated; support tickets piled up    (H × M) — mitigate: phased rollout with rollback gates
+5. Second-order: caused a downstream service to miss its SLO        (L × H) — surface to the downstream team
+```
+
+**What it reveals**: failure paths the Yellow hat's optimism skipped. Classic save: finds a "how could we have missed this?" that's cheap to prevent now, expensive to fix later.
+
+**Interactions**: Black Hat in Six Thinking Hats is mid-brainstorm; Inversion is post-decision. Both downside-focused but Inversion has teeth because the option is already chosen.
+
+## Ladder of Inference — Reasoning Audit
+
+**Core idea**: trace how you got from raw data to this recommendation. Every rung is a chance to have jumped incorrectly. Climb down (to the evidence), then climb back up (deliberately).
+
+**The seven rungs** (bottom-up):
+
+1. **Available data** — all data that could have been relevant
+2. **Selected data** — what you actually looked at
+3. **Interpretations** — what you made the selected data mean
+4. **Assumptions** — what you took as given to reach those interpretations
+5. **Conclusions** — what the assumptions + interpretations led to
+6. **Beliefs** — the ongoing principles that conclusions reinforce
+7. **Actions** — the recommendation you're about to make
+
+**Diagnostic questions per rung** (climb down):
+
+- Actions: *Why is this the right action? What alternatives did I not take seriously?*
+- Beliefs: *What beliefs am I carrying into this? How did I form them?*
+- Conclusions: *Why did I conclude this? What evidence is the conclusion based on?*
+- Assumptions: *Am I assuming things that aren't true? What alternative assumptions would change the conclusion?*
+- Interpretations: *Am I looking at the data objectively? What other meanings could it have?*
+- Selected data: *What data did I ignore? What other sources haven't I considered?*
+- Available data: *What data is out there that I haven't looked at?*
+
+**Mechanics**:
+
+1. State the recommendation (top of ladder).
+2. Climb down — at each rung, answer the diagnostic. Write each rung's content.
+3. Flag any rung where you can't defend the move up. That's the jumped rung.
+4. Climb back up, revising the jumped-rung content.
+5. If the revised climb produces a different recommendation, re-run Step 4 (evaluation) with the new reasoning.
+
+**Output**:
+
+```
+## Ladder of Inference — audit
+
+Recommendation: <winning option from Step 4>
+    ↑
+Beliefs: <the ongoing principles this reinforces>
+    ↑
+Conclusions: <what the data + assumptions led to>
+    ↑ [CHECK] Are the assumptions defensible? If not, climb down further
+Assumptions: <what was taken as given>
+    ↑
+Interpretations: <what the selected data was made to mean>
+    ↑ [CHECK] Is this the most plausible interpretation?
+Selected data: <what you looked at>
+    ↑ [CHECK] What was excluded? Why?
+Available data: <what exists that could be relevant>
+
+Jumped rungs found: <list, or "none">
+Revised recommendation (if changed): <option>
+```
+
+**What it reveals**: the rung you jumped. Common failures: selected data that only supports the winning option; an interpretation that's one of three plausible but the others weren't considered; an assumption you haven't checked in 6 months that's no longer true.
+
+**Interactions**: Ladder of Inference operates on *reasoning*; Inversion operates on *outcomes*. Run Inversion for "what could go wrong in the future?" and Ladder of Inference for "was my thinking sound to get here?"
+
+## Second-Order Thinking
+
+**Core idea**: first-order effects are the immediate consequences. Second-order effects are what happens *after* the first-order effect settles. Most decisions optimize for first-order and get surprised by second-order.
+
+**Two methods** (use both):
+
+### Method 1: Consequence chain
+
+1. Name the immediate (first-order) effect of the decision.
+2. Ask: **"And then what?"** — generate the second-order consequence.
+3. Ask "and then what?" again — third-order.
+4. Repeat until consequences become too speculative to reason about.
+
+### Method 2: Timeline analysis
+
+Evaluate consequences at:
+
+- **10 minutes from now** — immediate operational effect
+- **10 months from now** — downstream impact at typical-quarter scale
+- **10 years from now** — generational or strategic consequence
+
+**Mechanics**:
+
+1. State the recommendation.
+2. Run both methods.
+3. Surface consequences that are surprising, that change the pick, or that require mitigation.
+
+**Output**:
+
+```
+## Second-Order Thinking
+
+Recommendation: <option>
+
+Consequence chain:
+  Immediate: <first-order impact>
+  → Next: <what that causes>
+    → Next: <and what that causes>
+      → Next: <diminishing clarity — stop here>
+
+Timeline analysis:
+  10 minutes: <operational effect — code shipped, dashboard updated, etc.>
+  10 months: <team / process / user / dependency impact at the quarter level>
+  10 years: <strategic consequence — market position, culture, architecture drift>
+
+Surprising effects (change the pick or require mitigation):
+- <effect that wasn't obvious>
+- <effect that compounds over time>
+
+Effects to accept:
+- <downsides that are worth the trade>
+```
+
+**What it reveals**: long-term consequences that first-order optimization hides. Classic save: "the quick win at 10 minutes creates a maintenance burden at 10 months that outweighs it."
+
+**Interactions**: Complements Inversion — Inversion asks "what if it fails?"; Second-Order asks "what if it succeeds but then?" Both are required for high-reversibility-cost decisions.
+
+## Combining the three
+
+For each of the three, produce a short artifact. Then synthesize:
+
+```
+## Stress-test synthesis
+
+Inversion mitigations (now part of the plan):
+- <mitigation 1>
+- <mitigation 2>
+
+Ladder of Inference — jumped rungs found:
+- <rung + revised thinking>
+
+Second-Order effects changing the pick:
+- <effect>
+
+Changes to the recommendation (if any): <what moved + why>
+```
+
+If the stress-test produces NO changes, that's a legitimate outcome — the Step 4 pick was robust. But if every stress-test produces no changes every time, suspicion: the stress-test is running shallow. Re-run Inversion with a harder "what if" premise.
+
+## Fork 5 output
+
+After stress-test, surface:
+
+```
+## Stress-test results
+
+<Inversion pre-mortem inline>
+<Ladder of Inference audit inline>
+<Second-Order analysis inline>
+
+Synthesis:
+- Mitigations folded into the plan: <list>
+- Jumped-rung revisions: <list or "none">
+- Second-order concerns: <list>
+
+Updated recommendation (if changed): <option or "no change">
+
+Any of these change the pick? Should we revisit Step 3 (more options) or Step 4 (re-evaluate)?
+```
+
+Wait for approval or redirect. Common redirects:
+
+- User sees a new failure mode → add to Inversion + mitigate
+- User says a jumped rung is bigger than flagged → revisit Step 4 with revised reasoning
+- User says second-order is a non-issue → acknowledge, note the dissent, move on
+- User wants to add an option in light of stress-test → loop back to Step 3
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Skipping Inversion because "we already did Black hat" | Black hat was during generation; Inversion has the chosen option — teeth are different |
+| Ladder of Inference that doesn't find any jumped rungs | Push harder — ask "what data did I not look at?" Shallow audits miss real rungs |
+| Second-Order that's just "it'll be fine" | Both methods: consequence chain AND timeline. If both are silent, the decision probably doesn't warrant this skill |
+| Running stress-tests on every option instead of the winner | Only the winner gets full stress-test; other options get Inversion-lite if they're close runners-up |
+| Treating "no change" as "stress-test validated the pick" | Often true, but check the stress-test wasn't shallow — would a harder scenario have moved the needle? |
+| Folding every Inversion failure mode into the plan | Only H × H failures get mitigations; everything else is a watch-item, not a plan item |

--- a/skills/do-brainstorm/skills/do-brainstorm/references/systems.md
+++ b/skills/do-brainstorm/skills/do-brainstorm/references/systems.md
@@ -1,0 +1,197 @@
+# Systems Thinking — Loops and Concept Maps
+
+Used in Step 2 or Step 3 when the problem has **dynamics over time** — feedback, compounding, resistance to change — rather than static structure. Three tools: Connection Circles for mapping, Reinforcing/Balancing Feedback for classifying loops, and Concept Map for surfacing mental models of unfamiliar systems.
+
+## When systems thinking applies
+
+Signals the problem needs a systems lens:
+
+- Small interventions produce outsized effects ("we pushed one button and everything broke")
+- Interventions get absorbed ("we've tried 5 fixes and the problem keeps coming back")
+- Exponential trends (growth or decline that's accelerating)
+- Plateaus (metric stops improving despite continued effort — something's balancing)
+- Delayed effects (action now, effect in 6 months)
+- Counter-intuitive behavior ("we added more engineers and velocity went down")
+
+If none of these apply, stick to Issue Trees / Ishikawa in `decompose.md`. Systems thinking is load-bearing but overused — don't reach for it when static decomposition would do.
+
+## Connection Circles
+
+**When**: you've decomposed (Issue Trees / Ishikawa) and notice the causes aren't independent — they cycle back on each other.
+
+**Mechanics**:
+
+1. Draw a circle. Place 5-10 **elements** around it. Rules:
+   - Each element must be able to increase or decrease (noun with a measurable quantity)
+   - Each element must be important to changes in the system
+   - Cap at ~10 — more becomes unreadable
+2. Draw arrows between elements where one directly causes the other to change.
+3. Label each arrow with **"+"** (if the source increases the target) or **"−"** (if the source decreases the target).
+4. Look for **closed loops** — chains of arrows that cycle back to their start. Each closed loop is a feedback loop.
+
+**Output** (inline text or mermaid):
+
+```
+Elements: unhappy_customers, bugs, response_time, support_tickets, new_features
+
+Relationships:
+  unhappy_customers  →(+) support_tickets
+  support_tickets    →(+) response_time
+  response_time      →(+) unhappy_customers         ← closes loop 1 (reinforcing)
+
+  new_features       →(−) unhappy_customers          ← counteracts loop 1
+  new_features       →(+) bugs
+  bugs               →(+) unhappy_customers          ← undermines new_features' help
+
+Loop 1 (reinforcing): unhappy → tickets → slow response → unhappier
+Loop 2 (balancing via feature work): new features reduce unhappiness but increase bugs
+```
+
+**What it reveals**: where the **feedback loops** are — the places where leverage is highest.
+
+**Interactions**: operates at the **Structures** level of the Iceberg Model — use Iceberg to decide *whether* to map at this level, Connection Circles to actually map it. Feeds **Reinforcing/Balancing Feedback** (below) for classifying each loop.
+
+## Reinforcing Feedback Loops
+
+**What**: a loop where each cycle **amplifies** the previous — exponential growth (virtuous) or exponential decline (vicious).
+
+**Signature**:
+
+```
+Variable A increases → Variable B increases → Variable A increases further → ...
+```
+
+**Common examples**:
+
+- **Compound interest** (positive direction): balance → more interest earned → higher balance
+- **Network effects**: more users → more content → more users
+- **Technical debt**: more debt → slower shipping → more pressure → more debt
+- **Unhappy customers → support load → slower response → more unhappy customers** (vicious)
+
+**What to do with a reinforcing loop**:
+
+- If virtuous: find the inputs that accelerate it, invest in those
+- If vicious: find the weakest link in the cycle; break it there
+- Don't try to stop the loop by adding more of the amplifying input — you accelerate the wrong direction
+
+**Beware**: "exponential growth looks linear until it isn't." Reinforcing loops can be invisible for a long time, then explode.
+
+## Balancing Feedback Loops
+
+**What**: a loop that **corrects deviations** from a target — produces stability, pushes back against change.
+
+**Signature**:
+
+```
+Variable A moves away from goal → correction applied → Variable A returns to goal
+```
+
+**Three elements required**:
+- **Goal** — the desired level (often implicit)
+- **Actual level** — the measured state
+- **Gap** — the difference
+
+The loop fires whenever the gap grows. Finding the implicit **goal** is the key to understanding any balancing loop.
+
+**Common examples**:
+
+- **Thermostat**: room temp drifts → heater kicks on → room warms → heater off
+- **Budget variance control**: spending spike → review triggered → spending cut
+- **Peer review**: dip in quality → more scrutiny → quality recovers
+- **Team capacity**: velocity rises → scope creeps → overload → velocity drops (stability around a medium level)
+
+**What to do with a balancing loop**:
+
+- If useful (stabilizing something good): don't break it; understand what it's protecting
+- If resisting your intervention (you're trying to change something the loop defends): find the goal, negotiate the goal before the change, OR disable the correction mechanism
+
+**Beware**: "why aren't my improvements sticking?" is almost always a balancing loop defending the old state.
+
+## Systems: loops combine
+
+Real systems have **both** loop types. Diagnose by mapping:
+
+- Reinforcing loop alone → exponential; system eventually breaks
+- Balancing loop alone → stable; system doesn't respond to input
+- Both present → dynamic equilibrium (most realistic)
+
+**Intervention strategy**:
+
+- Identify the loop type first
+- For reinforcing: accelerate virtuous, break vicious at the weakest edge
+- For balancing: surface the goal; the goal is often what needs to change, not the mechanism
+
+## Concept Map
+
+**When**: learning or brainstorming on an unfamiliar system; workshop with multiple people whose mental models might diverge; identifying gaps in your own understanding before committing.
+
+**Mechanics**:
+
+1. Formulate a **focus question**: "How does X work?" / "What's the context in which Y exists?"
+2. List 15-25 **entities** — people, places, organizations, actions, processes, activities.
+3. Sort from most general to most specific (hierarchy hint).
+4. Place on a board. Connect with lines labeled with **linking verbs**: "contributes to", "is made of", "creates", "conflicts with".
+5. Rule: any two connected entities should read as a meaningful sentence (e.g., "Designer creates a concept map"). If they don't, the linking verb is wrong.
+6. Iterate. Gaps in knowledge that surface must be filled before continuing.
+
+**Output**:
+
+```
+Focus question: How do sharing permissions work in this product?
+
+Entities + relationships:
+  User  [has role]  → Permission Tier
+  Permission Tier  [grants]  → Action
+  Document  [belongs to]  → Workspace
+  Workspace  [has]  → User[]
+  Action  [applies to]  → Document
+  User  [can perform]  → Action   (derived via Permission Tier + Workspace membership)
+  Invitation  [elevates]  → User's Permission Tier   (temporary)
+```
+
+**What it reveals**: structure and hierarchy; gaps in the author's or team's understanding; disagreements across team members on what a term means.
+
+**Interactions**: different from Connection Circles — Concept Map shows **static structure**; Connection Circles show **dynamics over time**. Use Concept Map when onboarding; Connection Circles when diagnosing recurring dynamic problems.
+
+## When to use which
+
+| Situation | Tool |
+|---|---|
+| Recurring problem, one-off fixes absorbed | Iceberg (`decompose.md`) → Connection Circles → classify loops |
+| "We added X and the opposite of X started happening" | Connection Circles + look for reinforcing loops |
+| "We keep trying but the metric plateaus" | Balancing feedback loop — find the implicit goal |
+| "I don't understand this system enough to brainstorm" | Concept Map to build the model, then proceed |
+| Static problem; no feedback dynamics | Skip systems thinking; stick to Issue Trees |
+
+## Output for Fork 2 (when systems tools were used)
+
+If you used systems tools in Step 2 instead of (or alongside) plain decomposition, surface:
+
+```
+## Decomposition (systems view)
+
+Systems tool: <Connection Circles / Concept Map>
+
+<Entities + relationships inline>
+
+Loops identified:
+- Loop 1 (reinforcing): <elements around the cycle>
+- Loop 2 (balancing): goal=<implicit goal>, correction=<mechanism>
+
+Priority leverage points:
+- <where to intervene in Loop 1 to break/accelerate it>
+- <whether the implicit goal in Loop 2 is what needs to change>
+
+Does this capture the system dynamics? Missing relationships or loops?
+```
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Treating a loop as linear cause-effect | If tracing the arrows returns to the start, it's a loop — use systems terminology |
+| Trying to break a reinforcing loop by adding more input | You accelerate the direction; break at the weakest edge instead |
+| Intervening on a balancing loop without finding the goal | The loop defends the goal — changes get absorbed; surface the goal first |
+| Mapping 30 elements in one Connection Circle | Cap at ~10; decompose the system into sub-systems if it's larger |
+| Running Connection Circles on a static problem | Overkill; Issue Trees are lighter. Feedback loops are only useful when dynamics matter |
+| Mistaking Concept Map (static) for Connection Circles (dynamic) | Different purposes: Concept Map for understanding; Connection Circles for loop-hunting |


### PR DESCRIPTION
## Summary

Framework-aware, user-in-the-loop brainstorming session. Cynefin-first classifier routes across a 25-framework catalog (from untools.co), pausing at five forks to bring the user along. Not a feature-design linear flow (obra/brainstorming) and not solo reasoning (existing `think-deeper`) — this is interactive exploration across architecture decisions, debugging direction, scoping, prioritization, and novel problem-solving.

## Context

Research: obra/superpowers/brainstorming + 3 obra adjacents (executing-plans, writing-plans, using-superpowers) + all 25 untools mental-model pages (5 read directly, 20 via 3 parallel Explore subagents) + cross-referenced `think-deeper` for adjacency.

## Workflow

1. **CLASSIFY** — Cynefin 3-question classifier → Clear / Complicated / Complex / Chaotic / Disorder
2. **DECOMPOSE** — Issue Trees / Ishikawa / Iceberg / Abstraction Laddering
3. **EXPLORE** — Six Thinking Hats / First Principles / Zwicky Box / Connection Circles (≥3 options)
4. **EVALUATE** — Hard Choice Model → Decision Matrix / Impact-Effort / Eisenhower
5. **STRESS-TEST** — Inversion + Ladder of Inference + Second-Order (always all three)
6. **COMMUNICATE** — Minto-structured output with explicit next-step + user question

## Files touched

- `skills/do-brainstorm/README.md` (new)
- `skills/do-brainstorm/skills/do-brainstorm/SKILL.md` — 242 lines (under 500 guard)
- `skills/do-brainstorm/skills/do-brainstorm/references/` — 11 references (under 20 cap):
  - classify-problem, decompose, explore, systems, evaluate, stress-test, communicate, meta, interaction-patterns, output-format (has TOC, 342 lines), cross-runtime
- Root `README.md` — one row added + count 49→51 (main's 50 + this)

## Verification

- `python3 scripts/validate-skills.py` → 51 skills, all pass
- Orphan check: 0
- Every reference routed from SKILL.md
- All references independently actionable (one-level-deep rule)

## Weaknesses and open questions

1. **RED baseline not executed** — the rationalizations / pressure scenarios in `interaction-patterns.md` and each framework reference are designed; they have not been tested against a fresh agent without the skill loaded. Follow-up work.
2. **The 16-runtime ask-user-tool table duplicates content** from `enhance-prompt/references/ask-user-tools.md`. Intentional (one-level-deep rule + this skill is usable standalone), but means two files to keep in sync when new runtimes emerge.
3. **New prefix `do-`** — joins `request-`, `evaluate-`, `check-`, `audit-` from earlier session branches. NAMING.md registry would need updating separately if we want to codify these.

**Reviewer:** please confirm the Cynefin routing table in `SKILL.md` aligns with your expectation for what "Complex" vs "Complicated" should call for in practice — this is the load-bearing decision of the skill.

## Follow-ups (not in scope)

- Live trigger tests + RED baseline execution
- Formalize the four new session prefixes (`do-`, `request-`, `evaluate-`, `check-`) in NAMING.md
- Potential visual-companion (mermaid/ascii) follow-up if requested

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `do-brainstorm`, a framework-aware, user-in-the-loop brainstorming skill with Cynefin-first routing across 25 frameworks. Also softens cross-skill references and fixes markdown rendering issues flagged in review.

- **New Features**
  - New skill: `skills/do-brainstorm` with `SKILL.md`, README, and 11 reference guides.
  - Cynefin-first classifier to route Clear/Complicated/Complex/Chaotic/Disorder across 25 frameworks.
  - 6-step workflow with five user checkpoints; produces a 10-section output (incl. Assumptions, Blind spots, Second-order effects).
  - Cross-runtime ask-user tool mapping for 16 runtimes with a prose fallback; root `README.md` updated (count to 51, skill added).

- **Bug Fixes**
  - Softened cross-skill references to conditionally mention optional skills (e.g., `evaluate-code-review`, `request-code-review`) and `enhance-prompt` paths.
  - Fixed markdown rendering issues (removed triple-backtick fences inside parentheses); corrected a stray "Risks" reference to use Assumptions/ranked summary.
  - Revalidated the pack; all skills pass `validate-skills.py`.

<sup>Written for commit 7fb16be1b162da74bb55474a376ee8ffb6a30323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

