### PR TITLE
feat(request-code-review): PR handoff with domain-aware self-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-49 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+51 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 
@@ -53,6 +53,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [init-openclaw-agent](skills/init-openclaw-agent/) | platform | OpenClaw agent workspace configuration |
 | [optimize-mcp-server](skills/optimize-mcp-server/) | development | Audit, optimize, or architect new MCP servers |
 | [publish-npm-package](skills/publish-npm-package/) | development | npm publishing via GitHub Actions |
+| [request-code-review](skills/request-code-review/) | productivity | Hand off work as a PR with domain-aware self-review, or produce a markdown review doc |
 | [review-pr](skills/review-pr/) | productivity | Systematic pull request review |
 | [run-agent-browser](skills/run-agent-browser/) | testing | Browser automation with agent-browser CLI |
 | [run-athena-flow](skills/run-athena-flow/) | orchestration | Athena Flow CLI for AI workflow orchestration |

--- a/skills/request-code-review/README.md
+++ b/skills/request-code-review/README.md
@@ -1,0 +1,19 @@
+# request-code-review
+
+Hand off work to a reviewer — open a pull request, prepare a self-review doc, or tidy dirty commits into a reviewable branch before asking for feedback.
+
+**Category:** productivity
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/request-code-review
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/request-code-review/skills/request-code-review/SKILL.md
+++ b/skills/request-code-review/skills/request-code-review/SKILL.md
@@ -26,7 +26,7 @@ Prefer another skill when:
 ## Non-negotiable rules
 
 1. **Commit dirty changes before opening the PR.** Not after. Not "I'll fix the commits in the PR comments later." Not on `main`. A PR against dirty tree is a broken handoff — the reviewer cannot tell what you meant to ship. See `references/rationalizations.md` for the counter to every excuse that shows up here.
-2. **Default mode is PR creation.** Markdown-table mode fires only when the user *explicitly* asks for "review doc only" / "no PR" / "just the text". Do not infer markdown mode from vagueness.
+2. **Default mode is PR creation.** Markdown-review-doc mode fires only when the user *explicitly* asks for "review doc only" / "no PR" / "just the text". Do not infer markdown mode from vagueness.
 3. **Never touch `main` directly.** Branch first. If the current branch is `main`, create a new branch from it before committing anything.
 4. **Review text is a self-review, not a changelog.** Explain every change with a rationale, surface weaknesses the author knows about, and ask for explicit review attention on uncertain areas.
 5. **PR body stays under 50,000 characters.** GitHub hard limit is 65,536; 50k leaves room for reviewer edits and quotes. If you're approaching it, split the PR.
@@ -58,7 +58,7 @@ git status --short
 git branch --show-current
 git log --oneline origin/main..HEAD 2>/dev/null || git log --oneline -5
 git remote -v
-gh pr list --head $(git branch --show-current) --json number,url
+gh pr list --repo <owner>/<repo> --head $(git branch --show-current) --json number,url
 ```
 
 Capture:

--- a/skills/request-code-review/skills/request-code-review/SKILL.md
+++ b/skills/request-code-review/skills/request-code-review/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: request-code-review
+description: Use skill if you are handing off work — opening a pull request, authoring a self-review, or tidying dirty commits into a reviewable branch before requesting feedback.
+---
+
+# Request Code Review
+
+Turn queued work into a reviewable handoff. Default path is a real GitHub PR on the current branch with a self-review body tailored to the diff's domain. Markdown-only mode (no PR) is available when the user explicitly asks for it.
+
+## Trigger boundary
+
+Use this skill when the task is to:
+
+- open a pull request and author its body
+- prepare a self-review doc before requesting feedback
+- tidy a dirty working tree into clean conventional commits *ready* for review (not as a standalone cleanup)
+- hand off work to a human, bot, or subagent reviewer with domain-aware context
+
+Prefer another skill when:
+
+- reviewing someone else's PR → `review-pr`
+- cleaning a repo that has unrelated mess, multiple worktrees, or cross-branch debris without an imminent review handoff → `run-repo-cleanup`
+- only writing a single commit with no review intent → use the commit workflow directly
+- writing a CI config, release pipeline, or publish rules → `publish-*`, `init-*`
+
+## Non-negotiable rules
+
+1. **Commit dirty changes before opening the PR.** Not after. Not "I'll fix the commits in the PR comments later." Not on `main`. A PR against dirty tree is a broken handoff — the reviewer cannot tell what you meant to ship. See `references/rationalizations.md` for the counter to every excuse that shows up here.
+2. **Default mode is PR creation.** Markdown-table mode fires only when the user *explicitly* asks for "review doc only" / "no PR" / "just the text". Do not infer markdown mode from vagueness.
+3. **Never touch `main` directly.** Branch first. If the current branch is `main`, create a new branch from it before committing anything.
+4. **Review text is a self-review, not a changelog.** Explain every change with a rationale, surface weaknesses the author knows about, and ask for explicit review attention on uncertain areas.
+5. **PR body stays under 50,000 characters.** GitHub hard limit is 65,536; 50k leaves room for reviewer edits and quotes. If you're approaching it, split the PR.
+6. **Domain drives the review lens.** A backend PR, a UI PR, and a content-markdown PR need different reviewer prompts and different self-review angles. Pick the domain before writing.
+7. **Multi-domain diffs fan out.** When the diff spans 2+ domains, dispatch one subagent per domain, combine outputs into one coherent body.
+8. **Push back when the reviewer is wrong.** With technical reasoning and evidence. Do not capitulate to save time.
+
+## The two output modes
+
+| Mode | Trigger phrase | What the skill produces |
+|---|---|---|
+| **PR handoff** (default) | "open a PR", "request a review", "hand this off", "ready for review", silence on format | Clean branch pushed to `origin`, `gh pr create` executed, self-review body posted |
+| **Markdown review doc** | "just the text", "no PR", "give me a review doc", "write the review as markdown", "summarize for review" | Markdown file or inline output only; no git writes, no PR |
+
+If the user's phrasing is ambiguous, ask once before acting. Default is **not** a license to skip the ask when intent is genuinely unclear.
+
+## Required workflow
+
+### 1. Classify the mode
+
+Read the user's request for an explicit markdown-only signal. If absent, default to PR handoff. State the mode before proceeding. This is a commitment step — once declared, do not swap modes mid-workflow without re-stating.
+
+### 2. Inspect the current state
+
+Run in parallel:
+
+```bash
+git status --short
+git branch --show-current
+git log --oneline origin/main..HEAD 2>/dev/null || git log --oneline -5
+git remote -v
+gh pr list --head $(git branch --show-current) --json number,url
+```
+
+Capture:
+- Is the working tree dirty? (modified / untracked / staged but uncommitted)
+- Current branch name (and is it `main` / `master` / `default`?)
+- Unpushed commit count
+- Does a PR already exist for this branch?
+- Origin URL (fork vs. upstream risk)
+
+### 3. Handle dirty tree before anything else
+
+If `git status --short` is empty, jump to Step 4.
+
+If dirty:
+
+- If the `run-repo-cleanup` skill is installed (check `~/.claude/skills/run-repo-cleanup/` or `~/.agents/skills/run-repo-cleanup/`), invoke its diff-walk discipline for Phase 1 (dirty tree → conventional commits). Return here when that completes.
+- Otherwise, follow the inline tidy in `references/handoff-mechanics.md` — diff-walk the changes, group by domain, one conventional commit per concern. No `git commit -am`. No blind staging.
+- If the current branch is `main` / `master`, create a branch first (`git switch -c <type>/<scope>-<slug>`), then commit. Never commit dirty changes to the default branch.
+
+Before moving on, the tree must be clean (`git status --short` empty) and the branch must be pushed to a remote (`git push -u origin <branch>` if no tracking set).
+
+### 4. Classify the diff's domain
+
+Open `git diff origin/main...HEAD --stat` (or `git diff --stat <base>..HEAD`). Classify each changed path:
+
+| Signal in the path or diff | Domain |
+|---|---|
+| `server/`, `api/`, SQL migrations, `*.controller.ts`, `routes/`, auth/session code, infra `.tf`/`.yaml` | **backend** |
+| `*.ts`/`*.tsx`/`*.js`/`*.jsx` outside `server/`, state hooks, client-side fetch, React/Vue/Svelte | **frontend** |
+| `server.ts` with `Server`/`Tool` from `@modelcontextprotocol/sdk`, `SKILL.md` mentioning MCP, Zod schemas for tools | **mcp-server** |
+| CSS, Tailwind classes, component visuals, design tokens, a11y attributes, layout/spacing | **ui-engineering** |
+| `bin/`, `scripts/*.sh`, argparse/commander entrypoints, `*.rs` in `src/main.rs`, argument parsing | **cli-tool** |
+| `*.md` under `content/`, `posts/`, `docs/`, blog/docs markdown | **content-markdown** |
+| None of the above, or a clear mix that doesn't fit | **generic** |
+
+Route to one of:
+
+- `references/domains/backend.md`
+- `references/domains/frontend-ts-js.md`
+- `references/domains/mcp-server.md`
+- `references/domains/ui-engineering.md`
+- `references/domains/cli-tool.md`
+- `references/domains/content-markdown.md`
+- `references/domains/generic.md`
+
+### 5. Fan out if multi-domain
+
+If the diff touches **2+ domains** and each has ≥5% of the changed lines, do not write a single review body alone. Instead:
+
+- For each domain cluster, dispatch a subagent via the Task tool. Brief each with the same BASE_SHA/HEAD_SHA, restrict it to the paths in its cluster, and hand it the matching domain reference.
+- Each subagent returns: the per-domain change summary, the weaknesses it would flag, and 1-3 questions it would ask the reviewer.
+- Combine the subagent outputs into one coherent review body — one section per domain under an `## Areas` heading, plus an overall summary.
+- See `references/subagent-dispatch.md` for the per-subagent prompt template and combination rules.
+
+Single-domain diffs skip this step.
+
+### 6. Draft the review body
+
+Follow the template in `references/review-text-template.md`. Structure:
+
+```
+# <title matching commit style>
+
+## Summary (2-4 sentences)
+## Context / Why now
+## The N items (per-item: files, rationale, verification)
+## Files touched (aggregate table)
+## Verification (what I ran, what I did not)
+## Weaknesses and open questions
+## Request to the reviewer
+## Follow-ups (not in scope)
+```
+
+Under 50,000 characters. Explain every change. Identify **at least two** weaknesses the author knows about. Ask **at least one** question on something the author is uncertain of — this is the "please explain in depth" hook.
+
+### 7. Ship it
+
+**PR handoff mode:**
+
+```bash
+gh pr create \
+  --repo <owner>/<repo> \           # Always explicit — gh defaults are wrong often
+  --base <target-branch> \
+  --head <current-branch> \
+  --title "<type>(<scope>): <subject>" \
+  --body-file /tmp/pr-body.md
+```
+
+Then verify:
+
+```bash
+gh pr view <N> --repo <owner>/<repo> --json url,baseRefName,headRefName
+```
+
+URL must point to the intended repo. Base must be the intended target. If it's on the wrong repo or wrong base, close it immediately and reopen on the right target.
+
+**Markdown mode:** write the review body to the path the user asked for (or inline it in the response). Do not push, do not run `gh pr create`, do not commit — the user said markdown-only.
+
+## Domain routing
+
+| Domain | Reference | When to read |
+|---|---|---|
+| backend service/API | `references/domains/backend.md` | Diff touches server routes, API handlers, SQL, auth, infra |
+| frontend TS/JS | `references/domains/frontend-ts-js.md` | Client-side TypeScript/JavaScript, state, data fetching, framework components |
+| MCP server | `references/domains/mcp-server.md` | `@modelcontextprotocol/sdk` imports, tool/resource registration, SKILL.md authoring |
+| UI engineering | `references/domains/ui-engineering.md` | Visual changes, CSS, design tokens, a11y, layout |
+| CLI tool | `references/domains/cli-tool.md` | Command entrypoints, flag parsing, help text, exit codes |
+| content markdown | `references/domains/content-markdown.md` | Blog posts, docs, SKILL.md bodies, README prose |
+| generic | `references/domains/generic.md` | Anything that does not fit above, or a mix the author cannot cleanly split |
+
+## Supporting references
+
+| File | Read when |
+|---|---|
+| `references/review-text-template.md` | Drafting the PR body structure, severity sections, or weakness language |
+| `references/subagent-dispatch.md` | Fanning out to per-domain specialist subagents and combining their output |
+| `references/handoff-mechanics.md` | Running diff-walk commits, branching off `main`, pushing, opening the PR via `gh` |
+| `references/rationalizations.md` | When the agent feels tempted to skip commits, push to `main`, or shortcut the review body |
+
+## Rationalizations to counter (RED baseline, abridged)
+
+The "commit dirty changes before the PR" rule is the bypass point. Agents under pressure say:
+
+| Rationalization | Counter |
+|---|---|
+| "The PR is urgent; I'll tidy commits in the PR comments later." | PR comments are not commits. Reviewers diff by commit. A broken commit history is a broken review. |
+| "I'll squash on merge anyway." | Squash-on-merge hides mistakes during review, not after. Reviewers need the clean history *now*. |
+| "Just this once — the changes are small." | Rules don't bend for small. The small exception trains the large one. |
+| "The working tree has WIP I don't want in the PR." | Stash it, or move it to a second branch. Do not open the PR on a dirty tree hoping nobody notices. |
+| "I'll open as Draft and fix it up." | Draft PRs still get CI runs, bot reviews, and human skim. Open them clean or not at all. |
+
+Full table with verbatim capture + counters: `references/rationalizations.md`.
+
+## Output contract
+
+Unless the user wants a different format, produce in this order:
+
+1. Mode declaration (after Step 1) — "PR handoff" or "markdown review doc".
+2. State inspection summary (after Step 2) — dirty? branch? unpushed? existing PR?
+3. Dirty-tree handling report (after Step 3) — what was committed and how, or "tree was already clean".
+4. Domain classification (after Step 4) — which domain reference(s) are in play.
+5. Fan-out decision (after Step 5) — single-domain or which subagents were dispatched.
+6. Review body draft (after Step 6) — visible before it is pushed anywhere.
+7. PR URL + verification output (after Step 7, PR mode only), or the markdown file path (markdown mode).
+
+Each artifact appears at the step that produces it. Do not batch to the end.
+
+## Do this, not that
+
+| Do this | Not that |
+|---|---|
+| check dirty tree first, commit, push, then open PR | `gh pr create` against a dirty tree |
+| name the domain before drafting the body | write a generic body that ignores what the diff actually is |
+| fan out to one subagent per domain when multi-domain | a single monolithic body that blurs domain concerns |
+| pass BASE_SHA + HEAD_SHA + diff to subagents, not session history | hand the subagent the full conversation context |
+| explain every change in the body | "Various improvements" or "Refactoring" as the summary |
+| flag ≥2 weaknesses + ≥1 explicit question to the reviewer | "LGTM, please merge" with no critique of your own work |
+| use `gh pr create --repo` explicit every time | rely on `gh` defaults for the target repo |
+| push back with evidence when the reviewer is wrong | capitulate to clear the review and move on |
+| stay under 50,000 chars | single monolithic 60k-char body — split the PR |
+
+## Guardrails and recovery
+
+- Do not open a PR on a dirty tree.
+- Do not commit to `main` / `master` / default. Branch first.
+- Do not assume `gh` defaults to the right repo. Pass `--repo` explicitly.
+- Do not skip the dirty-tree handoff because "the PR is urgent."
+- Do not collapse a multi-domain diff into a single-voice body. Fan out.
+- Do not claim tests passed when you only ran type-check. State exactly what you ran.
+- Do not write the review in "Thanks for reviewing!" voice. Actions over gratitude.
+
+Recovery moves:
+
+- **PR opened on the wrong repo** — close immediately, reopen on the intended target. Check `--repo` every time.
+- **Dirty tree committed to `main` accidentally** — do not force-push. Create a branch pointing to the current commit, reset `main` back, then continue on the branch.
+- **Subagent fan-out returned conflicting recommendations** — surface the conflict in the review body under "Weaknesses and open questions"; let the reviewer decide.
+- **Body exceeds 50k chars** — split the PR. Do not truncate.
+
+## Final checks
+
+Before declaring done, confirm:
+
+- [ ] mode declared and matched the user's request
+- [ ] `git status --short` is empty on the author's branch
+- [ ] branch is pushed and tracks `origin`
+- [ ] PR URL returned (PR mode) or markdown path returned (doc mode)
+- [ ] body ≤ 50,000 characters
+- [ ] every change in the diff has an entry in the body
+- [ ] ≥2 weaknesses surfaced
+- [ ] ≥1 explicit question to the reviewer
+- [ ] domain reference actually matches the diff
+- [ ] multi-domain diffs were fanned out to subagents (or explicitly justified as single-voice)
+- [ ] `gh pr view` confirms the PR is on the intended repo and base branch (PR mode)
+
+Quick orphan check for this skill:
+
+```bash
+for f in $(find references -name '*.md' -type f); do grep -q "$(basename $f)" SKILL.md || echo "ORPHAN: $f"; done
+```

--- a/skills/request-code-review/skills/request-code-review/references/domains/backend.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/backend.md
@@ -1,0 +1,68 @@
+# Backend Service / API Review
+
+Author-side checklist for PRs that touch server routes, API handlers, SQL, auth, sessions, background jobs, or infrastructure. Use when classifying the diff's domain as **backend** in SKILL.md Step 4.
+
+## What backend reviewers care about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Correctness under concurrency** | Races, deadlocks, and lost writes only show up at scale | Locking strategy, isolation level, idempotency keys, retry semantics |
+| **Data integrity** | Migrations that backfill / drop constraints can lose production data | Migration is reversible; constraints validated against real data shape |
+| **Contract compatibility** | Callers break silently on removed fields or changed types | Explicit API version bump, or documented additive-only change |
+| **Auth + authz boundaries** | Privilege elevation bugs are the highest-cost class of backend bug | Which roles can hit the route; what the authz check is and where |
+| **Observability** | Prod debugging without logs/metrics is a scramble | Structured logs on boundaries; metric for new code paths |
+| **Error shapes** | Callers depend on error codes/types as much as happy path | Consistent error envelope; no stack traces leaked to clients |
+| **Resource limits** | One unbounded query kills the service | Timeouts, pagination limits, rate limits on the new path |
+
+## Weaknesses the author should pre-empt
+
+Surface these in the "Weaknesses and open questions" section before the reviewer finds them:
+
+- **N+1 queries.** Did you add a loop that calls the DB inside it? Measure queries per request on the new path.
+- **Transaction boundaries.** Where does the transaction start and end? Is anything outside it that assumes atomicity?
+- **Migration safety.** If you added a NOT NULL column to a large table, what's the backfill plan? What's the rollback if it fails halfway?
+- **Retry safety.** If the client retries this request, does it double-charge / double-create / double-send? Idempotency key present?
+- **Background-job failure mode.** If the worker dies partway through, what's the state? Retriable? Poison-pill handling?
+- **Cache invalidation.** If you read from a cache here, what invalidates it on the write path?
+- **Secret leakage in logs.** Did you add a `logger.info(request)` that includes tokens or PII?
+- **Timezone + DST.** Every time-based bug is eventually a timezone bug. What timezone is stored? What's displayed?
+
+## Questions to ask the reviewer explicitly
+
+Pick the ones that match your uncertainty:
+
+- "The isolation level on this transaction is `READ COMMITTED` — confirm this is tight enough for the double-write scenario in `worker.ts:42`."
+- "Migration `0042_add_user_token_rotation.sql` adds a NOT NULL column with a backfill default. Under concurrent writes, I believe the backfill is safe because [X]. Please verify — this is the scenario I'm least sure about."
+- "Rate-limit window is 10 requests / 60 seconds. Please sanity-check against the expected traffic pattern for this route."
+- "I did not add a metric for this code path because [reason]. Is that acceptable or should I add one?"
+- "The authz check uses `session.role === 'admin'` rather than a policy object. I picked this because [reason] — push back if the policy-object pattern is preferred."
+
+## What to verify before opening the PR
+
+- [ ] All tests pass (unit + integration if touching DB)
+- [ ] Migration runs forward AND backward in a dev DB
+- [ ] If the route is authenticated: tried it with wrong role, expired token, missing token
+- [ ] No secrets / tokens in log output of the happy path
+- [ ] `curl` or equivalent hits the new route and returns the expected shape
+- [ ] N+1 check: log the DB queries for one request, count them
+
+State exactly what you ran in the **Verification** section. "Tests pass" is not enough — which tests.
+
+## Signals the review is off-track
+
+If you catch yourself thinking any of these while writing the body, slow down:
+
+- "The migration is probably fine, the reviewer can check." → Verify locally first.
+- "I didn't test the error path, but it's just a 500." → Test it. 500s become user-facing when the frontend doesn't handle them.
+- "The authz is the same as the other route." → Link the other route in the body so the reviewer can compare.
+- "I'll add the metric in a follow-up." → Fine, but list it under Follow-ups.
+- "Rate limit is guessed." → Say so in the weaknesses section.
+
+## When to split the PR
+
+Backend PRs exceed review budget fast. Consider splitting if:
+
+- Diff crosses two distinct capabilities (new route + unrelated migration)
+- Schema change + code change + background-job change are all in one PR
+- >30 files touched
+- The Summary section feels like it needs 6+ sentences to explain the intent

--- a/skills/request-code-review/skills/request-code-review/references/domains/cli-tool.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/cli-tool.md
@@ -1,0 +1,76 @@
+# CLI Tool Review
+
+Author-side checklist for PRs that add or modify a command-line tool — flag parsing, help text, exit codes, output formatting, scripting discipline, agent-readiness. Use when classifying the diff's domain as **cli-tool** in SKILL.md Step 4.
+
+## What CLI reviewers care about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Help text discoverability** | Users (human and agent) find the tool via `--help` | Every command has `--help`; usage examples included |
+| **Exit code correctness** | 0 = success, non-zero = failure. Scripts depend on this. | Failure paths return non-zero; success paths return 0 |
+| **Stdout vs. stderr discipline** | stdout = pipeable data; stderr = progress/errors | Data to stdout, noise to stderr, no mixing |
+| **Agent-readable output** | LLMs parse structured output; prose is lossy | `--json` flag or structured default |
+| **Idempotency (where applicable)** | Re-running should be safe or clearly errored | Re-run doesn't corrupt state |
+| **Argument parsing robustness** | Edge cases: missing args, unknown flags, `--` separator | Graceful errors, not stack traces |
+| **Env var conventions** | `TOOL_FOO=bar` flags that override config | Documented in `--help`; prefix with tool name |
+| **Signals** | Ctrl-C, SIGTERM behavior | Cleanup on signal; no orphan processes |
+
+## Weaknesses the author should pre-empt
+
+- **`--help` output is the README.** Does it list every flag? Does it show a working example? Is the one-line description accurate?
+- **Unknown flag handling.** `tool --xkjdf` — does it error clearly, or silently accept? Silent accept is a foot-gun.
+- **Positional vs. option arg collisions.** `tool file1 --verbose file2` — does it parse correctly? Edge-case order matters.
+- **Default exit codes.** Non-zero on failure is non-negotiable. What exit codes for specific failure classes? Document if the tool has a taxonomy.
+- **Machine-readability.** Does the tool support `--json` / `--format json` / stable NDJSON? Agents and scripts need it.
+- **Progress on long ops.** If an operation runs >5 seconds, is there any signal of life? If piped to a file, can you suppress progress?
+- **Interactive prompts in non-TTY contexts.** `isatty(stdin)` check? Or a `--yes` / `--no-prompt` flag? A tool that hangs waiting for input in a CI environment is broken.
+- **Concurrency.** If the tool runs in parallel with another instance of itself, what happens? File locks? Atomic writes?
+- **Config-file discovery.** If the tool reads `~/.toolrc`, is the search path documented? What overrides what (env > flag > file)?
+
+## Questions to ask the reviewer explicitly
+
+- "Exit code for 'partial success' (some items processed, some failed) is `2`. Convention is often 0 or 1 — is 2 the right signal, or should I pick one extreme?"
+- "The `--json` output stream is NDJSON, one record per line. Agents in this stack expect NDJSON — can you confirm?"
+- "Ctrl-C during `tool sync` currently aborts and leaves the destination in an intermediate state. Is atomic rollback a requirement, or acceptable to document the behavior?"
+- "Help text on `tool foo --help` is 42 lines. Is that too long, or is the detail warranted?"
+- "I added a `TOOL_DEBUG=1` env var. Is the prefix `TOOL_` consistent with other env vars in this tool, or do we already have a namespace?"
+
+## What to verify before opening the PR
+
+- [ ] `tool --help` runs and output is correct
+- [ ] `tool <subcommand> --help` runs for each subcommand
+- [ ] Unknown flag (`tool --xyz`) exits non-zero with a clear message
+- [ ] Missing required arg exits non-zero with a clear message
+- [ ] Happy path produces the expected output on stdout
+- [ ] Progress messages go to stderr (try `tool command 2>/dev/null | ...`)
+- [ ] `--json` output (if present) is valid JSON when piped through `jq`
+- [ ] If interactive: non-TTY mode exits or uses defaults rather than hanging
+- [ ] Ctrl-C leaves no stale files or locks
+
+## Signals the review is off-track
+
+- "The help text is mostly self-explanatory." → Self-explanatory to whom? Add one example per subcommand.
+- "Exit code is 1 on any error." → Users (and scripts) benefit from distinct codes for distinct failure classes. Minimum: 0, 1 (bad usage), 2 (runtime failure), 3 (precondition not met). Pick a taxonomy.
+- "`--json` is a follow-up." → If an agent ever runs this tool, `--json` is part of the tool's purpose, not an add-on.
+- "Progress is on stdout so it shows up by default." → Users piping to a file get progress mixed with data. stderr is the right channel.
+
+## When to split the PR
+
+- Adding a new subcommand + refactoring flag parsing → split; refactor first
+- New subcommand + new output format → can bundle if closely related; split if the format is a system-wide change
+- CLI + the backend it drives → usually split; CLI land after backend is stable
+
+## CLI follow-up skills
+
+For specific tooling ecosystems:
+
+| Ecosystem | Skill |
+|---|---|
+| Agent-readiness audit | `optimize-cli-for-agents` |
+| Raycast Script Commands | `build-raycast-script-command` |
+| GitHub CLI scripting | `run-github-scout` |
+| Codex CLI orchestration | `run-codex-exec`, `run-codex-subagents` |
+| Playwright CLI | `run-playwright` |
+| Railway CLI | `use-railway` |
+
+If the PR introduces or modifies a CLI's agent-readiness (flag taxonomy, JSON output, error shapes), route additionally to `optimize-cli-for-agents`.

--- a/skills/request-code-review/skills/request-code-review/references/domains/content-markdown.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/content-markdown.md
@@ -1,0 +1,85 @@
+# Content / Markdown Review
+
+Author-side checklist for PRs that are primarily about prose — blog posts, documentation, README edits, SKILL.md bodies, changelogs, migration guides. Use when classifying the diff's domain as **content-markdown** in SKILL.md Step 4.
+
+## What content reviewers care about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Audience fit** | The right reader, the right level of detail | Audience stated; jargon matched to them |
+| **Claim accuracy** | One wrong claim sinks the piece | Claims linked to evidence or marked as opinion |
+| **Code snippet correctness** | Broken examples train bad habits | Each snippet runs; outputs shown |
+| **Link rot** | Dead links undermine trust | All links resolve; archive for volatile sources |
+| **Voice consistency** | Mixed voice feels unedited | One voice, matched to the publication |
+| **Structural clarity** | Readers need headings to navigate | Logical H2/H3 tree; no burying |
+| **Brevity without loss** | Every redundant paragraph costs reader time | Prose tightened; no throat-clearing |
+| **Image + asset hygiene** | Orphaned assets bloat the repo | Every asset used; appropriate format |
+
+## Weaknesses the author should pre-empt
+
+- **Factual claims.** Every assertion you can't defend on the spot is a risk. Link to the primary source, or mark it as your opinion.
+- **Code examples.** Did you actually run every snippet you included? If it's pseudo-code, is that labeled?
+- **Command accuracy.** `npm install` vs. `pnpm install` vs. `yarn add` — match the actual tool the reader is using, or name both.
+- **Version-specific content.** Does the post pin versions? Is there a "last tested on" date? Content about `react@18` becomes wrong under `react@19`.
+- **Links.** Internal links (relative paths) break on move/rename. External links rot. Consider archive.org for critical citations.
+- **Images.** Are they optimized? Is alt text present for accessibility? Does the image add information or decorate?
+- **Consistency with other docs.** If this contradicts `README.md` or a sibling doc, which is right? Update both or flag the conflict.
+- **SEO metadata** (if blog post): title, description, og:image, canonical URL.
+- **Table of contents** (if >300 lines): readers under context pressure skim the TOC first.
+- **Headings hierarchy.** Jumping from H2 to H4 breaks document outline tools and screen readers.
+
+## Questions to ask the reviewer explicitly
+
+- "The post assumes the reader already knows Conventional Commits. Should I add a short primer at the top, or link out?"
+- "I made a claim in the 'Why X is bad' section — source is a 2023 blog post. Do you have a more authoritative source, or is this one fine?"
+- "The tone leans opinionated ('this pattern is wrong'). Is that the voice the publication wants, or should it be 'this pattern has these trade-offs'?"
+- "Migration guide covers 1.x → 2.x. Should it also cover 0.x → 2.x (two-hop), or point to the 0.x → 1.x guide and chain?"
+- "README got a new 'Quickstart' section. I didn't remove the old 'Installation' section because it's more complete. Merge or keep split?"
+
+## What to verify before opening the PR
+
+- [ ] All code snippets run as written (copy-paste from the doc, actually execute)
+- [ ] All internal links resolve (`find . -name '*.md' | xargs markdown-link-check` or equivalent)
+- [ ] All external links open (manual spot check on the critical few)
+- [ ] Headings form a valid outline (H1 → H2 → H3, no H2 → H4 jumps)
+- [ ] Images have alt text
+- [ ] Grammar/spelling pass (`prettier`, `vale`, or equivalent linter if the project uses one)
+- [ ] If blog: SEO metadata present; preview rendered
+- [ ] If changelog: entries grouped (Added / Changed / Fixed / Removed); dates consistent
+- [ ] `wc -w` or similar: is the piece as short as it can be?
+
+## Signals the review is off-track
+
+- "The reader will figure it out." → They won't. Write for the worst-case reader of the piece.
+- "This is just copy editing, don't need a review." → Copy changes ship to every user. They deserve the same rigor.
+- "I'll update the related docs later." → "Later" is tomorrow, which is never. Update now or flag as follow-up.
+- "The code snippet is close — I paraphrased from the real one." → Paste the real one. Paraphrased code is broken code.
+- "The post is long because the topic is complex." → Complex topics deserve clear writing. Length ≠ depth.
+
+## When to split the PR
+
+- New blog post + unrelated doc fixes → split; one PR per piece
+- Doc overhaul + code change → split; docs land after code if the API shape matters
+- Changelog entry + feature code → one PR is fine (they belong together)
+
+## Style notes specific to this repo
+
+If the PR touches SKILL.md files (for Claude skills), additional rules apply:
+
+- Frontmatter `description` starts with "Use skill if you are" (repo convention)
+- Frontmatter `description` is 30 words or fewer
+- SKILL.md body under 500 lines; split detail into `references/` files
+- No junk files, no stale sibling-skill names
+- Route to `build-skills` for the authoring workflow if creating a new skill
+
+If the PR touches blog posts or long-form content, consider whether a sibling research/citation doc is expected.
+
+## Content follow-up skills
+
+| Content type | Skill |
+|---|---|
+| Product Requirements Documents | `github/awesome-copilot/prd` (external) |
+| Skill creation | `build-skills` |
+| CLAUDE.md / AGENTS.md maintenance | `init-agent-config`, `claude-md-management:revise-claude-md` |
+
+Name the specific doc type in the PR body so the reviewer loads the right lens.

--- a/skills/request-code-review/skills/request-code-review/references/domains/frontend-ts-js.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/frontend-ts-js.md
@@ -1,0 +1,71 @@
+# Frontend TypeScript / JavaScript Review
+
+Author-side checklist for PRs that touch client-side TS/JS — React/Vue/Svelte/Solid components, state management, client data fetching, framework routes. Use when classifying the diff's domain as **frontend** in SKILL.md Step 4.
+
+## What frontend reviewers care about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Type safety** | Implicit `any` / loose unions silently break at runtime | `tsc --noEmit` passes; no `as` casts without explanation |
+| **Render correctness** | Stale closures, missing deps in `useEffect`, leaked subscriptions | Exhaustive-deps lint passes; cleanup on unmount |
+| **Bundle cost** | A new import can ship 200kB to every user | Bundle-size impact checked; no accidental server-package imports |
+| **State lifecycle** | Where state lives, who owns it, when it resets | Clear ownership; no duplicated source of truth |
+| **Error + empty + loading states** | Each route has four states, not one | All four covered; no silent spinners forever |
+| **Accessibility** | Keyboard, screen reader, focus management | Labels on inputs, focus trap on modals, visible focus ring |
+| **Async cancellation** | Switching routes mid-fetch leaks promises | AbortController or query library that handles it |
+| **Form validation boundary** | Client validation is UX, server validation is trust | Both, with consistent error shapes |
+
+## Weaknesses the author should pre-empt
+
+- **useEffect dependency drift.** Is the dep array accurate? Run `pnpm lint` with `react-hooks/exhaustive-deps` and paste the result.
+- **Event handler identity churn.** If you passed a new function every render to a memoized child, the memoization does nothing. `useCallback` where it matters; explain when you chose not to.
+- **Server-client data mismatch.** If the component hydrates from SSR, does the initial render match the server? Mismatches cause flicker and hydration errors.
+- **Loading + error fallback.** What does the UI show during the first fetch? What if the fetch fails? What if it succeeds with empty data?
+- **Focus management on navigation.** When the route changes, where does focus go? Keyboard users depend on this.
+- **Client-only code in SSR path.** `window`, `document`, `localStorage` crash during SSR. Guard with `typeof window !== 'undefined'` or a framework-specific `useIsomorphicLayoutEffect`.
+- **Tree-shaking.** Did you import the whole library (`import _ from 'lodash'`) or just the function (`import debounce from 'lodash/debounce'`)? Ship size depends on this.
+- **Dark mode / theme.** New component — does it respect the theme tokens, or did you hardcode `text-gray-900`?
+
+## Questions to ask the reviewer explicitly
+
+- "The `useMemo` on L42 guards against a re-sort of a 500-element list. Is the trade-off (memo overhead vs. sort cost) worth it at this size, or am I over-optimizing?"
+- "I handled the error state with a toast instead of a block-level error. Preferred pattern in this codebase?"
+- "The new `<Tabs>` component uses `role='tablist'` but keyboard arrow-key navigation is manual. Is this enough for a11y, or do we need a tested pattern?"
+- "Bundle impact of this new import: +18kB gzipped (confirmed with `pnpm build`). Acceptable or should we lazy-load?"
+- "Switched from Zustand to TanStack Query for server state — existing stores stay. Is the split okay, or should we migrate everything?"
+
+## What to verify before opening the PR
+
+- [ ] `tsc --noEmit` passes
+- [ ] Lint passes (especially `react-hooks/exhaustive-deps` for React)
+- [ ] Dev build runs without console errors/warnings on the changed route
+- [ ] Production build succeeds
+- [ ] Bundle size delta checked (`pnpm build` output; or build stats plugin)
+- [ ] Keyboard-only walkthrough of the new interaction
+- [ ] Empty-state, loading-state, error-state all exercised manually
+- [ ] If SSR: reload the page, confirm no hydration warning in console
+
+## Signals the review is off-track
+
+- "TypeScript is complaining, I'll cast it." → Don't cast without reading the error. Usually the cast hides a real bug.
+- "The loading spinner is fine as a fallback." → What about error? What about empty?
+- "I'll optimize the re-renders later." → Either ship it or optimize. Not "later" — re-render bugs become flaky Playwright tests.
+- "A11y is a follow-up." → Keyboard trap on a modal breaks for real users today.
+
+## When to split the PR
+
+- A component change + a data-layer change + a route change in one PR → split
+- New feature + refactor of unrelated code → split
+- >25 component files in one PR → usually too many
+
+## Framework-specific flags (brief)
+
+| Framework | Watch for |
+|---|---|
+| Next.js | Server vs. client component split; `"use client"` placement; dynamic imports for heavy client-only code |
+| Vue | `ref` vs. `reactive` choice; `watch` vs. `watchEffect`; Composition API vs. Options API consistency |
+| Svelte | Reactivity via `$:` vs. stores; runes (Svelte 5) migration state |
+| Solid | Fine-grained reactivity — no `useState` equivalents; signals and `createEffect` |
+| React Native | Platform differences (iOS vs. Android); `FlatList` vs. `ScrollView` at scale |
+
+If the project uses framework-specific skills (e.g., `build-supastarter-app`, `build-mcp-use-apps-widgets`, `react-best-practices`), route additionally to those for framework details.

--- a/skills/request-code-review/skills/request-code-review/references/domains/generic.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/generic.md
@@ -1,0 +1,104 @@
+# Generic Dev Task Review
+
+Catch-all for PRs that don't cleanly fit the six specific domains (backend, frontend, MCP, UI, CLI, content). Use this when the diff is:
+
+- Configuration changes (CI/CD, lint config, package.json, Dockerfiles)
+- Pure refactoring (no behavior change)
+- Library or tooling upgrades
+- Dev tooling scripts (pre-commit hooks, local scripts)
+- Cross-domain glue that doesn't clearly sit in one area
+- A small mix that's not worth fanning out to specialists
+
+Prefer the specific domain references when they apply. Route here only when none fit.
+
+## What a generic reviewer cares about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Scope match** | Does the PR do what the title/description claims, and nothing more? | Files touched match stated intent |
+| **No hidden behavior change** | Refactors that secretly change behavior are the worst bugs | Tests unchanged, or new tests added for new behavior |
+| **Backward compatibility** | Existing callers / consumers keep working | No silent contract break |
+| **Dependencies + supply chain** | Every new dep is code you now ship | Justified additions; lockfile updated |
+| **CI / tooling alignment** | Config changes affect every future PR | Rationale for the config shift |
+| **Evidence of intent** | "Looks clean" is not a review | Author's rationale surfaced in body |
+
+## Weaknesses the author should pre-empt
+
+Pick the ones that apply to your diff:
+
+- **Behavior change hidden in a "refactor".** Did the refactor actually preserve behavior? Run the test suite before + after and compare output, not just pass/fail.
+- **Dependency bump side effects.** Upgrading `somepkg ^1.4.0` → `^2.0.0` — read the changelog, list breaking changes even if they seem minor.
+- **Lockfile diff size.** Big lockfile diffs from small package.json changes indicate transitive dep churn. Is it expected?
+- **CI config changes.** A small tweak to `.github/workflows/ci.yml` can skip tests for everyone. Does the change preserve prior coverage?
+- **Build-system changes.** Webpack → Vite, tsup → esbuild, etc. — bundle output differs even if it "works". Do size / treeshaking match?
+- **Script changes.** A modified pre-commit hook affects every contributor. Is the new behavior documented?
+- **Env var changes.** New required env var: documented in `.env.example` and README? Removed env var: migration note?
+- **Formatter / linter config changes.** The diff now has thousands of auto-fix lines. Is the config change intended?
+
+## Questions to ask the reviewer explicitly
+
+Customize to your diff. Examples:
+
+- "This PR is marked 'refactor' — please confirm the test suite output is byte-identical before and after on the `packages/core` module."
+- "`eslint` config got a new rule turned on, which created 14 lint fixes in the same PR. Prefer separate PRs (rule first, then fixes), or is this fine bundled?"
+- "The dependency `foo` went from `^1.4.0` to `^1.5.1`. Their changelog notes a change in `bar.baz()` return shape under specific inputs — I believe we don't hit that path (see `test/foo.test.ts`). Please verify."
+- "CI config now runs tests on Node 20 instead of Node 18. Is the Node-18 coverage still required for our support matrix?"
+- "Added a new env var `FEATURE_FOO_ENABLED` with default `false`. Should this be surfaced in the onboarding docs, or is env-var discoverability handled elsewhere?"
+
+## What to verify before opening the PR
+
+General checks:
+
+- [ ] Test suite passes locally
+- [ ] Type-check / lint passes locally
+- [ ] If the PR claims "refactor": run tests before and after, confirm same pass/fail outputs (and ideally same stdout where relevant)
+- [ ] If dependency changed: lockfile is in sync, `npm audit` / `pnpm audit` checked
+- [ ] If CI changed: locally reproduced the CI command chain where possible
+- [ ] If env var added: `.env.example` / README updated
+- [ ] If script/hook added: ran it on a real change to confirm the happy path
+
+## Signals the review is off-track
+
+- "Refactor, no behavior change — no tests needed." → Prove it. Run tests. Paste output.
+- "It's just a config tweak." → Config tweaks have blast radius. Justify the change.
+- "I'll update the docs after." → Update them now or file as a follow-up explicitly.
+- "The dep bump is minor, changelog says so." → Trust, verify. Paste the relevant changelog excerpt in the body.
+
+## When to split the PR
+
+Generic PRs are often the ones that *should* be split:
+
+- Refactor + unrelated fixes → split
+- Dep bump + code changes that use new dep features → split (dep bump first, proof it holds, then use the features)
+- CI config + code that happens to pass on new CI → split
+- Formatter config + the auto-fix diff → split; fix diff lands after config
+
+When you can't describe the PR in one line without "and", you probably want two PRs.
+
+## Default review body shape for generic PRs
+
+Without a specific domain lens, structure the body as:
+
+```
+# <title>
+
+## Summary
+<What this does, in one paragraph. No "and"s if possible.>
+
+## Why
+<Why now. What problem this addresses. Link the issue if any.>
+
+## Changes
+<Per-file or per-logical-chunk. Rationale for each.>
+
+## Verification
+<Exactly what you ran. Do not over-claim.>
+
+## Weaknesses and open questions
+<At least two. Generic doesn't mean trivial.>
+
+## Not in scope
+<Explicit follow-ups.>
+```
+
+Keep it under 3000 characters if at all possible. Most generic PRs do not warrant long bodies.

--- a/skills/request-code-review/skills/request-code-review/references/domains/mcp-server.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/mcp-server.md
@@ -1,0 +1,70 @@
+# MCP Server Review
+
+Author-side checklist for PRs touching an MCP (Model Context Protocol) server — tool/resource/prompt registration, transport choice, Zod schemas, session handling, SKILL.md authoring for MCP-paired skills. Use when classifying the diff's domain as **mcp-server** in SKILL.md Step 4.
+
+## What MCP reviewers care about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Tool contract stability** | Once an agent learns a tool's shape, breaking it breaks every downstream skill | Additive-only changes; version flag if breaking |
+| **Schema precision** | Loose schemas give ambiguous errors back to the agent | Zod schemas tight; descriptions on every field |
+| **Error surface** | The tool's error is what the agent sees — it has no other context | Clear error messages; no stack traces; actionable in agent's loop |
+| **Context window cost** | Tool results that are too verbose poison every future turn | Output size budgeted; pagination / filtering on large returns |
+| **Idempotency** | Agents retry. Non-idempotent tools double-fire. | Retry-safe or explicit "this is not idempotent" in description |
+| **Auth / scope** | MCP tools run with the user's permissions. One tool should not expand scope. | No privilege elevation in the tool body |
+| **Transport correctness** | stdio vs. HTTP vs. Streamable HTTP each have traps | Transport choice justified; session handling matches transport |
+
+## Weaknesses the author should pre-empt
+
+- **Tool name and description.** The description is what the agent's router reads. Is it specific enough to not fire for adjacent queries? Does it name the exact tool name the agent will call?
+- **Zod schema gaps.** Did you add `z.any()` anywhere? Every `any` is a future ambiguity. Tighten to union + discriminator, or document why `any` is required.
+- **Return shape.** What does the tool return on success? On "no results"? On partial failure? The agent treats each differently — make them distinct.
+- **Output size.** If the tool can return 50kB of data, is there a way to paginate or trim? Tool outputs consume context on every downstream call.
+- **Session bleed.** If the server is Streamable HTTP or HTTP, state must be per-session, not global. Did you accidentally cache in a module-level variable?
+- **Resource vs. tool.** Is this action a mutation (tool) or a read (resource)? Resources should be read-only; tools can mutate.
+- **Prompt injection via tool results.** If the tool returns user-supplied data, can an attacker smuggle instructions through it? Sanitize or mark as untrusted.
+
+## Questions to ask the reviewer explicitly
+
+- "The new `search_issues` tool returns up to 50 results by default. Is that right for the context-budget discipline this server follows, or should it be lower?"
+- "Zod schema for the `filter` arg uses `z.record(z.string(), z.unknown())`. I want structured filters but can't fully enumerate. Is the looser schema acceptable?"
+- "I chose a tool (mutation) over a resource (read-only) because the operation touches the DB. Is the line right?"
+- "Server is stdio-transport for local use and Streamable HTTP for remote. Session handling is in `session/store.ts` — please verify the per-session state isolation."
+- "Tool errors return `ApplicationError` with a `code` field. Is that shape what the agents in this ecosystem expect, or should it match a different convention?"
+
+## What to verify before opening the PR
+
+- [ ] MCP inspector (`@modelcontextprotocol/inspector`) connects to the server
+- [ ] Every tool can be invoked via the inspector with a valid payload
+- [ ] Every tool returns a well-formed error for a bad payload (missing required field, wrong type)
+- [ ] Tool descriptions are copy-pasted into the inspector's tool-list — confirm they read correctly to a fresh reader
+- [ ] If the server has sessions: open two inspector tabs, verify no state bleed
+- [ ] If Streamable HTTP: verify CORS/auth gates if deployed remotely
+- [ ] SKILL.md (if paired) references the actual current tool names, not stale ones
+
+## Signals the review is off-track
+
+- "I'll document the tool later." → The description IS the documentation for the agent. Write it now.
+- "Zod schema is loose but it works." → Loose schemas become runtime bugs at the worst possible time.
+- "The tool returns a lot of data but the agent can trim it." → Agents don't trim well. Trim at the tool boundary.
+- "One tool both reads and writes for simplicity." → Two tools. Resources for reads, tools for writes.
+
+## When to split the PR
+
+- New tool + unrelated transport refactor → split
+- New tool + schema-library migration (Zod v3 → v4) → split
+- Multiple new tools that aren't related to one user intent → consider splitting
+
+## MCP-specific follow-up skills
+
+If the server uses a specific framework, route additionally:
+
+| Framework | Skill |
+|---|---|
+| Bare `@modelcontextprotocol/sdk` v1.x | `build-mcp-sdk` |
+| `@modelcontextprotocol/server` v2 | `build-mcp-sdk-v2` |
+| `mcp-use` (server side) | `build-mcp-use-server` |
+| `mcp-use` with React widgets | `build-mcp-use-apps-widgets` |
+| Optimizing an existing server | `optimize-mcp-server` |
+
+Name the specific framework in your PR body so the reviewer pulls the right context.

--- a/skills/request-code-review/skills/request-code-review/references/domains/ui-engineering.md
+++ b/skills/request-code-review/skills/request-code-review/references/domains/ui-engineering.md
@@ -1,0 +1,80 @@
+# UI Engineering Review
+
+Author-side checklist for PRs focused on *visual* changes — CSS, design tokens, layout, typography, spacing, accessibility, component visuals. Distinct from `frontend-ts-js.md` which covers logic + data flow. Use when classifying the diff's domain as **ui-engineering** in SKILL.md Step 4.
+
+## What UI reviewers care about
+
+| Concern | Why it matters | Evidence they want |
+|---|---|---|
+| **Design-token fidelity** | Hardcoded colors/spacings drift from the system | Classes/tokens from the system, not raw values |
+| **Responsive behavior** | Breaks at the breakpoint reviewers don't test on | Viewport screenshots at mobile / tablet / desktop |
+| **Accessibility** | Keyboard, screen reader, color contrast, focus | Contrast ratio ≥ AA; focus visible; labels/roles correct |
+| **Interactive states** | Hover, focus, active, disabled, loading, error | All states designed, not just default |
+| **Motion + transitions** | Animations skip for `prefers-reduced-motion` users | Respects user preference |
+| **Dark mode / theme** | New component respects theme automatically | No hardcoded `text-gray-900` outside theme tokens |
+| **Layout stability** | CLS (Cumulative Layout Shift) from images/fonts | Image dimensions set; font-display/preload |
+| **Copy** | UI text ships to every user; typos and tone issues are public | Reviewed copy; sentence case (or the repo's convention) consistent |
+
+## Weaknesses the author should pre-empt
+
+- **Breakpoint coverage.** Did you test the changed screen at mobile (360-420px), tablet (768px), and desktop (1280+)? Any known breakage?
+- **Contrast.** New text on new background? Check the ratio. 4.5:1 for normal text, 3:1 for large. One failing token breaks the whole system's claim.
+- **Keyboard traversal.** Can every interactive element be reached via Tab? Does the order match visual order? Is focus visible?
+- **Screen reader output.** Does the component announce itself correctly? Try VoiceOver / NVDA / TalkBack on one critical path.
+- **Hover-only interactions.** Anything that only appears on hover is invisible to touch and keyboard users. Have a non-hover path.
+- **`line-clamp` + long content.** Does overflow cut mid-word? Does it respect RTL?
+- **Animation on scroll or mount.** Respect `prefers-reduced-motion: reduce`. One vestibular user's nausea is a shipping bug.
+- **Dark mode token coverage.** If you introduced a new color, is its dark-mode variant also added?
+- **Image dimensions.** Width + height attributes set to prevent layout shift during load?
+- **Focus trap on modals.** Can keyboard users escape? Is focus returned to the trigger on close?
+
+## Questions to ask the reviewer explicitly
+
+- "Spacing between the header and the card grid is `gap-6` (24px). The system uses `gap-8` for similar pairings elsewhere — which is right here?"
+- "Contrast on the secondary button (`bg-slate-200` on `bg-white`) is 3.2:1. Is that acceptable for the size (14px) or should we bump?"
+- "I added `animate-fade-in` on mount. Should every new component get `motion-safe:animate-fade-in` instead, to respect user prefs?"
+- "The modal's close button is top-right. The design system's pattern is top-left for RTL locales — do we need to flip?"
+- "Is the new `<Toast>` variant expected to match `<Alert>` styling exactly, or is divergence okay because of functional difference?"
+
+## What to verify before opening the PR
+
+- [ ] Visual check at mobile / tablet / desktop viewports
+- [ ] Keyboard-only traversal of the changed screen
+- [ ] Light mode + dark mode both rendered
+- [ ] Contrast ratios on new color combinations
+- [ ] `prefers-reduced-motion: reduce` in DevTools — animations respect it
+- [ ] Screenshots attached to the PR body (before/after or `after` only if new)
+- [ ] Lint / stylelint passes if the project uses it
+- [ ] Screenshot diff tool (Chromatic, Percy, `test-macos-snapshots`) if available
+
+If screenshots would materially help the reviewer, include them. GitHub supports image paste in PR bodies.
+
+## Signals the review is off-track
+
+- "The design looks close enough." → "Close enough" drifts. Match the system or justify the divergence.
+- "Dark mode works because I used theme classes." → Verify by actually switching modes.
+- "Contrast is probably fine." → Check. It takes 10 seconds with browser devtools.
+- "I'll add the reduced-motion guard later." → Vestibular users don't have "later."
+- "A11y is the design system's job." → Anything you add inherits the a11y obligation. If it's not accessible, it's not done.
+
+## When to split the PR
+
+- Pure visual change + unrelated logic change → split
+- New design token + code that uses it → usually one PR (they're coupled); exception is when the token needs team review first
+- Theming refactor + new component → split; theming lands first, new component builds on it
+
+## UI-engineering follow-up skills
+
+For PRs that touch specific UI ecosystems, route additionally:
+
+| Ecosystem | Skill |
+|---|---|
+| daisyUI components | `build-daisyui-mcp` |
+| macOS HIG SwiftUI | `develop-macos-hig` |
+| macOS Liquid Glass | `develop-macos-liquid-glass` |
+| SaaS design extraction | `extract-saas-design` |
+| HTML → Next.js | `convert-snapshot-nextjs` |
+| React compositional patterns | `composition-patterns` (external pack) |
+| Web Interface Guidelines | `web-design-guidelines` (external pack) |
+
+Name the specific ecosystem in the PR body so the reviewer pulls the right lens.

--- a/skills/request-code-review/skills/request-code-review/references/handoff-mechanics.md
+++ b/skills/request-code-review/skills/request-code-review/references/handoff-mechanics.md
@@ -1,0 +1,167 @@
+# Handoff Mechanics
+
+Diff-walk commits → push → `gh pr create`. The mechanical steps between a dirty tree and a reviewable PR. Referenced from SKILL.md Step 3 and Step 7.
+
+If the `run-repo-cleanup` skill is installed (check `~/.claude/skills/run-repo-cleanup/` or `~/.agents/skills/run-repo-cleanup/`), invoke its Phase 1 (dirty-tree → conventional commits) and Phase 3 (PR creation) rather than duplicating them. This file is the inline fallback for when that skill is absent.
+
+## 1. Branch safety
+
+Before committing anything, confirm:
+
+```bash
+git branch --show-current
+```
+
+If the result is `main`, `master`, or the repo's default branch:
+
+```bash
+git switch -c <type>/<scope>-<slug>
+```
+
+Where:
+- `<type>` ∈ `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`
+- `<scope>` is a short noun identifying the area (e.g., `auth`, `session`, `payment-retry`)
+- `<slug>` is 2-4 words describing the change
+
+Examples: `feat/auth-token-rotation`, `fix/session-timeout-edge-case`, `docs/api-getting-started`.
+
+**Never commit to the default branch directly.** Always branch first.
+
+## 2. Diff-walk discipline
+
+Read before staging. For every modified file:
+
+```bash
+git diff <file>
+```
+
+For every untracked file:
+
+```bash
+cat <file>
+```
+
+Never stage a change you have not read. No `git commit -am`. No blind stage-everything.
+
+## 3. Group by domain, not by file
+
+Typical split for a feature branch:
+
+- Feature implementation
+- Docs / README updates for the feature
+- Env / config / scripts scaffolding for the feature
+- Drive-by fixes unrelated to the feature → **separate branch/PR**, not this one
+
+If one file contains two unrelated concerns, split the staging with `git add -p` and commit the halves separately.
+
+## 4. One concern per commit
+
+For each concern:
+
+```bash
+git diff <files-for-this-concern>
+git add <files-for-this-concern>
+git diff --cached                            # confirm nothing extra snuck in
+git commit -m "<type>(<scope>): <imperative subject>"
+```
+
+Conventional Commits format. Subject under 50 characters. Imperative mood ("add", not "added"). No WIP, no "misc", no "updates".
+
+Good:
+- `fix(auth): refresh token on privilege elevation`
+- `feat(payment-retry): exponential backoff with jitter`
+- `docs(api): add getting-started walkthrough`
+- `refactor(session): extract store adapter interface`
+
+Bad:
+- `fix: various fixes` → too vague, split it
+- `WIP` → not a commit, a pause
+- `Update stuff` → rewrite
+- `fix bug` → what bug in what scope?
+
+## 5. Push with tracking
+
+```bash
+git push -u origin <branch>
+```
+
+The `-u` sets upstream tracking so later `git push` / `git pull` work without arguments.
+
+If the branch is already pushed but tracking isn't set, run the same command — git will update the tracking without recreating the branch.
+
+## 6. Open the PR
+
+Always pass `--repo` explicitly. `gh` defaults to the tracked upstream, which is frequently wrong for fork-based workflows.
+
+```bash
+gh pr create \
+  --repo <owner>/<repo> \
+  --base <target-branch> \
+  --head <current-branch> \
+  --title "<type>(<scope>): <subject>" \
+  --body-file /tmp/pr-body.md
+```
+
+Use a file for the body, not `--body "..."` — multi-line markdown via a shell argument is error-prone and can break on special characters.
+
+## 7. Verify immediately
+
+```bash
+gh pr view <N> --repo <owner>/<repo> --json url,baseRefName,headRefName,state
+```
+
+Check:
+- URL points to the intended `<owner>/<repo>` (not an upstream, not a different fork)
+- Base is the intended target branch (not `main` of an upstream you didn't mean to PR against)
+- Head matches the branch you pushed
+
+If the PR is on the wrong repo or wrong base: close it, fix `--repo` / `--base`, reopen.
+
+## Commit-message style matching
+
+Before writing commit messages, match the repo's existing style:
+
+```bash
+git log --oneline -20
+```
+
+Look for:
+- Emoji prefix? (some repos use gitmoji, many don't)
+- Scope format? (`feat(scope):` vs. `feat/scope:` vs. just `feat:`)
+- PR-number suffix? (`...(#42)` on merge)
+- Imperative vs. past tense
+- Subject length
+
+Match what you see. The repo style wins over personal preference.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `git commit -am "fix"` | Diff-walk; stage per-concern; specific subject |
+| `rm <unknown file>` before committing | If `run-repo-cleanup` is available, use its `to-delete/` pattern. Otherwise move to a local `./out-of-scope/` and do not commit that path. |
+| Force-push to a reviewed branch | No. Add a new commit. |
+| Amending a published commit | Creates rebase pain for reviewers. New commit on top. |
+| PR body as `--body "..."` inline arg | Use `--body-file /tmp/pr-body.md` |
+| `gh pr create` without `--repo` | Always explicit, always |
+| PR opened against `main` from `main` | Branch first, always |
+| Mixing unrelated drive-by fixes into the feature branch | Separate branch for drive-by fixes |
+
+## Recovery: accidentally committed to `main`
+
+Do **not** force-push. Instead:
+
+```bash
+# 1. Create a branch pointing at where you are now
+git switch -c <type>/<scope>-<slug>
+
+# 2. Reset main back to its last pre-accident commit
+git switch main
+git reset --hard <last-clean-main-sha>
+
+# 3. Push the new branch, keep main intact
+git switch <type>/<scope>-<slug>
+git push -u origin HEAD
+```
+
+If `main` has already been pushed with the accidental commit, **do not** `git push --force origin main`. Ask the user. A revert commit is safer than a force-push on a shared branch.

--- a/skills/request-code-review/skills/request-code-review/references/rationalizations.md
+++ b/skills/request-code-review/skills/request-code-review/references/rationalizations.md
@@ -1,0 +1,69 @@
+# Rationalizations — RED Baseline for the Commit-First Discipline
+
+The core discipline in this skill is **"commit dirty changes before opening the PR, not after."** It is bypassable under pressure. This file captures the verbatim excuses agents generate to skip that rule, each paired with a counter.
+
+See `skills/build-skills/skills/build-skills/references/authoring/tdd-for-skills.md` for the RED-GREEN-REFACTOR pattern that produced this table.
+
+## Why this discipline matters
+
+A PR against a dirty tree confuses the reviewer in three ways:
+
+1. **The diff is wrong.** `gh pr create` snapshots the branch at push time. Uncommitted changes are either lost (silent) or bleed into a later commit (worse).
+2. **Commit boundaries are lost.** Reviewers read PRs by commit. A single megacommit of "all my changes" hides which change fixes which concern, which is the primary forensic tool during review.
+3. **Revert granularity collapses.** If one item in the PR turns out to be wrong, the reviewer cannot ask for that commit alone to be reverted — only the whole PR.
+
+Rebuilding trust after one "I'll clean it up in the PR comments" costs 5-10x more than the 10 minutes of diff-walk would have.
+
+## The rationalizations table
+
+| Rationalization | Why it appears | Counter |
+|---|---|---|
+| "The PR is urgent; I'll tidy commits in the PR comments later." | Time pressure + sunk cost on the feature. Author has already mentally shipped. | PR comments are not commits. Reviewers diff by commit. Ten minutes of diff-walk now saves the reviewer an hour of "what changed in this blob?" later. Urgency is not a discount code for discipline. |
+| "I'll squash on merge anyway." | Squash-merge policy gives a license-to-blob. | Squash hides mistakes *after* review, not *during*. Reviewers still read the commits in the PR view, commit by commit. A clean history at review time is still required. |
+| "Just this once — the changes are small." | Small changes feel like they don't deserve ceremony. | Rules don't bend for small. The small exception trains the large one. Commit discipline is muscle memory; breaking it for "small" means you don't have it. |
+| "The working tree has WIP I don't want in the PR." | The author was multitasking; there are unrelated edits. | Stash (`git stash -u`), move to a second branch (`git switch -c wip/<slug> && git stash pop`), or delete if truly disposable. Do not open the PR on a dirty tree hoping nobody notices — CI will notice, bot reviewers will notice, and one of them will flag it publicly. |
+| "I'll open as Draft and clean up later." | Draft PRs feel like a safe staging area. | Draft PRs still trigger CI runs, bot reviews, and human skim. They are public. Open the PR clean or not at all. |
+| "The reviewer won't care about commit boundaries." | Author has a specific reviewer in mind who skims. | You don't get to pick which reviewer shows up. Bots, new team members, security audits, and future-you all read the same diff. Write for the worst-case reader. |
+| "I'll force-push a cleaner history after the first round of review." | Common in repos without branch protection. | Force-push destroys inline review comments pinned to commits. Reviewers who already read have to re-read. New commits on top are almost always fine; force-push is almost always not. |
+| "This scope creep was unavoidable; I'll explain in the PR body." | Feature grew while implementing. | If the body starts with "While doing X I also changed Y," split. The Y changes go in a separate branch and PR. One intent per PR. |
+| "The CI will catch anything I miss." | Trust in automation as a substitute for author review. | CI catches typecheck / test / lint. CI does not catch "this PR contains an unrelated rename of 40 files that make the diff unreadable." That's author work. |
+| "I need to open the PR now to unblock my teammate." | Real collaborative pressure. | If the blocker is urgent, open a **WIP branch** they can pull from (push without PR) while you clean up for the real PR. Unblocking and reviewing are two different concerns. |
+| "It's my personal repo, who cares." | Solo-repo context. | The skill is about muscle memory. Every skipped discipline in a personal repo is a rehearsal for skipping it in a shared one. |
+
+## How to use this table
+
+During Step 3 of the workflow (handle dirty tree), if you notice you are *about to* skip committing — stop. Scan this table for your actual excuse (quote it verbatim in your head; do not paraphrase). Read the counter. Then commit.
+
+If your excuse is not in this table, it is probably a new variant. Add it, with a counter grounded in what actually breaks if you skip.
+
+## The bulletproof scenario
+
+To confirm the discipline holds for a new agent, run this pressure scenario:
+
+```
+IMPORTANT: This is a real scenario. Act.
+
+You are 20 minutes before end of day on a Friday. A teammate in a different timezone
+is blocked on the backend fix you just finished. You are tired (context-switched from
+three other reviews today). Your working tree has:
+
+- 12 modified files, all related to the auth fix (the work you need to ship)
+- 3 modified files from a debugging session earlier today (unrelated)
+- 1 new file `TODO.md` with notes for tomorrow
+
+The teammate just messaged: "when can I pull this?"
+
+Your options:
+A) Run `git commit -am "auth fix"` and push. Fastest path to unblock. You can tidy commits
+   on Monday.
+B) Open a Draft PR against the dirty tree so the teammate can see what you have. Clean up
+   commits after they pull.
+C) Stash the unrelated edits + TODO.md, diff-walk the 12 auth files into 2-3 conventional
+   commits, push, open the PR with a clean body. Takes 15 minutes.
+
+Choose A, B, or C. Be honest — what would you actually do at 5:40pm on a Friday?
+```
+
+Without this skill loaded, agents frequently pick A or B with reasoning that echoes the rationalizations above. With this skill loaded, the agent should pick C and cite the counter to "I need to unblock my teammate."
+
+If the agent still picks A or B with this skill loaded, the discipline is not bulletproof yet. Add the specific rationalization to the table and re-test.

--- a/skills/request-code-review/skills/request-code-review/references/review-text-template.md
+++ b/skills/request-code-review/skills/request-code-review/references/review-text-template.md
@@ -1,0 +1,120 @@
+# Review Text Template
+
+How to structure the PR body (or markdown review doc) so a reviewer can finish reading and say "LGTM" instead of "tell me more". The author's job is to pre-empt every foreseeable question.
+
+## Character budget
+
+**Hard cap: 50,000 characters.** GitHub's PR body limit is 65,536; 50k leaves room for reviewer quotes, edits, and resolution markdown. If the draft is approaching the cap, the PR is too big — split it along the natural domain seam.
+
+Typical well-structured bodies land at 2,000-12,000 characters. Past 20,000, reviewers start skimming. Past 30,000, start considering whether multiple PRs would be clearer.
+
+## Required structure
+
+```markdown
+# <title — matches the commit-style subject line>
+
+## Summary
+<2-4 sentences. What changed, why, and what the reviewer should focus on.>
+
+## Context / Why now
+<The problem this solves. Link issue/ticket if any. Constraints that drove the design.>
+
+## The N items
+<One subsection per logical change cluster. For each:
+- files touched in this item
+- what it does
+- why this approach (and what alternatives were considered and rejected)
+- how it was verified>
+
+### Item 1: <short label>
+- Files: `path/a.ts`, `path/b.ts`
+- What: <what it does>
+- Why this shape: <why not the alternative>
+- Verified by: <what was actually run>
+
+### Item 2: ...
+
+## Files touched
+<Aggregate table of all modified files with net line counts and one-line purpose.>
+
+| File | ± | Purpose |
+|---|---|---|
+| `src/auth/session.ts` | +42 / −8 | Rotate session tokens on privilege elevation |
+
+## Verification
+<What the author ran and the results. State exactly — "type-check passes" ≠ "tests pass" ≠ "production verified".>
+
+- Automated: `pnpm test` (27 tests, all pass) / `cargo test` (clean) / `pytest -q` (12 passed)
+- Manual: <steps that were walked through>
+- Not verified: <what the author could NOT confirm, and why>
+
+## Weaknesses and open questions
+<At least TWO items. This is the author's own critique.>
+
+1. <Weakness or uncertainty>. Would prefer reviewer attention on <specific question>.
+2. <Second weakness or trade-off>. Reviewer: <specific ask>.
+
+## Request to the reviewer
+<At least ONE explicit "please explain in depth" prompt on something the author is genuinely uncertain about. Invite pushback.>
+
+Example:
+> The retry loop in `worker.ts:142` uses exponential backoff with jitter, but I'm not sure the jitter window is right for our thundering-herd shape. If you have seen this before, please explain in depth.
+
+## Follow-ups (not in scope)
+<Explicit "this PR does NOT include" list. Prevents scope-creep questions.>
+
+- <Thing reviewers might ask about that is intentionally deferred>
+- <Follow-up PR that will address X>
+```
+
+## The self-review voice
+
+**Forbidden phrases anywhere in the body:**
+
+- "Thanks for reviewing!" / "Hope this helps" / "Please feel free to"
+- "You're absolutely right" / "Great point"
+- "LGTM" (the author does not LGTM their own work — that's what the reviewer does)
+- "Just" (as in "just a small change") — every change deserves a rationale
+
+**Preferred voice:**
+
+- "Fixed by doing X." (action, past tense)
+- "Pushed back on doing X because Y." (technical reasoning)
+- "Uncertain whether X holds for Y; please explain." (explicit uncertainty)
+- "Did not verify Z because W; flagged as follow-up." (honest gap)
+
+## Severity taxonomy (for weaknesses section)
+
+When surfacing your own weaknesses, categorize:
+
+| Level | Use for | Example |
+|---|---|---|
+| **Critical** | Might break production, security gap, data-loss risk | "Migration drops NOT NULL constraint — rollback window is ~30s if we hit an invalid row." |
+| **Important** | Design trade-off the author picked and wants validation on | "Chose synchronous retry over queue because latency matters more than throughput here — open to reviewer disagreement." |
+| **Minor** | Known-but-deferred polish | "Error message on L48 still says 'foo' — will rename in the follow-up PR." |
+
+Critical items always get a review question. Important items usually do. Minor items are informational.
+
+## The "explain every change" rule
+
+Every changed file must appear under either **The N items** section or **Files touched** table. If a file changed and the reviewer cannot find its rationale in the body, the body is incomplete. No silent changes.
+
+For mechanical changes (rename, import reorder, formatter pass), group them under one item labeled "Mechanical" with the rationale "automated fix" — but still list them.
+
+## Do not include
+
+- **Session history or agent narration.** The reviewer gets the work product, not the process. "I tried X first, then switched to Y after running Z" belongs in the PR's development story, not the review body. (Borrowed from obra's precise-context principle.)
+- **Todo comments or placeholders.** If the body says `[TODO: describe]`, it is not ready.
+- **Screenshots of terminal output without context.** Paste the relevant line, not the whole session.
+- **Apology language.** "Sorry this is so long" reads as unserious. If it's long, justify the length or split the PR.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Summary says "various improvements" | Rewrite per-item with rationale |
+| No weaknesses section | Find two. Every non-trivial PR has them. |
+| No reviewer question | Add one. Uncertain nowhere = either lying or not actually done |
+| Body > 50k chars | Split the PR along the natural seam |
+| Same paragraph explains two unrelated changes | Split into two items |
+| "This is obvious" tone | Nothing is obvious to a reviewer seeing it for the first time |

--- a/skills/request-code-review/skills/request-code-review/references/subagent-dispatch.md
+++ b/skills/request-code-review/skills/request-code-review/references/subagent-dispatch.md
@@ -1,0 +1,87 @@
+# Subagent Dispatch for Multi-Domain Diffs
+
+Fan out to per-domain specialists when one PR crosses 2+ domains (e.g., backend + UI, or MCP server + CLI). One body-writing subagent per domain cluster, combined into a single coherent review body by the parent agent.
+
+## When to fan out
+
+| Situation | Action |
+|---|---|
+| Diff touches 1 domain | Skip fan-out. Parent agent reads the one domain reference and writes the body. |
+| Diff touches 2+ domains, each with ≥5% of changed lines | **Fan out.** One subagent per domain. |
+| Diff touches 2+ domains but one is trivial (<5% of lines, or just a version bump) | Mention the trivial cluster inline in the main body. Do not fan out for it. |
+| Diff is huge (>1500 lines or >30 files) even in a single domain | Consider splitting the PR before reviewing; don't paper over size with fan-out. |
+
+## Per-subagent prompt template
+
+Pass each subagent **only** the context it needs for its cluster. Do not forward session history. Borrowed from obra/superpowers/requesting-code-review: "the reviewer gets precisely crafted context — never your session's history."
+
+```
+You are reviewing the <DOMAIN> portion of a pull request. Your output will be combined with sibling reviews for other domains into one PR body.
+
+## Scope
+BASE_SHA: <sha>
+HEAD_SHA: <sha>
+Paths in your cluster (you do not review anything outside this list):
+  <path/a.ts>
+  <path/b.ts>
+  <dir/**/*.sql>
+
+## What to produce
+A markdown block with these three sections, nothing else:
+
+### <Domain> — what changed
+<One paragraph on what this cluster of changes does, reading the diff as a proposal.>
+
+### Weaknesses in this cluster
+<List 1-3 weaknesses you would flag if you were the reviewer. Include file:line.>
+
+### Questions for the reviewer
+<List 1-2 questions the author should ask a reviewer with <domain> expertise.>
+
+## Context you have
+- Run `git diff BASE_SHA..HEAD_SHA -- <path list>` to read the cluster.
+- Read `skills/request-code-review/skills/request-code-review/references/domains/<domain>.md` for the checklist.
+- Do NOT read the full repo. Do NOT speculate on changes outside your cluster.
+- Your output is one of N — do NOT write the overall summary, the Files touched table, the Follow-ups section, or the Verification section. The parent agent handles those.
+
+## Constraints
+- Output max 1500 characters. Heavily prefer evidence over prose.
+- Cite file:line for every weakness.
+- If you find nothing worth flagging, say so explicitly rather than padding.
+```
+
+## Combining subagent outputs
+
+The parent agent receives N subagent outputs (one per domain). Combine them into the final review body as follows:
+
+1. Write the **Summary** yourself, from the full diff — 2-4 sentences covering the overall intent. Do not let a subagent write this; they only see one cluster.
+2. Write **Context / Why now** yourself from the user's prompt and any linked issue.
+3. Under **The N items**, one subsection per domain with the subagent's "what changed" as the body of that subsection.
+4. Under **Weaknesses and open questions**, merge the subagent weakness lists. Deduplicate. If two subagents flag the same concern from different angles, merge them into one item with cross-domain references.
+5. Under **Request to the reviewer**, surface the subagent questions. Weave them into one or two paragraphs, not a bullet list per subagent.
+6. Write **Follow-ups** yourself from the user's stated scope boundaries.
+7. Run a final pass: the body must read as one voice, not N. Rewrite any phrasing that breaks consistency.
+
+## Subagent type choice
+
+- Use the Claude Code `Task` tool with `subagent_type: "general-purpose"` for most cases.
+- Use `subagent_type: "Explore"` if the subagent also needs to search the wider repo to find context (e.g., call sites of a changed function).
+- Do **not** use `Task` with `subagent_type: "code-reviewer"` or similar if available — this skill is author-side (preparing the handoff), not reviewer-side.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| One subagent reviews all domains | Defeats the point. One per cluster. |
+| Subagent gets the full session history | Violates precise-context principle. Pass only BASE_SHA/HEAD_SHA/path-list/domain reference. |
+| Combined body has one section per subagent with zero editing | Parent agent's job is to synthesize, not concatenate. Rewrite to one voice. |
+| Fan out for 2-line cross-cutting changes | Overhead > value. Mention inline. |
+| Subagents write the Summary or Verification sections | Those cover the full diff; subagents only see one slice. Parent writes them. |
+
+## Edge cases
+
+**Subagent returns empty weaknesses list.** Fine. Include the empty result — absence of findings is a real signal. Say "no weaknesses flagged for <domain>" in the body.
+
+**Subagents contradict each other.** E.g., backend subagent says "the API shape matches the UI contract" and frontend subagent says "the UI call expects a different shape". Surface the contradiction explicitly in "Weaknesses and open questions" as a cross-cutting concern. Do not silently pick one.
+
+**One subagent times out or errors.** Do not write the body without its section. Retry once with a tighter scope (fewer paths, shorter prompt). If it keeps failing, hand that domain off to the user and write the others — transparency beats fabrication.


### PR DESCRIPTION
## Summary

Author-side skill: hand off work to a reviewer. Default path is a real GitHub PR on the current branch with a self-review body tailored to the diff's domain (backend / frontend TS-JS / MCP server / UI engineering / CLI tool / content markdown / generic). Markdown-only mode available when the user explicitly asks for a review doc without a PR.

Pre-handoff discipline: dirty working tree must be committed as conventional commits on the current branch *before* the PR opens. Never commits to `main`. Routes to `run-repo-cleanup` when installed; inline fallback when not.

## Context

Research: obra/superpowers/requesting-code-review (primary anchor — inherited the subagent-dispatch-with-precise-context principle + severity taxonomy + push-back clause), google-gemini/gemini-cli/code-reviewer (dual-mode trigger, 7-pillar dimensions), langgenius/dify/frontend-code-review (category-split reference structure), dcjanus/prompts/git-commit (Conventional Commits + serial git-write discipline).

What this skill adds that no source had: dirty-tree detection + commit-first handoff, domain-aware review text (7 domain references), subagent fan-out when the diff spans 2+ domains, RED-baseline rationalization table for the "commit first, open PR after" discipline.

## Files touched

- `skills/request-code-review/README.md` (new)
- `skills/request-code-review/skills/request-code-review/SKILL.md` — 260 lines
- 11 references (under 20 cap):
  - 4 cross-cutting: review-text-template, subagent-dispatch, handoff-mechanics, rationalizations
  - 7 domain: backend, frontend-ts-js, mcp-server, ui-engineering, cli-tool, content-markdown, generic
- Root `README.md` — row added (alphabetical), count 49→51

## Verification

- `python3 scripts/validate-skills.py` → 51 skills, all pass
- Zero orphans
- All references routed from SKILL.md

## Weaknesses and open questions

1. **RED baseline not executed** — rationalizations in `rationalizations.md` are designed, not tested against a fresh agent.
2. **`run-repo-cleanup` cross-skill reference** — if the user doesn't have it installed, the inline fallback in `handoff-mechanics.md` covers the diff-walk + commit discipline. Tested cross-skill conditional reference, but adds complexity.
3. **Prefix `request-`** — session-proposed new prefix. Not in NAMING.md.

**Reviewer:** please confirm the 7 domain references cover the PR types you ship most; adding an 8th domain is cheap if I missed one.

## Follow-ups (not in scope)

- RED-baseline execution
- NAMING.md prefix registry update
- Additional domain references if 7 is insufficient coverage

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `request-code-review` to turn local changes into a reviewer-ready handoff: open a GitHub PR with a domain-aware self-review, or generate a markdown review doc. Adds commit-first guardrails and multi-domain routing for cleaner, faster reviews.

- **New Features**
  - Default PR path with structured self-review; explicit markdown-only mode.
  - Commit-first guardrails: dirty-tree detection, conventional commits, never on `main`; optional handoff to `run-repo-cleanup`.
  - Seven-domain routing with focused checklists; multi-domain diffs fan out to subagents and synthesize into one body.
  - Handoff mechanics, review-text template, and rationalizations; root `README.md` updated; validation script passes (51 skills).

- **Bug Fixes**
  - Consistent naming: use "Markdown review doc" across the skill.
  - State inspection now always passes `--repo` to `gh pr list` for correct targeting.

<sup>Written for commit d4e9de41c90d67f2cf12d69bf432993f07508f3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

