### PR TITLE
chore(readme): sync skill count 51 → 54

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-51 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+54 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 


### PR DESCRIPTION
After merging PRs #38-#42, main has 54 skills but the README header lagged at 51 due to sequential-merge interaction on the count line. This brings it in sync with the validator-reported total.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README header skill count from 51 to 54 to match the current validated number of skills.

<sup>Written for commit 19ac8e097ef5f52b04edc6415850b5da37f26ae8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

