### PR TITLE
improve(enhance-prompt): add planning-questions + ask-user-tools references

### DIFF
--- a/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
@@ -33,11 +33,19 @@ Read the prompt. Form an internal opinion on these questions — do NOT show thi
 | Is this code-related? | If yes, the agent can see the filesystem, run commands, read files. Don't repeat what it can discover. |
 | What's the done signal? | How does the agent know to stop? Most prompts forget this and the agent spins. |
 
-### Step 2 — Plan via `AskUserQuestion` (Round 1, default)
+### Step 2 — Plan via the runtime's ask-user tool (Round 1, default)
 
 **Default: run Round 1.** For non-trivial prompts, a short upfront planning round catches misalignment cheaper than rewriting after enhancement.
 
-Dispatch **one** `AskUserQuestion` call with up to **4 bundled questions** (tool cap) covering the axes most likely to change the enhancement. Read `references/planning-questions.md` for the canonical axis bank + selection rules.
+Dispatch **one** user-question call with up to **4 bundled questions** covering the axes most likely to change the enhancement. The tool name depends on the runtime:
+
+- **Claude Code / Anthropic SDK** → `AskUserQuestion`
+- **OpenAI Codex** → `ask_user_question`
+- **Factory Droid CLI** → `ask_user`
+- **Gemini CLI** → `ask-user`
+- **Other / unknown runtime** → prose fallback (same options, presented as markdown)
+
+See `references/ask-user-tools.md` for the full runtime-to-tool table, invocation shape, and the prose fallback template. See `references/planning-questions.md` for the canonical axis bank + selection rules.
 
 Per question:
 - **2-4 options**, mutually exclusive unless `multiSelect: true` is clearly right (e.g., "which failure modes to block" — multiple is common)
@@ -62,7 +70,7 @@ After Round 1 answers come back, assess: did the answers surface a new ambiguity
 - Round 1 cleared the picture — go straight to Step 3
 - You are tempted to use Round 2 to "double-check" Round 1 answers → no, just proceed
 
-Round 2 is **one** `AskUserQuestion` call, **1-3 focused questions**. Total question budget across both rounds: **≤ 7**. If the budget is blown, make a reasoned default and proceed with a note.
+Round 2 is **one** call to the runtime's ask-user tool, **1-3 focused questions**. Total question budget across both rounds: **≤ 7**. If the budget is blown, make a reasoned default and proceed with a note.
 
 ### Step 3 — Enhance
 
@@ -129,7 +137,7 @@ If the user says "run it" — execute the enhanced prompt directly. Reset framin
 - No five-shot examples unless the user asks for them
 - No "agent writes its own prompt" meta-prompting
 - No 26-principle dumps or academic prompt engineering
-- No more than 2 `AskUserQuestion` rounds, ever — and no more than 4 questions per round (tool cap)
+- No more than 2 ask-user rounds, ever — and no more than 4 questions per round (Claude Code cap; keep portable)
 - No forcing Round 1 on surgical one-liners — skip it when Step 1 diagnosis is unambiguous
 - No "Option A / B / C" filler labels — every option must be a meaningful choice the user can compare
 - No manually-added "Other" option — the tool auto-provides it
@@ -140,6 +148,7 @@ If the user says "run it" — execute the enhanced prompt directly. Reset framin
 
 | File | Read when |
 |---|---|
+| `references/ask-user-tools.md` | Dispatching the planning round — picks the right tool name for the current runtime (AskUserQuestion / ask_user_question / ask_user / ask-user / prose fallback) |
 | `references/planning-questions.md` | Running Step 2 (Round 1) — canonical axis bank, picking the "(Recommended)" option, swap rules, worked examples |
 | `references/enhancement-layers.md` | Applying the 5 enhancement layers — detailed guidance per layer |
 | `references/code-prompt-patterns.md` | Prompt targets a coding agent — file paths, verification, tech-stack awareness |

--- a/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
@@ -55,7 +55,7 @@ Per question:
 - **2-4 options**, mutually exclusive unless `multiSelect: true` is clearly right (e.g., "which failure modes to block" — multiple is common)
 - **First option marked "(Recommended)"** based on your Step 1 diagnosis — not a static default
 - **Short labels** (1-5 words), one-line descriptions
-- **Do not manually add "Other"** — the tool auto-provides it
+- **Do not manually add "Other"** — Claude Code auto-provides it and most other runtimes mimic this convention; see `references/ask-user-tools.md` for per-runtime differences
 
 **Skip Round 1 only when:**
 - The prompt is a one-line surgical edit with unambiguous intent ("fix typo in README line 12")
@@ -144,7 +144,7 @@ If the user says "run it" — execute the enhanced prompt directly. Reset framin
 - No more than 2 ask-user rounds, ever — and no more than 4 questions per round (Claude Code cap; keep portable)
 - No forcing Round 1 on surgical one-liners — skip it when Step 1 diagnosis is unambiguous
 - No "Option A / B / C" filler labels — every option must be a meaningful choice the user can compare
-- No manually-added "Other" option — the tool auto-provides it
+- No manually-added "Other" option — Claude Code auto-provides it and most runtimes mimic this; see `references/ask-user-tools.md` if running on a runtime that differs
 - No rewriting the user's voice — enhance the content, preserve the tone
 - No spawning agents — this skill enhances a user message, period
 
@@ -152,7 +152,7 @@ If the user says "run it" — execute the enhanced prompt directly. Reset framin
 
 | File | Read when |
 |---|---|
-| `references/ask-user-tools.md` | Dispatching the planning round — picks the right tool name for the current runtime (AskUserQuestion / ask_user_question / ask_user / ask-user / prose fallback) |
+| `references/ask-user-tools.md` | Dispatching the planning round — picks the right tool name for the current runtime across 16 mapped agents (Claude Code / Codex / Factory Droid / Cursor / Gemini CLI / Cline / Roo / and 9 more), with a prose fallback when no structured tool is available |
 | `references/planning-questions.md` | Running Step 2 (Round 1) — canonical axis bank, picking the "(Recommended)" option, swap rules, worked examples |
 | `references/enhancement-layers.md` | Applying the 5 enhancement layers — detailed guidance per layer |
 | `references/code-prompt-patterns.md` | Prompt targets a coding agent — file paths, verification, tech-stack awareness |

--- a/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
@@ -37,15 +37,19 @@ Read the prompt. Form an internal opinion on these questions — do NOT show thi
 
 **Default: run Round 1.** For non-trivial prompts, a short upfront planning round catches misalignment cheaper than rewriting after enhancement.
 
-Dispatch **one** user-question call with up to **4 bundled questions** covering the axes most likely to change the enhancement. The tool name depends on the runtime:
+Dispatch **one** user-question call with up to **4 bundled questions** covering the axes most likely to change the enhancement. The tool name depends on the runtime — here is a quick lookup, full table in `references/ask-user-tools.md`:
 
-- **Claude Code / Anthropic SDK** → `AskUserQuestion`
-- **OpenAI Codex** → `ask_user_question`
-- **Factory Droid CLI** → `ask_user`
-- **Gemini CLI** → `ask-user`
-- **Other / unknown runtime** → prose fallback (same options, presented as markdown)
+- **claude-code** / **kimi-cli** → `AskUserQuestion`
+- **codex** / **qwen-code** / **mistral-vibe** → `ask_user_question`
+- **gemini-cli** / **deepagents** / **github-copilot** / **pi** → `ask_user`
+- **cline** / **roo** → `ask_followup_question`
+- **cursor** / **continue** → `AskQuestion`
+- **droid** → `AskUser`
+- **antigravity** → `suggested_responses`
+- **opencode** → `question`
+- **Unknown runtime** → prose fallback (same options, presented as markdown)
 
-See `references/ask-user-tools.md` for the full runtime-to-tool table, invocation shape, and the prose fallback template. See `references/planning-questions.md` for the canonical axis bank + selection rules.
+See `references/ask-user-tools.md` for the full 16-runtime table with confidence notes, invocation shape, naming-convention lookup, and the prose fallback template. See `references/planning-questions.md` for the canonical axis bank + selection rules.
 
 Per question:
 - **2-4 options**, mutually exclusive unless `multiSelect: true` is clearly right (e.g., "which failure modes to block" — multiple is common)

--- a/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/SKILL.md
@@ -33,19 +33,36 @@ Read the prompt. Form an internal opinion on these questions — do NOT show thi
 | Is this code-related? | If yes, the agent can see the filesystem, run commands, read files. Don't repeat what it can discover. |
 | What's the done signal? | How does the agent know to stop? Most prompts forget this and the agent spins. |
 
-### Step 2 — Ask ONLY if scope is genuinely ambiguous
+### Step 2 — Plan via `AskUserQuestion` (Round 1, default)
 
-**Default: skip questions entirely.** Most prompts don't need clarification — they need enhancement.
+**Default: run Round 1.** For non-trivial prompts, a short upfront planning round catches misalignment cheaper than rewriting after enhancement.
 
-Ask ONLY when the prompt could go in 2+ meaningfully different directions and you can't make a reasonable default assumption. If you must ask, use `AskUserQuestion` with:
-- **Maximum 2 questions**, 2-3 options each
-- Put the best default first with "(Recommended)"
-- Always include an option that says "Just go with your best judgment"
+Dispatch **one** `AskUserQuestion` call with up to **4 bundled questions** (tool cap) covering the axes most likely to change the enhancement. Read `references/planning-questions.md` for the canonical axis bank + selection rules.
 
-**Skip questions when:**
-- The intent is clear even if details are vague (you'll fill them in)
-- You can make a sensible default and note it
-- The prompt is code-related and the agent can discover context from the filesystem
+Per question:
+- **2-4 options**, mutually exclusive unless `multiSelect: true` is clearly right (e.g., "which failure modes to block" — multiple is common)
+- **First option marked "(Recommended)"** based on your Step 1 diagnosis — not a static default
+- **Short labels** (1-5 words), one-line descriptions
+- **Do not manually add "Other"** — the tool auto-provides it
+
+**Skip Round 1 only when:**
+- The prompt is a one-line surgical edit with unambiguous intent ("fix typo in README line 12")
+- The user explicitly said "just enhance, don't ask"
+- Step 1 diagnosis shows the prompt is already excellent → proceed with the light-touch path and a one-line note
+
+### Step 2a — Round 2 (conditional, narrower)
+
+After Round 1 answers come back, assess: did the answers surface a new ambiguity Round 1 could not have anticipated?
+
+**Fire Round 2 only if:**
+- An answer steered the enhancement into an axis Round 1 did not cover (e.g., user picked "Plan of attack" on the outcome axis → now you need to ask what shape the plan should take)
+- The user chose "Other" with text that introduces a new axis
+
+**Skip Round 2 when:**
+- Round 1 cleared the picture — go straight to Step 3
+- You are tempted to use Round 2 to "double-check" Round 1 answers → no, just proceed
+
+Round 2 is **one** `AskUserQuestion` call, **1-3 focused questions**. Total question budget across both rounds: **≤ 7**. If the budget is blown, make a reasoned default and proceed with a note.
 
 ### Step 3 — Enhance
 
@@ -112,7 +129,10 @@ If the user says "run it" — execute the enhanced prompt directly. Reset framin
 - No five-shot examples unless the user asks for them
 - No "agent writes its own prompt" meta-prompting
 - No 26-principle dumps or academic prompt engineering
-- No excessive AskUserQuestion rounds — 0 or 1 question max
+- No more than 2 `AskUserQuestion` rounds, ever — and no more than 4 questions per round (tool cap)
+- No forcing Round 1 on surgical one-liners — skip it when Step 1 diagnosis is unambiguous
+- No "Option A / B / C" filler labels — every option must be a meaningful choice the user can compare
+- No manually-added "Other" option — the tool auto-provides it
 - No rewriting the user's voice — enhance the content, preserve the tone
 - No spawning agents — this skill enhances a user message, period
 
@@ -120,6 +140,7 @@ If the user says "run it" — execute the enhanced prompt directly. Reset framin
 
 | File | Read when |
 |---|---|
+| `references/planning-questions.md` | Running Step 2 (Round 1) — canonical axis bank, picking the "(Recommended)" option, swap rules, worked examples |
 | `references/enhancement-layers.md` | Applying the 5 enhancement layers — detailed guidance per layer |
 | `references/code-prompt-patterns.md` | Prompt targets a coding agent — file paths, verification, tech-stack awareness |
 | `references/failure-modes.md` | Predicting and pre-empting common agent failure modes |

--- a/skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md
@@ -1,0 +1,111 @@
+# Ask-User Tools by Runtime
+
+This skill dispatches planning questions via a user-question tool. The tool's name and signature vary by runtime. Pick the right one for the runtime you are running in; fall back to plain prose if the tool is unavailable.
+
+## Runtime → tool mapping
+
+| Runtime | Tool name | Invocation style |
+|---|---|---|
+| **Claude Code** (and Anthropic Agent SDK) | `AskUserQuestion` | 1-4 questions per call, 2-4 options each; first option marked `(Recommended)`; `multiSelect: true` for multi-choice; "Other" auto-provided |
+| **OpenAI Codex** | `ask_user_question` | Snake-case variant of the same pattern; payload fields parallel Claude Code's shape |
+| **Factory Droid CLI** | `ask_user` | Structured user-question flow; see Factory's hooks/tools reference for the exact schema |
+| **Gemini CLI** | `ask-user` | Kebab-case CLI tool; used the same way as the structured-question pattern above |
+| **GitHub Copilot CLI** | *(not clearly exposed in public docs)* | Public CLI docs describe approvals and interactive prompts but don't name a first-class ask-user tool; fall back to a prose prompt (see below) |
+| **Unknown / other** | N/A | Fall back to prose prompt (see "Fallback" below) |
+
+Sources for the mapping: Claude Code Agent SDK user-input docs; OpenAI Codex issue tracker referencing `ask_user_question`; Factory Droid CLI hooks reference mentioning `ask_user`; Gemini CLI tools docs mentioning `ask-user`. The GitHub Copilot CLI reference does not surface a direct equivalent name; treat as unknown.
+
+## Picking the right one at runtime
+
+Detect the runtime before invoking a tool:
+
+1. **If running under Claude Code / Anthropic SDK** → `AskUserQuestion` is available. Prefer it.
+2. **If running under OpenAI Codex** → `ask_user_question`.
+3. **If running under Factory Droid CLI** → `ask_user`.
+4. **If running under Gemini CLI** → `ask-user`.
+5. **If the runtime is unclear** → try `AskUserQuestion` first; if it fails with "unknown tool," fall back to prose.
+6. **If no tool works at all** → prose prompt.
+
+If you are writing this skill's instructions into an agent's system prompt, include the table above so the agent routes correctly without calling a missing tool.
+
+## Signature shape (common across structured-question tools)
+
+Each of the structured tools (Claude's `AskUserQuestion`, Codex's `ask_user_question`, etc.) exposes roughly the same payload shape:
+
+```
+questions: [
+  {
+    question: "<user-facing question text>",
+    header: "<short chip label>",
+    multiSelect: true | false,
+    options: [
+      { label: "<short label>", description: "<one-line description>" },
+      ...
+    ]
+  },
+  ...
+]
+```
+
+Constraints to honor across runtimes:
+
+- **1-4 questions per call** (Claude Code's cap; other runtimes may allow more but keeping to 4 is portable)
+- **2-4 options per question** (same portability logic)
+- **First option marked `(Recommended)`** in the label, based on your Step 1 diagnosis
+- **Do NOT include an "Other" option manually** — Claude Code auto-adds it; other runtimes may differ, but mimicking this convention keeps the prompt clean
+- **Use `multiSelect: true`** only when the choices are genuinely orthogonal (e.g., "which failure modes to block" — multiple can apply)
+
+## Fallback — prose prompt
+
+When no structured tool is available, produce the same decision surface in prose. Format:
+
+```markdown
+Before I enhance the prompt, pick your preference on these axes:
+
+1. **Outcome type** — which primary outcome do you need?
+   - (Recommended) Working code — runnable code that solves the task
+   - Plan or strategy — a plan to execute later
+   - Understanding — explanation or walkthrough
+   - Research summary — gathered info, synthesized
+
+2. **Enhancement depth** — how aggressive should the rewrite be?
+   - (Recommended) Moderate — narrative + failure pre-emption + halt
+   - Light touch — only halt + verification
+   - Full restructure — all 5 layers
+
+3. **Verification style** — how should the agent confirm it's done?
+   - (Recommended) Run tests
+   - Smoke-test manually
+   - Self-describe the fix
+   - Visual / screenshot
+
+4. **Failure modes to block** — pick all that apply:
+   - (Recommended) Scope creep
+   - (Recommended) Over-engineering
+   - Silent degradation
+   - Assumption cascade
+
+Reply with your picks (e.g., "1A, 2B, 3A, 4: scope creep + silent degradation") or "other" with free text.
+```
+
+Key rule: the prose fallback presents the *same* options as the structured tool — don't reduce the decision surface just because the tool is missing.
+
+## Why this matters
+
+Hard-coding `AskUserQuestion` in a skill means the skill quietly breaks on non-Claude runtimes — the call fails, the agent either skips the planning round or makes up an answer. Neither is a good failure mode.
+
+Routing via this reference keeps the planning round portable: the skill works on Claude Code, Codex, Factory Droid, Gemini CLI, or (with the prose fallback) any runtime.
+
+## When this reference is read
+
+This reference is primarily consumed by:
+
+- **`enhance-prompt`** — during Step 2 (Round 1 planning), the skill dispatches a question tool. The tool name depends on the runtime.
+
+Other skills in this pack that occasionally ask user questions (e.g. `check-completion` when scope is unclear, `build-skills` when design tradeoffs need user input) can reuse the table above without a cross-skill dependency — the table is short enough to inline by reference when needed.
+
+## Update policy
+
+When a new runtime emerges with its own ask-user tool, add a row to the table above and include the source. When a documented tool name changes, update the row and note the change date in a footnote.
+
+Do not silently drop rows. A runtime's absence from this table means "not yet verified", not "doesn't exist."

--- a/skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md
@@ -4,29 +4,52 @@ This skill dispatches planning questions via a user-question tool. The tool's na
 
 ## Runtime → tool mapping
 
-| Runtime | Tool name | Invocation style |
-|---|---|---|
-| **Claude Code** (and Anthropic Agent SDK) | `AskUserQuestion` | 1-4 questions per call, 2-4 options each; first option marked `(Recommended)`; `multiSelect: true` for multi-choice; "Other" auto-provided |
-| **OpenAI Codex** | `ask_user_question` | Snake-case variant of the same pattern; payload fields parallel Claude Code's shape |
-| **Factory Droid CLI** | `ask_user` | Structured user-question flow; see Factory's hooks/tools reference for the exact schema |
-| **Gemini CLI** | `ask-user` | Kebab-case CLI tool; used the same way as the structured-question pattern above |
-| **GitHub Copilot CLI** | *(not clearly exposed in public docs)* | Public CLI docs describe approvals and interactive prompts but don't name a first-class ask-user tool; fall back to a prose prompt (see below) |
-| **Unknown / other** | N/A | Fall back to prose prompt (see "Fallback" below) |
+Detect the runtime first, then look up its tool name below. Invoke that tool with the shared payload shape in the next section.
 
-Sources for the mapping: Claude Code Agent SDK user-input docs; OpenAI Codex issue tracker referencing `ask_user_question`; Factory Droid CLI hooks reference mentioning `ask_user`; Gemini CLI tools docs mentioning `ask-user`. The GitHub Copilot CLI reference does not surface a direct equivalent name; treat as unknown.
+| Agent / runtime | Tool name | Confidence basis |
+|---|---|---|
+| **claude-code** | `AskUserQuestion` | All 3 docs agree |
+| **codex** | `ask_user_question` | All 3 docs agree |
+| **gemini-cli** | `ask_user` | All 3 docs agree |
+| **deepagents** | `ask_user` | All 3 docs agree |
+| **kimi-cli** | `AskUserQuestion` | 2 docs agree; 1 silent → positive wins |
+| **cline** | `ask_followup_question` | 2 docs agree; 1 silent → positive wins |
+| **droid** (Factory) | `AskUser` | Research overrode vote — Factory release notes use PascalCase exclusively across 6+ changelog entries |
+| **cursor** | `AskQuestion` | 2 docs agree + research confirmed native Plan Mode tool via official bug reports |
+| **github-copilot** | `ask_user` | Research overrode vote — changelog proves shipped Jan 2025, listed in official tool reference table |
+| **roo** | `ask_followup_question` | 1 doc positive; 2 silent → positive wins |
+| **opencode** | `question` | 1 doc positive; 2 silent → positive wins |
+| **continue** | `AskQuestion` | 1 doc positive; 2 silent → positive wins |
+| **antigravity** | `suggested_responses` | 1 doc positive; 2 silent → positive wins |
+| **pi** | `ask_user` | 1 doc positive; 2 silent → positive wins |
+| **qwen-code** | `ask_user_question` | 1 doc positive; 2 silent → positive wins |
+| **mistral-vibe** | `ask_user_question` | 1 doc positive; 2 silent → positive wins |
+| **unknown / other** | — | Prose fallback (see "Fallback" below) |
+
+### Fast lookup by naming convention
+
+When you know the runtime but forget the exact casing, the grouping below is a memory aid:
+
+| Pattern | Runtimes |
+|---|---|
+| PascalCase `AskUserQuestion` | claude-code, kimi-cli |
+| PascalCase `AskUser` | droid |
+| PascalCase `AskQuestion` | cursor, continue |
+| `ask_user_question` | codex, qwen-code, mistral-vibe |
+| `ask_user` | gemini-cli, deepagents, github-copilot, pi |
+| `ask_followup_question` | cline, roo |
+| `suggested_responses` | antigravity |
+| `question` | opencode |
+
+Casing matters — the tool is an exact-match lookup. `ask_user_question` and `AskUserQuestion` are different tools in different runtimes.
 
 ## Picking the right one at runtime
 
-Detect the runtime before invoking a tool:
+1. Look at the runtime table above; invoke the listed tool.
+2. If the runtime is not in the table → try `AskUserQuestion` (most common PascalCase) once; if it fails with "unknown tool," try `ask_user` (most common snake_case) once.
+3. If both fail → prose fallback. Do not skip the planning round.
 
-1. **If running under Claude Code / Anthropic SDK** → `AskUserQuestion` is available. Prefer it.
-2. **If running under OpenAI Codex** → `ask_user_question`.
-3. **If running under Factory Droid CLI** → `ask_user`.
-4. **If running under Gemini CLI** → `ask-user`.
-5. **If the runtime is unclear** → try `AskUserQuestion` first; if it fails with "unknown tool," fall back to prose.
-6. **If no tool works at all** → prose prompt.
-
-If you are writing this skill's instructions into an agent's system prompt, include the table above so the agent routes correctly without calling a missing tool.
+When writing this skill's instructions into an agent's system prompt on a specific runtime, pre-resolve the tool name so the agent does not have to route at runtime.
 
 ## Signature shape (common across structured-question tools)
 

--- a/skills/enhance-prompt/skills/enhance-prompt/references/planning-questions.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/references/planning-questions.md
@@ -1,0 +1,174 @@
+# Planning Questions — Round 1 Axis Bank
+
+Round 1 of `enhance-prompt` dispatches a single `AskUserQuestion` call with up to **4 questions** (tool cap) covering the axes most likely to change the final enhancement. This file is the canonical bank; swap axes when the prompt warrants.
+
+## The four canonical axes
+
+For a typical non-trivial prompt, Round 1 picks 3-4 of these. If an axis is irrelevant, drop it — do not pad to hit 4.
+
+### Axis 1 — Outcome type
+
+> What's the primary outcome you need from this prompt?
+
+| Option | Description |
+|---|---|
+| Working code | Agent produces runnable code that solves the task |
+| Plan or strategy | Agent produces a plan to be executed later |
+| Understanding / explanation | Agent explains a concept, walks through a system, maps the landscape |
+| Research summary | Agent gathers external info and synthesizes |
+
+Mark "(Recommended)" based on Step 1 diagnosis:
+- Step 1 said "this is a coding task with a clear done state" → Recommended = Working code
+- Step 1 said "the user is exploring" → Recommended = Understanding
+- Step 1 said "multi-step with unclear sequencing" → Recommended = Plan or strategy
+
+### Axis 2 — Enhancement depth
+
+> How aggressive should the enhancement be?
+
+| Option | Description |
+|---|---|
+| Light touch | Add halt condition + verification only; prompt is already clear |
+| Moderate | Add narrative arc + failure pre-emption + halt |
+| Full restructure | Apply all 5 layers; show the transformation |
+
+Mark "(Recommended)":
+- Prompt is 1-3 sentences and already specific → Recommended = Light touch
+- Prompt has intent but lacks structure → Recommended = Moderate
+- Raw / stream-of-consciousness / vague → Recommended = Full restructure
+
+### Axis 3 — Verification style
+
+> How should the agent confirm the work is done?
+
+| Option | Description |
+|---|---|
+| Run tests | Agent runs the test suite and confirms green |
+| Smoke-test manually | Agent demonstrates the happy path end-to-end |
+| Self-describe the fix | Agent explains why the change is correct with file:line evidence |
+| Visual / screenshot | Agent produces a screenshot or demo |
+
+Mark "(Recommended)":
+- Code task, test suite exists in the repo → Recommended = Run tests
+- Code task, no tests → Recommended = Smoke-test manually
+- Diagnostic / debugging → Recommended = Self-describe the fix
+- UI / frontend → Recommended = Visual / screenshot
+
+### Axis 4 — Failure modes to block (multi-select)
+
+> Which failure modes should the enhanced prompt block most aggressively? Pick all that apply.
+
+| Option | Description |
+|---|---|
+| Scope creep | Agent refactors surrounding code, adds abstractions not asked for |
+| Assumption cascade | Agent builds on a wrong initial assumption |
+| Silent degradation | Agent gives up on the hard part and produces partial work |
+| Over-engineering | Agent adds flexibility, config, or abstractions not requested |
+
+Set `multiSelect: true` — failure modes co-occur.
+
+Mark "(Recommended)" on the highest-likelihood modes per prompt type:
+- Refactor / fix task → Recommended = Scope creep, Over-engineering
+- "Add feature X" prompt → Recommended = Over-engineering
+- Hard / ambiguous task → Recommended = Silent degradation, Assumption cascade
+- Multi-step exploration → Recommended = Assumption cascade
+
+## When to swap an axis
+
+The four canonical axes cover most prompts. Swap one for a prompt-specific axis when the canonical set misses the decision that would change the enhancement.
+
+Common swap candidates:
+
+| Candidate axis | Use when | Sample question |
+|---|---|---|
+| Target agent | Prompt might go to Claude Code, Codex, an API call, Gemini, etc. | "Which agent will consume this prompt?" |
+| Context scope | Prompt mentions files but is vague on which | "Which files should the agent focus on?" |
+| Boundary | Change could be file / module / system level | "What's the scope boundary for this work?" |
+| Blast radius | Prompt could affect shared systems (prod, shared infra) | "Should the agent act directly, or produce a plan for your approval?" |
+| Existing-code sensitivity | Codebase has strong conventions the prompt doesn't surface | "Should the agent strictly match existing patterns or propose improvements?" |
+
+Never swap just to vary the question set — swap only when the canonical axis is genuinely orthogonal to this prompt's decision space.
+
+## Picking the "(Recommended)" option per question
+
+The "(Recommended)" marker reflects your Step 1 diagnosis, not a static default. If you don't know which option to recommend, your Step 1 diagnosis was thin — read the prompt again before asking.
+
+Concrete rules:
+
+- Always mark exactly **one** option per question as Recommended (unless multiSelect, where you can mark up to 2)
+- The Recommended option goes **first** in the list
+- Append `(Recommended)` to the label — e.g., `Working code (Recommended)`
+- If genuinely uncertain between two, prefer the less aggressive / lower-blast-radius option
+
+## Round 1 example — code task
+
+User prompt: *"Make the login page faster, it's slow."*
+
+**Step 1 diagnosis**: vague (what's "slow"? what metric?), code-related (frontend), no verification criterion stated, no scope boundary.
+
+**Round 1 AskUserQuestion call** (4 bundled questions):
+
+```
+Questions:
+
+1. Outcome type:
+   - Plan of attack (Recommended) — measure first, then decide what to change
+   - Working code — jump straight to a fix
+   - Research summary — gather benchmark data only
+
+2. Enhancement depth:
+   - Moderate (Recommended) — add narrative, failure pre-emption, halt
+   - Full restructure — all 5 layers
+   - Light touch — only halt + verification
+
+3. Verification style:
+   - Before/after timing with Lighthouse (Recommended)
+   - Run existing tests
+   - Smoke test in browser
+   - Visual comparison screenshot
+
+4. Failure modes to block (multi-select):
+   - Scope creep (Recommended)
+   - Over-engineering (Recommended)
+   - Silent degradation
+   - Assumption cascade
+```
+
+After the user answers, Step 3 applies the enhancement with the picked axes.
+
+## Round 2 example — conditional follow-up
+
+Round 1 answers came back:
+- Outcome: **Plan of attack** (not code directly)
+- Depth: Moderate
+- Verification: Before/after Lighthouse
+- Failure modes: Scope creep, Over-engineering
+
+**New axis emerged**: user picked "Plan of attack" → now the enhancement must produce *a plan*, not *working code*. Plan-shaping is an axis Round 1 didn't cover.
+
+**Round 2 AskUserQuestion call** (1 question, targeted):
+
+```
+Question:
+
+1. Plan shape:
+   - Step-by-step execution sequence (Recommended)
+   - Tradeoff analysis of 2-3 approaches
+   - Prioritized backlog of improvements
+```
+
+Total budget used across rounds: 5 questions. Under the ≤ 7 cap. Proceed to Step 3.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Ask 4 questions on every prompt | For 1-2 sentence surgical prompts, skip Round 1 entirely |
+| Ask questions whose answers don't change the enhancement | Only ask if Step 3 would branch on the answer |
+| Always mark Option 1 as Recommended regardless of diagnosis | Recommended reflects the Step 1 diagnosis; if you can't pick, your diagnosis is thin |
+| Pad out to 4 questions when 2 would do | 2 focused questions > 4 diluted ones |
+| Generic "Option A / Option B / Option C" labels | Labels must be meaningful; the user is comparing them at a glance |
+| Include a manual "Just go with your best judgment" option | The tool auto-adds "Other" — the user can type there |
+| Fire Round 2 to validate Round 1 answers | Round 2 fires only for newly-emerged axes, not double-checks |
+| Round 2 with 4 questions (same size as Round 1) | Round 2 caps at 3 focused questions; if you need 4, it's really a Round 1 you should have run |
+| Forget to set `multiSelect: true` on the failure-modes question | Failure modes co-occur; single-select there is wrong |

--- a/skills/enhance-prompt/skills/enhance-prompt/references/planning-questions.md
+++ b/skills/enhance-prompt/skills/enhance-prompt/references/planning-questions.md
@@ -1,6 +1,6 @@
 # Planning Questions — Round 1 Axis Bank
 
-Round 1 of `enhance-prompt` dispatches a single `AskUserQuestion` call with up to **4 questions** (tool cap) covering the axes most likely to change the final enhancement. This file is the canonical bank; swap axes when the prompt warrants.
+Round 1 of `enhance-prompt` dispatches a single ask-user call (`AskUserQuestion` on Claude Code, `ask_user_question` on Codex, `ask_user` on Gemini CLI / deepagents / pi / GitHub Copilot, `ask_followup_question` on Cline / Roo, etc. — see `references/ask-user-tools.md` for the 16-runtime table + prose fallback) with up to **4 questions** (Claude Code cap; portable across runtimes) covering the axes most likely to change the final enhancement. This file is the canonical bank; swap axes when the prompt warrants.
 
 ## The four canonical axes
 
@@ -106,7 +106,7 @@ User prompt: *"Make the login page faster, it's slow."*
 
 **Step 1 diagnosis**: vague (what's "slow"? what metric?), code-related (frontend), no verification criterion stated, no scope boundary.
 
-**Round 1 AskUserQuestion call** (4 bundled questions):
+**Round 1 ask-user-tool call** (4 bundled questions; the example below is the logical structure — the tool name depends on the runtime, see `references/ask-user-tools.md`):
 
 ```
 Questions:
@@ -146,7 +146,7 @@ Round 1 answers came back:
 
 **New axis emerged**: user picked "Plan of attack" → now the enhancement must produce *a plan*, not *working code*. Plan-shaping is an axis Round 1 didn't cover.
 
-**Round 2 AskUserQuestion call** (1 question, targeted):
+**Round 2 ask-user-tool call** (1 question, targeted; same runtime-dependent tool name as Round 1):
 
 ```
 Question:


### PR DESCRIPTION
## Summary

Three-commit stack on the existing `enhance-prompt` skill:

1. **Flip AskUserQuestion from last-resort to default** (`785bc6f`) — Step 2 now runs a planning round by default; skip only for surgical one-liners
2. **Make Step 2 portable across runtimes** (`f2ac0b9`) — add `references/ask-user-tools.md` with a runtime table + prose fallback
3. **Expand ask-user-tools to 16 runtimes** (`0ffaf59`) — user-verified table covering Claude Code, Codex, Factory Droid, Cursor, Gemini CLI, Cline, Roo, Opencode, Continue, Antigravity, Pi, Qwen-code, Mistral-vibe, deepagents, kimi-cli, GitHub Copilot + confidence-basis per row

Plus: fix commit `ba18f97` addressing the automated review feedback (see below).

## Context

Previous flow treated AskUserQuestion as a last resort ("default: skip questions entirely"). For non-trivial prompts this caused the skill to guess at scope / depth / verification and frequently misaligned with the user's actual intent.

After the flip: a single planning round bundles up to 4 questions covering the axes most likely to change the enhancement (outcome type / depth / verification style / failure modes to block). Round 2 fires only when Round 1 reveals a new axis. Total question budget ≤ 7.

## Files touched

- `skills/enhance-prompt/skills/enhance-prompt/SKILL.md` — Step 2 + 2a rewritten; reference-routing table extended; "What NOT to do" updated with runtime-portability notes
- `skills/enhance-prompt/skills/enhance-prompt/references/ask-user-tools.md` (new, 134 lines after review fixes) — 16-runtime lookup + fast-lookup-by-naming-convention + payload-shape + prose fallback
- `skills/enhance-prompt/skills/enhance-prompt/references/planning-questions.md` (new, 174 lines) — 4 canonical axes with Recommended-marker rules + worked examples

## Verification

- `python3 scripts/validate-skills.py` → 50 skills, all pass (no count change — edit to existing skill)
- Zero orphans

## Review feedback addressed (`ba18f97`)

Copilot flagged that several places in SKILL.md and planning-questions.md hard-coded `AskUserQuestion` or the "Other auto-provided" convention as universal when ask-user-tools.md correctly documents per-runtime variation. Fixed in the follow-up commit:

- SKILL.md per-question rules + What-NOT-to-do: Claude-specific conventions now tagged as such with a pointer to ask-user-tools.md for runtimes that differ
- SKILL.md routing-table description: 16-runtime scope named with exemplars rather than an incomplete 4-name list
- planning-questions.md opening + worked examples: runtime-neutral language with per-runtime tool names called out and pointer to the full table

## Weaknesses and open questions

1. **Cross-skill duplication** — the 16-runtime table is also duplicated in `do-brainstorm/references/cross-runtime.md` (PR #38). Intentional (one-level-deep rule; each skill is usable standalone) but means two files to keep in sync when new runtimes emerge. Both files note this tradeoff.
2. **PR body correction** — an earlier version of this PR body claimed SKILL.md edits were reverted; that was wrong (the user reverted a local working-tree copy in a separate session, but the pushed branch always contained the full three-commit series). This version is correct.

## Follow-ups (not in scope)

- Single-source the 16-runtime table if cross-skill duplication becomes a maintenance burden
- Possible RED-baseline execution on the flipped-default flow to confirm it outperforms the prior "skip by default" approach on real prompts
