### PR TITLE
feat(use-chezmoi-dotfiles): add chezmoi-backed dotfiles orchestration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [test-by-mcpc-cli](skills/test-by-mcpc-cli/) | development | MCP server testing with mcpc 0.2.x |
 | [test-macos-snapshots](skills/test-macos-snapshots/) | testing | macOS app screenshot validation and drift checks |
 | [think-deeper](skills/think-deeper/) | productivity | Generic deep-thinking framework for hard tasks |
+| [use-chezmoi-dotfiles](skills/use-chezmoi-dotfiles/) | platform | chezmoi-backed dotfiles with age-encrypted secrets, canonical MCP catalog, and CLI wrappers (`sync`/`skill`/`mcp-manage`/`mcp-verify`) fronting all 5 AI coding assistants |
 | [use-railway](skills/use-railway/) | platform | Railway CLI commands, workflows, and version-drift routing |
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [test-by-mcpc-cli](skills/test-by-mcpc-cli/) | development | MCP server testing with mcpc 0.2.x |
 | [test-macos-snapshots](skills/test-macos-snapshots/) | testing | macOS app screenshot validation and drift checks |
 | [think-deeper](skills/think-deeper/) | productivity | Generic deep-thinking framework for hard tasks |
-| [use-chezmoi-dotfiles](skills/use-chezmoi-dotfiles/) | platform | chezmoi-backed dotfiles with age-encrypted secrets, canonical MCP catalog, and CLI wrappers (`sync`/`skill`/`mcp-manage`/`mcp-verify`) fronting all 5 AI coding assistants |
+| [use-chezmoi-dotfiles](skills/use-chezmoi-dotfiles/) | platform | chezmoi-backed dotfiles + MCP catalog + CLI wrappers for all AI assistants |
 | [use-railway](skills/use-railway/) | platform | Railway CLI commands, workflows, and version-drift routing |
 
 ## Notes

--- a/skills/use-chezmoi-dotfiles/README.md
+++ b/skills/use-chezmoi-dotfiles/README.md
@@ -1,6 +1,6 @@
 # use-chezmoi-dotfiles
 
-Drive the `sync` / `skill` / `mcp-manage` / `mcp-verify` CLI wrappers that front a chezmoi-managed dotfiles repo unifying Claude Code, OpenAI Codex, Factory Droid, Cursor, and GitHub Copilot through one AGENTS.md + one skill library + one MCP catalog.
+Edit yigitkonur's chezmoi-backed dotfiles on macOS — AI configs, MCP servers, skills, zsh, Homebrew, macOS defaults via `sync`/`skill`/`mcp-manage`/`mcp-verify` wrappers.
 
 **Category:** platform
 

--- a/skills/use-chezmoi-dotfiles/README.md
+++ b/skills/use-chezmoi-dotfiles/README.md
@@ -1,0 +1,19 @@
+# use-chezmoi-dotfiles
+
+Drive the `sync` / `skill` / `mcp-manage` / `mcp-verify` CLI wrappers that front a chezmoi-managed dotfiles repo unifying Claude Code, OpenAI Codex, Factory Droid, Cursor, and GitHub Copilot through one AGENTS.md + one skill library + one MCP catalog.
+
+**Category:** platform
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/use-chezmoi-dotfiles
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/use-chezmoi-dotfiles/skills/use-chezmoi-dotfiles/SKILL.md
+++ b/skills/use-chezmoi-dotfiles/skills/use-chezmoi-dotfiles/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: use-chezmoi-dotfiles
-description: Use skill if you are editing yigitkonur's dotfiles on any Mac — AI configs (Claude/Codex/Factory/Cursor/Copilot), MCP servers, skills, zsh, Homebrew, macOS defaults. The repo `yigitkonur/script-dotfiles` uses chezmoi + age-encrypted secrets. Use `sync`/`skill`/`mcp-manage`/`mcp-verify` wrappers instead of raw chezmoi.
+description: Use skill if you are editing yigitkonur's chezmoi-backed dotfiles on macOS — AI configs, MCP servers, skills, zsh, Homebrew, macOS defaults via `sync`/`skill`/`mcp-manage`/`mcp-verify` wrappers.
 ---
 
 # Use chezmoi dotfiles (yigitkonur/script-dotfiles)
 
-`yigitkonur` runs every Mac on a single private chezmoi repo with an age-encrypted secrets catalog. Everything routes through five CLI wrappers; never touch raw chezmoi commands unless you know exactly why.
+`yigitkonur` runs every Mac on a single private chezmoi repo with an age-encrypted secrets catalog. Everything routes through four CLI wrappers (`sync`, `skill`, `mcp-manage`, `mcp-verify`); never touch raw chezmoi commands unless you know exactly why.
 
 ## When to use
 
@@ -37,12 +37,12 @@ Trigger when asked to:
 
 ---
 
-## Command matrix — the 4 CLI wrappers
+## Command matrix — the 4 wrappers + aliases
 
 | Goal | Command |
 |---|---|
 | Resolve drift interactively | `sync` |
-| Add MCP server (all non-Claude providers) | `mcp-manage add <name> --stdio npx --arg '-y' --arg pkg [--env-secret KEY=secret_key] [--providers ...]` |
+| Add MCP server (all non-Claude providers) | `mcp-manage add <name> --stdio npx --arg '-y' --arg <pkg> [--env-secret KEY=secret_key] [--providers ...]` |
 | Add MCP HTTP server | `mcp-manage add <name> --http https://…` |
 | Remove MCP | `mcp-manage remove <name>` |
 | Set a secret | `mcp-manage secret set <key> <value>` |
@@ -77,7 +77,7 @@ MM      both changed                            sync → pick: keep live OR sour
  A      new source file                         chezmoi apply
 ```
 
-For a Claude edit to `~/.agents/agents/foo.md` that needs to land in the repo: **always `re-add`**, never naive `apply` (would overwrite the edit).
+For a Claude edit to `~/.agents/AGENTS.md` that needs to land in the repo: **always `re-add`**, never naive `apply` (would overwrite the edit).
 
 `sync` encodes this decision tree. Prefer it.
 

--- a/skills/use-chezmoi-dotfiles/skills/use-chezmoi-dotfiles/SKILL.md
+++ b/skills/use-chezmoi-dotfiles/skills/use-chezmoi-dotfiles/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: use-chezmoi-dotfiles
+description: Use skill if you are editing yigitkonur's dotfiles on any Mac — AI configs (Claude/Codex/Factory/Cursor/Copilot), MCP servers, skills, zsh, Homebrew, macOS defaults. The repo `yigitkonur/script-dotfiles` uses chezmoi + age-encrypted secrets. Use `sync`/`skill`/`mcp-manage`/`mcp-verify` wrappers instead of raw chezmoi.
+---
+
+# Use chezmoi dotfiles (yigitkonur/script-dotfiles)
+
+`yigitkonur` runs every Mac on a single private chezmoi repo with an age-encrypted secrets catalog. Everything routes through five CLI wrappers; never touch raw chezmoi commands unless you know exactly why.
+
+## When to use
+
+Trigger when asked to:
+
+- Add / remove / rotate an MCP server (Morph, Brave, etc.)
+- Add a skill from a GitHub repo or local path
+- Edit shared `AGENTS.md` that Claude + Codex + Factory + Copilot all read
+- Change a zsh alias, function, or prompt setting
+- Install a brew formula or cask
+- Toggle a macOS default
+- Understand why `chezmoi status` shows `MM`
+
+**Skip** for: one-off code changes inside a repo that isn't `~/.local/share/chezmoi/`; anything inside `~/.claude.json`, `~/.codex/sessions/`, or other paths listed in `.chezmoiignore`.
+
+---
+
+## The canonical workflow
+
+1. **Check drift** first, always:
+   ```bash
+   sync           # interactive TUI — shows drifts, ripple effects, lets you pick resolution
+   # or quick read-only:
+   czs            # = chezmoi status
+   ```
+2. **Edit** via the right wrapper (see command matrix below). Never hand-edit a generated file — find its source.
+3. **Verify** with `mcp-verify` or `chezmoi diff`.
+4. **Push** happens automatically (autoCommit + autoPush in chezmoi.toml) after any re-add or apply that changes source.
+
+---
+
+## Command matrix — the 4 CLI wrappers
+
+| Goal | Command |
+|---|---|
+| Resolve drift interactively | `sync` |
+| Add MCP server (all non-Claude providers) | `mcp-manage add <name> --stdio npx --arg '-y' --arg pkg [--env-secret KEY=secret_key] [--providers ...]` |
+| Add MCP HTTP server | `mcp-manage add <name> --http https://…` |
+| Remove MCP | `mcp-manage remove <name>` |
+| Set a secret | `mcp-manage secret set <key> <value>` |
+| Add skill from repo | `skill add <gh-owner/repo>` or `skill add <gh-owner/repo> --skill <name>` |
+| Add skill from local dir | `skill add <path>` |
+| Refresh skills from upstream | `skill update` |
+| Remove skill | `skill remove <name>` |
+| List skills | `skill list` |
+| Snapshot all provider MCP + skills + symlinks + secrets (redacted) | `mcp-verify` |
+| Force re-run of run_once scripts (macOS defaults etc.) | `cz-reset-scripts` |
+| Pull remote + apply | `czu` (= `chezmoi update`) |
+
+Raw chezmoi you still need:
+
+- `chezmoi edit ~/<target>` — opens source in `$EDITOR`, auto-applies on save
+- `chezmoi re-add <path>` — the "keep my live edits" move for `MM` drift
+- `chezmoi merge <path>` — 3-way merge when both sides legit changed
+
+---
+
+## The five drift scenarios
+
+From `chezmoi status` output:
+
+```
+Status  Meaning                                 Correct action
+──────  ───────────────────────────────────────  ─────────────────────────────────
+ M      source changed, live still old          chezmoi apply  (or sync)
+M       live edited, source still old           chezmoi re-add <path>
+MM      both changed                            sync → pick: keep live OR source
+ R      run-script pending                      chezmoi apply
+ A      new source file                         chezmoi apply
+```
+
+For a Claude edit to `~/.agents/agents/foo.md` that needs to land in the repo: **always `re-add`**, never naive `apply` (would overwrite the edit).
+
+`sync` encodes this decision tree. Prefer it.
+
+---
+
+## Architecture cheat sheet
+
+```
+Canonical (edit here)                   Rendered targets (don't edit)
+─────────────────────                   ──────────────────────────────
+.chezmoidata/mcp-servers.yaml      →    ~/.codex/config.toml           (TOML)
+                                   →    ~/.factory/mcp.json            (type:stdio/http)
+                                   →    ~/.cursor/mcp.json             (bare JSON)
+                                   →    ~/.copilot/mcp-config.json     (type:local/http)
+                                        Claude — runtime, register via `claude mcp add`
+
+.chezmoidata/ai-defaults.yaml      →    ~/.codex/config.toml
+                                   →    ~/.factory/settings.json
+
+dot_agents/AGENTS.md               →    ~/.agents/AGENTS.md  (file)
+                                        ~/.claude/CLAUDE.md  (symlink → ^)
+                                        ~/.codex/AGENTS.md   (symlink → ^)
+                                        ~/.factory/AGENTS.md (symlink → ^)
+                                        ~/.copilot/copilot-instructions.md (symlink → ^)
+
+dot_agents/skills/<name>/          →    ~/.agents/skills/<name>/
+                                        ~/.claude/skills/   (symlink → ~/.agents/skills)
+                                        ~/.codex/skills/    (symlink → ^)
+                                        ~/.factory/skills/  (symlink → ^)
+                                        ~/.copilot/skills/  (symlink → ^)
+                                        ~/.cursor/skills/   (symlink → ^)
+
+secrets.yaml.age                   →    decrypted at apply time via
+                                        includeTemplate "secrets" | fromYaml
+```
+
+---
+
+## Hard boundaries
+
+- **Never commit a plaintext API key, bearer token, SSH private key, or `.env` file.** Always via `mcp-manage secret set` → age-encrypted.
+- **Never rename `symlink_X.tmpl` → `X.tmpl`** or vice versa. The prefix is semantic.
+- **Never touch files listed in `.chezmoiignore`** (`~/.claude.json`, `cache/`, `sessions/`, `logs_*.sqlite`, `history.jsonl`, auth tokens). These are runtime-owned.
+- **`cz-sync` binary at `~/.local/bin/cz-sync` is built from `cz-sync/main.go`** via `run_onchange_after_40-build-cz-sync.sh`. Do not edit the binary; edit the Go source and chezmoi rebuilds.
+
+---
+
+## Template variables quick reference
+
+```go
+.chezmoi.homeDir          // /Users/yigitkonur
+.chezmoi.hostname         // mbp-m3 | macmini | ...
+.chezmoi.sourceDir        // ~/.local/share/chezmoi
+.servers.<name>.transport // stdio | http (from mcp-servers.yaml)
+.servers.<name>.providers // []string
+.codex.model              // from ai-defaults.yaml
+.factory.autonomy_mode    // from ai-defaults.yaml
+
+{{- $secrets := (includeTemplate "secrets" . | fromYaml).secrets -}}
+{{ $secrets.morph_api_key }}
+{{ $secrets.codex_bearer_token }}
+```
+
+---
+
+## Before ending your task
+
+1. Run `czs` (or `sync`) to confirm the working tree is clean.
+2. If you edited a generated target (not a source), run `chezmoi re-add <path>` first — otherwise the next agent will overwrite your edit.
+3. Verify with `mcp-verify` if you touched any provider's MCP config.
+4. All commits auto-push. If `czs` shows nothing and `git log -1` shows your change on `origin/main`, you're done.


### PR DESCRIPTION
## Summary

Adds a new `use-chezmoi-dotfiles` skill. Teaches an agent to drive the `sync` / `skill` / `mcp-manage` / `mcp-verify` CLIs that front a chezmoi-managed dotfiles repo which unifies Claude Code, OpenAI Codex, Factory Droid, Cursor, and GitHub Copilot through one AGENTS.md + one skill library + one MCP catalog + age-encrypted secrets.

## Naming

Verb prefix: \`use-\`. Fits the definition ("drive a specific CLI utility to accomplish a targeted workflow"). Adjacent to \`use-railway\` in shape.

## What's inside

- \`SKILL.md\` covers:
  - When to trigger vs skip
  - Full command matrix — 4 wrapper CLIs + raw-chezmoi escape hatches
  - 5 drift scenarios (' M' / 'M ' / 'MM' / ' R' / ' A') with the right command per code
  - Canonical → rendered path graph (one yaml → 4 MCP dialects; Claude stays runtime)
  - Hard boundaries (secrets, \`symlink_\` / \`executable_\` prefixes, \`.chezmoiignore\` runtime paths)
  - Template-variable quick reference
  - Before-end-of-task checklist
- \`README.md\` with install snippets (individual + full pack)
- Entry added to root README.md skills table

## Test plan

- [x] Skill discovered by Claude Code via canonical \`~/.agents/skills/\` symlinks on 2 Macs
- [x] Visible to Codex, Factory, Cursor, Copilot via their per-provider symlinks
- [x] Matches verb-first naming in NAMING.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `use-chezmoi-dotfiles`, a skill for orchestrating a chezmoi-backed dotfiles repo via `sync`, `skill`, `mcp-manage`, and `mcp-verify`. It unifies MCP configs and skills across Claude Code, OpenAI Codex, Factory Droid, Cursor, and GitHub Copilot with canonical sources and age-encrypted secrets.

- **New Features**
  - Added `SKILL.md` with when-to-use, command matrix, drift handling, canonical→rendered path map, boundaries, template refs, and an end-of-task checklist.
  - Added `skills/use-chezmoi-dotfiles/README.md` with install snippets; registered the skill in the root `README.md` table.

- **Bug Fixes**
  - Clarified wrapper count (now four), fixed `<pkg>` placeholder, and corrected `~/.agents/AGENTS.md` path; renamed the matrix section to note aliases.
  - Shortened SKILL and root README descriptions to meet validator/table limits; aligned the skill README with the SKILL frontmatter.
  - Validation passes via `scripts/validate-skills.py`.

<sup>Written for commit 2443ab448c9756582fe89d660ddab6531826266c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

