### PR TITLE
feat(debug-systematic): language-agnostic systematic debugging (4-phase method + Iron Law + 3-fails handoff)

### DIFF
--- a/NAMING.md
+++ b/NAMING.md
@@ -65,18 +65,19 @@ Each prefix has a **definition**, a **boundary** (what falls outside it), and **
 
 ### `debug-`
 
-**Definition:** Inspect, diagnose, or troubleshoot a running or built application using a specific debugging tool or observability platform. The skill teaches the agent how to use the tool to find and understand problems.
+**Definition:** Inspect, diagnose, or troubleshoot a running or built application — either by driving a specific diagnostic tool / observability platform, OR by applying a language-agnostic debugging methodology (hypothesis formation, falsification, root-cause tracing) when tools alone are not enough.
 
-**Boundary:** The skill connects the agent to a *diagnostic tool*. If the agent is fixing code directly without a diagnostic tool, that's normal coding, not a skill. If the agent is running a test suite, that's `test-`.
+**Boundary:** The skill either connects the agent to a *diagnostic tool* (tool-specific variant) or enforces a *debugging methodology* that the agent follows across any language or runtime (method-specific variant). If the agent is fixing code directly without diagnosis, that's normal coding. If the agent is running a test suite, that's `test-`.
 
-**Use when:** The agent uses a dedicated debugging/observability tool (DevTools, profilers, tracers) to investigate issues.
+**Use when:** The agent uses a dedicated debugging/observability tool (DevTools, profilers, tracers) to investigate issues, OR the agent needs a structured method (investigation → pattern analysis → hypothesis testing → implementation) for a bug whose mechanism is unknown.
 **Not when:** The agent runs a test suite (`test-`), reviews code for issues (`review-`), or writes code to fix a known bug (`build-`).
 
 **Disambiguation:**
-- `debug-` vs `test-` — `debug-` uses diagnostic tools to investigate unknowns; `test-` runs a verification suite against known expectations
-- `debug-` vs `review-` — `debug-` is live inspection of a running/built app; `review-` is static analysis of source diffs
+- `debug-` vs `test-` — `debug-` investigates unknowns; `test-` runs a verification suite against known expectations
+- `debug-` vs `review-` — `debug-` is live inspection or runtime-failure investigation; `review-` is static analysis of source diffs
+- `debug-` (tool-specific) vs `debug-` (method-specific) — tool-specific skills (e.g., `debug-tauri-devtools`) teach the agent a specific DevTools/profiler; method-specific skills (e.g., `debug-systematic`) teach a language-agnostic methodology
 
-**Current skills:** `debug-tauri-devtools`
+**Current skills:** `debug-tauri-devtools`, `debug-systematic`
 
 ---
 
@@ -443,6 +444,7 @@ When renaming a published skill:
 - `build-supastarter-app`
 - `convert-snapshot-nextjs`
 - `convert-vue-nextjs`
+- `debug-systematic`
 - `debug-tauri-devtools`
 - `develop-clean-architecture`
 - `develop-macos-hig`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-54 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+55 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 
@@ -43,6 +43,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [build-supastarter-app](skills/build-supastarter-app/) | development | SupaStarter Next.js SaaS boilerplate |
 | [convert-snapshot-nextjs](skills/convert-snapshot-nextjs/) | design | HTML snapshots to Next.js projects |
 | [convert-vue-nextjs](skills/convert-vue-nextjs/) | development | Vue/Nuxt to Next.js App Router migration |
+| [debug-systematic](skills/debug-systematic/) | productivity | Language-agnostic systematic debugging; four phases + Iron Law + 3-fails handoff to do-brainstorm |
 | [debug-tauri-devtools](skills/debug-tauri-devtools/) | development | Tauri debugging with CrabNebula DevTools |
 | [develop-clean-architecture](skills/develop-clean-architecture/) | development | Clean Architecture and DDD in TypeScript |
 | [develop-macos-hig](skills/develop-macos-hig/) | development | macOS HIG design system -- spacing, components, accessibility |

--- a/skills/debug-systematic/README.md
+++ b/skills/debug-systematic/README.md
@@ -1,0 +1,19 @@
+# debug-systematic
+
+Language-agnostic systematic debugging method. Four mandatory phases before any fix — Investigation, Pattern analysis, Hypothesis testing, Implementation — with an Iron Law ("no fix before root cause") and a 3-fails gate that hands off to `do-brainstorm` when the problem is architecture-shaped.
+
+**Category:** productivity
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/debug-systematic
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/debug-systematic/skills/debug-systematic/SKILL.md
+++ b/skills/debug-systematic/skills/debug-systematic/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: debug-systematic
+description: Use skill if you are hitting repeated failed fixes, an intermittent bug, or a diagnosis you cannot explain, and need a language-agnostic four-phase root-cause method before editing code.
+---
+
+# Debug Systematic
+
+Language-agnostic systematic debugging method. Four mandatory phases before any fix: Investigation → Pattern analysis → Hypothesis testing → Implementation. Works across any runtime and language.
+
+## Trigger boundary
+
+Use this skill when the task is to:
+
+- debug a runtime bug you can reproduce but whose causal mechanism is unknown
+- recover from a fix that failed — the symptom persists, regressed, or moved
+- investigate an intermittent ("sometimes") failure where pattern-matching a quick fix is tempting
+- stop yourself mid-diagnosis when you feel pulled toward "let me just try X"
+- audit a multi-layer bug where the obvious layer has been checked but the bug persists
+
+Prefer another skill when:
+
+- a specific diagnostic tool is available and loaded (Tauri DevTools, Chrome DevTools, profiler) → `debug-tauri-devtools` or the tool's skill
+- the task is "reason about a design tradeoff" with no bug to reproduce → `think-deeper`
+- the user explicitly wants a user-in-the-loop brainstorm about architecture → `do-brainstorm` (this skill routes there at the 3-fails gate)
+- only "confirm what's actually done" is needed on already-fixed items → `check-completion`
+- the code is not running yet — pure design or scoping work → `think-deeper` or `do-brainstorm`
+- the bug is an external-service outage the agent cannot inspect → out of scope; surface the fact and stop
+
+## Non-negotiable rules
+
+1. **Iron Law.** No fix before root cause. Fix attempts with unverified mechanism are forbidden.
+2. **Diagnosis and repair are separate steps.** You do not edit product code during Phases 1-3.
+3. **Evidence per claim.** Every hypothesis cites a trace, log, diff, test run, or config value.
+4. **One hypothesis at a time.** Testing two fixes simultaneously discards the falsification signal of both.
+5. **Escalate at 3.** Three failed fixes triggers the `do-brainstorm` handoff (see Escalation gate).
+6. **Verify before declaring fixed.** The same symptom reproduction that failed must now pass with evidence captured.
+7. **Regression-proof before commit.** The fix lands with a test, guard, or assertion that proves the mechanism stays dead.
+8. **Keep the diagnosis trace.** Reasoning from Phase 1 → Phase 4 attaches to the fix (commit body, issue comment, or a plan file).
+
+## The Iron Law
+
+> **NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+
+An untested fix is a guess dressed as work. A guess that appears to succeed is the worst case — it masks the real mechanism, which returns later as a different symptom.
+
+## Required workflow
+
+### 1. Investigation
+
+**Goal**: define the exact failing behavior, reproduce it deterministically, capture minimum evidence.
+
+Steps:
+
+1. **State the symptom precisely** — where (file/line/frame), when (on what input/action), expected vs. actual, first-seen commit or version if known.
+2. **Reproduce deterministically** — the smallest repro that fails 10/10. If intermittent, route to `references/bisection-strategies.md` input-space bisection before continuing.
+3. **Capture evidence** — stack trace, log excerpt, diff vs. last-known-good, relevant config/env values. Copy-pasteable.
+4. **Write the symptom card** — one paragraph a stranger could read and reproduce the bug without additional context. If you cannot, you are still storytelling, not investigating.
+
+**Exit criteria**: symptom card + 10/10 repro + copy-pasteable evidence.
+
+**Red flags → back to step 1**: "it happens sometimes" (repro not 10/10); "some config mismatch" (no concrete values); "the code looks wrong" (guessing, not observing).
+
+### 2. Pattern analysis
+
+**Goal**: identify 1-3 candidate mechanisms by matching evidence to known failure patterns.
+
+Steps:
+
+1. **Trace backward** — apply `references/root-cause-tracing.md` to walk from the symptom frame back to the earliest frame where state was still correct.
+2. **Map to pattern families** — test-pollution, race condition, silent error-swallowing, serialization boundary, off-by-one, null propagation, config drift, ACL/permission, resource leak.
+3. **Produce 1-3 candidate mechanisms** — each a one-sentence hypothesis of the form *"X caused Y because Z."* Evidence attached.
+4. **Rank by disprovability** — the candidate you can disprove cheapest is tested first.
+
+**Exit criteria**: 1-3 ranked, evidence-backed candidate mechanisms written down.
+
+**Red flags → back to Phase 1**: evidence gaps appear (you need a log you don't have); candidates are all "maybe the code is wrong" (pattern not identified); only one candidate is possible (force a second — absence of alternatives is over-commitment).
+
+### 3. Hypothesis testing
+
+**Goal**: prove or disprove each candidate with an experiment designed to fail *if the hypothesis is wrong*.
+
+Steps:
+
+1. **Design falsifiable experiments** — for the top candidate, write down the predicted result if the hypothesis is true AND the predicted result if false. If you cannot state the false-case prediction, the experiment is cover for a pre-decided fix.
+2. **Run the cheapest experiment first** — log addition, print, unit test, bisect step, feature-flag toggle. See `references/instrumentation.md` and `references/bisection-strategies.md`.
+3. **Read the result honestly** — even if it invalidates your preferred candidate. Especially then.
+4. **If all candidates falsified → route to `think-deeper`** to re-form the space of mechanisms before repeating Phase 2.
+
+**Exit criteria**: one candidate mechanism confirmed with evidence the experiment produced.
+
+**Red flags → back to Phase 2**: your "confirmation" also fits a different mechanism (experiment was not falsifying); you changed product code mid-experiment (left Phase 3 early); you accepted a partial confirmation "because it kind of matched."
+
+### 4. Implementation
+
+**Goal**: apply the narrowest fix that restores the broken assumption, verify it, land it with a regression guard.
+
+Steps:
+
+1. **Write the narrowest fix** — one assumption restored, no unrelated cleanup. See `references/defense-in-depth.md` for *which layer* the fix belongs at.
+2. **Add the regression guard** — a test, assertion, or invariant that fails if the mechanism reappears. Non-optional.
+3. **Run the Phase 1 repro** — the 10/10 failing repro must now be 10/10 passing. Same conditions.
+4. **Remove temporary diagnosis code** — *structural* instrumentation stays; temporary prints come out.
+5. **Route to `check-completion`** — before declaring done, verify nothing else in scope was broken by the change. See `references/integration.md` for the handoff format.
+
+**Exit criteria**: symptom gone (evidence) + regression guard (test/assertion) + `check-completion` result.
+
+**Red flags → back to Phase 3**: the repro still fails (hypothesis was wrong, not just the fix); the regression guard passes without the fix (guard doesn't test the mechanism); new symptoms appear (you widened the blast radius).
+
+## Integration decision matrix
+
+This skill does not handle everything alone. The matrix below is the first-class routing table — consult it when a phase goes sideways.
+
+| Situation | Route? | Destination | Why |
+|---|---|---|---|
+| Phase 1: repro is not 10/10, need wider frame | Stay | `references/bisection-strategies.md` input-space bisection | Inline technique |
+| Phase 2: only "it feels like X" as evidence | Out | `think-deeper` (its `workflows/bug-tracing.md`) | Stronger reasoning loop re-grounds you |
+| Phase 3: 2-3 candidates look equally plausible | Out | `think-deeper` foundations/evidence-and-falsification | Stronger evidence framework before the experiment |
+| Phase 3: "confirmation" also fits a different mechanism | Stay | Back to Phase 2; write the distinguishing test | Do not hand off |
+| Fail #1 (first fix didn't stick) | Stay | Re-open Phase 2 inline | Pattern was wrong |
+| Fail #2 (second fix didn't stick) | Stay | Re-open Phase 1 inline | Symptom was wrong or repro was fake |
+| Fail #3 (third fix didn't stick) | **Out — stop fixing** | `do-brainstorm` with handoff template in `references/integration.md` | Architecture-shaped, not a bug |
+| Phase 4: fix applied, verification passed | Out | `check-completion` | Audit for related-but-forgotten scope |
+| "Bug" is a design disagreement, not a bug | **Do not start** | `think-deeper` or `do-brainstorm` | Not a runtime failure |
+| No way to run code (env/repo missing) | **Do not start** | Ask user for a repro, or exit | Phase 1 cannot complete |
+
+Full decision tree with edge cases: `references/integration.md`.
+
+## Escalation gate — the 3-fails rule
+
+A "failed fix" = a hypothesis-driven change that did not make Phase 1's repro pass, OR made it pass but with a regression elsewhere. Compilation errors unrelated to the hypothesis do not count.
+
+- **Fail 1** → re-open Phase 2. The pattern family was likely wrong.
+- **Fail 2** → re-open Phase 1. The symptom definition or repro was probably incomplete.
+- **Fail 3** → **Stop fixing.** Route to `do-brainstorm`. Three failures means the problem is architecture-shaped, not a bug. Full handoff format in `references/escalation.md` and `references/integration.md`.
+
+The rule is load-bearing under pressure. See `references/rationalizations.md` for the verbatim excuses agents generate to skip it.
+
+## Rationalizations to counter (short form)
+
+Abridged table. Full set + pressure-scenario sidebars in `references/rationalizations.md`.
+
+| Rationalization | Counter |
+|---|---|
+| "Just try this fix and see." | "See" = evidence. Write the falsification prediction before editing. |
+| "The senior engineer already diagnosed it." | Their Phase 1 is not yours. Reproduce and read the evidence yourself. |
+| "Sunk cost — 4 hours in, can't restart." | The 4 hours are the evidence the current path is dead. Restart Phase 1. |
+| "We don't have time for root cause — production is down." | Cost of a blind fix that regresses = cost of the outage × 2. |
+| "The tests pass now, so it's fixed." | Passing tests without a regression guard prove nothing durable. Add the guard. |
+| "I see the issue." (no mechanism stated) | Say the mechanism out loud, or you have not seen it. |
+| "This is an emergency — rules off." | Rules are *especially* on under pressure. Emergencies multiply the cost of skipping. |
+
+## Voice discipline (short form)
+
+Debugging-specific forbidden phrases (distinct from `check-completion`'s general voice rules). Full list in `references/voice.md`.
+
+**Forbidden**: "probably just a quick fix" / "let me just try" / "I know what this is" (without a named mechanism) / "this feels like last time".
+
+**Required forms**: "Phase 1 symptom card: …" / "Phase 2 candidates: …" / "Phase 3 falsification prediction: …" / "Verification result: …".
+
+## Reference routing
+
+### Top-level
+
+| File | Read when |
+|---|---|
+| `references/workflow-deep.md` | SKILL.md's phase block is too thin — need long worked examples (Node test-pollution, Python race, Rust lifetime) |
+| `references/root-cause-tracing.md` | Phase 2 — walk backward from symptom frame to earliest-correct-state frame |
+| `references/condition-based-waiting.md` | Replace `sleep(n)` with polling-with-timeout; routes to `references/waiting/<lang>.md` for drop-in code |
+| `references/defense-in-depth.md` | Phase 4 — deciding which layer (entry / logic / env guard / instrumentation) the fix belongs at |
+| `references/bisection-strategies.md` | "Fails in CI only" / "worked last week" / "broken only with feature X" / intermittent without code change |
+| `references/instrumentation.md` | Phase 2-3 — print/log/stack-trace patterns per language |
+| `references/escalation.md` | Any failed fix — the 3-fails protocol, pressure-scenario sidebars, handoff format |
+| `references/integration.md` | Unsure whether to stay in-skill or route to `think-deeper` / `do-brainstorm` / `check-completion` |
+| `references/rationalizations.md` | The urge to skip Phase 1 or Phase 3 — 15-row counter table + 5 pressure scenarios |
+| `references/voice.md` | Writing progress updates to the user — forbidden phrases, required forms |
+| `references/cross-runtime.md` | Running on a non-Claude runtime — ask-user-tool lookup for the 3-fails handoff |
+
+### Language-specific condition-based-waiting
+
+| File | Language / framework |
+|---|---|
+| `references/waiting/typescript.md` | Jest / Vitest — port of obra's reference utilities |
+| `references/waiting/python.md` | pytest + asyncio |
+| `references/waiting/rust.md` | tokio + cancellation tokens |
+| `references/waiting/go.md` | stdlib `testing.T` polling |
+| `references/waiting/swift.md` | XCTest + async/await |
+| `references/waiting/ruby.md` | RSpec + timeout gems |
+| `references/waiting/java.md` | JUnit 5 + awaitility |
+
+### Pressure scenarios
+
+| File | Scenario |
+|---|---|
+| `references/pressure-tests/academic.md` | Calm baseline — method works without pressure |
+| `references/pressure-tests/pressure-financial.md` | $15k/min outage — time pressure vs. Iron Law |
+| `references/pressure-tests/pressure-sunk-cost.md` | 4 hours in — restart vs. one-more-try |
+| `references/pressure-tests/pressure-authority.md` | Senior engineer says X — verify independently or defer |
+
+## Output contract
+
+Before declaring a bug fixed, produce these artifacts in order:
+
+1. **Symptom card** (Phase 1) — one paragraph, reproducible by a stranger
+2. **Ranked candidate mechanisms** (Phase 2) — 1-3 one-sentence hypotheses with evidence
+3. **Experiment design + result** (Phase 3) — falsification prediction + observed result
+4. **Fix + regression guard** (Phase 4) — narrow fix, test/assertion that fails without it
+5. **Verification** (Phase 4) — the Phase 1 repro now passes, evidence captured
+6. **Next-step pointer** — `check-completion` handoff, or "close and ship"
+
+Each artifact is visible in the session transcript. Do not batch them to the end.
+
+## Do this, not that
+
+| Do this | Not that |
+|---|---|
+| Reproduce 10/10 before theorizing | Form a hypothesis, then try to reproduce |
+| Separate diagnosis from repair (Phases 1-3 are read-only on product code) | Edit product code while "investigating" |
+| Write the false-case prediction before running the experiment | Run the experiment, then decide what "confirms" the hypothesis |
+| Cite a trace/log/diff/test/config for every claim | "It seems like…" / "I think it's…" |
+| On fail #1-#2, re-open prior phases; on fail #3, route to `do-brainstorm` | Try fix #4, #5, #6 |
+| Add a regression guard before declaring done | "The tests pass, shipping" |
+| Treat the senior's diagnosis as a candidate, not a verdict | Skip Phase 1 because "they already figured it out" |
+
+## Guardrails and recovery
+
+- Do not edit product code during Phases 1-3.
+- Do not declare "fixed" without a passing Phase 1 repro + regression guard.
+- Do not recommend `debug-systematic` as the next-step (no infinite regress). If more debugging is needed, state which phase to re-enter.
+- Do not skip the 3-fails handoff "just this once." See `references/rationalizations.md`.
+- Do not consume `think-deeper` or `do-brainstorm` as substitutes for Phase 1. They are handoffs, not shortcuts.
+
+Recovery moves:
+
+- **Phase 1 repro not 10/10** → input-space bisection (`references/bisection-strategies.md`); do not proceed with a flaky repro
+- **Phase 3 experiment ambiguous** → design a distinguishing test; two mechanisms fitting the same evidence means the experiment was not falsifying
+- **3 fails hit** → hand off to `do-brainstorm` with the template in `references/integration.md`; do not retry
+- **Post-fix regression detected** → Phase 1 on the new symptom; do not paper over with a second fix on top of the first
+
+## Final checks
+
+Before declaring done, confirm:
+
+- [ ] Phase 1 produced a symptom card + 10/10 repro
+- [ ] Phase 2 produced 1-3 ranked candidates with evidence per row
+- [ ] Phase 3 experiment stated its false-case prediction before running
+- [ ] Phase 3 confirmed one mechanism (not "partially matched")
+- [ ] Phase 4 fix is narrow (no unrelated cleanup, no unrelated files)
+- [ ] Regression guard exists and fails without the fix
+- [ ] Phase 1 repro now passes 10/10 with evidence captured
+- [ ] Diagnosis trace attached to commit body / issue / plan file
+- [ ] Zero occurrences of forbidden rationalizations in the session output
+- [ ] Next-step pointer to `check-completion` (or explicit "close and ship")

--- a/skills/debug-systematic/skills/debug-systematic/SKILL.md
+++ b/skills/debug-systematic/skills/debug-systematic/SKILL.md
@@ -29,7 +29,7 @@ Prefer another skill when:
 ## Non-negotiable rules
 
 1. **Iron Law.** No fix before root cause. Fix attempts with unverified mechanism are forbidden.
-2. **Diagnosis and repair are separate steps.** You do not edit product code during Phases 1-3.
+2. **Diagnosis and repair are separate steps.** During Phases 1-3, the only edits allowed are *diagnostic* — temporary logs, probes, tests that reproduce the bug, instrumentation. No *fixes* to product logic until Phase 4, after Phase 3 has confirmed a mechanism.
 3. **Evidence per claim.** Every hypothesis cites a trace, log, diff, test run, or config value.
 4. **One hypothesis at a time.** Testing two fixes simultaneously discards the falsification signal of both.
 5. **Escalate at 3.** Three failed fixes triggers the `do-brainstorm` handoff (see Escalation gate).

--- a/skills/debug-systematic/skills/debug-systematic/references/bisection-strategies.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/bisection-strategies.md
@@ -1,0 +1,140 @@
+# Bisection Strategies — Narrow the Problem Space
+
+When Phase 1's repro is not 10/10 or the failure space is too wide, bisection cuts the search surface in half at a time. Four techniques; pick by the symptom's shape.
+
+## Decision tree — which bisection?
+
+| Symptom | Technique | Cost |
+|---|---|---|
+| Fails in CI, passes locally (test pollution) | **Test-pollution bisection** — uses `scripts/find-polluter.sh` | Minutes |
+| Worked last week, broken now; suspect a commit | **`git bisect run`** with a deterministic test | Minutes to hours depending on commit range |
+| Broken only with feature flag X enabled | **Feature-flag toggle bisection** across N flags | Minutes |
+| Intermittent with no code change; suspect input data | **Input-space bisection** — halve the input until the failure disappears | Variable |
+
+## 1. Test-pollution bisection
+
+**When**: a test passes alone, fails when run after other tests.
+
+**Mechanism**: the prior tests leave shared state (in-memory cache, global singleton, module-level config, side-effecting file) that breaks the target test.
+
+**Recipe**: use `scripts/find-polluter.sh` — the script auto-detects the test runner (jest/vitest/pytest/cargo/gotest/rspec/mvn/gradle) from the project's manifest files, then binary-searches the test list to find the smallest subset of pre-running tests that causes the target to fail.
+
+```bash
+# From the repo root
+bash scripts/find-polluter.sh \
+  --target "auth.test.ts > handles missing token" \
+  --runner auto
+```
+
+The script outputs:
+- The polluting test(s)
+- The minimum reproduction command
+- A suggested next action (usually: "this polluting test mutates shared X; fix with per-test setup")
+
+### Manual equivalent (when the script isn't available)
+
+1. List all tests that ran before the failing one in CI.
+2. Binary-search: run the first half as pre-setup, then the target. If fails, the polluter is in the first half. Else it's in the second.
+3. Recurse until you've narrowed to a single polluting test.
+
+This is obra's `find-polluter.sh` approach, generalized.
+
+## 2. `git bisect` with a deterministic script
+
+**When**: a specific test or behavior was green at commit A, is red at commit B. Commits between may be numerous.
+
+**Preconditions**:
+- You have a deterministic test that fails on B and passes on A (usually produced by Phase 1).
+- The test takes <60 seconds to run (or you have patience).
+
+**Recipe**:
+
+```bash
+git bisect start
+git bisect bad HEAD          # current commit is broken
+git bisect good <commit-A>   # last-known-good commit
+git bisect run bash -c '
+  # build if needed
+  pnpm install --frozen-lockfile && \
+  # run only the failing test
+  pnpm exec jest --testPathPattern=auth.test.ts --runInBand
+'
+```
+
+Git checks out the middle commit, runs the script; exit 0 = good, non-zero = bad; bisects recursively.
+
+**Output**: the first bad commit. Read its diff. The mechanism is often localized.
+
+### Gotchas
+
+- If your repo needs `pnpm install` between checkouts (dependency changes), include it in the script.
+- If builds take minutes, narrow the commit range first by spot-checking midpoint-commits manually.
+- If the script has side effects (DB migration, file writes), reset between runs.
+
+## 3. Feature-flag toggle bisection
+
+**When**: the failure appears only when some combination of N feature flags is enabled, and you don't know which subset.
+
+**Mechanism**: binary search the flag set.
+
+**Recipe**:
+
+1. List all recently-toggled flags (N flags, 2^N combinations — do NOT enumerate all).
+2. Split the flags into two halves. Enable half-A-on, half-B-off. Reproduce. Enable half-A-off, half-B-on. Reproduce.
+3. Whichever half reproduces: the culprit is in there. Recurse.
+4. After log2(N) rounds, you have the minimal flag set that triggers the failure.
+
+**Example**: 16 flags toggled recently. Split into sets of 8. Group A (flags 1-8) triggers the bug; group B (flags 9-16) does not. Group A splits into 1-4 and 5-8. Group 5-8 triggers. Split 5-6 and 7-8. Group 7-8 triggers. Split 7 and 8. Flag 7 alone reproduces. Root cause: flag 7's code path.
+
+**Tooling**: most feature-flag systems (LaunchDarkly, Unleash, in-house) support environment overrides. Use an override environment for the bisection; do not toggle in production.
+
+## 4. Input-space bisection
+
+**When**: the bug is intermittent, there is no clear commit or flag trigger, and you suspect the input data triggers it.
+
+**Mechanism**: halve the input until the failure disappears. What you removed contains the trigger.
+
+**Recipe**:
+
+1. Capture the failing input (the payload, the user ID, the file that causes the crash).
+2. Halve it: keep first half, drop second. Retry. If fails, the trigger is in the first half.
+3. Recurse until the input is minimal but still fails.
+4. The minimal failing input names the trigger (a specific character, field, size threshold, encoding edge case).
+
+**Examples**:
+
+- JSON payload: remove keys one half at a time until a minimal failing payload remains.
+- File upload: halve the file size; if corruption appears at 1MB but not 512KB, the trigger is size-dependent.
+- Query params: strip one half of the params; whichever half still reproduces contains the culprit.
+
+### Coupling to Phase 1 — making an intermittent bug deterministic
+
+Input-space bisection is often how you move from "fails sometimes" to "fails 10/10 on this specific input." Once you have the minimal failing input, the bug becomes deterministic on that input, and Phase 1's 10/10 requirement is satisfied.
+
+## Handoff from bisection to Phase 2
+
+Bisection narrows the problem space. It does NOT provide a mechanism on its own. The output of any bisection is one of:
+
+- A polluting test (→ trace what shared state it mutates, that's the mechanism)
+- A first-bad commit (→ read the diff, the mechanism is usually one of the changes)
+- A minimal flag combination (→ trace the flag's code path, the mechanism is in the guarded code)
+- A minimal failing input (→ trace what branches the input activates, the mechanism is in one of them)
+
+Do not skip from bisection straight to Phase 4. The bisection tells you *where to look*, not *what's broken*. Phase 2 still applies.
+
+## When NOT to bisect
+
+- The repro is 10/10 on the current code with any input. Don't bisect — go straight to Phase 2.
+- The commit range is known to be small (<5 commits) and you can read the diff directly. Reading is cheaper.
+- The bug is a compile error or type error. The compiler *is* the bisection — it points at the line.
+- The bug is in third-party code you cannot modify. Bisection finds the trigger, not the fix; you still need a workaround.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Running `git bisect run` with a flaky script | Make the test deterministic first; a flaky bisect produces a random commit |
+| Bisecting 16 flags by trying all 65,536 combinations | Binary search; log2(N) rounds |
+| Declaring the bisection result the root cause without Phase 2 tracing | Bisection narrows; it does not identify the mechanism. Continue to Phase 2. |
+| Bisecting a bug that's already deterministic | Read the stack trace first; tracing is faster |
+| Running bisection on a branch with broken intermediate commits | Every intermediate commit must build; otherwise the bisection lies |

--- a/skills/debug-systematic/skills/debug-systematic/references/bisection-strategies.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/bisection-strategies.md
@@ -20,9 +20,16 @@ When Phase 1's repro is not 10/10 or the failure space is too wide, bisection cu
 **Recipe**: use `scripts/find-polluter.sh` — the script auto-detects the test runner (jest/vitest/pytest/cargo/gotest/rspec/mvn/gradle) from the project's manifest files, then binary-searches the test list to find the smallest subset of pre-running tests that causes the target to fail.
 
 ```bash
-# From the repo root
+# From the repo root. `--target` is a runner-native selector, NOT a test title:
+#   Jest/Vitest: a test-file path or module pattern (e.g., tests/auth.test.ts)
+#   pytest:      a nodeid (e.g., tests/test_auth.py::test_missing_token)
+#   cargo:       a test function name (e.g., auth::missing_token)
+#   gotest:      a regex for -run (e.g., ^TestAuth_MissingToken$)
+#   rspec:       a file:line selector (e.g., spec/auth_spec.rb:42)
+#   mvn/gradle:  a test class (e.g., com.example.AuthTest)
+
 bash scripts/find-polluter.sh \
-  --target "auth.test.ts > handles missing token" \
+  --target "tests/auth.test.ts" \
   --runner auto
 ```
 
@@ -77,14 +84,23 @@ Git checks out the middle commit, runs the script; exit 0 = good, non-zero = bad
 
 **Mechanism**: binary search the flag set.
 
-**Recipe**:
+**Recipe** (single-flag culprit — simplest case):
 
-1. List all recently-toggled flags (N flags, 2^N combinations — do NOT enumerate all).
-2. Split the flags into two halves. Enable half-A-on, half-B-off. Reproduce. Enable half-A-off, half-B-on. Reproduce.
+1. List all recently-toggled flags (N flags).
+2. Split the flags into two halves. Enable half-A, disable half-B; reproduce. Then enable half-B, disable half-A; reproduce.
 3. Whichever half reproduces: the culprit is in there. Recurse.
 4. After log2(N) rounds, you have the minimal flag set that triggers the failure.
 
 **Example**: 16 flags toggled recently. Split into sets of 8. Group A (flags 1-8) triggers the bug; group B (flags 9-16) does not. Group A splits into 1-4 and 5-8. Group 5-8 triggers. Split 5-6 and 7-8. Group 7-8 triggers. Split 7 and 8. Flag 7 alone reproduces. Root cause: flag 7's code path.
+
+**Important — cross-half interactions**: if NEITHER half reproduces alone but the bug fires when BOTH groups are enabled, the mechanism requires flags from both halves interacting. The simple binary search fails. In that case:
+
+1. Keep the A-on/B-off and A-off/B-on probes as the first split; both will be green.
+2. Run A-on+B-on (the original failing state). Confirm it reproduces.
+3. Pair-bisect: hold one flag from half A on; toggle half B in halves. Find the smallest subset of B that co-triggers with the held A flag.
+4. Repeat for each A-flag until you identify the minimum pair (or triple) that reproduces.
+
+Cross-half interactions are uncommon but they do happen — often when two unrelated flags both feature-gate code paths that share a data structure. Spot the "neither half alone fails" symptom and switch to pair-bisection instead of concluding "can't be reproduced."
 
 **Tooling**: most feature-flag systems (LaunchDarkly, Unleash, in-house) support environment overrides. Use an override environment for the bisection; do not toggle in production.
 

--- a/skills/debug-systematic/skills/debug-systematic/references/condition-based-waiting.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/condition-based-waiting.md
@@ -1,0 +1,133 @@
+# Condition-Based Waiting — Polling With Timeout
+
+Replace `sleep(n)` with a loop that polls a condition. Arbitrary delays hide races; condition-based waits either pass quickly on success or fail loudly on timeout. Language-neutral template here; drop-in code per language in `references/waiting/<lang>.md`.
+
+## The pattern
+
+```
+fn wait_for(condition, timeout_ms, interval_ms=10):
+    deadline = now() + timeout_ms
+    while now() < deadline:
+        if condition():                    # re-read fresh state per iteration
+            return OK
+        sleep(interval_ms)
+    return TIMEOUT_ERROR("wait_for: <condition description>; timed out after N ms")
+```
+
+**Mandatory elements**:
+
+1. **Fresh read per iteration.** Do not cache the condition's inputs; the whole point is that state changes.
+2. **Tight interval.** 10ms default; increase only if the condition is legitimately expensive to check.
+3. **Hard timeout.** Never wait forever. Every call has a deadline.
+4. **Descriptive timeout error.** The error names *what* was being waited for so Phase 1 has evidence.
+
+## Why this beats `sleep(n)`
+
+| Issue with `sleep(n)` | Resolution |
+|---|---|
+| "Sometimes passes, sometimes fails" — the sleep is short enough to race | Condition-based waits are deterministic: they return as soon as the condition is true |
+| Tests slow to an unnecessary floor because every `sleep(500)` takes 500ms even when the event happens in 10ms | Condition-based waits return fast on success |
+| When the condition never happens, `sleep(n)` hides the failure — the assertion later produces a confusing error | Condition-based waits produce a named timeout error with context |
+| Test flakiness under load — the "safe" sleep value is hardware-dependent | Condition-based waits adapt to the actual event timing |
+
+## When NOT to poll
+
+- **Deterministic signal available** — event hook, callback, promise, channel, future. Use the signal directly.
+- **Mock-clock available** — test framework provides a fake timer; advance the clock instead of waiting.
+- **The wait is for a build or compile step** — use the build tool's completion signal, not a sleep loop around file mtime.
+- **The resource is reachable via a synchronous API** — call the API, don't poll.
+
+Polling is the fallback. Prefer direct signals when they exist.
+
+## Drop-in code by language
+
+Each language reference contains three utility functions (`waitForEvent` / `waitForEventCount` / `waitForEventMatch`), idiomatic to the language's test framework, plus a timeout helper.
+
+| Language | Reference |
+|---|---|
+| TypeScript / Jest / Vitest | `references/waiting/typescript.md` |
+| Python / pytest | `references/waiting/python.md` |
+| Rust / tokio | `references/waiting/rust.md` |
+| Go / stdlib testing | `references/waiting/go.md` |
+| Swift / XCTest | `references/waiting/swift.md` |
+| Ruby / RSpec | `references/waiting/ruby.md` |
+| Java / JUnit 5 / awaitility | `references/waiting/java.md` |
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `sleep(500)` with a "this should be enough" comment | Replace with `wait_for` + condition |
+| Polling interval of 1 second because "it's just a test" | 10ms default; the test completes faster and errors surface faster |
+| Reusing a cached value inside the poll loop | Re-read fresh state every iteration |
+| No timeout (`while !condition { sleep(10) }`) | Add a deadline; hung tests are worse than failed tests |
+| Timeout error without context ("timed out waiting") | Name what was being waited for: "timed out waiting for session store to reach size 10" |
+| Polling instead of using a signal when a signal exists | Use the signal; polling is fallback |
+
+## Designing the condition
+
+The condition function is the load-bearing part. Two rules:
+
+1. **Idempotent and side-effect-free.** Calling the condition a hundred times must not change the system.
+2. **Cheap.** Under 1ms typically. If the check is expensive, widen the interval; don't pay the cost a hundred times.
+
+Example (good):
+
+```
+condition = () => sessionStore.size >= 10
+```
+
+Example (bad — mutates state):
+
+```
+condition = () => {
+  sessions = fetchAllSessions();   // network call, expensive, may mutate observability metrics
+  return sessions.length >= 10;
+}
+```
+
+The bad example poll every 10ms will produce 100 network calls per second, pollute metrics, and still may not return when expected.
+
+## Worked examples
+
+### Test-pollution debug — waiting for cleanup to complete
+
+Symptom: test A starts before test B's teardown finishes. Before: `sleep(200)` in test A's setup.
+
+After:
+
+```
+wait_for(
+  condition = () => globalStore.size() == 0,
+  timeout_ms = 5000,
+  interval_ms = 10
+)
+```
+
+Result: test passes immediately when cleanup completes (~50ms), fails loudly with "timed out waiting for globalStore to empty" if cleanup hangs.
+
+### Race-condition repro — waiting for both workers to commit
+
+Symptom: race only reproducible when two workers commit within 2ms of each other. Before: `sleep(50)` between workers.
+
+After:
+
+```
+worker1.start()
+worker2.start()
+wait_for(
+  condition = () => worker1.done && worker2.done,
+  timeout_ms = 10000
+)
+assert that both results were merged (tests the race-safe code path)
+```
+
+Result: test completes in actual elapsed time, and the race window is captured because both workers are launched before either completes.
+
+## Integration with Phase 1
+
+Condition-based waits are the primary tool for making intermittent bugs deterministic. If Phase 1 cannot produce a 10/10 repro because of timing variability:
+
+1. Find the timing-dependent assertion.
+2. Replace the surrounding `sleep(n)` calls with `wait_for` against the actual condition.
+3. The bug is now either (a) 10/10 reproducible (and Phase 1 exits) or (b) 0/10 reproducible (which means the original symptom was timing-masked; re-run Phase 1 with the new Phase 1 symptom — what's actually wrong now that timing is controlled).

--- a/skills/debug-systematic/skills/debug-systematic/references/cross-runtime.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/cross-runtime.md
@@ -51,9 +51,8 @@ questions: [
     multiSelect: false,
     options: [
       { label: "Route to do-brainstorm (Recommended)", description: "Hand off with the full 3-fails template; do-brainstorm investigates the architectural question" },
-      { label: "Re-open Phase 2 once more", description: "Try one more pattern family before escalating" },
-      { label: "Defer to a human", description: "Document and stop; surface the question to a named owner" },
-      { label: "Abandon the session", description: "Document all three fails and close without a fix" }
+      { label: "Defer to a human owner", description: "Document the architectural question and stop; surface to a named owner for decision" },
+      { label: "Abandon the session", description: "Document all three fails and close without a fix (last resort)" }
     ]
   }
 ]
@@ -77,18 +76,14 @@ The skill has reached the 3-fails gate. Full handoff template is below. Pick one
 Hand off with the 3-fails template; do-brainstorm investigates the architectural
 question surfaced by the three fails.
 
-**2. Re-open Phase 2 once more**
-Try one more pattern family. Only do this if the three fails all trace to the
-same pattern-family assumption and you have an alternative family in mind.
-
-**3. Defer to a human**
+**2. Defer to a human owner**
 Document the architectural question and stop. A named owner picks it up.
 
-**4. Abandon the session**
-Close without a fix. Document all three fails so the next session does not
-repeat them.
+**3. Abandon the session**
+Close without a fix (last resort). Document all three fails so the next session
+does not repeat them.
 
-Reply with "1", "2", "3", "4", or "other: <your note>".
+Reply with "1", "2", "3", or "other: <your note>".
 ```
 
 ## Mirroring the enhance-prompt convention

--- a/skills/debug-systematic/skills/debug-systematic/references/cross-runtime.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/cross-runtime.md
@@ -1,0 +1,119 @@
+# Cross-Runtime — Portability Notes
+
+This skill runs on any runtime that supports an ask-user tool (needed at the 3-fails handoff fork, per `references/escalation.md`) or a prose fallback. Most debugging work is solo — the user is invoked only when the skill hands off to `do-brainstorm`.
+
+If the `enhance-prompt` skill is installed in this pack, its `ask-user-tools.md` reference is the canonical source and uses the same mapping. The two are intentionally kept in sync.
+
+## Runtime → tool lookup
+
+| Runtime | Tool name | Style |
+|---|---|---|
+| **claude-code** (Anthropic SDK) | `AskUserQuestion` | PascalCase |
+| **codex** (OpenAI) | `ask_user_question` | snake_case |
+| **gemini-cli** | `ask_user` | snake_case |
+| **deepagents** | `ask_user` | snake_case |
+| **kimi-cli** | `AskUserQuestion` | PascalCase |
+| **cline** | `ask_followup_question` | snake_case |
+| **droid** (Factory) | `AskUser` | PascalCase |
+| **cursor** | `AskQuestion` | PascalCase |
+| **github-copilot** | `ask_user` | snake_case |
+| **roo** | `ask_followup_question` | snake_case |
+| **opencode** | `question` | plain |
+| **continue** | `AskQuestion` | PascalCase |
+| **antigravity** | `suggested_responses` | snake_case |
+| **pi** | `ask_user` | snake_case |
+| **qwen-code** | `ask_user_question` | snake_case |
+| **mistral-vibe** | `ask_user_question` | snake_case |
+| **unknown / other** | — | use prose fallback (see below) |
+
+Casing matters. Lookup is exact-match.
+
+## When this skill asks the user
+
+Only at the 3-fails handoff fork. Every other interaction is solo-reasoning — the skill produces evidence-bearing artifacts inline and the user reads them at their own pace.
+
+At the handoff:
+
+1. The skill has already written the handoff template (see `references/escalation.md` and `references/integration.md`).
+2. The skill uses the runtime's ask-user tool to present 1-4 options:
+   - Continue investigating (re-enter Phase 2 with a new framing)
+   - Route to `do-brainstorm` (recommended at Fail 3)
+   - Defer and surface the architectural question to a human
+   - Abandon the session (document the failed hypotheses and stop)
+
+## Portable payload shape
+
+```
+questions: [
+  {
+    question: "Three hypothesis-driven fixes failed. What should happen next?",
+    header: "3-fails fork",
+    multiSelect: false,
+    options: [
+      { label: "Route to do-brainstorm (Recommended)", description: "Hand off with the full 3-fails template; do-brainstorm investigates the architectural question" },
+      { label: "Re-open Phase 2 once more", description: "Try one more pattern family before escalating" },
+      { label: "Defer to a human", description: "Document and stop; surface the question to a named owner" },
+      { label: "Abandon the session", description: "Document all three fails and close without a fix" }
+    ]
+  }
+]
+```
+
+Portability constraints (tightest across runtimes):
+
+- 1-4 questions per call (Claude Code cap)
+- 2-4 options per question
+- First option marked `(Recommended)` in label, based on the current state (at Fail 3, "Route to do-brainstorm" is the recommended option)
+- Do NOT manually add "Other" — Claude Code auto-adds it; other runtimes may differ, but mimicking keeps the prompt clean
+
+## Prose fallback — when no ask-user tool is available
+
+```markdown
+## Three hypothesis-driven fixes failed — what should happen next?
+
+The skill has reached the 3-fails gate. Full handoff template is below. Pick one:
+
+**1. Route to do-brainstorm (Recommended)**
+Hand off with the 3-fails template; do-brainstorm investigates the architectural
+question surfaced by the three fails.
+
+**2. Re-open Phase 2 once more**
+Try one more pattern family. Only do this if the three fails all trace to the
+same pattern-family assumption and you have an alternative family in mind.
+
+**3. Defer to a human**
+Document the architectural question and stop. A named owner picks it up.
+
+**4. Abandon the session**
+Close without a fix. Document all three fails so the next session does not
+repeat them.
+
+Reply with "1", "2", "3", "4", or "other: <your note>".
+```
+
+## Mirroring the enhance-prompt convention
+
+If `enhance-prompt` is installed, its `ask-user-tools.md` is the canonical source. When a new runtime emerges with its own ask-user tool, update both files. The tables are small enough that manual propagation is cheap; single-source coupling across skills would break the one-level-deep rule.
+
+## Picking at runtime
+
+1. Look up the runtime in the table above.
+2. If the runtime isn't listed → try `AskUserQuestion` once; if unknown-tool error, try `ask_user` once; otherwise use the prose fallback.
+3. Never silently skip the handoff. If no tool works, emit the prose fallback and wait for the user's reply.
+
+## Claude-native affordances
+
+On Claude Code:
+
+- Markdown tables render well — use them for the handoff template and the 3-fails context.
+- The `(Recommended)` suffix is a rendering convention Claude Code highlights in its UI.
+- `multiSelect: true` is first-class in `AskUserQuestion` (not used in this skill — the 3-fails fork is single-select).
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Hard-coding `AskUserQuestion` in the skill's examples | Use the runtime table; fall back to prose if the runtime isn't listed |
+| Skipping the 3-fails handoff because "no tool is available" | Use the prose fallback; a missed handoff is worse than a prose prompt |
+| Asking the user at Fail 1 or Fail 2 | No — those are handled by re-opening prior phases inline. The ask-user tool fires only at Fail 3. |
+| Asking multiple questions at the handoff ("which pattern family? which layer? which fix?") | One question, 2-4 options. More is friction. |

--- a/skills/debug-systematic/skills/debug-systematic/references/defense-in-depth.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/defense-in-depth.md
@@ -1,0 +1,112 @@
+# Defense in Depth — Four-Layer Validation
+
+Ported from obra's `defense-in-depth.md`, generalized across languages. Read during Phase 4 when you've found the root cause and are about to write the fix — this file decides *which layer* the fix belongs at, and which other layers to add guards at so the bug cannot re-appear.
+
+## The principle
+
+A single-layer fix ("add a null check here") treats the symptom. A defense-in-depth fix restores the broken assumption *at the layer where it belongs* AND adds guards at adjacent layers so the invariant is checked multiple times along the call path. The bug becomes structurally impossible, not just operationally unreachable.
+
+## The four layers
+
+| Layer | Role | What belongs here | What does NOT belong here |
+|---|---|---|---|
+| **1. Entry-point validation** | Reject malformed input at the boundary | Schema check, type assertion, auth/permission check at the request/CLI/event entrance | Business-logic decisions, expensive lookups |
+| **2. Business-logic invariants** | Assert the core domain rules hold | Pre/post-conditions on operations, invariants on data structures, state-machine edge checks | Input parsing, external I/O |
+| **3. Environment guards** | Catch environmental drift | Env-var presence checks, feature-flag gating, runtime preconditions (DB up, cache reachable, clock sane) | Per-request validation |
+| **4. Debug instrumentation** | Surface anomalies that pass other layers | Structured log at anomaly, metric on rare branch, assertion in test build | User-visible error handling |
+
+## Layer 1 — Entry-point validation
+
+**Role**: fail at the boundary with caller context, not deep in the call stack where context is lost.
+
+**Pattern**: every public entrypoint (HTTP handler, CLI command, event consumer, public library function) validates its inputs against a precise type / schema, and returns a boundary-appropriate error (HTTP 400, non-zero exit, NACK, typed Result-Err) on violation.
+
+**Micro-examples**:
+
+- TypeScript: `const parsed = RequestSchema.safeParse(req.body); if (!parsed.success) return res.status(400).json(parsed.error);`
+- Python: `raise ValueError(f"user_id must be a positive int, got {user_id!r}")` at function entry
+- Rust: `fn handle(req: Request) -> Result<Response, Error> { req.validate()?; ... }` — `validate` is a single-pass schema check
+
+**Signals to add Layer 1 guard**: the bug's symptom arrived via `req.body.field` being the wrong shape, the function was called with an argument of the wrong type, or a CLI flag was parsed but never checked.
+
+## Layer 2 — Business-logic invariants
+
+**Role**: encode the domain rules the code relies on, and check them at the points those rules could be violated.
+
+**Pattern**: assertions + invariant checks scattered through business logic — not external validation (that's Layer 1), but internal "this code assumes X" made explicit.
+
+**Micro-examples**:
+
+- TypeScript: `invariant(balance >= 0, 'balance cannot be negative after debit');`
+- Python: `assert len(rows) == len(ids), "ids and rows must be 1:1 after join"`
+- Rust: `debug_assert!(self.state != State::Closed, "closed channel cannot send");`
+
+**Signals to add Layer 2 guard**: the bug was caused by a domain invariant silently drifting (negative balance, duplicate IDs, out-of-range index, state machine skipped a transition). Layer 2 assertions fail fast with a named invariant; Layer 1 validation does not catch these because inputs were technically well-formed.
+
+**When to throw vs. return-error**: invariants that should never be violated under any correct input → throw / panic / assert. Invariants that could be violated by legitimate-but-unexpected input → return a typed error.
+
+## Layer 3 — Environment guards
+
+**Role**: catch drift between what the code assumes about its environment and what the environment actually provides.
+
+**Pattern**: at startup (or first-use of a subsystem), probe the environment and fail loudly if assumptions are violated.
+
+**Micro-examples**:
+
+- TypeScript: `if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL required');` — at module load
+- Python: `if not os.path.exists(CONFIG_PATH): raise EnvironmentError(f"{CONFIG_PATH} not found")` — at service startup
+- Rust: `env::var("API_KEY").expect("API_KEY must be set")` — at initialization
+
+**Signals to add Layer 3 guard**: the bug was caused by a missing env var, a feature flag defaulting to a stale value, a disk/cache/DB not reachable at runtime, or a clock-drift / time-zone mismatch. These bugs often manifest as "works on my machine."
+
+## Layer 4 — Debug instrumentation that survives the fix
+
+**Role**: if all three layers above are already correct but the bug still slipped through, add instrumentation that would have caught it.
+
+**Pattern**: a log line, metric, or test-build assertion at the anomaly point — not for users, for the next debugging session.
+
+**Micro-examples**:
+
+- TypeScript: `logger.warn({ userId, reason: 'token-refresh-fell-back-to-credentials' })`
+- Python: `logging.info("cache.miss: %s, age=%ss", key, age)` on rare-path
+- Rust: `tracing::warn!(user_id = %uid, "session rotated after privilege elevation")`
+
+**Signals to add Layer 4**: the bug was invisible during Phase 2 because no log existed for the rare path. Without Layer 4, Phase 2 would have guessed. Add a log/metric/assertion that would have made Phase 2 cheaper next time.
+
+**What stays vs. what comes out in Phase 4**:
+
+- Stays: structured logs at anomaly points, metrics on rare branches, assertions in test builds
+- Comes out: `println!`, `console.log`, dbg!, commented-out debug code, temporary variable renames
+
+## When to pick which layer — matrix
+
+| Symptom type | Primary layer | Also guard at |
+|---|---|---|
+| Malformed external input | Layer 1 | Layer 2 if it bypasses normal entry |
+| Internal state drift (negative balance, inconsistent caches) | Layer 2 | Layer 4 log on transition |
+| Missing/stale env var or config | Layer 3 | Layer 1 for request-time overrides |
+| Silently-swallowed error returned as success | Layer 4 log + Layer 2 assertion | — |
+| Race condition | Layer 2 (invariant on shared state) | Layer 4 metric on retry/backoff |
+| Auth/permission boundary violation | Layer 1 (reject at boundary) | Layer 2 (assert in protected code) |
+
+## Anti-pattern: the single-layer fix
+
+Most tempting failure: adding a null-check or try-catch at the symptom frame and declaring victory.
+
+Example: symptom is `TypeError: cannot read 'id' of undefined` at `handlers/profile.ts:42`. The tempting "fix" is `if (!req.user) return res.status(401).end();` at line 42. This:
+
+1. Does not say *why* `req.user` is undefined (the auth middleware swallowed a lookup failure)
+2. Silently turns a middleware bug into a user-visible 401
+3. Leaves the auth middleware bug in place for the next endpoint to hit
+
+The defense-in-depth fix: Layer 1 at the auth middleware (return 401 with context on lookup failure) + Layer 4 log (why did the lookup fail? stale session? corrupt cookie?). Phase 2 should have identified the middleware as the causal frame; Phase 4 picks the layer.
+
+## Handoff from Phase 3 to Phase 4
+
+Once Phase 3 has confirmed a mechanism, answer three questions before writing the fix:
+
+1. **Which layer did the violation originate at?** (This is where the primary fix goes.)
+2. **Which adjacent layer, if guarded, would have made the bug structurally impossible?** (Add a guard there.)
+3. **Which layer, if instrumented, would have made this bug cheaper to detect next time?** (Add instrumentation there.)
+
+Fill these in before editing. If you cannot, you do not yet have the mechanism — return to Phase 3.

--- a/skills/debug-systematic/skills/debug-systematic/references/escalation.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/escalation.md
@@ -1,0 +1,159 @@
+# Escalation — The 3-Fails Gate
+
+Three failed fixes means you are in the wrong frame. This file defines what counts as a "failed fix," how to re-enter the prior phase cleanly, when to route out to `do-brainstorm`, and how to write the handoff so the receiving skill has the context.
+
+## What "one failed fix" means
+
+A **failed fix** is a hypothesis-driven change that:
+
+- did not make Phase 1's 10/10 repro pass (symptom persists), OR
+- made Phase 1's repro pass but introduced a regression elsewhere (new bug surfaced), OR
+- made Phase 1's repro pass but the mechanism is suspicious and the fix "coincidentally" masked a different bug
+
+What does **not** count as a failed fix:
+
+- Compilation / lint errors unrelated to the hypothesis (you fixed a typo, not tested the fix)
+- The fix works but a `pnpm install` / `cargo build` / build step was stale
+- The fix works in dev but not in a staging environment with different config (that's a new symptom; restart Phase 1 on the new symptom)
+
+The distinction matters because the 3-fails counter must reflect real hypothesis failures, not mechanical friction.
+
+## The 3-fails rule
+
+```
+Fail 1 → re-open Phase 2. The pattern family was likely wrong.
+Fail 2 → re-open Phase 1. The symptom definition or repro was probably incomplete.
+Fail 3 → STOP. Route to do-brainstorm. The problem is architecture-shaped.
+```
+
+### Fail 1 — re-open Phase 2
+
+The pattern you matched (test-pollution / race / serialization / etc.) was probably wrong. Go back to the evidence from Phase 1 and force a **different** pattern family this round.
+
+What to keep from round 1:
+
+- The symptom card (still accurate — the symptom hasn't changed)
+- The Phase 1 evidence (logs, traces, repro)
+- The failed fix's code (as a candidate, in case the NEXT pattern family explains why even this fix didn't work)
+
+What to discard:
+
+- The ranked candidate mechanisms from round 1 (they led nowhere)
+- Any assumption that the "obvious" mechanism is right
+
+### Fail 2 — re-open Phase 1
+
+The symptom or repro was incomplete. Common signs:
+
+- You treated an intermittent bug as deterministic ("fails 10/10 on this input" but actually "fails 6/10")
+- The repro works but misses a contributing condition (the bug only fires with feature flag X, and your repro didn't set it)
+- The symptom is actually two symptoms merged (a race condition that *also* triggers a silent error-swallow; fixing one without the other leaves half the bug)
+
+Restart Phase 1 with the new information from the two failed fixes — what did those failures teach about the real symptom?
+
+### Fail 3 — stop and route
+
+Three failures with three different hypotheses means the problem is structurally different from what you thought. Common terminal patterns:
+
+- The "bug" is a design limitation — the code works as written, but what was written is wrong at the architecture level
+- Two independent bugs are interacting; single-fix attempts each address one but not both
+- The code path has no correct fix — it needs to be removed or rewritten
+
+Route to `do-brainstorm` with the handoff template below. Do not try a 4th fix.
+
+## How to re-enter Phase 2 or Phase 1 cleanly
+
+### Re-enter Phase 2 (after Fail 1)
+
+Write this block before doing anything else:
+
+```
+## Fail 1 — re-opening Phase 2
+
+Previous pattern family: <test-pollution | race | serialization | null propagation | etc.>
+Previous hypothesis: <the one-sentence "X caused Y because Z">
+Why it failed: <what the fix predicted and what actually happened>
+New pattern families to consider: <at least 2 that are NOT the previous one>
+```
+
+Then generate new candidates under the new pattern families. Do not re-run the same tree of reasoning that produced fail 1.
+
+### Re-enter Phase 1 (after Fail 2)
+
+Write this block:
+
+```
+## Fail 2 — re-opening Phase 1
+
+Previous symptom card: <paste from round 1>
+What the 2 fails revealed about the real symptom: <what's actually different or additional>
+New repro conditions to include: <what was missing>
+```
+
+Then re-run the Phase 1 workflow. The new symptom card should be measurably richer than the previous one; if it isn't, you're going in circles — route to `do-brainstorm` even at Fail 2.
+
+## Handoff format to `do-brainstorm`
+
+At Fail 3, dispatch to `do-brainstorm` with this exact template. Drop it into the conversation or, on runtimes with an ask-user tool, into the initial prompt:
+
+```
+## Handoff from debug-systematic → do-brainstorm
+
+### Symptom card
+<the Phase 1 card from the most recent round>
+
+### Three fixes tried
+
+1. Fail #1: <hypothesis>. Fix attempted: <code or diff>. Result: <what failed>.
+2. Fail #2: <hypothesis>. Fix attempted: <code or diff>. Result: <what failed>.
+3. Fail #3: <hypothesis>. Fix attempted: <code or diff>. Result: <what failed>.
+
+### Pattern across failures
+<one paragraph: what the three failures have in common, if anything>
+
+### Architectural question surfaced
+<one sentence: the question do-brainstorm should investigate — e.g., "Is our session
+store assumption still valid?" or "Should this code path exist at all?">
+
+### Constraints / non-negotiables
+<anything do-brainstorm should know — deadlines, deployment constraints, user-facing
+commitments>
+```
+
+`do-brainstorm` picks up from "architectural question surfaced" — its Cynefin classifier will usually route this to Complex (unknown unknowns) and run the full 6-phase brainstorm. When it returns a recommendation, re-enter at Phase 2 with the new framing. Do not restart `debug-systematic` from Phase 1 — the Phase 1 card is still valid.
+
+## Pressure-scenario sidebars (abridged)
+
+Full scenarios in `references/pressure-tests/`. The summaries below show how the 3-fails rule interacts with pressure.
+
+### Academic baseline
+
+No pressure. If the skill works here, the 3-fails rule is load-bearing. If the agent improvises fixes without re-opening prior phases, the skill's structure is broken.
+
+### Financial outage
+
+$15k/min outage. Fail 1 happens at minute 15, Fail 2 at minute 28. Temptation: try fix #3 fast, skip the re-open-Phase-1 block.
+
+**Counter**: the re-open block takes 2 minutes. If you skip it and fix #3 also fails, you are now at minute 35, Fail 3, and routing to `do-brainstorm` with incomplete context. The 2-minute re-open is the cheaper path even under outage pressure.
+
+### Sunk cost
+
+4 hours of debugging, 2 failed fixes. Temptation: try fix #3 as "one more shot."
+
+**Counter**: 2 fails means the symptom card is incomplete. Re-enter Phase 1. The 4 hours are the evidence the current path is dead — they are not sunk, they are the data that says "symptom is not what I thought."
+
+### Authority / social
+
+Senior engineer diagnosed the bug as pattern X. You ran Phase 2 with X as the lead candidate, it failed (Fail 1). Temptation: the senior is rarely wrong; fix #2 within the same pattern family ("maybe I applied X wrong").
+
+**Counter**: the senior's diagnosis is a *candidate mechanism*, not a *confirmed one*. If your experiment on X falsified it, X is out. Re-open Phase 2 with a genuinely different pattern family. If the senior pushes back, route to `do-brainstorm` early — the architectural question is now social as well as technical.
+
+## Anti-patterns at the escalation gate
+
+| Anti-pattern | Fix |
+|---|---|
+| Trying a 4th, 5th, 6th fix because "one of them has to work" | No. Three fails = route. |
+| Skipping the re-open block ("I know what went wrong, just let me try X") | Write the block anyway. The act of writing catches hidden assumptions. |
+| Routing to `do-brainstorm` with only the most recent fix's context | Full handoff template above. All three fixes. |
+| Restarting `debug-systematic` from Phase 1 after `do-brainstorm` returns | No — re-enter at Phase 2 with the new framing. Infinite regress otherwise. |
+| Counting compile errors toward the 3-fails budget | Only count hypothesis-driven attempts. Mechanical failures don't. |

--- a/skills/debug-systematic/skills/debug-systematic/references/escalation.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/escalation.md
@@ -90,7 +90,7 @@ What the 2 fails revealed about the real symptom: <what's actually different or 
 New repro conditions to include: <what was missing>
 ```
 
-Then re-run the Phase 1 workflow. The new symptom card should be measurably richer than the previous one; if it isn't, you're going in circles — route to `do-brainstorm` even at Fail 2.
+Then re-run the Phase 1 workflow. The new symptom card should be measurably richer than the previous one. If it isn't — if re-opening produced the same symptom card you started with — that's evidence the pattern families you're considering are exhausted. Proceed to **Fail 3 immediately** (don't wait for a third fix attempt) and route to `do-brainstorm` with the two-fails handoff template below. The 3-fails rule is the upper bound; hitting it earlier when the signal is clear is not a violation, it's a time-saver.
 
 ## Handoff format to `do-brainstorm`
 

--- a/skills/debug-systematic/skills/debug-systematic/references/instrumentation.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/instrumentation.md
@@ -1,0 +1,178 @@
+# Instrumentation — Print, Log, Stack Trace Per Language
+
+Phase 2 and Phase 3 need evidence. When the existing logging doesn't surface what you need, you add temporary instrumentation. This file covers the three modes and the per-language idioms.
+
+## The three instrumentation modes
+
+| Mode | When | Lifetime |
+|---|---|---|
+| **Stdout print** | Quick-check during active debugging. "Does this branch run?" | Temporary — removed in Phase 4 |
+| **Structured log** | Evidence you want retained. "This path is rare; log it with context." | Often persists after the fix |
+| **Stack-trace capture** | "Who called this function?" — tracing the call chain backward | Temporary unless the anomaly is rare-and-recurring |
+
+Pick by longevity: if the anomaly should leave a production breadcrumb, use a structured log. If it's scaffolding for this debug session only, use a print. If you need the caller's identity, capture the stack.
+
+## Universal patterns
+
+### Stdout print
+
+For any language, the minimum useful print includes:
+
+- A tag naming the file / module / context
+- The variable(s) being inspected with their types
+- The current state of any guard that gated this code path
+
+Anti-pattern: `println(x)`. Too low context to survive five minutes of debugging.
+
+### Structured log
+
+Fields to always include:
+
+- The identifier that lets you correlate this log with others (request ID, task ID, user ID, operation key)
+- The value being reported, with unambiguous units
+- The reason this log was added ("rare branch", "retry attempt", "cache miss with age")
+
+### Stack-trace capture
+
+When the question is "who called this?", capture the current call stack and write it to log. Do not use this as a substitute for the stack trace of an actual exception; use it where no exception is thrown but the caller's identity matters.
+
+## Per-language patterns
+
+### TypeScript / Node
+
+```ts
+// Print
+console.debug('[auth.middleware]', { userId, sessionValid, reason });
+
+// Structured log (pino / winston / bunyan all similar)
+logger.warn({ userId, reason: 'session-lookup-miss', cacheAge }, 'session lookup failed');
+
+// Stack trace (no exception thrown)
+console.debug('[auth.middleware] caller stack:', new Error().stack);
+```
+
+### Python
+
+```python
+# Print
+print(f"[auth.middleware] user_id={user_id} session_valid={valid} reason={reason}")
+
+# Structured log
+logger.warning("session lookup failed",
+               extra={"user_id": user_id, "reason": "cache-miss", "cache_age_s": age})
+
+# Stack trace
+import traceback
+logger.debug("caller stack:\n%s", "".join(traceback.format_stack()))
+```
+
+### Rust
+
+```rust
+// Print (dev only — use eprintln! for stderr)
+eprintln!("[auth.middleware] user_id={:?} session_valid={} reason={:?}", user_id, valid, reason);
+
+// Structured log (tracing is standard)
+tracing::warn!(
+    user_id = %user_id,
+    reason = "session-lookup-miss",
+    cache_age_s = cache_age,
+    "session lookup failed"
+);
+
+// Stack trace
+use std::backtrace::Backtrace;
+tracing::debug!(backtrace = %Backtrace::capture(), "caller location");
+```
+
+### Go
+
+```go
+// Print
+log.Printf("[auth.middleware] userID=%v sessionValid=%v reason=%s", userID, valid, reason)
+
+// Structured log (zap / zerolog / slog)
+logger.Warn("session lookup failed",
+    zap.Int64("user_id", userID),
+    zap.String("reason", "cache-miss"),
+    zap.Duration("cache_age", cacheAge))
+
+// Stack trace
+import "runtime/debug"
+log.Printf("caller stack:\n%s", debug.Stack())
+```
+
+### Swift
+
+```swift
+// Print
+print("[auth.middleware] userId=\(userId) sessionValid=\(valid) reason=\(reason)")
+
+// Structured log (os_log)
+os_log(.info, log: .auth, "session lookup failed: user=%{public}d reason=%{public}@ age=%{public}f",
+       userId, reason, cacheAge)
+
+// Stack trace
+print("caller stack: \(Thread.callStackSymbols.joined(separator: "\n"))")
+```
+
+### Ruby
+
+```ruby
+# Print
+puts "[auth.middleware] user_id=#{user_id} session_valid=#{valid} reason=#{reason}"
+
+# Structured log (Rails.logger or semantic_logger)
+Rails.logger.warn(
+  'session lookup failed',
+  user_id: user_id, reason: 'cache-miss', cache_age_s: age
+)
+
+# Stack trace
+Rails.logger.debug("caller stack:\n#{caller.join("\n")}")
+```
+
+### Java / Kotlin
+
+```java
+// Print
+System.out.printf("[auth.middleware] userId=%d sessionValid=%b reason=%s%n", userId, valid, reason);
+
+// Structured log (SLF4J + Logback/Log4j2 with MDC or key-value arguments)
+logger.warn("session lookup failed user_id={} reason={} cache_age_s={}",
+            userId, "cache-miss", cacheAge);
+
+// Stack trace
+logger.debug("caller stack: {}", Thread.currentThread().getStackTrace());
+```
+
+## Instrumentation that survives the fix
+
+Phase 4 removes temporary diagnosis code. Decide per-line: stays or comes out.
+
+| Code | Decision |
+|---|---|
+| Temporary `println!` / `console.log` / `dbg!` added during Phase 3 | **Remove** |
+| Structured log on a rare branch that would have helped Phase 2 | **Keep** — it makes the next debug session cheaper |
+| Stack-trace capture added to prove a caller identity | **Remove** (unless the anomaly is expected to recur rarely in prod, in which case convert to structured log with context) |
+| Debug assertion that failed during Phase 3 and surfaced the mechanism | **Keep as a production assertion** (if the cost is acceptable) or **keep as a test assertion** (always) |
+| Comment-out debug code ("// TODO: remove this") | **Remove** |
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `console.log(x)` with no context | Include the file/module tag + the values around x |
+| Logging at INFO level for noise that should be DEBUG | Use DEBUG for rare-branch diagnostics; INFO is user-facing |
+| Logging secrets or PII during debugging | Redact (`"***"` for secrets, `hash(user_id)` for PII) even in temporary instrumentation |
+| Removing the log after the fix "because it's noisy" | If it helped once, it will help again. Either keep at DEBUG or convert to a metric. |
+| Adding 20 `println` calls in one round | Add 2-3 with specific hypotheses; more means you are fishing, not testing. |
+| Logging "here" / "reached here 1" | Logs must carry context (file, line, values). "Here" is a placeholder, not a log. |
+
+## When logging is not enough
+
+If the symptom is performance (not correctness), stdout/log is the wrong tool. Use a profiler, tracing system (OpenTelemetry, Jaeger), or a runtime debugger. `references/bisection-strategies.md` covers the search-space techniques; this file covers evidence capture.
+
+## When the existing logging is enough
+
+Before adding any instrumentation, read the existing logs with the symptom's timestamp and identifiers. In mature codebases, 70%+ of bugs have enough evidence in existing logs if you query them correctly. Run the query first, add instrumentation only when the existing logs genuinely don't surface the needed evidence.

--- a/skills/debug-systematic/skills/debug-systematic/references/integration.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/integration.md
@@ -1,0 +1,198 @@
+# Integration — When to Route Out, When to Stay Inline
+
+This skill coordinates with three siblings in the pack: `think-deeper` (solo reasoning), `do-brainstorm` (user-in-loop framework routing), `check-completion` (audit-then-remediate). The inline routing matrix in SKILL.md covers the common cases; this file covers edge cases and the handoff templates.
+
+## Overview: when to hand off
+
+The decision is almost always between "do I have enough signal to stay in the current phase" vs. "am I stuck in a way that more debugging won't resolve."
+
+- **Stuck on evidence** (Phase 2 pattern can't form) → route to `think-deeper`
+- **Stuck on architecture** (3 fixes failed) → route to `do-brainstorm`
+- **Fix applied, want to verify nothing else broke** → route to `check-completion`
+
+Never route to yourself (`debug-systematic` → `debug-systematic` is infinite regress). When a routed-out skill returns, re-enter at the appropriate phase of this skill; do not restart from Phase 1.
+
+## Route to `think-deeper` when...
+
+`think-deeper` is the pack's tool-agnostic solo-reasoning skill. It does not require user input (unlike `do-brainstorm`) and applies a stronger evidence-and-falsification loop than Phase 2/3.
+
+### When it helps
+
+1. **Phase 2 candidates are weak** — you can articulate only "it feels like X" for every candidate. Evidence is thin across the board.
+2. **Phase 3 candidates tied** — two candidates fit the evidence equally well and you cannot design a cheap distinguishing test.
+3. **Phase 1 repro is solid but Phase 2 is blocked** — the symptom is clear; you just can't form a mechanism hypothesis worth testing.
+
+### When it doesn't help
+
+- Phase 1 is incomplete (no 10/10 repro). `think-deeper` can't fix an unreproducible bug; go back to Phase 1.
+- Phase 3 experiment was falsifying and a candidate was confirmed. You have a mechanism; go to Phase 4.
+- You are at the 3-fails gate. That's `do-brainstorm` territory, not `think-deeper`.
+
+### Worked handoff examples
+
+**Example A** — Phase 2 candidates all weak:
+
+> Handing to `think-deeper`. Phase 1 is solid (symptom card + 10/10 repro). Phase 2 produced three candidate mechanisms, all rated "maybe": (1) race on the session store, (2) middleware order issue, (3) cache invalidation timing. None has evidence stronger than "it could be this." Need a stronger evidence frame before running Phase 3.
+
+**Example B** — Phase 3 tied:
+
+> Handing to `think-deeper`. Two candidates fit: (1) connection pool exhaustion under load, (2) DNS resolution timing out on the cold path. Both would produce the observed "intermittent slow requests + error log." Tests so far have not distinguished them. Need a design for a falsifying experiment.
+
+### Re-entry after `think-deeper`
+
+Re-enter this skill at **Phase 2** with the sharper evidence frame. Do not re-run Phase 1.
+
+## Route to `do-brainstorm` when...
+
+`do-brainstorm` is the pack's user-in-the-loop brainstorming skill. It requires the user to participate at 5 forks (Cynefin classification, decomposition, exploration, evaluation, stress-test). Use it when the debug question becomes an architectural question and the user's context is needed.
+
+### When it helps
+
+1. **3-fails gate hit** — three hypothesis-driven fixes failed. The problem is architecture-shaped; pure debugging will not resolve it.
+2. **Phase 2 surfaces a scope question** — the candidates are technical but each implies a different product scope / team-ownership / architectural decision. The user needs to pick.
+3. **The bug crosses team boundaries** — the fix requires a decision about *who owns this*.
+
+### When it doesn't help
+
+- You haven't tried three fixes yet. Stay in this skill and use the re-open cycles first.
+- The bug is clearly technical (no product/scope/architecture implication). Stay technical.
+- You just want to "bounce ideas" but don't have the 3-fails evidence. `do-brainstorm` expects substantive input.
+
+### Worked handoff example
+
+> Handing to `do-brainstorm`. Three fixes failed (attached below). All three tried to preserve the current session-store architecture. The pattern across the fails: each fix ran into the same synchronization boundary between the auth service and the session cache. The architectural question: *should the session cache be colocated with the auth service rather than shared?* This is a design decision, not a bug.
+
+### Handoff template (required fields)
+
+Use this exact shape:
+
+```
+## Handoff from debug-systematic → do-brainstorm
+
+### Symptom card (from Phase 1)
+<paste>
+
+### Three fixes tried
+1. <hypothesis + fix + result>
+2. <hypothesis + fix + result>
+3. <hypothesis + fix + result>
+
+### Pattern across the fails
+<one paragraph>
+
+### Architectural question
+<one sentence the brainstorm should investigate>
+
+### Constraints
+<deadline, rollback window, commitments, team ownership>
+```
+
+### Re-entry after `do-brainstorm`
+
+If `do-brainstorm` returns a recommendation that is a new architecture:
+
+- Re-enter this skill at **Phase 2** with the new framing. The symptom card is still valid; the pattern families to consider have changed.
+- Do not try to squeeze the new architecture into the old Phase 2 candidate list. Regenerate candidates under the new framing.
+
+If `do-brainstorm` returns "this is not a bug, it's a scope decision; defer":
+
+- Close the debug session with the scope note.
+- Do not continue to Phase 4.
+
+## Route to `check-completion` when...
+
+`check-completion` is the pack's audit-then-remediate skill with a 22-status taxonomy. Route to it after Phase 4's fix is verified, before declaring the session done.
+
+### When it helps
+
+1. **Phase 4 fix applied and Phase 1 repro passes** — the bug is fixed, but you want to verify nothing else in scope was broken by the change.
+2. **Multiple files / modules touched** — the fix crossed module boundaries. Check-completion audits whether the session's full scope is still intact.
+3. **Fix landed but the session started with multiple tasks** — check-completion's scope-disambiguation will identify what's still outstanding.
+
+### When it doesn't help
+
+- Only one file changed and the regression guard is tight. Skip `check-completion`; declare done.
+- Phase 4 hasn't produced a fix yet. Don't route prematurely.
+- The bug was a compile error; the compiler validates the fix. No audit needed.
+
+### Re-entry after `check-completion`
+
+Usually `check-completion` returns a list of things to verify. Either:
+
+- Everything is clean → declare the debug session done, commit, move on.
+- Something else broke → that's a new bug. Start a new `debug-systematic` session on the new symptom. Do NOT treat the original bug as unresolved; it's fixed. You have a *new* bug.
+
+## Do NOT route when...
+
+1. **Phase 1 is incomplete.** Routing out without a 10/10 repro makes the receiving skill invent evidence. Finish Phase 1 first.
+2. **You are tired and looking for a shortcut.** `think-deeper` and `do-brainstorm` are not substitutes for the work you should be doing in this skill. They are genuine handoffs for genuine stuck-points.
+3. **The session has already routed out twice.** Three skill handoffs in one debug session means the problem is something else entirely — surface this to the user and stop.
+4. **The route would be recursive** (`debug-systematic` → `debug-systematic`). Never. If more debugging is needed, re-enter at the correct phase.
+
+## Handoff templates — copy-paste ready
+
+### To `think-deeper`
+
+```
+## Route: debug-systematic (Phase 2/3) → think-deeper
+
+### Why routing
+<one sentence: Phase 2 candidates too weak / Phase 3 experiments not distinguishing>
+
+### Phase 1 artifact
+<symptom card + repro>
+
+### Phase 2 artifact (if Phase 2 completed)
+<ranked candidates with evidence>
+
+### What think-deeper should produce
+<e.g., "a sharper evidence frame that lets me distinguish between candidates A and B"
+or "a design for a falsifying experiment that would kill candidate X">
+```
+
+### To `do-brainstorm`
+
+```
+## Route: debug-systematic (Fail 3) → do-brainstorm
+
+### Symptom card (Phase 1)
+<paste>
+
+### Three fails
+1. <...>
+2. <...>
+3. <...>
+
+### Pattern across fails
+<one paragraph>
+
+### Architectural question
+<one sentence>
+
+### Constraints
+<bullet list>
+```
+
+### To `check-completion`
+
+```
+## Route: debug-systematic (Phase 4 complete) → check-completion
+
+### Scope
+<e.g., "session-loading fix touched middlewares/load-session.ts, tests/fixtures/app.ts,
+and added tests/middleware/session-missing.test.ts. Audit these and confirm no other
+session-related tests regressed.">
+
+### Specific concerns
+<e.g., "login flow uses the same middleware. Audit that login's integration tests pass.">
+```
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Routing to `think-deeper` at Fail 1 | No — use the re-open-Phase-2 block first. `think-deeper` is for stuck evidence, not stuck hypotheses. |
+| Routing to `do-brainstorm` at Fail 2 | Try the re-open-Phase-1 block first. Fail 3 is the gate, not Fail 2. |
+| Routing to `check-completion` before Phase 4 is done | You don't have a fix yet — nothing to audit. |
+| Routing to multiple skills in sequence without re-entering this one | Re-enter at the correct phase; the handoffs are not a pipeline. |
+| Restarting `debug-systematic` from Phase 1 after any routed-out skill returns | Re-enter at Phase 2 (post-`think-deeper`/`do-brainstorm`) or declare done (post-`check-completion`). Never Phase 1 unless the symptom actually changed. |

--- a/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/academic.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/academic.md
@@ -1,0 +1,145 @@
+# Pressure Test — Academic Baseline
+
+Calm conditions. No time pressure, no authority, no sunk cost. This scenario exists to verify the skill produces Phases 1 → 4 in order under ideal conditions. If the agent skips or improvises phases here, the skill's structure is broken — the problem is not "pressure defeats discipline," it's "discipline was never there."
+
+Adapted from obra's `test-academic.md`. Language-neutralized.
+
+## Scenario
+
+You have a small service that processes webhook events. A new integration test has started failing:
+
+```
+FAIL tests/webhook/order_created.test
+    expected: order.status == "confirmed"
+    actual:   order.status == "pending"
+```
+
+You have:
+
+- Time: as much as you need
+- Access: full repo, logs, test environment
+- Social: no one is watching; no deadline
+- Authority: you own this code; no diagnosis was provided
+- History: the test was passing in CI three days ago; two PRs have merged since
+
+The test:
+
+```
+describe("webhook: order.created", () => {
+  it("confirms the order and emits events", async () => {
+    const order = await fixtures.order({ amount: 10_00 });
+    await webhook.post("/webhooks/stripe", stripePayload(order, "order.created"));
+    await waitForEventCount(() => eventBus.events.length, 2);
+    const updated = await orderStore.find(order.id);
+    expect(updated.status).toBe("confirmed");   // <-- fails
+  });
+});
+```
+
+## Expected methodology
+
+### Phase 1 — Investigation
+
+The agent should:
+
+1. State the symptom precisely — the exact assertion, the expected vs. actual values, the test name, the last known passing commit.
+2. Reproduce 10/10 — run the test locally 10 times, observe 10 failures. Confirm it is not intermittent.
+3. Capture evidence — the full test output, any related log lines, the git log between the last passing commit and HEAD.
+4. Produce the symptom card.
+
+Example symptom card (what the agent should emit):
+
+> `tests/webhook/order_created.test` asserts `order.status === "confirmed"` after the webhook processes. Actual: `"pending"`. Last known passing: commit `abc123` (3 days ago). Reproduction: `pnpm test webhook/order_created` fails 10/10. PRs merged since: #441 (refactored the payment module), #445 (added event-bus buffering).
+
+### Phase 2 — Pattern analysis
+
+Apply `root-cause-tracing.md` backward from the failure:
+
+- Frame 1: the assertion (victim).
+- Frame 2: `orderStore.find` (reads correctly; not the cause).
+- Frame 3: the webhook handler (looks for `payment.confirmed` event, updates order status).
+- Frame 4: the payment module — changed recently in PR #441.
+
+Candidate mechanisms:
+
+1. PR #441 changed the event name from `payment.confirmed` to `payment.confirmation_received`; the webhook handler still listens for the old name. Evidence: `grep payment.confirm` shows diverged usage.
+2. PR #445's event-bus buffering introduces a delay such that `waitForEventCount(2)` returns before both events arrive — but the status update requires the second event. Evidence: the buffer's docs and the timing of recent test changes.
+3. Some config drift — the test env's new feature flags suppress one of the events. Evidence: check env between the last passing run and now.
+
+Ranked by disprovability: #1 (one grep), #2 (single log), #3 (env diff).
+
+### Phase 3 — Hypothesis testing
+
+Top candidate: #1.
+
+False-case prediction: if #1 is wrong, restoring the event name to `payment.confirmed` should NOT fix the test.
+
+Experiment: `grep -r "payment.confirm" src/`. Confirmed: PR #441 renamed the emit to `payment.confirmation_received` while the handler still subscribes to `payment.confirmed`.
+
+Distinguishing check: apply the rename locally (handler subscribes to new name). Test passes 10/10. #1 confirmed.
+
+### Phase 4 — Implementation
+
+Layer pick (`defense-in-depth.md`): Layer 2 (business-logic invariant). Rename the handler's subscription to the new event name.
+
+Regression guard: add a test asserting that the webhook handler subscribes to `payment.confirmation_received` specifically (so a future rename does not silently reintroduce the bug).
+
+Verification: the Phase 1 repro passes 10/10. Full suite passes.
+
+Remove temporary diagnosis code: none added (the investigation used `grep` and the existing tests).
+
+Route to `check-completion`: audit the scope of PR #441 for any other missed renames.
+
+## What a correct trace looks like in the transcript
+
+```
+Entering Phase 1.
+Phase 1 symptom card: <paste>.
+Reproduction: pnpm test ... (fails 10/10).
+Evidence: <git log between abc123 and HEAD>; <test output>.
+Phase 1 complete.
+
+Entering Phase 2.
+Root-cause trace: Frame 1 (assertion) → Frame 3 (handler subscribes to "payment.confirmed") → Frame 4 (emitter renamed in PR #441).
+Ranked candidates:
+  1. Event-name rename in PR #441 — evidence: grep shows divergence. Disprovable via rename.
+  2. Buffered bus timing from PR #445 — evidence: recent docs. Disprovable via log.
+  3. Config drift — evidence: check env diff.
+Phase 2 complete.
+
+Entering Phase 3.
+Top candidate: #1.
+False-case prediction: if #1 is wrong, restoring the event name would not fix the test.
+Experiment: apply the rename; rerun. Result: 10/10 pass.
+Mechanism confirmed: event-name rename.
+Phase 3 complete.
+
+Entering Phase 4.
+Layer: Layer 2 (business-logic invariant). Fix: rename handler subscription to payment.confirmation_received.
+Regression guard: new test asserts specific subscription name.
+Verification: Phase 1 repro passes 10/10; full suite green.
+Routing to check-completion to audit the scope of PR #441.
+Phase 4 complete.
+```
+
+## What failure looks like
+
+Failure modes for the academic baseline (any of these means the skill itself is broken):
+
+- Agent jumps to "probably the event name" and applies the fix without running the experiment (skips Phase 3)
+- Agent runs the test three times, sees three failures, calls it "confirmed" without reproducing deterministically (Phase 1 shortcut)
+- Agent adds a `try/catch` around the failing assertion as the "fix" (symptom whack-a-mole; `root-cause-tracing.md` anti-pattern)
+- Agent does not add a regression guard (Phase 4 shortcut)
+- Agent does not state the false-case prediction before the experiment (Phase 3 shortcut)
+
+Any of these under academic conditions means the skill's structural language is too weak. Revisit SKILL.md's non-negotiable rules and `voice.md`'s required forms.
+
+## Key signals to watch for
+
+1. **"Phase 1 symptom card:"** announced at the entry
+2. **1-3 ranked candidates with evidence** written out
+3. **Falsification prediction stated before the experiment**
+4. **Regression guard added before declaring done**
+5. **Route to `check-completion`** at Phase 4 exit
+
+If all five appear in the transcript, the skill works under calm conditions. If any is missing, fix that aspect of the skill (via `voice.md` required forms, via SKILL.md non-negotiable rules, or by tightening the phase workflow).

--- a/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-authority.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-authority.md
@@ -1,0 +1,126 @@
+# Pressure Test — Authority / Social
+
+The senior engineer: "I looked at it — the bug is on line 147 of worker.ts. It's a null-pointer from the session refactor last week. Go fix it." The tech lead nods. The team is silent. Everyone seems to agree.
+
+Adapted from obra's `test-pressure-3.md`. Language-neutralized. Tests whether the Iron Law holds when authority + social pressure align on a diagnosis.
+
+## Scenario
+
+- **Authority**: the senior engineer has more tenure than you. They're usually right. They stated the bug and its location.
+- **Social**: the tech lead nods. Silence in the room is implicit agreement. Disagreeing is socially costly.
+- **Plausibility**: the diagnosis (null-pointer from the session refactor) is *plausible* — there was a session refactor last week, and `worker.ts:L147` does dereference a session-related object.
+- **Incomplete evidence**: the senior engineer did not show the evidence. They said "I looked at it." You did not see their Phase 1 or Phase 3.
+
+The stack trace you were sent:
+
+```
+TypeError: Cannot read properties of null (reading 'user_id')
+    at processEvent (worker.ts:147:34)
+    at onMessage (queue.ts:88:12)
+    at <anonymous> (event-loop:56)
+```
+
+## The temptation
+
+"Senior said it's at line 147. Let me add a null check there." Done in 5 minutes. Everyone happy. Team moves on.
+
+## Why this is a Phase 1-3 skip
+
+The senior engineer provided a **candidate mechanism**, not a **confirmed mechanism**. The difference matters:
+
+- **Candidate** = Phase 2 raw material. Go into the ranked list alongside other candidates.
+- **Confirmed** = Phase 3 output. Requires an experiment the agent ran this session.
+
+Treating a candidate as confirmed is the authority-pressure rationalization. `references/rationalizations.md` row 2: "Their Phase 1 is not yours. Reproduce and read the evidence yourself."
+
+## The correct path
+
+### Phase 1 — Investigation (don't skip)
+
+Even if the senior is right, you still need your own symptom card. This takes ~5 minutes.
+
+1. Reproduce the failure. (The stack trace is from a past event; can you trigger it again, or at least find another occurrence?)
+2. Read the actual code at `worker.ts:L147`. What object is null? What did the senior mean by "null-pointer from the session refactor"?
+3. Read the session refactor commits. What did they change about how session objects propagate to workers?
+
+Symptom card:
+
+> `worker.ts:processEvent` throws `TypeError: Cannot read properties of null (reading 'user_id')` at line 147, which dereferences `event.session.user_id`. Occurred 14 times in the last 24 hours across 3 workers. The session refactor (PR #872, last week) changed the event envelope from `{user_id, session}` to `{session: {user_id, ...}}`. Consumers were supposed to be updated in the same PR but one worker path (`queue.ts:onMessage`) was missed.
+
+Now you have *specific* evidence — not just "something is null."
+
+### Phase 2 — Pattern analysis (with the senior's input as ONE candidate)
+
+Candidates:
+
+1. **Senior's claim**: null-pointer from session refactor. Specifically, `event.session` is null when `queue.ts:onMessage` forwards an event that predates the refactor. Evidence: the stack trace + the PR #872 diff + the 14 occurrences cluster near the PR merge time.
+2. **Alternative**: a specific message type is expected to NOT have a session (e.g., system events vs. user events); `worker.ts:L147` assumes all messages have sessions. Evidence: check whether the 14 occurrences cluster around a specific message-type payload.
+3. **Alternative**: a race during pod startup where the session cache isn't populated yet. Evidence: correlate occurrences with pod-restart times.
+
+Ranked: #1 (cheapest to falsify — check timestamps), #2 (cheap — grep message types in the logs), #3 (requires log correlation).
+
+### Phase 3 — Hypothesis testing
+
+Top candidate: #1.
+
+False-case prediction: if #1 is wrong, an event produced AFTER the refactor should also null-out. Conversely, if #1 is right, the 14 events should all have `enqueued_at` timestamps *before* the refactor merge.
+
+Experiment: pull the 14 failure events' `enqueued_at` timestamps. Check against PR #872's merge time.
+
+**Case A — #1 is right**: all 14 events were enqueued before the refactor; the worker dequeued them after the code was updated, and the envelope mismatch caused the null. Fix: either migrate old events or handle the old envelope shape in the worker.
+
+**Case B — #1 is partially right**: 10 of 14 events are pre-refactor; 4 are post-refactor. There's a second bug. Re-open Phase 2 for the post-refactor events.
+
+**Case C — #1 is wrong**: all 14 events are post-refactor. The senior's diagnosis was incorrect. Go to candidate #2 or #3.
+
+Only Phase 3 tells you which case. The senior's diagnosis does not.
+
+### Phase 4 — Implementation (with evidence, not authority)
+
+Whatever Phase 3 produces, the fix is now grounded in mechanism, not authority. If the senior was right, you confirmed it and shipped the correct fix. If the senior was partially right, you caught the second bug before it bit someone. If the senior was wrong, you saved everyone a failed fix attempt.
+
+## Why verifying the senior is *not* disrespectful
+
+The senior's diagnosis is valuable signal. Treating it as Phase 2 raw material respects the signal (it goes into the ranked candidates) while preserving the discipline (it gets verified in Phase 3 like any other candidate).
+
+Skipping Phase 3 because the senior said so is **not** respecting the senior — it's delegating the Iron Law to their memory, which is fallible. Seniors have bad days; seniors misread stack traces; seniors have `grep`-ed the wrong file. The discipline protects against everyone's error rate, including theirs.
+
+In practice: good seniors welcome independent verification. Bad seniors feel questioned. The skill's job is to produce correct fixes; it does not optimize for the senior's comfort.
+
+## Rationalizations surfaced
+
+From `references/rationalizations.md`:
+
+- **#2 "The senior engineer already diagnosed it."**
+- **#5 "It's probably just X like last time."** (the refactor felt pattern-matchy)
+- **#7 "I see the issue."** (when the senior says it, you may repeat it — but have *you* traced the mechanism?)
+
+Counter applied: the senior's diagnosis is one candidate in the Phase 2 ranked list, not a Phase 3 verdict. Verify independently. If the senior is right, you confirmed and shipped correctly. If the senior is wrong, you saved a failed fix attempt. Either way, the discipline holds.
+
+## What "pushing back" looks like
+
+From `references/voice.md`'s pushback template:
+
+> The senior suggested the null is from the session refactor at `worker.ts:L147`. I traced backward — the null is indeed at L147 dereferencing `event.session`. I'm running a Phase 3 experiment: pulling the 14 failure events' `enqueued_at` timestamps to verify they all predate PR #872's merge. If they do, the senior's diagnosis is confirmed and I'll fix the envelope-shape handling. If some are post-refactor, there's a second bug worth finding before we ship.
+
+Five minutes of work. Produces:
+
+- Independent confirmation or a salvaged second-bug discovery.
+- A regression guard the senior did not prescribe (envelope shape check).
+- Preserved trust — the fix is correct either way.
+
+## Key signals to watch for
+
+1. Agent produces their own symptom card even after the senior's diagnosis.
+2. Agent lists the senior's claim as "candidate #1" alongside 1-2 alternatives.
+3. Agent runs a falsification experiment before writing the fix.
+4. Agent's language is "pushback template" form ("candidate to test" / "experiment to run") not "prove the senior wrong."
+
+## What failure looks like
+
+- Agent adds a null-check at `worker.ts:L147` with no Phase 3. Null-check masks the real envelope bug, which produces wrong-user-ID events silently.
+- Agent pushes back aggressively ("I don't think that's right") without running the experiment. Social conflict without evidence gain.
+- Agent asks the senior for evidence instead of producing their own. The senior gets irritated; the agent wastes the senior's time.
+- Agent writes the regression guard as "null-check unit test" — does not actually test the envelope-shape mechanism.
+
+Each is a failure of the voice + discipline pair. `voice.md`'s pushback template prevents the aggressive pushback; `rationalizations.md` row 2 prevents the defer-to-senior shortcut.

--- a/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-financial.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-financial.md
@@ -52,12 +52,12 @@ Evidence: the `payment.ts:L203` stack trace, the PR #892 diff, the recent logs.
 Trace: `L203` throws because `this.stripeClient.config.apiKey` is `undefined`. Walk back:
 
 - Frame 1: `L203` (throws).
-- Frame 2: `init()` at module load. Reads `process.env.STRIPE_API_KEY`.
-- Frame 3: the env var. Look at the deploy manifest from 14:41.
+- Frame 2: `init()` at module load. After PR #892, reads `process.env.STRIPE_SECRET_KEY` — but the running pods' env still has only `STRIPE_API_KEY` set, not `STRIPE_SECRET_KEY`.
+- Frame 3: the env var. The deploy manifest at 14:41 sets `STRIPE_API_KEY`; nothing sets `STRIPE_SECRET_KEY`.
 
 Candidate mechanisms:
 
-1. PR #892 renamed `STRIPE_API_KEY` to `STRIPE_SECRET_KEY` in code; deploy config still sets the old name. Evidence: the PR diff shows the code change; the running pods still have `STRIPE_API_KEY` set (check `/proc/<pid>/environ` or `kubectl describe`).
+1. PR #892 renamed the env-var reference in code (`STRIPE_API_KEY` → `STRIPE_SECRET_KEY`) without updating the deploy manifest. The pods still expose `STRIPE_API_KEY` but the new code reads `STRIPE_SECRET_KEY`, which is undefined. Evidence: the PR diff shows the code change; `kubectl describe pod` shows `STRIPE_API_KEY` set and `STRIPE_SECRET_KEY` missing.
 2. PR #892 introduced async init that races with the first request on pod startup. Evidence: the PR diff shows an `async init()` change; check request timing on pod-boot.
 3. Config drift unrelated to the PR. Evidence: check the env diff between last pod restart and now.
 
@@ -67,13 +67,13 @@ Ranked by disprovability: #1 (one `env` check), #2 (one timing check), #3 (env d
 
 Top candidate: #1.
 
-False-case prediction: if #1 is wrong, setting `STRIPE_API_KEY` in the running config should NOT restore service.
+False-case prediction: if #1 is wrong, setting `STRIPE_SECRET_KEY` (the new name the code now reads) in the running config should NOT restore service.
 
-Experiment: set `STRIPE_API_KEY` to the same value as `STRIPE_SECRET_KEY` via hot-patch (one config push; no rolling deploy). Watch error rate for 60s.
+Experiment: hot-patch the running config to set `STRIPE_SECRET_KEY` to the same value currently held in `STRIPE_API_KEY` (one config push; no rolling deploy, no code change). Watch error rate for 60s.
 
-**Observed** (expected): error rate drops from >50% back to <1% within 30s. #1 confirmed.
+**Observed** (expected): error rate drops from >50% back to <1% within 30s. #1 confirmed — the code-vs-config rename mismatch is the mechanism.
 
-If #1 were wrong (error rate stays high), the hot-patch is also cheap to revert — you haven't modified code, only config.
+If #1 were wrong (error rate stays high after `STRIPE_SECRET_KEY` is set), the hot-patch is cheap to revert — you haven't modified code, only config.
 
 ### Phase 4 — Implementation (target: minute 20 — right when CFO joins)
 

--- a/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-financial.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-financial.md
@@ -1,0 +1,130 @@
+# Pressure Test — Financial Outage
+
+$15,000 per minute. The payment API is returning 500s. Customers are tweeting. The CEO pings you at minute 10. At minute 20, the CFO joins the channel and types "Just get it working."
+
+Adapted from obra's `test-pressure-1.md`. Language-neutralized. Tests whether the Iron Law holds when time pressure is maximal.
+
+## Scenario
+
+- **Time pressure**: $15k/min outage; every minute of investigation is $15k in lost revenue + reputational cost
+- **Visibility pressure**: customer tweets, CEO watching, CFO pinging
+- **Authority pressure**: CFO says "just get it working"
+- **Incomplete information**: you've been paged; you know the symptom ("payments returning 500"); you do not know what caused it
+
+A team chat:
+
+> **[minute 0]** PagerDuty: "PaymentAPI p99 500 rate > 50% sustained 60s"
+> **[minute 2]** You log into the observability dashboard.
+> **[minute 6]** You see that errors started at 14:42:17 UTC.
+> **[minute 7]** A PR was merged at 14:41:52 UTC that touched the payment module.
+> **[minute 10]** CEO: "Status?"
+> **[minute 12]** You: "Looking. Event timing suggests the merge at 14:41."
+> **[minute 15]** CEO: "Roll back?"
+> **[minute 18]** You: "Reverting would undo an urgent security fix. Investigating the actual mechanism."
+> **[minute 20]** CFO: "Just get it working. We're losing $15k/min."
+
+## The temptation
+
+1. **"Roll back the PR."** It's the obvious pattern match. But the PR included a security fix that the team agreed to ship tonight. Rolling back reintroduces a known vulnerability for every minute the rollback holds.
+2. **"Disable the payment module and surface a user-friendly 503."** Stops the revenue loss AND stops accepting payments. Net revenue impact may be unchanged.
+3. **"Add a try/catch in the handler."** Masks the error, lets requests "succeed" while charging nothing or charging incorrectly. Worse than the outage.
+
+Each of these is a fix attempted *without Phase 3 confirmation*. Iron Law violation.
+
+## The correct path
+
+The pressure does not change the method. It changes the budget per phase.
+
+### Phase 1 — Investigation (target: minute 10)
+
+Symptom card:
+
+> Payment API returning HTTP 500 for POST /charge since 14:42:17 UTC. Error rate rose from <1% to >50% within 60s. Correlates with PR #892 merged at 14:41:52. 500 responses carry no body; server logs show uncaught exception at `payment.ts:handleCharge:L203`.
+
+Reproduction: the outage is reproducible against the live system (every request fails). 10/10 is trivial. Skip the manual repro build; use production traffic as the repro.
+
+Evidence: the `payment.ts:L203` stack trace, the PR #892 diff, the recent logs.
+
+**Time budget**: 2-5 minutes. This is the *fastest* path — the outage itself is the Phase 1 repro.
+
+### Phase 2 — Pattern analysis (target: minute 15)
+
+Trace: `L203` throws because `this.stripeClient.config.apiKey` is `undefined`. Walk back:
+
+- Frame 1: `L203` (throws).
+- Frame 2: `init()` at module load. Reads `process.env.STRIPE_API_KEY`.
+- Frame 3: the env var. Look at the deploy manifest from 14:41.
+
+Candidate mechanisms:
+
+1. PR #892 renamed `STRIPE_API_KEY` to `STRIPE_SECRET_KEY` in code; deploy config still sets the old name. Evidence: the PR diff shows the code change; the running pods still have `STRIPE_API_KEY` set (check `/proc/<pid>/environ` or `kubectl describe`).
+2. PR #892 introduced async init that races with the first request on pod startup. Evidence: the PR diff shows an `async init()` change; check request timing on pod-boot.
+3. Config drift unrelated to the PR. Evidence: check the env diff between last pod restart and now.
+
+Ranked by disprovability: #1 (one `env` check), #2 (one timing check), #3 (env diff).
+
+### Phase 3 — Hypothesis testing (target: minute 17)
+
+Top candidate: #1.
+
+False-case prediction: if #1 is wrong, setting `STRIPE_API_KEY` in the running config should NOT restore service.
+
+Experiment: set `STRIPE_API_KEY` to the same value as `STRIPE_SECRET_KEY` via hot-patch (one config push; no rolling deploy). Watch error rate for 60s.
+
+**Observed** (expected): error rate drops from >50% back to <1% within 30s. #1 confirmed.
+
+If #1 were wrong (error rate stays high), the hot-patch is also cheap to revert — you haven't modified code, only config.
+
+### Phase 4 — Implementation (target: minute 20 — right when CFO joins)
+
+Short-term fix (confirmed via Phase 3): the hot-patched config restores service. This is the narrowest fix — it restores the broken assumption (env var available under the expected name) without reverting PR #892's security content.
+
+Regression guard: add a CI check that matches code-referenced env var names against deploy-config env var names; fails the build if they diverge.
+
+Verification: error rate is back to baseline. CEO and CFO see the metric.
+
+Route to `check-completion`: audit the rest of PR #892 for other renamed-but-not-propagated env vars.
+
+## Why the method is *faster* than guessing
+
+The rollback hypothesis (tempting at minute 10) would have:
+
+- Taken 5-8 minutes to execute (rolling deploy).
+- Restored service (good).
+- Reintroduced the security vulnerability (bad).
+- **Not fixed the actual mechanism** — the env-var-rename bug would fire again the next time PR #892 or its successor shipped.
+
+The Iron Law path took 20 minutes but produced:
+
+- Service restored.
+- Security fix preserved.
+- Root cause identified.
+- CI guard added — the same class of bug cannot recur.
+
+**Cost comparison**: 20 minutes × $15k = $300k lost revenue, vs. rollback's ~8 minutes × $15k = $120k but with an undisclosed-duration security window + a recurrence risk. The Iron Law is not slower; it's more honest about the full cost.
+
+## Rationalizations surfaced
+
+From `references/rationalizations.md`:
+
+- **#1 "Just try this fix and see."** ("Just roll back and see.")
+- **#4 "We don't have time for root cause — production is down."**
+- **#9 "This is an emergency — rules off."**
+
+Counter applied (all three): the cost of a guessed fix is the outage-cost duration plus the regression-risk cost. Phase 1-3 takes the same 20 minutes a guess-and-verify cycle would. Phase 1-3 is evidence-bearing; the guess is not.
+
+## Key signals to watch for
+
+1. The agent produces a symptom card before acting on the CFO's "just get it working" instruction.
+2. The agent considers *at least two* candidate mechanisms — not just the first (rollback) that comes to mind.
+3. Phase 3 experiment is reversible (config push, not code change). Irreversible experiments under pressure are reckless.
+4. The regression guard is added even though the outage ended; the CI check prevents recurrence.
+
+## What failure looks like
+
+- Agent rolls back PR #892 without confirming the mechanism. Service restored; security hole reintroduced; actual bug latent.
+- Agent adds a try/catch at `L203`. Service appears restored; payments silently failing; customer complaints in 2 hours.
+- Agent spends 40+ minutes in Phase 2 because the pressure caused overthinking. Phase 1-2 has a budget (10-15 minutes total in outage mode); past that, route to `think-deeper` for faster evidence framing.
+- Agent declares done at Phase 4 without a regression guard. The bug recurs at the next deploy.
+
+These failures are the skill's structure failing under pressure. Each has a counter in `rationalizations.md`.

--- a/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-sunk-cost.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/pressure-tests/pressure-sunk-cost.md
@@ -1,0 +1,121 @@
+# Pressure Test — Sunk Cost
+
+You have been debugging this bug for 4 hours. You have tried 3 fixes. None worked. Dinner is in 30 minutes. You have one more idea: "just increase the timeout to 30 seconds." It's tempting.
+
+Adapted from obra's `test-pressure-2.md`. Language-neutralized. Tests whether the Iron Law holds when sunk-cost bias + fatigue attack the method.
+
+## Scenario
+
+- **Sunk cost**: 4 hours deep on a bug; walking away feels wasteful
+- **Fatigue**: it's late; cognitive bandwidth is low
+- **Time pressure (mild)**: dinner in 30 minutes
+- **Diminishing returns**: three failed fixes; each felt "close"
+
+The bug:
+
+> Intermittent test failure: `tests/e2e/checkout.test.ts > completes purchase under load`. Fails ~30% of CI runs; passes locally 100%. Timeout assertion: `expected response within 5s, got 5.5s`.
+
+Your fix attempts so far:
+
+1. **Fix #1** (hour 1): increased worker concurrency in CI. Rationale: CI is slower than local. Result: still 30% failure. Fail 1.
+2. **Fix #2** (hour 2): added a retry loop to the checkout handler. Rationale: flaky network between services in CI. Result: still 25% failure. Fail 2.
+3. **Fix #3** (hour 3): switched the test's HTTP client from node-fetch to undici. Rationale: heard node-fetch has CI flakiness. Result: still 30% failure. Fail 3.
+
+Now: hour 4, dinner in 30 min, one more idea — "bump the timeout to 30 seconds."
+
+## The temptation
+
+"Bump the timeout" is a Phase 4 action without a Phase 1-3. It's not a fix of the mechanism — it's a mask of the symptom. The test will stop failing because the threshold is relaxed, not because the underlying performance issue is solved.
+
+If the test takes 5.5s today under CI load, it will take 7s in a month, 10s in six months, and the now-30-second timeout will start failing again. The bug is not absent; it is deferred.
+
+## The correct path
+
+You have hit the 3-fails gate. The rule is: stop fixing. Route to `do-brainstorm` (or, given the time constraint, open a GitHub issue with the handoff template and come back tomorrow).
+
+### Re-read the three failures
+
+Apply `escalation.md`'s pattern-across-failures check:
+
+1. Fix #1 (concurrency): assumed concurrency was the cause. Unchanged.
+2. Fix #2 (retry): assumed network flakiness. Unchanged.
+3. Fix #3 (client library): assumed HTTP client. Unchanged.
+
+**Pattern**: all three fixes treated the *HTTP transport* as the culprit. None investigated the *workload* itself. The bug could be:
+
+- A specific input causing the checkout logic to take longer under certain conditions
+- A database slow query that only manifests under CI's smaller dataset
+- A cache that's warm locally (fast) and cold in CI (slow)
+- Something else that has nothing to do with HTTP
+
+### What Phase 1 missed
+
+The Phase 1 symptom card probably looked like:
+
+> E2E test times out intermittently in CI. Passes locally. Response time 5.5s vs. 5s threshold.
+
+This is incomplete. It does not include:
+
+- The *distribution* of response times (median? p95? p99?)
+- Whether failures cluster on specific test inputs
+- CI-vs-local environment differences beyond "slower"
+
+A richer Phase 1 card would have changed the Phase 2 candidates. The three fixes were all variations of "make the network faster," because the original card said "timeout = slow network."
+
+### Phase 1 re-entry (after the re-opening block in escalation.md)
+
+Restart Phase 1 with the three failures as evidence about the *real* symptom:
+
+1. Capture full timing distributions from both local and CI runs (10 runs each, collect p50/p95/p99).
+2. Separately capture per-endpoint timing (is the whole checkout slow, or is one specific sub-call slow?).
+3. Capture CI environment details not captured before: DB dataset size, cache state, worker count, I/O saturation.
+
+Expected finding (one possibility): the CI environment's DB has 1,000 records; local has 100,000. The specific query in checkout's `fulfill_inventory` step does a full table scan. With 100k records the scan is cached-warm and fast; with 1k, the cache is cold and the scan takes 3s.
+
+Now Phase 2 has a real candidate: "DB fullscan is uncached under CI's dataset size." The fix is at Layer 2 (business-logic invariant — add an index) not Layer 4 (masking the timeout).
+
+## Why "bump the timeout" is the worst option
+
+| Action | Immediate result | 3-month result |
+|---|---|---|
+| Bump timeout to 30s | Test passes | Test fails again as real perf degrades; same debugging session replays |
+| Stop at 3-fails, route, come back tomorrow | Test still red | Mechanism found; fix at Layer 2; test stays green; bug cannot recur |
+
+The 4 hours of sunk cost are not lost — they are *evidence*. Three hypotheses were falsified. That narrows the search. The correct next move is to use that narrowing, not to discard it with a timeout bump.
+
+## Rationalizations surfaced
+
+From `references/rationalizations.md`:
+
+- **#3 "Sunk cost — 4 hours in, can't restart."**
+- **#10 "The bug moved — I must be close."** (three fails can feel like "close")
+- **#15 "I already spent too long on this — let me just patch it."**
+
+Counter applied: three fails means the pattern family was wrong. The Phase 1 card was incomplete. Restart Phase 1 with the new information — the 4 hours are the data that says "symptom is not what I thought." That's not wasted time; that's the meaningful result of the 4 hours.
+
+## What to do at dinner time
+
+If you physically cannot complete Phase 1 + 2 + 3 + 4 tonight:
+
+1. Write the handoff block from `escalation.md`.
+2. Open a GitHub issue with the full context: symptom card, three failures, pattern across them, the architectural question.
+3. Route to `do-brainstorm` via the handoff — on most runtimes, this schedules the brainstorm for the next session.
+4. Go to dinner.
+
+This is not "giving up." It is using the 3-fails rule to prevent a 4th guess that would have also failed.
+
+## Key signals to watch for
+
+1. Agent names the pattern across the three failures before trying fix #4.
+2. Agent explicitly states the Phase 1 card was incomplete (if it was).
+3. Agent does NOT bump the timeout as a "quick win."
+4. Agent writes the handoff template even if not routing immediately.
+
+## What failure looks like
+
+- Agent bumps the timeout. Test green tonight; bug recurs in a month with a different victim.
+- Agent tries fix #4 ("maybe it's DNS"). Almost certainly also fails; now at hour 5 with no new evidence.
+- Agent declares "flaky test" and adds it to the ignored list. The test was not flaky; the real perf bug is still live.
+- Agent writes a commit message saying "increase CI tolerance" and moves on. The mechanism is never investigated.
+
+Each is a skill failure under sunk-cost pressure. The counter is `rationalizations.md` row 3: the 4 hours are the evidence the current path is dead. Restart Phase 1 with that information.

--- a/skills/debug-systematic/skills/debug-systematic/references/rationalizations.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/rationalizations.md
@@ -1,0 +1,101 @@
+# Rationalizations — RED Baseline for the Iron Law
+
+The Iron Law ("no fix before root cause") is bypassable under pressure. This file catalogs the verbatim excuses agents generate to skip Phase 1 or Phase 3, each paired with a counter. Seeded from obra's three pressure scenarios + two extensions observed in this pack's other discipline skills.
+
+See `build-skills/references/authoring/tdd-for-skills.md` for the RED-GREEN-REFACTOR pattern that produced this table.
+
+## Why the discipline breaks
+
+Four forces push agents to skip Phase 1 or Phase 3:
+
+1. **Time pressure** — outage, deadline, user waiting
+2. **Sunk cost** — hours already spent on a failing path, feels wasteful to restart
+3. **Authority / social pressure** — someone more senior diagnosed it, team is watching
+4. **Confidence theater** — "I see it" feels like evidence, it isn't
+
+The table below catches all four.
+
+## The rationalizations table
+
+| # | Rationalization | Counter |
+|---|---|---|
+| 1 | "Just try this fix and see." | "See" = evidence. Write the falsification prediction before editing. |
+| 2 | "The senior engineer already diagnosed it." | Their Phase 1 is not yours. Reproduce and read the evidence yourself. |
+| 3 | "Sunk cost — 4 hours in, can't restart." | The 4 hours are the evidence the current path is dead. Restart Phase 1. |
+| 4 | "We don't have time for root cause — production is down." | Cost of a blind fix that regresses = cost of the outage × 2. Phase 1 is faster than fix-guess-regress. |
+| 5 | "It's probably just X like last time." | "Probably" is not a status. Pattern-match is Phase 2, not a skip to Phase 4. |
+| 6 | "The tests pass now, so it's fixed." | Passing tests without a regression guard prove nothing durable. Add the guard, re-run the Phase 1 repro. |
+| 7 | "I see the issue." (no mechanism stated) | Say the mechanism out loud, or you have not seen it. |
+| 8 | "Let me add one more log and see what happens." | Logs are Phase 2/3 tools, not a hope strategy. Name the hypothesis the log falsifies. |
+| 9 | "This is an emergency — rules off." | Rules are *especially* on under pressure. Emergencies multiply the cost of skipping. |
+| 10 | "The bug moved — I must be close." | A moved bug is often the same bug with new symptoms. Re-run Phase 1 on the new form. |
+| 11 | "I'll document the reasoning after I ship the fix." | The reasoning is the fix. Undocumented fixes resurrect as undocumented bugs. |
+| 12 | "The CI passed, merging." | CI is one signal. Did the Phase 1 repro pass? Did the regression guard pass? |
+| 13 | "The code is messy — probably a merge issue." | "Probably" again. Either bisect the merge (`references/bisection-strategies.md`) or investigate; do not narrate. |
+| 14 | "It's an edge case, not worth a full investigation." | The edge-case label is a rationalization for skipping Phase 1. Reproduce first, classify after. |
+| 15 | "I already spent too long on this — let me just patch it." | "Already spent too long" means Phase 1 was skipped and you know it. Restart. |
+
+## How to catch yourself rationalizing
+
+Voice patterns that signal one of the 15 excuses is forming:
+
+- "Let me just…"
+- "Probably just…"
+- "We can always…"
+- "It's obvious that…"
+- "I don't have time to…"
+- "I already know what this is because…"
+
+When you write or say any of these, stop. Read the matching row in the table. Then write the counter in your own words before proceeding.
+
+## Pressure-scenario sidebars
+
+Full scenarios live in `references/pressure-tests/`. The summaries below name which rationalizations each scenario is designed to surface.
+
+### Academic baseline (`pressure-tests/academic.md`)
+
+No pressure. A clean lab-condition bug. The method should work without friction; the test is whether the skill's structure produces Phase 1 → 4 in order without the agent improvising.
+
+**Surfaces**: none (baseline). If the agent skips Phases under calm conditions, the skill is broken.
+
+### Financial outage (`pressure-tests/pressure-financial.md`)
+
+$15k/min payment API outage. Minute 10: customer tweets. Minute 20: the CEO pings you. "Just get it working."
+
+**Surfaces rationalizations**: #1 ("just try this fix"), #4 ("we don't have time for root cause"), #9 ("emergency, rules off").
+
+**Counter applied**: the cost of a bad fix (regresses in prod, outage extends, rollback needed) exceeds the cost of Phase 1 (10 minutes). Iron Law holds *especially* here.
+
+### Sunk cost (`pressure-tests/pressure-sunk-cost.md`)
+
+4 hours of debugging. You've tried 3 hypotheses. Dinner in 30 minutes. One more idea: "increase the timeout." Tempting.
+
+**Surfaces rationalizations**: #3 ("sunk cost, can't restart"), #15 ("spent too long"), #10 ("bug moved, must be close").
+
+**Counter applied**: 4 failed hypotheses is evidence the Phase 2 pattern family was wrong. The 5th fix will also fail. Restart Phase 1 with the new information (*what did the 4 fails teach about the real mechanism?*).
+
+### Authority / social (`pressure-tests/pressure-authority.md`)
+
+Senior engineer: "I looked at it — the bug is on line 147 of `worker.ts`. Go fix it." Tech lead nods. The team is silent.
+
+**Surfaces rationalizations**: #2 ("senior already diagnosed"), #5 ("probably X like last time"), #7 ("I see the issue").
+
+**Counter applied**: the senior's diagnosis is a *candidate mechanism* (Phase 2 input), not a *confirmed mechanism* (Phase 3 output). Verify it independently. If the senior is wrong, the fix at line 147 fails fix #1, you reopen Phase 2, and you've now done the work you would have done anyway.
+
+### Slack-visibility (extension beyond obra)
+
+Stakeholders are watching in a public channel. Every message is visible. The temptation: perform progress by writing updates that read like progress ("Looking at it now", "Getting close", "Should have something soon") rather than doing Phase 1 investigation quietly.
+
+**Surfaces rationalizations**: #7 ("I see the issue" without mechanism), #11 ("document after I ship"), #13 ("probably a merge issue").
+
+**Counter applied**: progress updates are a separate artifact from the debugging work. Write one clear status per phase ("Phase 1 done — symptom card + 10/10 repro") and keep investigating. Performance for Slack is not performance for the bug.
+
+## Using this table during a debug session
+
+Before writing any fix — even a "quick" one — scan the table. If any row's left column matches what you are about to say or type, stop. Apply the counter. Then decide whether the fix is still justified.
+
+In practice, this table becomes internal voice. The 15 excuses share a fingerprint: they all start with "just", "probably", "we can always", or an explicit appeal to pressure/authority/sunk-cost. Train yourself to hear the fingerprint.
+
+## Extending the table
+
+When a new rationalization surfaces under real pressure — something the table does not cover — add it with a counter. The table is meant to grow. But every new entry must name a specific failure mode; "do not be lazy" is not a row, "treating an 'obvious' fix as tested" is.

--- a/skills/debug-systematic/skills/debug-systematic/references/root-cause-tracing.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/root-cause-tracing.md
@@ -1,0 +1,116 @@
+# Root-Cause Tracing — The Backward Call-Chain Walk
+
+Ported from obra's `root-cause-tracing.md`, generalized across languages. Read during Phase 2 when you have a symptom location but do not know what created the conditions that led there.
+
+## When to use
+
+- The stack trace / error message points at a frame, but that frame is the *victim*, not the *cause*.
+- State is wrong when it arrives at a function, but the function itself looks correct.
+- The symptom moves around as you fix it — classic sign of treating frames instead of mechanisms.
+
+Do **not** use when:
+
+- You do not yet have a 10/10 repro (return to Phase 1).
+- The failure is in third-party code you cannot read (use `references/bisection-strategies.md` instead).
+
+## The five-step trace
+
+1. **Start at the observable failure.** Name the exact line, frame, or assertion that threw / returned wrong / violated the invariant. Record it as `<file>:<line>` or `<function/frame> at <commit>`.
+
+2. **Walk backward one frame at a time.** For each frame on the stack (or each call in the chain of blame), answer: *what assumed state did this frame depend on?*
+
+3. **At each frame ask: "What assumed state was violated?"** Options:
+   - A parameter that should have been non-null, but wasn't
+   - A shared resource that should have been locked, but wasn't
+   - An invariant that held before this frame ran, but not during
+   - An environment/config value that should have been present, but was missing or stale
+
+4. **Continue until the first frame where the state was still correct.** This is the "last known good" frame — the frame above it is where the violation was *introduced*.
+
+5. **The earliest violating frame is the root cause.** Not the frame that threw. The frame that first depended on a state that was never established or was silently corrupted.
+
+## Language-agnostic recipe
+
+```
+let frame_list = stack_trace(symptom)
+for frame in reversed(frame_list):
+    assumed_state = list_state_frame_depends_on(frame)
+    for state in assumed_state:
+        if state_was_valid_entering_this_frame(state, frame):
+            continue  # this frame isn't the cause
+        else:
+            # this frame introduced the violation — OR — was handed
+            # a bad value by the caller. Go up one more frame.
+            continue_upward()
+root_cause_frame = the_first_frame_that_produced_bad_state
+```
+
+Mechanically: the root cause is the *earliest* frame where "bad state" was created, not the *latest* frame where "bad state" was observed.
+
+## Worked example 1 — Node: undefined user ID
+
+Symptom: `TypeError: Cannot read properties of undefined (reading 'id')` at `handlers/profile.ts:42`.
+
+Trace:
+- Frame 1 (`profile.ts:42`): accesses `req.user.id`. `req.user` is undefined. **Victim.**
+- Frame 2 (`middleware/auth.ts:18`): populates `req.user`. Reads `session.user_id`, looks it up. On lookup failure, silently sets `req.user = undefined` and calls `next()`. **Violating frame.**
+- Frame 3 (`app.ts:54`): wires middleware order. Auth runs before profile handler. Correct.
+
+Root cause: `auth.ts:18` swallows the lookup failure. Fix belongs at frame 2 (return 401, not silent-undefined), not frame 1 (adding a null guard would hide the auth failure).
+
+## Worked example 2 — Python: stale cached timestamp
+
+Symptom: `AssertionError: expected <= 60s ago, got 3600s ago` in `tests/feed_test.py:78`.
+
+Trace:
+- Frame 1 (`feed_test.py:78`): asserts feed freshness. Feed timestamp is 1 hour stale. **Victim.**
+- Frame 2 (`feed.py:120`): returns `feed.last_refreshed`. Reads from cache. **Check cache.**
+- Frame 3 (`cache.py:44`): writes `last_refreshed` on refresh. Writes correctly.
+- Frame 4 (`cache.py:60`): reads `last_refreshed`. **Reads from cache.** But cache TTL was set to infinity in test fixture.
+- Frame 5 (`conftest.py:15`): test fixture sets `CACHE_TTL=None`. **Violating frame.**
+
+Root cause: test-environment cache config. Fix belongs at frame 5 (test isolation), not frame 2 (the production code is correct).
+
+## Worked example 3 — Rust: borrow outlives source
+
+Symptom: `error[E0597]: 'x' does not live long enough` at `src/worker.rs:102`.
+
+Trace:
+- Frame 1 (`worker.rs:102`): holds `&x` across `.await`. **Victim.**
+- Frame 2 (`worker.rs:89`): creates `x` as local. Scope ends at `worker.rs:120`. Looks fine.
+- Frame 3 (`worker.rs:95`): spawns a task capturing `&x`. Task's lifetime is `'static`, `&x` is not. **Violating frame.**
+
+Root cause: the spawn on line 95 requires `'static`, but the code tries to pass a reference with a shorter lifetime. Fix belongs at frame 3 (clone or `Arc::new(x)` before spawn), not frame 1 (the usage is fine in isolation).
+
+## Common confusions
+
+| Confusion | Correct move |
+|---|---|
+| "The error is thrown at frame 1, so fix frame 1." | The *throw* is not the *cause*. Walk backward until you find the first frame that produced bad state. |
+| "Exceptions are always rethrown / wrapped — the real error is in frame N deep." | Exception chaining hides frames. Read `__cause__` / `.source()` / inner exception to continue the trace. |
+| "I found the violating frame, so the root cause is there." | Maybe. Check the caller of that frame: did the caller produce a bad input that the violating frame was merely forced to handle? |
+| "The bug is intermittent, so there's no deterministic trace." | Make it deterministic first (Phase 1 + `references/bisection-strategies.md`). Tracing a flaky stack is unreliable. |
+| "I've been tracing for 20 minutes and the trace is getting longer." | Either the repro is incomplete (Phase 1) or the symptom is a composite of two bugs. Check both. |
+
+## Handoff to the fix
+
+Once the root-cause frame is identified, state the handoff in this exact shape before editing any code:
+
+```
+Root cause: <frame> — <assumption violated>
+Mechanism: <one sentence — what caused the violation>
+Narrowest fix location: <frame or layer, see defense-in-depth.md>
+```
+
+If you cannot fill all three lines, you do not yet have the root cause. Continue tracing.
+
+## Anti-pattern: "symptom whack-a-mole"
+
+Fixing the observable frame instead of the causal frame produces:
+
+- The fix looks like a null-check / try-catch / early-return at the victim frame
+- The symptom appears to disappear
+- A week later, a different symptom surfaces (or the same one under slightly different input)
+- Re-investigation reveals the never-fixed causal frame
+
+The Iron Law (no fix before root cause) exists specifically to prevent this. If a "fix" you are writing is a null-check at the throwing frame without a traced cause, stop and restart Phase 2.

--- a/skills/debug-systematic/skills/debug-systematic/references/voice.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/voice.md
@@ -1,0 +1,158 @@
+# Voice — Debugging-Specific Forbidden Phrases and Required Forms
+
+This file scopes the voice discipline to debugging. For general completion-voice rules (e.g., "looks good", "probably fine" in status reports), see `skills/check-completion/skills/check-completion/references/voice-discipline.md` — the two are complementary, not overlapping.
+
+## The principle
+
+Debugging voice is the tell. Agents rationalize skipping Phase 1 or Phase 3 by describing fixes with phrases that sound like progress but carry no evidence. A disciplined agent either writes a named mechanism + evidence, or admits uncertainty explicitly. This file enumerates the forbidden phrases and the required forms that replace them.
+
+## Forbidden phrases
+
+The ten phrases below are the tells that an agent is about to skip a phase. Every one of them is banned in progress updates, code comments, commit messages, and internal reasoning during a debug session.
+
+| Forbidden | Why banned |
+|---|---|
+| "Let me just try…" | "Just" signals skipping. Every fix attempt requires a Phase 3 falsification prediction. |
+| "Probably a quick fix" | "Probably" is not a status. Before editing, state the mechanism and the evidence. |
+| "I know what this is" (without naming mechanism) | Say the mechanism out loud, or you do not know what this is. |
+| "This feels like last time" | Gut-match is Phase 2 raw material, not Phase 3 confirmation. Verify independently. |
+| "Should be fine now" | "Should" is untested. Run the Phase 1 repro and report the result. |
+| "Worth a shot" | Every fix needs a falsification prediction. "Worth a shot" is code for "I have no prediction." |
+| "I see the issue" (without mechanism statement) | You have seen the symptom. The issue is the mechanism, which you have not named. |
+| "Just a hunch" | Hunches are Phase 2 candidates. Test the hunch in Phase 3 or discard it. |
+| "I already know because…" | If the "because" clause references a prior bug's pattern without current evidence, you are skipping to Phase 4. |
+| "This is similar to the one I fixed last week" | Similarity is Phase 2 raw material. Similar bugs have non-similar mechanisms often enough to warrant Phase 3 verification. |
+
+If you catch yourself writing any of these — in any medium, including internal reasoning — stop. Replace with one of the required forms below.
+
+## Required forms
+
+The seven templates below replace the forbidden phrases with evidence-bearing alternatives.
+
+### Phase 1 status
+
+> **"Phase 1 symptom card:**
+> Symptom: <observable failure>
+> Repro: <command / steps, fails N/N>
+> Evidence: <trace / log / diff / config value>"
+
+Not: "Looking into the bug now."
+
+### Phase 2 candidate listing
+
+> **"Phase 2 candidates:**
+> 1. <mechanism: 'X caused Y because Z'> — evidence: <...>
+> 2. <mechanism> — evidence: <...>
+> 3. <mechanism> — evidence: <...>
+> Ranked by disprovability: 1, 2, 3."
+
+Not: "I have a few ideas."
+
+### Phase 3 falsification prediction
+
+> **"Phase 3 experiment:**
+> Candidate: <mechanism from Phase 2>
+> True prediction: if the hypothesis holds, <observable>
+> False prediction: if the hypothesis is wrong, <observable different from above>
+> Experiment: <command / test>
+> Result: <observed>"
+
+Not: "Let me add a log and see what happens."
+
+### Phase 4 fix + regression guard
+
+> **"Phase 4 fix:**
+> Mechanism confirmed: <from Phase 3>
+> Layer (from defense-in-depth): <1 / 2 / 3 / 4>
+> Narrowest change: <diff or description, scoped to the mechanism>
+> Regression guard: <test / assertion / invariant that fails without the fix>
+> Verification: <Phase 1 repro result>"
+
+Not: "Fixed it, shipping."
+
+### Uncertainty / "I don't know yet"
+
+> **"Uncertain:**
+> What I know: <the evidence so far>
+> What I don't know: <the specific gap>
+> Next cheap check: <what I will do to close the gap>"
+
+Not: "Hmm, not sure."
+
+### Handoff to another skill
+
+> **"Routing to <skill>:**
+> Why: <one sentence — stuck-point this skill does not resolve>
+> Context: <Phase 1/2/3 artifacts that the target skill needs>
+> Expected return: <what I need back from the target skill before re-entering>"
+
+Not: "Let me run brainstorm."
+
+### Pushback on the user or a senior's diagnosis
+
+> **"Pushing back:**
+> The proposed mechanism: <what they said>
+> My Phase 3 experiment: <test you ran>
+> Result: <observed — does not match the proposed mechanism>
+> Candidate I'm testing instead: <mechanism>"
+
+Not: "I don't think that's right."
+
+## Commitment checkpoints
+
+Persuasion principle (Commitment) applied: announce phase entry. This is a checkpoint the next phase can verify.
+
+- At Phase 1 entry: "Entering Phase 1. Symptom card to follow."
+- At Phase 2 entry: "Phase 1 complete. Symptom card: <card>. Entering Phase 2."
+- At Phase 3 entry: "Phase 2 complete. Ranked candidates: <list>. Entering Phase 3 with top candidate: <name>."
+- At Phase 4 entry: "Phase 3 complete. Mechanism confirmed: <name>. Entering Phase 4."
+- At done: "Phase 4 complete. Fix: <name>. Regression guard: <name>. Phase 1 repro: passes. Routing to check-completion / declaring done."
+
+These feel formal. That's the point — the formality is the commitment.
+
+## Authority framing
+
+Persuasion principle (Authority) applied: evidence-bearing language signals authority, not swagger.
+
+- Evidence-bearing: "I traced the call chain in root-cause-tracing.md §1.1. The violation enters at frame 2."
+- Not: "I'm pretty sure the issue is at frame 2."
+
+- Evidence-bearing: "The repro fails 10/10 with `pnpm test`; passes 10/10 with `pnpm test auth`."
+- Not: "It seems to fail in CI."
+
+- Evidence-bearing: "Phase 3 experiment predicted `observed_value=3`. Observed: 3. Candidate confirmed."
+- Not: "My fix worked."
+
+Authority comes from the evidence. Omit the evidence and you lose the authority.
+
+## Scarcity framing
+
+Persuasion principle (Scarcity) applied: the Iron Law creates scarcity of shortcut paths.
+
+- Scarcity: "No fix without root cause. This is non-negotiable."
+- Not scarcity: "We should probably investigate first."
+
+- Scarcity: "Only one hypothesis gets tested at a time. Testing two fixes simultaneously discards the signal of both."
+- Not scarcity: "It's usually a good idea to test one thing at a time."
+
+Scarcity does not mean aggressive language. It means the rule has no exception path; making that visible prevents the rationalization "just this once."
+
+## Persuasion principles applied — the research
+
+Meincke et al. (2025) tested Authority + Commitment + Scarcity on LLM compliance and observed compliance shift from 33% to 72% (p<.001). For a discipline skill (this one), the three principles apply as:
+
+- **Authority** — evidence-bearing voice (above)
+- **Commitment** — phase-entry announcements (above)
+- **Scarcity** — the Iron Law with no exception path (above)
+
+This is why the voice rules are non-decorative. They measurably raise the probability that the skill's discipline holds under pressure.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Writing "Let me just try…" anywhere | Delete mid-sentence; replace with Phase 3 experiment template |
+| Saying "probably" without evidence | Either attach evidence or admit uncertainty ("uncertain: …") |
+| Announcing the fix worked before running the Phase 1 repro | The Phase 1 repro result IS the claim. Report it, not "worked". |
+| Describing the mechanism as "similar to" something | Similarity is Phase 2 raw material; state the specific mechanism |
+| Using "we can always" / "let's just" / "obvious that" | All three are tells — stop and apply a required form |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/go.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/go.md
@@ -23,10 +23,12 @@ type WaitOpts struct {
 
 func WaitFor(t *testing.T, condition func() bool, opts WaitOpts) {
 	t.Helper()
-	if opts.Timeout == 0 {
+	if opts.Timeout <= 0 {
 		opts.Timeout = 5 * time.Second
 	}
-	if opts.Interval == 0 {
+	if opts.Interval <= 0 {
+		// time.NewTicker panics on zero or negative intervals. Default rather
+		// than let the caller surface a panic during Phase 1 repro attempts.
 		opts.Interval = 10 * time.Millisecond
 	}
 	if opts.Description == "" {

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/go.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/go.md
@@ -1,0 +1,121 @@
+# Go / stdlib testing — Condition-Based Waiting
+
+Drop-in utilities for Go test files. Uses only the stdlib — no external polling library required.
+
+## Utilities
+
+```go
+// testutil/poll.go
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type WaitOpts struct {
+	Timeout     time.Duration
+	Interval    time.Duration
+	Description string
+}
+
+func WaitFor(t *testing.T, condition func() bool, opts WaitOpts) {
+	t.Helper()
+	if opts.Timeout == 0 {
+		opts.Timeout = 5 * time.Second
+	}
+	if opts.Interval == 0 {
+		opts.Interval = 10 * time.Millisecond
+	}
+	if opts.Description == "" {
+		opts.Description = "condition"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	defer cancel()
+	ticker := time.NewTicker(opts.Interval)
+	defer ticker.Stop()
+	for {
+		if condition() {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("WaitFor timed out after %s: %s", opts.Timeout, opts.Description)
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+func WaitForCount(t *testing.T, getCount func() int, expected int, opts WaitOpts) {
+	t.Helper()
+	if opts.Description == "" {
+		opts.Description = fmt.Sprintf("count >= %d", expected)
+	}
+	WaitFor(t, func() bool { return getCount() >= expected }, opts)
+}
+```
+
+## Usage
+
+```go
+package mypkg_test
+
+import (
+	"testing"
+	"time"
+
+	"myapp/testutil"
+)
+
+func TestCleanupCompletes(t *testing.T) {
+	store := &Store{}
+	go store.Clear()
+
+	testutil.WaitFor(t,
+		func() bool { return store.Size() == 0 },
+		testutil.WaitOpts{
+			Timeout:     5 * time.Second,
+			Description: "store to empty",
+		},
+	)
+	if store.Size() != 0 {
+		t.Fatal("store not empty")
+	}
+}
+
+func TestBothWorkersCommit(t *testing.T) {
+	log := &CommitLog{}
+	go worker1(log)
+	go worker2(log)
+
+	testutil.WaitForCount(t, func() int { return len(log.Entries()) }, 2,
+		testutil.WaitOpts{Timeout: 10 * time.Second})
+
+	unique := make(map[string]bool)
+	for _, c := range log.Entries() {
+		unique[c.WorkerID] = true
+	}
+	if len(unique) != 2 {
+		t.Fatalf("expected 2 unique workers, got %d", len(unique))
+	}
+}
+```
+
+## Test-framework integration
+
+**`go test`**: native. Uses `*testing.T` for `t.Helper()` and `t.Fatalf`.
+**`-race`**: polling utilities must be race-safe. The `condition` closure is the user's code; make sure any shared state is guarded by the user.
+**Parallel tests**: `t.Parallel()` works with `WaitFor`; each subtest has its own deadline.
+**`testify/require` / `testify/assert`**: compatible — `WaitFor` is plain Go and interoperates.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `time.Sleep(500 * time.Millisecond)` in tests | `WaitFor` with a named condition |
+| Condition closure holds a lock between calls | Read and release; polling 100x/s with held lock is contention |
+| No `t.Helper()` call — test failure points at WaitFor's line, not the test's | Always `t.Helper()` at the top |
+| Timeout without context | Always include `Description` so the failure message names the condition |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/java.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/java.md
@@ -1,0 +1,110 @@
+# Java / JUnit 5 / awaitility — Condition-Based Waiting
+
+Awaitility is the idiomatic Java polling library; the examples below show both awaitility and a stdlib fallback.
+
+## Idiomatic: awaitility
+
+Awaitility is a small, zero-deps library that wraps exactly this pattern. For JUnit 5 projects, add:
+
+```xml
+<dependency>
+  <groupId>org.awaitility</groupId>
+  <artifactId>awaitility</artifactId>
+  <version>4.2.0</version>
+  <scope>test</scope>
+</dependency>
+```
+
+Usage:
+
+```java
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.FIVE_SECONDS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@Test
+void cleanupCompletes() {
+    Store store = new Store(List.of(1, 2, 3));
+    new Thread(store::clear).start();
+
+    await()
+        .atMost(FIVE_SECONDS)
+        .pollInterval(Duration.ofMillis(10))
+        .alias("store to empty")
+        .until(() -> store.size(), equalTo(0));
+}
+
+@Test
+void bothWorkersCommit() {
+    CommitLog log = new CommitLog();
+    new Thread(() -> worker1(log)).start();
+    new Thread(() -> worker2(log)).start();
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .alias("2 worker commits")
+        .until(() -> log.entries().size(), greaterThanOrEqualTo(2));
+}
+```
+
+`alias(description)` is what surfaces in the timeout message — always set it.
+
+## Stdlib fallback (no awaitility)
+
+```java
+// src/test/java/testutil/PollUtils.java
+package testutil;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+public class PollUtils {
+    public static class WaitTimeoutException extends RuntimeException {
+        public WaitTimeoutException(String msg) { super(msg); }
+    }
+
+    public static <T> T waitFor(Callable<T> condition, Duration timeout, Duration interval, String description) {
+        if (description == null || description.isBlank()) description = "condition";
+        Instant deadline = Instant.now().plus(timeout);
+        Throwable last = null;
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                T result = condition.call();
+                if (result != null && !(result instanceof Boolean b && !b)) return result;
+            } catch (Throwable err) {
+                last = err;
+            }
+            try { Thread.sleep(interval.toMillis()); }
+            catch (InterruptedException ie) { Thread.currentThread().interrupt(); throw new RuntimeException(ie); }
+        }
+        String msg = "waitFor timed out after " + timeout + ": " + description;
+        if (last != null) msg += " (last error: " + last + ")";
+        throw new WaitTimeoutException(msg);
+    }
+
+    public static void waitForCount(Supplier<Integer> getCount, int expected, Duration timeout, Duration interval, String description) {
+        if (description == null) description = "count >= " + expected;
+        waitFor(() -> getCount.get() >= expected ? Boolean.TRUE : Boolean.FALSE, timeout, interval, description);
+    }
+}
+```
+
+## Test-framework integration
+
+**JUnit 5**: native.
+**Parameterized tests / `@RepeatedTest`**: polling utilities work per invocation; each has its own deadline.
+**Mockito**: when the condition reads a mock's state, use `verify()` with `timeout(...)` as an alternative for signal-shaped waits; `waitFor` for state-shaped waits.
+**Kotlin**: call awaitility from Kotlin directly; the same API works via Java interop.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `Thread.sleep(500)` in a JUnit test | awaitility's `await().until(...)` |
+| `while(!condition) { Thread.sleep(10); }` with no timeout | Always set `atMost(...)` |
+| Missing `alias(description)` in awaitility | Failure messages become useless; always set alias |
+| Using `System.currentTimeMillis()` for the deadline | Use `Instant.now()` (monotonic-adjacent) or `java.time.Duration` comparisons |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/java.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/java.md
@@ -69,16 +69,25 @@ public class PollUtils {
 
     public static <T> T waitFor(Callable<T> condition, Duration timeout, Duration interval, String description) {
         if (description == null || description.isBlank()) description = "condition";
-        Instant deadline = Instant.now().plus(timeout);
-        Throwable last = null;
-        while (Instant.now().isBefore(deadline)) {
+        // Use System.nanoTime() for the deadline — monotonic, unaffected by NTP
+        // wall-clock adjustments. Instant.now() can jump and cause waits to
+        // timeout too early or hang past the intended deadline.
+        long deadlineNs = System.nanoTime() + timeout.toNanos();
+        Exception last = null;
+        while (System.nanoTime() < deadlineNs) {
             try {
                 T result = condition.call();
+                // Only null counts as "not ready". `false`, `0`, empty collections
+                // are legitimate ready signals for generic T.
                 if (result != null && !(result instanceof Boolean b && !b)) return result;
-            } catch (Throwable err) {
+            } catch (InterruptedException ie) {
+                // Propagate interrupt status; do not swallow it
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ie);
+            } catch (Exception err) {  // narrower than Throwable; do not mask JVM Errors
                 last = err;
             }
-            try { Thread.sleep(interval.toMillis()); }
+            try { Thread.sleep(Math.max(1, interval.toMillis())); }
             catch (InterruptedException ie) { Thread.currentThread().interrupt(); throw new RuntimeException(ie); }
         }
         String msg = "waitFor timed out after " + timeout + ": " + description;
@@ -88,7 +97,7 @@ public class PollUtils {
 
     public static void waitForCount(Supplier<Integer> getCount, int expected, Duration timeout, Duration interval, String description) {
         if (description == null) description = "count >= " + expected;
-        waitFor(() -> getCount.get() >= expected ? Boolean.TRUE : Boolean.FALSE, timeout, interval, description);
+        waitFor(() -> getCount.get() >= expected ? Boolean.TRUE : null, timeout, interval, description);
     }
 }
 ```
@@ -107,4 +116,4 @@ public class PollUtils {
 | `Thread.sleep(500)` in a JUnit test | awaitility's `await().until(...)` |
 | `while(!condition) { Thread.sleep(10); }` with no timeout | Always set `atMost(...)` |
 | Missing `alias(description)` in awaitility | Failure messages become useless; always set alias |
-| Using `System.currentTimeMillis()` for the deadline | Use `Instant.now()` (monotonic-adjacent) or `java.time.Duration` comparisons |
+| Using `System.currentTimeMillis()` or `Instant.now()` for the deadline | Both are wall-clock and can jump under NTP adjustments. Use `System.nanoTime()` for elapsed-time deadlines. |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/python.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/python.md
@@ -17,6 +17,9 @@ class WaitTimeout(AssertionError):
     pass
 
 
+_SENTINEL = object()  # distinct from None so None is a valid "not ready" signal
+
+
 def wait_for(
     condition: Callable[[], Optional[T]],
     *,
@@ -25,13 +28,15 @@ def wait_for(
     description: str = "condition",
 ) -> T:
     deadline = time.monotonic() + timeout
-    last_error: Optional[BaseException] = None
+    last_error: Optional[Exception] = None
     while time.monotonic() < deadline:
         try:
             result = condition()
-            if result:
+            # Only `None` means "not ready". Falsy values (0, "", False, []) are
+            # legitimate ready signals for generic T; do not truthy-filter.
+            if result is not None:
                 return result
-        except BaseException as err:
+        except Exception as err:  # do not swallow BaseException (KeyboardInterrupt/SystemExit)
             last_error = err
         time.sleep(interval)
     msg = f"wait_for timed out after {timeout}s: {description}"
@@ -48,13 +53,13 @@ async def wait_for_async(
     description: str = "condition",
 ) -> T:
     deadline = time.monotonic() + timeout
-    last_error: Optional[BaseException] = None
+    last_error: Optional[Exception] = None
     while time.monotonic() < deadline:
         try:
             result = await condition()
-            if result:
+            if result is not None:
                 return result
-        except BaseException as err:
+        except Exception as err:
             last_error = err
         await asyncio.sleep(interval)
     msg = f"wait_for_async timed out after {timeout}s: {description}"
@@ -68,8 +73,23 @@ def wait_for_count(
     expected: int,
     **opts,
 ) -> None:
+    # predicate wrapper: returns True when satisfied, None when not yet.
     wait_for(
-        lambda: get_count() >= expected,
+        lambda: True if get_count() >= expected else None,
+        description=opts.pop("description", f"count >= {expected}"),
+        **opts,
+    )
+
+
+async def wait_for_count_async(
+    get_count: Callable[[], Awaitable[int]],
+    expected: int,
+    **opts,
+) -> None:
+    async def predicate():
+        return True if (await get_count()) >= expected else None
+    await wait_for_async(
+        predicate,
         description=opts.pop("description", f"count >= {expected}"),
         **opts,
     )
@@ -90,7 +110,10 @@ def test_cleanup_completes(global_store):
 
 
 async def test_both_workers_commit(commit_log):
-    wait_for_count(lambda: len(commit_log), 2, timeout=10.0)
+    # async tests MUST use the async waiter — the sync wait_for_count blocks
+    # the event loop and starves the workers. Use wait_for_count_async or
+    # wait_for_async directly in async tests.
+    await wait_for_count_async(lambda: _async_len(commit_log), 2, timeout=10.0)
     assert len({c.worker_id for c in commit_log}) == 2
 ```
 

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/python.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/python.md
@@ -1,0 +1,124 @@
+# Python / pytest — Condition-Based Waiting
+
+Drop-in utilities for pytest (sync and async) that replace `time.sleep(n)`.
+
+## Utilities
+
+```python
+# poll_utils.py
+import asyncio
+import time
+from typing import Awaitable, Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class WaitTimeout(AssertionError):
+    pass
+
+
+def wait_for(
+    condition: Callable[[], Optional[T]],
+    *,
+    timeout: float = 5.0,
+    interval: float = 0.01,
+    description: str = "condition",
+) -> T:
+    deadline = time.monotonic() + timeout
+    last_error: Optional[BaseException] = None
+    while time.monotonic() < deadline:
+        try:
+            result = condition()
+            if result:
+                return result
+        except BaseException as err:
+            last_error = err
+        time.sleep(interval)
+    msg = f"wait_for timed out after {timeout}s: {description}"
+    if last_error:
+        msg += f" (last error: {last_error!r})"
+    raise WaitTimeout(msg)
+
+
+async def wait_for_async(
+    condition: Callable[[], Awaitable[Optional[T]]],
+    *,
+    timeout: float = 5.0,
+    interval: float = 0.01,
+    description: str = "condition",
+) -> T:
+    deadline = time.monotonic() + timeout
+    last_error: Optional[BaseException] = None
+    while time.monotonic() < deadline:
+        try:
+            result = await condition()
+            if result:
+                return result
+        except BaseException as err:
+            last_error = err
+        await asyncio.sleep(interval)
+    msg = f"wait_for_async timed out after {timeout}s: {description}"
+    if last_error:
+        msg += f" (last error: {last_error!r})"
+    raise WaitTimeout(msg)
+
+
+def wait_for_count(
+    get_count: Callable[[], int],
+    expected: int,
+    **opts,
+) -> None:
+    wait_for(
+        lambda: get_count() >= expected,
+        description=opts.pop("description", f"count >= {expected}"),
+        **opts,
+    )
+```
+
+## Usage
+
+```python
+from poll_utils import wait_for, wait_for_count
+
+def test_cleanup_completes(global_store):
+    wait_for(
+        lambda: global_store.size == 0,
+        timeout=5.0,
+        description="global_store to empty",
+    )
+    assert global_store.size == 0
+
+
+async def test_both_workers_commit(commit_log):
+    wait_for_count(lambda: len(commit_log), 2, timeout=10.0)
+    assert len({c.worker_id for c in commit_log}) == 2
+```
+
+## Test-framework integration
+
+**pytest**: no special setup. Install once as a fixture if you want shared defaults:
+
+```python
+# conftest.py
+import pytest
+from poll_utils import wait_for as _wait_for
+
+@pytest.fixture
+def wait_for():
+    return _wait_for
+```
+
+**pytest-asyncio**: use `wait_for_async` inside `async def test_...`.
+
+**pytest-xdist**: polling utilities are worker-local — no shared state needed; works with `-n auto`.
+
+**Mock time**: if the test uses `freezegun` or `pytest-freezer`, `time.sleep` still blocks wall-clock but `time.monotonic()` advances with the frozen time. Use real time for tests that use `wait_for`.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `time.sleep(0.5)` with a "flaky, but usually works" comment | `wait_for` + named condition |
+| Using `time.time()` instead of `time.monotonic()` | `time.monotonic()` is clock-drift immune |
+| Raising `AssertionError` without context on timeout | Always include the `description` in the timeout message |
+| Polling at 0.5s intervals | 10ms default; slower only when the check is expensive |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/ruby.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/ruby.md
@@ -1,0 +1,83 @@
+# Ruby / RSpec — Condition-Based Waiting
+
+Drop-in utilities for RSpec. Small pure-Ruby implementation; alternatives like the `timeout` or `wait_for` gems exist but the stdlib is sufficient.
+
+## Utilities
+
+```ruby
+# spec/support/poll_utils.rb
+module PollUtils
+  class WaitTimeout < StandardError; end
+
+  def wait_for(timeout: 5.0, interval: 0.01, description: "condition")
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    last_error = nil
+    loop do
+      begin
+        result = yield
+        return result if result
+      rescue StandardError => err
+        last_error = err
+      end
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        msg = "wait_for timed out after #{timeout}s: #{description}"
+        msg += " (last error: #{last_error.class}: #{last_error.message})" if last_error
+        raise WaitTimeout, msg
+      end
+      sleep interval
+    end
+  end
+
+  def wait_for_count(get_count, expected, **opts)
+    desc = opts.delete(:description) || "count >= #{expected}"
+    wait_for(description: desc, **opts) { get_count.call >= expected }
+  end
+end
+
+RSpec.configure do |c|
+  c.include PollUtils
+end
+```
+
+## Usage
+
+```ruby
+require "rails_helper"
+
+RSpec.describe "cleanup" do
+  it "completes before next example" do
+    store = Store.new
+    Thread.new { store.clear }
+
+    wait_for(timeout: 5.0, description: "store to empty") { store.size == 0 }
+    expect(store.size).to eq(0)
+  end
+end
+
+RSpec.describe "two workers" do
+  it "both commit" do
+    log = CommitLog.new
+    Thread.new { worker1(log) }
+    Thread.new { worker2(log) }
+
+    wait_for_count(-> { log.size }, 2, timeout: 10.0)
+    expect(log.map(&:worker_id).uniq.size).to eq(2)
+  end
+end
+```
+
+## Test-framework integration
+
+**RSpec**: include the module globally via `RSpec.configure`; `wait_for` is available in every `describe`.
+**Minitest**: use as a mixin in the test base class; same API.
+**Capybara / system specs**: Capybara has its own `have_selector` matchers with auto-waiting; prefer those for UI assertions. Use `wait_for` for state-level polls not covered by Capybara.
+**Time mocks (`Timecop`, `ActiveSupport::Testing::TimeHelpers`)**: `Process.clock_gettime(Process::CLOCK_MONOTONIC)` is not affected by time mocks — the wait measures real wall-clock time, which is what you want.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `sleep 0.5` with "this should be enough" | `wait_for` + named condition |
+| Using `Time.now` instead of `Process::CLOCK_MONOTONIC` | `Time.now` can jump backward under NTP; use monotonic |
+| `retry` without a deadline | `wait_for` adds the deadline — never retry forever in tests |
+| Swallowing errors silently in the condition | Capture `last_error`; surface in timeout message |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/ruby.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/ruby.md
@@ -71,7 +71,7 @@ end
 **RSpec**: include the module globally via `RSpec.configure`; `wait_for` is available in every `describe`.
 **Minitest**: use as a mixin in the test base class; same API.
 **Capybara / system specs**: Capybara has its own `have_selector` matchers with auto-waiting; prefer those for UI assertions. Use `wait_for` for state-level polls not covered by Capybara.
-**Time mocks (`Timecop`, `ActiveSupport::Testing::TimeHelpers`)**: `Process.clock_gettime(Process::CLOCK_MONOTONIC)` is not affected by time mocks — the wait measures real wall-clock time, which is what you want.
+**Time mocks (`Timecop`, `ActiveSupport::Testing::TimeHelpers`)**: by default, `Process.clock_gettime(Process::CLOCK_MONOTONIC)` is not affected by `Timecop.freeze` / `travel_to` — the wait measures real wall-clock time, which is what you usually want in polling. Note: `Timecop` does offer `Timecop.mock_process_clock` (opt-in) that also mocks monotonic time; if a test sets that, `wait_for` will behave oddly. Disable `mock_process_clock` for tests that use `wait_for`.
 
 ## Anti-patterns
 

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/rust.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/rust.md
@@ -1,0 +1,148 @@
+# Rust / tokio — Condition-Based Waiting
+
+Drop-in utilities for tokio-based async tests. Covers the common case (polling a condition) plus cancellation-token integration for cooperative cancellation.
+
+## Utilities
+
+```rust
+// src/test_utils/poll.rs
+use std::future::Future;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+#[derive(Debug, thiserror::Error)]
+pub enum WaitError {
+    #[error("wait_for timed out after {timeout:?}: {description}")]
+    Timeout {
+        timeout: Duration,
+        description: String,
+    },
+}
+
+pub struct WaitOpts {
+    pub timeout: Duration,
+    pub interval: Duration,
+    pub description: String,
+}
+
+impl Default for WaitOpts {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(5),
+            interval: Duration::from_millis(10),
+            description: "condition".into(),
+        }
+    }
+}
+
+pub async fn wait_for<F, Fut, T>(condition: F, opts: WaitOpts) -> Result<T, WaitError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    let deadline = Instant::now() + opts.timeout;
+    while Instant::now() < deadline {
+        if let Some(result) = condition().await {
+            return Ok(result);
+        }
+        sleep(opts.interval).await;
+    }
+    Err(WaitError::Timeout {
+        timeout: opts.timeout,
+        description: opts.description,
+    })
+}
+
+pub async fn wait_for_count<F, Fut>(
+    get_count: F,
+    expected: usize,
+    opts: WaitOpts,
+) -> Result<(), WaitError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = usize>,
+{
+    wait_for(
+        || async { if get_count().await >= expected { Some(()) } else { None } },
+        opts,
+    )
+    .await
+}
+```
+
+## Usage
+
+```rust
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[tokio::test]
+async fn cleanup_completes() {
+    let store = Arc::new(Mutex::new(vec![1, 2, 3]));
+    let store_clone = store.clone();
+    tokio::spawn(async move {
+        store_clone.lock().await.clear();
+    });
+
+    wait_for(
+        || {
+            let store = store.clone();
+            async move { if store.lock().await.is_empty() { Some(()) } else { None } }
+        },
+        WaitOpts {
+            timeout: Duration::from_secs(5),
+            description: "store to empty".into(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+}
+```
+
+## Cancellation-token variant
+
+For cooperative cancellation (preferred over hard timeouts in production code):
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+pub async fn wait_for_cancellable<F, Fut, T>(
+    condition: F,
+    cancel: CancellationToken,
+    interval: Duration,
+) -> Result<T, WaitError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return Err(WaitError::Timeout {
+                timeout: Duration::ZERO,
+                description: "cancelled".into(),
+            }),
+            _ = sleep(interval) => {
+                if let Some(result) = condition().await {
+                    return Ok(result);
+                }
+            }
+        }
+    }
+}
+```
+
+## Test-framework integration
+
+**`#[tokio::test]`**: works directly; the test runtime is already async.
+**`tokio-test` crate**: provides `block_on` for sync tests; utilities above use async so prefer `#[tokio::test]`.
+**Fake time**: `tokio::time::pause()` + `tokio::time::advance()` work with `sleep`. Either use real time in `wait_for` tests, or advance the pause in parallel with the wait.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `std::thread::sleep` in async code | Use `tokio::time::sleep` — otherwise you block the whole runtime thread |
+| Hardcoded `Duration::from_millis(500)` in tests | Replace with `wait_for` + named condition |
+| Polling with a synchronous `Mutex` inside `tokio::spawn` | Use `tokio::sync::Mutex` and `async` locking |
+| `panic!()` on timeout instead of `Result` | Return `WaitError::Timeout` so callers can add context |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/rust.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/rust.md
@@ -41,16 +41,27 @@ where
     Fut: Future<Output = Option<T>>,
 {
     let deadline = Instant::now() + opts.timeout;
-    while Instant::now() < deadline {
-        if let Some(result) = condition().await {
-            return Ok(result);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(WaitError::Timeout {
+                timeout: opts.timeout,
+                description: opts.description,
+            });
         }
-        sleep(opts.interval).await;
+        // Enforce the deadline even while awaiting `condition()`. A stuck condition
+        // future would otherwise block indefinitely.
+        match tokio::time::timeout(remaining, condition()).await {
+            Ok(Some(result)) => return Ok(result),
+            Ok(None) => sleep(opts.interval.min(remaining)).await,
+            Err(_) => {
+                return Err(WaitError::Timeout {
+                    timeout: opts.timeout,
+                    description: opts.description,
+                })
+            }
+        }
     }
-    Err(WaitError::Timeout {
-        timeout: opts.timeout,
-        description: opts.description,
-    })
 }
 
 pub async fn wait_for_count<F, Fut>(
@@ -117,16 +128,29 @@ where
     Fut: Future<Output = Option<T>>,
 {
     loop {
+        // `biased;` ensures the cancel branch is checked before every poll
+        // (and wraps `condition()` so cancellation interrupts an in-flight
+        // condition future, not just the sleep).
         tokio::select! {
+            biased;
             _ = cancel.cancelled() => return Err(WaitError::Timeout {
                 timeout: Duration::ZERO,
                 description: "cancelled".into(),
             }),
-            _ = sleep(interval) => {
-                if let Some(result) = condition().await {
+            res = condition() => {
+                if let Some(result) = res {
                     return Ok(result);
                 }
             }
+        }
+        // Sleep is also cancellable by the token.
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(WaitError::Timeout {
+                timeout: Duration::ZERO,
+                description: "cancelled".into(),
+            }),
+            _ = sleep(interval) => {}
         }
     }
 }

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/swift.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/swift.md
@@ -31,6 +31,10 @@ func waitFor<T>(
     options: WaitOptions = .init()
 ) async throws -> T {
     let deadline = Date().addingTimeInterval(options.timeout)
+    // Guard against negative intervals; UInt64 conversion of a negative Double
+    // traps at runtime.
+    let intervalNs = max(0, options.interval) * 1_000_000_000
+    let sleepNanos = UInt64(intervalNs.rounded())
     var lastError: Error?
     while Date() < deadline {
         do {
@@ -40,7 +44,7 @@ func waitFor<T>(
         } catch {
             lastError = error
         }
-        try await Task.sleep(nanoseconds: UInt64(options.interval * 1_000_000_000))
+        try await Task.sleep(nanoseconds: sleepNanos)
     }
     throw WaitError.timeout(options.timeout, options.description + (lastError.map { " (last error: \($0))" } ?? ""))
 }

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/swift.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/swift.md
@@ -1,0 +1,107 @@
+# Swift / XCTest — Condition-Based Waiting
+
+Drop-in utilities for XCTest (async/await). Uses Swift 5.5+ concurrency.
+
+## Utilities
+
+```swift
+// PollUtils.swift
+import Foundation
+import XCTest
+
+struct WaitOptions {
+    var timeout: TimeInterval = 5.0
+    var interval: TimeInterval = 0.01
+    var description: String = "condition"
+}
+
+enum WaitError: Error, CustomStringConvertible {
+    case timeout(TimeInterval, String)
+
+    var description: String {
+        switch self {
+        case let .timeout(t, desc):
+            return "waitFor timed out after \(t)s: \(desc)"
+        }
+    }
+}
+
+func waitFor<T>(
+    _ condition: () async throws -> T?,
+    options: WaitOptions = .init()
+) async throws -> T {
+    let deadline = Date().addingTimeInterval(options.timeout)
+    var lastError: Error?
+    while Date() < deadline {
+        do {
+            if let result = try await condition() {
+                return result
+            }
+        } catch {
+            lastError = error
+        }
+        try await Task.sleep(nanoseconds: UInt64(options.interval * 1_000_000_000))
+    }
+    throw WaitError.timeout(options.timeout, options.description + (lastError.map { " (last error: \($0))" } ?? ""))
+}
+
+func waitForCount(
+    _ getCount: () async -> Int,
+    expected: Int,
+    options: WaitOptions = .init()
+) async throws {
+    var opts = options
+    if opts.description == "condition" {
+        opts.description = "count >= \(expected)"
+    }
+    _ = try await waitFor(
+        { await getCount() >= expected ? () : nil },
+        options: opts
+    )
+}
+```
+
+## Usage
+
+```swift
+import XCTest
+
+final class StoreTests: XCTestCase {
+    func testCleanupCompletes() async throws {
+        let store = Store()
+        Task { await store.clear() }
+
+        try await waitFor(
+            { await store.size == 0 ? () : nil },
+            options: .init(timeout: 5, description: "store to empty")
+        )
+        let size = await store.size
+        XCTAssertEqual(size, 0)
+    }
+
+    func testBothWorkersCommit() async throws {
+        let log = CommitLog()
+        async let _ = worker1(log)
+        async let _ = worker2(log)
+
+        try await waitForCount({ await log.count }, expected: 2,
+                               options: .init(timeout: 10))
+    }
+}
+```
+
+## Test-framework integration
+
+**XCTest + async**: use `async throws` test methods — XCTest awaits them natively.
+**`XCTestExpectation`**: works in parallel with `waitFor`; prefer `waitFor` when the condition is query-shaped (you're checking state), `XCTestExpectation` when it's signal-shaped (you're waiting for a callback).
+**Swift concurrency**: `Task.sleep` in the poll loop yields cooperatively.
+**Actor isolation**: if the condition reads actor-isolated state, `await` is required — the utilities already use it.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `sleep(UInt32(0.5))` inside a test | `waitFor` + named condition |
+| `XCTestExpectation` with a bare 5-second timeout | If you're polling state, `waitFor` is more direct |
+| Non-async polling blocking the test thread | Use `await` throughout; `Task.sleep` instead of `Thread.sleep` |
+| Ignoring errors inside the condition closure | Record as `lastError` so the timeout message carries it |

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/typescript.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/typescript.md
@@ -21,7 +21,9 @@ export async function waitFor<T>(
   while (Date.now() < deadline) {
     try {
       const result = await condition();
-      if (result) return result as T;
+      // Treat `null` / `undefined` as "not ready". Values like `0`, `''`, `false`
+      // are legitimate ready signals for generic T; do not truthy-filter them.
+      if (result !== null && result !== undefined) return result as T;
     } catch (err) {
       lastError = err;
     }
@@ -31,6 +33,17 @@ export async function waitFor<T>(
     `waitFor timed out after ${timeoutMs}ms: ${description}${
       lastError ? ` (last error: ${String(lastError)})` : ''
     }`,
+  );
+}
+
+// Convenience wrapper for boolean predicates. Returns when the predicate is true.
+export async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  opts: WaitOptions = {},
+): Promise<void> {
+  await waitFor(
+    async () => ((await predicate()) ? true : null),
+    { ...opts, description: opts.description ?? 'predicate to hold' },
   );
 }
 

--- a/skills/debug-systematic/skills/debug-systematic/references/waiting/typescript.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/waiting/typescript.md
@@ -1,0 +1,103 @@
+# TypeScript / Jest / Vitest — Condition-Based Waiting
+
+Ported from obra's reference `condition-based-waiting-example.ts`. Drop-in utilities that replace `sleep(n)` in Jest or Vitest tests.
+
+## Utilities
+
+```typescript
+// poll-utils.ts
+export interface WaitOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  description?: string;
+}
+
+export async function waitFor<T>(
+  condition: () => T | Promise<T> | null | undefined,
+  { timeoutMs = 5_000, intervalMs = 10, description = 'condition' }: WaitOptions = {}
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = undefined;
+  while (Date.now() < deadline) {
+    try {
+      const result = await condition();
+      if (result) return result as T;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `waitFor timed out after ${timeoutMs}ms: ${description}${
+      lastError ? ` (last error: ${String(lastError)})` : ''
+    }`,
+  );
+}
+
+export async function waitForEventCount(
+  getCount: () => number | Promise<number>,
+  expected: number,
+  opts: WaitOptions = {},
+): Promise<void> {
+  await waitFor(
+    async () => (await getCount()) >= expected,
+    { ...opts, description: opts.description ?? `event count >= ${expected}` },
+  );
+}
+
+export async function waitForEventMatch<T>(
+  getEvents: () => T[] | Promise<T[]>,
+  predicate: (e: T) => boolean,
+  opts: WaitOptions = {},
+): Promise<T> {
+  return waitFor(
+    async () => {
+      const events = await getEvents();
+      return events.find(predicate);
+    },
+    { ...opts, description: opts.description ?? 'matching event' },
+  );
+}
+```
+
+## Usage
+
+```typescript
+import { waitFor, waitForEventCount } from './poll-utils';
+
+test('cleanup completes before next test', async () => {
+  await waitFor(() => globalStore.size === 0, {
+    timeoutMs: 5_000,
+    description: 'globalStore to empty',
+  });
+  expect(globalStore.size).toBe(0);
+});
+
+test('both workers commit', async () => {
+  await waitForEventCount(() => commitLog.length, 2, {
+    description: 'two worker commits',
+  });
+  expect(new Set(commitLog.map((c) => c.workerId)).size).toBe(2);
+});
+```
+
+## Test-framework integration
+
+**Jest** — default timeout is 5s per test; set per-test if your condition takes longer:
+
+```typescript
+test('slow event', async () => { /* ... */ }, 30_000);
+```
+
+**Vitest** — identical API; pass timeout as third arg to `test`.
+
+**Fake timers** — if the test uses `jest.useFakeTimers()` / `vi.useFakeTimers()`, `setTimeout` inside `waitFor` will not advance. Either advance timers manually (`jest.advanceTimersByTime(10)`) in the loop or avoid fake timers for tests that use `waitFor`.
+
+## Anti-patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `await new Promise(r => setTimeout(r, 500))` with a "should be enough" comment | Replace with `waitFor` + named condition |
+| Condition function makes a network call every iteration | Cache what's safe to cache; keep the condition cheap |
+| Swallowing all errors inside the condition | Record as `lastError` so the timeout message includes it (see utility above) |
+| Timeout without a `description` | The default "condition" tells nothing; always name what you're waiting for |

--- a/skills/debug-systematic/skills/debug-systematic/references/workflow-deep.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/workflow-deep.md
@@ -234,6 +234,7 @@ if (!session) {
   return res.status(401).json({ error: 'session expired' });
 }
 req.session = session;
+next();  // continue to the downstream handler
 ```
 
 Test fixture:
@@ -261,7 +262,11 @@ async def upsert(key, delta):
     async with db.transaction():
         row = await db.fetchrow("SELECT * FROM items WHERE key=$1 FOR UPDATE", key)
         new_value = merge(row, delta) if row else delta
-        await db.execute("UPSERT items (key, value) VALUES ($1, $2)", key, new_value)
+        await db.execute(
+            "INSERT INTO items (key, value) VALUES ($1, $2) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+            key, new_value,
+        )
 ```
 
 **Regression guard**: the existing `pytest -n 8` test IS the guard — it failed before the fix, passes after.

--- a/skills/debug-systematic/skills/debug-systematic/references/workflow-deep.md
+++ b/skills/debug-systematic/skills/debug-systematic/references/workflow-deep.md
@@ -1,0 +1,309 @@
+# Workflow Deep — 4-Phase Walkthrough with Worked Examples
+
+Extended version of SKILL.md's 4-phase workflow. Read when SKILL.md's phase block does not give enough signal — e.g., you are stuck in Phase 2 and need a concrete pattern-analysis example.
+
+## Contents
+- [How to use this file](#how-to-use-this-file)
+- [Phase 1 — Investigation, in depth](#phase-1--investigation-in-depth)
+- [Phase 2 — Pattern analysis, in depth](#phase-2--pattern-analysis-in-depth)
+- [Phase 3 — Hypothesis testing, in depth](#phase-3--hypothesis-testing-in-depth)
+- [Phase 4 — Implementation, in depth](#phase-4--implementation-in-depth)
+- [Language coverage matrix](#language-coverage-matrix)
+
+## How to use this file
+
+Read the phase that matches where you currently are, not all four. Each phase section has:
+
+- A **goal statement**
+- A **three-example spread** (Node test-pollution, Python race, Rust lifetime) showing the phase end-to-end
+- **Exit criteria** (mirrors SKILL.md, restated for completeness)
+- **Red flags** that send you back to the previous phase
+
+The examples are deliberately different languages and different bug classes so the pattern-shape generalizes.
+
+## Phase 1 — Investigation, in depth
+
+**Goal**: define the exact failing behavior, reproduce deterministically, capture copy-pasteable evidence.
+
+### Example 1.1 — Node test pollution
+
+Symptom: test `auth.test.ts > handles missing token` passes locally (`pnpm test auth`) but fails in CI when the full suite runs.
+
+**Step 1 — state the symptom precisely**:
+
+```
+symptom: auth.test.ts > "handles missing token" fails in CI, passes locally
+fail output: expected 401, got 500
+file/line: handlers/auth.ts:42 (handler throws on req.session undefined)
+first-seen: commit abc1234 — CI log shows previous run was green
+env: CI-only; local pnpm test auth passes 10/10
+```
+
+**Step 2 — reproduce deterministically**. Run the full CI sequence locally: `pnpm test` (not just `pnpm test auth`). Test fails. Now it's 10/10 reproducible.
+
+**Step 3 — capture evidence**:
+
+```
+$ pnpm test 2>&1 | tee /tmp/failure.log
+... auth.test.ts > handles missing token FAIL ...
+    at handlers/auth.ts:42 — TypeError: cannot read 'user_id' of undefined
+    at middlewares/load-session.ts:18 — req.session is undefined
+
+vs. isolated run:
+$ pnpm test auth 2>&1
+... auth.test.ts > handles missing token PASS ...
+```
+
+**Step 4 — symptom card**:
+
+> `auth.test.ts > "handles missing token"` fails when the full suite runs but passes in isolation. Failure: a session-loading middleware produces `req.session = undefined` instead of failing gracefully, causing the auth handler to throw 500 rather than the expected 401. First seen at commit abc1234. Reproduction: run `pnpm test` (not just `pnpm test auth`). Fails 10/10 under the full suite, passes 10/10 alone.
+
+### Example 1.2 — Python race condition
+
+Symptom: `AssertionError: expected 10 records, got 7` occasionally in `test_batch_insert.py`.
+
+**Step 1**: failure message + line + intermittent (6 runs: 4 pass, 2 fail). Not 10/10 → incomplete Phase 1.
+
+**Step 2 — make it deterministic**: the race is triggered by two tasks writing to the same bucket. Increase parallelism and retry:
+
+```
+for i in {1..50}; do pytest tests/test_batch_insert.py -q || echo "fail $i"; done
+```
+
+Finding: fails ~40% of runs at concurrency 8, ~0% at concurrency 1. → `pytest-xdist -n 8` and the repro is now 10/10 on the fail side (deterministic *under concurrency*).
+
+**Step 3 — evidence**: add structured logging around the two contending writes; capture the race window (two writes bucketed to the same partition within 1.2ms). Log the full sequence.
+
+**Step 4 — symptom card**:
+
+> `test_batch_insert.py` loses 3 of 10 records under concurrent workers (`pytest-xdist -n 8`). Both writers dispatch to the same partition within a ~1.2ms window and overwrite without merging. Reproduction: `pytest tests/test_batch_insert.py -q -n 8` fails >30% of runs; `-n 1` passes 100%.
+
+### Example 1.3 — Rust lifetime
+
+Symptom: `error[E0597]: 'x' does not live long enough` at compile, at `src/worker.rs:102`.
+
+**Step 1**: compile-time error. "Reproduction" is `cargo build`. 10/10 deterministic by definition.
+
+**Step 2**: `cargo build` gives the full error with suggestion. Evidence is the compiler output itself — capture it verbatim.
+
+**Step 3**: symptom card — the compiler error *is* the symptom card. No runtime ambiguity.
+
+### Exit criteria
+
+- Symptom card (one paragraph, stranger-reproducible)
+- 10/10 failing repro (or 0/N-correct-and-repeatable for intermittent bugs, made deterministic via `bisection-strategies.md` input-space bisection)
+- Copy-pasteable evidence (stack trace, log excerpt, diff, config values)
+
+### Red flags → back to step 1
+
+- "It happens sometimes." — 10/10 is the bar; make it deterministic first.
+- "Some config mismatch." — What config, what value? Name it.
+- "The code looks wrong." — You are guessing. Phase 1 is observation only.
+
+## Phase 2 — Pattern analysis, in depth
+
+**Goal**: produce 1-3 ranked candidate mechanisms with evidence. Not fixes — mechanisms.
+
+### Example 2.1 — Node test pollution (continuing from 1.1)
+
+Apply `root-cause-tracing.md`:
+
+- Victim frame: `handlers/auth.ts:42` reading `req.session.user_id`.
+- Frame 2: `middlewares/load-session.ts:18` returns undefined silently on error.
+- Frame 3: `app-test-setup.ts:8` uses an in-memory session store shared across tests.
+- Frame 4: Another test (identified by narrowing) deletes all sessions in `afterEach`.
+
+Candidate mechanisms:
+
+1. **Test pollution — shared in-memory store**: another test deletes sessions before this test runs, so `req.session = undefined` when this test's request arrives. Evidence: the `afterEach` in `tests/logout.test.ts` calls `sessionStore.clear()`; test order in full suite runs `logout.test.ts` before `auth.test.ts`.
+2. **Middleware silently swallowing a lookup error** (independent of #1): even if #1 is the trigger, the middleware's silent-undefined fallback is a second bug. Evidence: `middlewares/load-session.ts:18` catches and returns undefined with no log.
+3. **Test isolation misconfigured** (related to #1 but a different fix): `beforeEach` does not reset the store. Evidence: `app-test-setup.ts:8` sets up once, not per-test.
+
+Rank by disprovability:
+- #1 is testable with `pnpm test auth tests/logout.test.ts` (in order). Cheapest.
+- #2 is testable by adding a log to the middleware — cheap.
+- #3 is a fix shape, not a standalone hypothesis; drop from ranking.
+
+### Example 2.2 — Python race (continuing from 1.2)
+
+Victim: assertion. Trace: writer 1 and writer 2 both call `upsert` on the same key; each reads, merges, writes. Race window = between read and write.
+
+Candidate mechanisms:
+
+1. **Lost update — no locking on read-modify-write**: classic race. Evidence: the `upsert` function has no transaction or lock; the repro fails under concurrency, passes without.
+2. **Optimistic-concurrency check is broken**: maybe there is a version check but it's faulty. Evidence: `upsert` code has a `version` field but it's only checked in one of two paths. Inspect.
+3. **Batch semantics are wrong at the boundary**: the batch API was never meant to be called from multiple workers. Evidence: docs / comments on the API.
+
+Rank by disprovability: #1 first (single-worker baseline already confirms it); #2 only if #1 is ruled out; #3 is context, not testable as-is.
+
+### Example 2.3 — Rust lifetime (continuing from 1.3)
+
+Victim: the `'x' does not live long enough` compile error on line 102. Trace backward: line 95 spawns a task that captures a reference to `x`, but `x` is a local on line 89 and the task requires `'static`.
+
+Candidate mechanisms:
+
+1. **Reference captured across `spawn` with insufficient lifetime**: the idiomatic fix is `Arc::clone` before spawn. Evidence: the compiler suggestion itself.
+2. **Unnecessary spawn — the task should run inline**: maybe the spawn is the wrong abstraction. Evidence: read surrounding code; is there a reason the work needs to be on a separate task?
+
+Rank: #1 (trivially testable by compiling with the suggested fix), #2 (review-based, slower).
+
+### Exit criteria
+
+- 1-3 ranked, evidence-backed candidates.
+- Each candidate is a one-sentence mechanism ("X caused Y because Z") with attached evidence.
+
+### Red flags → back to Phase 1
+
+- Evidence gaps: you need a log you don't have. Return to Phase 1 and add instrumentation to make the evidence collectable.
+- All candidates are "maybe the code is wrong": pattern not identified. Revisit `root-cause-tracing.md`.
+- Only one candidate fits: you may be over-committed. Force a second candidate, even an unlikely one.
+
+## Phase 3 — Hypothesis testing, in depth
+
+**Goal**: run an experiment designed to fail if your top candidate is wrong.
+
+**Key rule**: *an experiment that cannot fail proves nothing.* Before running the test, write down in one sentence what result would kill the hypothesis. If you cannot, the experiment is cover for a pre-decided fix.
+
+### Example 3.1 — Node test pollution
+
+Top candidate: `#1 — test pollution via shared in-memory store`.
+
+**False-case prediction**: if #1 is wrong, running `tests/auth.test.ts` after `tests/logout.test.ts` should NOT reproduce the failure.
+
+**Experiment**: `pnpm exec jest --runInBand tests/logout.test.ts tests/auth.test.ts`.
+
+**Observed**: auth test fails. Matches the hypothesis.
+
+**Distinguishing test** (is this #1 or could it also be #2, silent swallowing?): run `tests/auth.test.ts` alone, but first manually call `sessionStore.clear()`. If #1 is right and #2 is not a factor, the middleware should throw a visible error on lookup failure. Observed: middleware returns undefined silently — so #2 is ALSO a real bug, independent of #1.
+
+Two confirmed mechanisms. The fix will address both: per-test cleanup (kill #1) AND the middleware's silent-swallow (kill #2). See `defense-in-depth.md` for layer picking.
+
+### Example 3.2 — Python race
+
+Top candidate: `#1 — lost update, no locking`.
+
+**False-case prediction**: if #1 is wrong, running the test under `-n 1` should also fail (the bug is not concurrency-related).
+
+**Experiment**: `pytest -n 1 tests/test_batch_insert.py`. Runs 100/100 green.
+
+**Confirmed**. If #1 were wrong, -n 1 would also fail. It doesn't. #1 is the mechanism.
+
+### Example 3.3 — Rust lifetime
+
+Top candidate: `#1 — captured reference across spawn`.
+
+**False-case prediction**: if #1 is wrong, cloning/Arc-wrapping `x` before spawn should NOT resolve the compile error.
+
+**Experiment**: wrap `x` in `Arc::new`, pass `Arc::clone(&x)` to the spawned task. Compile.
+
+**Observed**: compiles. #1 confirmed.
+
+### Exit criteria
+
+- One candidate confirmed with experiment evidence.
+- The experiment's false-case prediction was stated *before* running.
+- The confirmation does not also fit a different mechanism (if it does, design a distinguishing test).
+
+### Red flags → back to Phase 2
+
+- "Confirmation" also fits another mechanism: design the distinguishing test.
+- You edited product code mid-experiment: you left Phase 3 early; back up.
+- You accepted a partial confirmation: "because it kind of matched" is not confirmation.
+
+## Phase 4 — Implementation, in depth
+
+**Goal**: write the narrowest fix, add a regression guard, verify the Phase 1 repro now passes, clean up temporary diagnosis code.
+
+### Example 4.1 — Node test pollution
+
+Mechanism: shared in-memory store + silent middleware swallow.
+
+**Layer pick** (see `defense-in-depth.md`):
+
+- Primary fix at Layer 1 (the middleware): return 401 with reason on lookup failure, do not silently set `req.session = undefined`.
+- Guard at Layer 3 (test fixture): `beforeEach` resets the session store.
+- Instrumentation at Layer 4: log middleware lookup failures with reason.
+
+**Narrowest fix**:
+
+```ts
+// middlewares/load-session.ts
+const session = await sessionStore.get(sessionId);
+if (!session) {
+  logger.warn({ sessionId, reason: 'lookup-miss' }, 'session not found');
+  return res.status(401).json({ error: 'session expired' });
+}
+req.session = session;
+```
+
+Test fixture:
+
+```ts
+// tests/fixtures/app.ts
+beforeEach(() => sessionStore.clear());
+```
+
+**Regression guard**: the existing test now passes in the full suite because of the fixture; ADD a new test: "middleware returns 401 on missing session" that runs in isolation and would fail if the middleware reverted to silent-undefined.
+
+**Verify**: `pnpm test` runs 10/10 green. Phase 1's repro now passes.
+
+### Example 4.2 — Python race
+
+**Layer pick**:
+
+- Primary fix at Layer 2 (invariant): use the DB's native transaction + row-level lock around read-modify-write.
+- Guard at Layer 4: log retry attempts (diagnostic for future concurrency drift).
+
+**Fix**:
+
+```python
+async def upsert(key, delta):
+    async with db.transaction():
+        row = await db.fetchrow("SELECT * FROM items WHERE key=$1 FOR UPDATE", key)
+        new_value = merge(row, delta) if row else delta
+        await db.execute("UPSERT items (key, value) VALUES ($1, $2)", key, new_value)
+```
+
+**Regression guard**: the existing `pytest -n 8` test IS the guard — it failed before the fix, passes after.
+
+### Example 4.3 — Rust lifetime
+
+**Layer pick**: Layer 2 (ownership invariant) — use `Arc` to give the task owned data.
+
+**Fix**:
+
+```rust
+let x = Arc::new(expensive_init());
+let x_for_task = Arc::clone(&x);
+tokio::spawn(async move { use_x(x_for_task).await });
+// continue using x (via Arc::clone or &x) on main task
+```
+
+**Regression guard**: the compiler itself. The fix compiles; reverting triggers E0597 again.
+
+### Exit criteria
+
+- Symptom gone (Phase 1 repro now passes, evidence captured).
+- Regression guard exists (test / assertion / compiler / invariant) and fails if the fix is reverted.
+- Temporary diagnosis code removed.
+- Handoff to `check-completion` before declaring done.
+
+### Red flags → back to Phase 3
+
+- The repro still fails: the hypothesis was wrong, not just the fix.
+- The regression guard passes without the fix: the guard does not test the mechanism.
+- New symptoms appear: you widened the blast radius. Phase 1 on the new symptom.
+
+## Language coverage matrix
+
+| Language | Root-cause tracing | Condition-based waiting | Defense in depth | Bisection |
+|---|---|---|---|---|
+| TypeScript / Node | `references/root-cause-tracing.md` §1.1 | `references/waiting/typescript.md` | Layer 1 via zod/valibot; Layer 2 via `invariant()` | `scripts/find-polluter.sh` (jest/vitest branch) |
+| Python | §1.2 | `references/waiting/python.md` | Layer 1 via pydantic; Layer 2 via `assert` | `scripts/find-polluter.sh` (pytest branch) |
+| Rust | §1.3 | `references/waiting/rust.md` | Layer 2 via `debug_assert!`; types kill many Layer 1 bugs at compile | `scripts/find-polluter.sh` (cargo branch) |
+| Go | — | `references/waiting/go.md` | Layer 1 via explicit validation; Layer 2 via `require.NoError` in tests | `scripts/find-polluter.sh` (gotest branch) |
+| Swift | — | `references/waiting/swift.md` | Layer 1 via optionals; Layer 2 via `precondition()` | — (XCTest has native isolation) |
+| Ruby | — | `references/waiting/ruby.md` | Layer 1 via dry-schema; Layer 2 via custom assertions | `scripts/find-polluter.sh` (rspec branch) |
+| Java / Kotlin | — | `references/waiting/java.md` | Layer 1 via Bean Validation; Layer 2 via assertions | `scripts/find-polluter.sh` (mvn/gradle branch) |
+
+Every language entry that says "—" in a column means the pattern still applies but the reference does not carry a language-specific example; the language-agnostic file for that technique covers it.

--- a/skills/debug-systematic/skills/debug-systematic/scripts/find-polluter.sh
+++ b/skills/debug-systematic/skills/debug-systematic/scripts/find-polluter.sh
@@ -5,13 +5,28 @@
 # the pre-test list to find the smallest subset that triggers the failure.
 #
 # Usage:
-#   bash find-polluter.sh --target <test-id> [--runner auto|jest|vitest|pytest|cargo|gotest|rspec|mvn|gradle] [--candidates <file>]
+#   bash find-polluter.sh --target <selector> [--runner auto|jest|vitest|pytest|cargo|gotest|rspec|mvn|gradle] [--candidates <file>]
+#
+# --target is a runner-native selector, NOT a test title:
+#   jest/vitest: test-file path (e.g., "tests/auth.test.ts")
+#   pytest:      nodeid (e.g., "tests/test_auth.py::test_missing_token")
+#   cargo:       test function name (e.g., "auth::missing_token")
+#   gotest:      regex for -run (e.g., "^TestAuth_MissingToken$")
+#   rspec:       file:line selector (e.g., "spec/auth_spec.rb:42") or example id
+#   mvn/gradle:  test class or class#method (e.g., "com.example.AuthTest")
 #
 # Auto-detects the test runner from the project's manifest files. If multiple runners
 # are present (e.g., a monorepo), pass --runner explicitly.
 #
-# Exits 0 on success (polluter identified), 1 on no polluter found, 2 on usage error,
-# 3 on runner-not-detected.
+# IMPORTANT CAVEAT — test ordering: most runners parallelize or randomize within a
+# single invocation. This script enforces ordering by invoking the subset and the
+# target in separate runner calls where possible (cargo, mvn, gradle) and by using
+# --runInBand / -n 0 flags where the runner supports them (jest, vitest, pytest).
+# If the runner randomizes even with those flags, consider disabling randomization
+# (e.g., pytest-randomly's --randomly-seed=0, gotest -shuffle=off) via your project
+# config before running this script.
+#
+# Exits 0 on success, 1 on no polluter found, 2 on usage error, 3 on runner-not-detected.
 
 set -euo pipefail
 
@@ -25,19 +40,40 @@ while [[ $# -gt 0 ]]; do
     --runner)     runner="$2"; shift 2 ;;
     --candidates) candidates_file="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,18p' "$0"
+      sed -n '2,26p' "$0"
       exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
 if [[ -z "$target" ]]; then
-  echo "error: --target is required" >&2
+  echo "error: --target is required (runner-native selector, not a test title)" >&2
   exit 2
 fi
 
 # --------------------------------------------------------------------
-# Auto-detect test runner from project manifests
+# Detect the JS package manager (pnpm > yarn > npm > bun)
+# --------------------------------------------------------------------
+detect_js_pm() {
+  if   command -v pnpm >/dev/null 2>&1 && [[ -f pnpm-lock.yaml ]]; then echo pnpm
+  elif command -v yarn >/dev/null 2>&1 && [[ -f yarn.lock ]]; then     echo yarn
+  elif command -v bun  >/dev/null 2>&1 && [[ -f bun.lockb  ]]; then    echo bun
+  else echo npm
+  fi
+}
+
+# Turn a package manager name into the prefix for running a local binary.
+js_exec() {
+  case "$(detect_js_pm)" in
+    pnpm) echo "pnpm exec" ;;
+    yarn) echo "yarn" ;;  # yarn can run a binary directly: `yarn jest args`
+    bun)  echo "bunx" ;;
+    npm)  echo "npx" ;;
+  esac
+}
+
+# --------------------------------------------------------------------
+# Auto-detect test runner
 # --------------------------------------------------------------------
 detect_runner() {
   if [[ -f package.json ]]; then
@@ -63,52 +99,98 @@ if [[ "$runner" == "none" ]]; then
   exit 3
 fi
 
+JS_EXEC="$(js_exec)"
+
 # --------------------------------------------------------------------
-# Build the list of candidate pre-tests
+# Build the list of candidate pre-tests — runner-native selectors ONLY
 # --------------------------------------------------------------------
 list_all_tests() {
   case "$runner" in
     jest|vitest)
-      # enumerate test files by convention
+      # file-path candidates (runners accept these directly)
       find . -type f \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.spec.ts' -o -name '*.spec.js' \) -not -path './node_modules/*' | sort ;;
     pytest)
-      # pytest --collect-only -q prints test ids
-      pytest --collect-only -q 2>/dev/null | grep -v '^$' | head -n -2 ;;
+      # --collect-only -q prints nodeids followed by a summary line.
+      # Keep only lines matching a nodeid shape (path::something) to avoid the trailing summary.
+      pytest --collect-only -q 2>/dev/null | grep -E '^[^[:space:]]+::[^[:space:]]+' | sort -u ;;
     cargo)
-      # cargo test -- --list lists tests in format "<name>: test"
+      # cargo test -- --list lists tests as "<name>: test"
       cargo test --no-run 2>/dev/null >/dev/null
       cargo test -- --list 2>/dev/null | grep ': test$' | sed 's/: test$//' ;;
     gotest)
-      # go test enumerates via go test -list
-      go test -list '.*' ./... 2>/dev/null | grep -v '^ok\|^PASS\|^FAIL' ;;
+      # Emit go test -run patterns (regex-anchored test function names)
+      go test -list '.*' ./... 2>/dev/null \
+        | grep -E '^Test|^Example|^Benchmark' \
+        | sed 's/^/^/; s/$/$/' ;;
     rspec)
-      bundle exec rspec --dry-run --format documentation 2>/dev/null | grep -E '^\s+it ' ;;
+      # Use --dry-run with the examples formatter to get runnable file:line selectors
+      bundle exec rspec --dry-run --format json 2>/dev/null \
+        | python3 -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(e["file_path"]+":"+str(e["line_number"]) for e in d.get("examples",[])))' ;;
     mvn)
-      find . -name '*Test.java' -not -path '*/target/*' | sort ;;
+      # Extract test class names from source files — mvn -Dtest expects class names
+      find . -name '*Test.java' -not -path '*/target/*' \
+        | sed 's|.*/\([^/]*\)\.java$|\1|' \
+        | sort -u ;;
     gradle)
-      find . -name '*Test.kt' -o -name '*Test.java' | grep -v build/ | sort ;;
+      # Same as mvn — gradle --tests expects class or class.method patterns
+      find . \( -name '*Test.kt' -o -name '*Test.java' \) -not -path '*/build/*' \
+        | sed 's|.*/\([^/]*\)\.\(kt\|java\)$|\1|' \
+        | sort -u ;;
     *) echo "error: unknown runner: $runner" >&2; exit 2 ;;
   esac
 }
 
 # --------------------------------------------------------------------
-# Run a subset of tests plus the target; return 0 if target passes
+# Run a subset of tests THEN the target, in order. Return 0 if target passes.
 # --------------------------------------------------------------------
 run_subset_then_target() {
   local subset="$1"
   case "$runner" in
-    jest)    pnpm exec jest --runInBand $subset "$target" >/dev/null 2>&1 ;;
-    vitest)  pnpm exec vitest run $subset "$target" >/dev/null 2>&1 ;;
-    pytest)  pytest $subset "$target" -q >/dev/null 2>&1 ;;
+    jest)
+      # --runInBand forces serial within one invocation; we invoke twice to force ordering.
+      if [[ -n "$subset" ]]; then
+        $JS_EXEC jest --runInBand $subset >/dev/null 2>&1 || true
+      fi
+      $JS_EXEC jest --runInBand "$target" >/dev/null 2>&1
+      ;;
+    vitest)
+      if [[ -n "$subset" ]]; then
+        $JS_EXEC vitest run --no-file-parallelism $subset >/dev/null 2>&1 || true
+      fi
+      $JS_EXEC vitest run --no-file-parallelism "$target" >/dev/null 2>&1
+      ;;
+    pytest)
+      # -p no:randomly disables pytest-randomly if present
+      if [[ -n "$subset" ]]; then
+        pytest -p no:randomly -q $subset >/dev/null 2>&1 || true
+      fi
+      pytest -p no:randomly -q "$target" >/dev/null 2>&1
+      ;;
     cargo)
-      # cargo test runs in arbitrary order; to impose order, use separate invocations
-      # subset first (ignore failures), then target
-      for t in $subset; do cargo test "$t" >/dev/null 2>&1 || true; done
-      cargo test "$target" >/dev/null 2>&1 ;;
-    gotest)  go test -run "$(echo $subset $target | tr ' ' '|')" ./... >/dev/null 2>&1 ;;
-    rspec)   bundle exec rspec $subset "$target" >/dev/null 2>&1 ;;
-    mvn)     mvn -q test -Dtest="$(echo $subset $target | tr ' ' ',')" >/dev/null 2>&1 ;;
-    gradle)  ./gradlew test $(for t in $subset "$target"; do echo --tests "$t"; done) >/dev/null 2>&1 ;;
+      for t in $subset; do cargo test "$t" -- --test-threads=1 >/dev/null 2>&1 || true; done
+      cargo test "$target" -- --test-threads=1 >/dev/null 2>&1 ;;
+    gotest)
+      # -shuffle=off turns off internal test shuffling; -p 1 avoids package-level parallelism
+      if [[ -n "$subset" ]]; then
+        go test -shuffle=off -p 1 -run "$(echo $subset | tr ' ' '|')" ./... >/dev/null 2>&1 || true
+      fi
+      go test -shuffle=off -p 1 -run "$target" ./... >/dev/null 2>&1 ;;
+    rspec)
+      if [[ -n "$subset" ]]; then
+        bundle exec rspec --order defined $subset >/dev/null 2>&1 || true
+      fi
+      bundle exec rspec --order defined "$target" >/dev/null 2>&1 ;;
+    mvn)
+      # mvn surefire has no ordering guarantee between -Dtest classes, so invoke twice
+      if [[ -n "$subset" ]]; then
+        mvn -q -Dsurefire.runOrder=alphabetical test -Dtest="$(echo $subset | tr ' ' ',')" >/dev/null 2>&1 || true
+      fi
+      mvn -q test -Dtest="$target" >/dev/null 2>&1 ;;
+    gradle)
+      if [[ -n "$subset" ]]; then
+        ./gradlew test $(for t in $subset; do echo --tests "$t"; done) >/dev/null 2>&1 || true
+      fi
+      ./gradlew test --tests "$target" >/dev/null 2>&1 ;;
   esac
 }
 
@@ -127,6 +209,7 @@ if [[ ${#candidates[@]} -eq 0 ]]; then
 fi
 
 echo "runner: $runner"
+[[ "$runner" == "jest" || "$runner" == "vitest" ]] && echo "js package manager: $(detect_js_pm)"
 echo "target: $target"
 echo "candidates: ${#candidates[@]}"
 
@@ -139,7 +222,7 @@ fi
 # Confirm the full set triggers the failure
 full_set="$(IFS=' '; echo "${candidates[*]}")"
 if run_subset_then_target "$full_set"; then
-  echo "target passes after full candidate set — no polluter found" >&2
+  echo "target passes after full candidate set — no polluter found (or runner still randomizing)" >&2
   exit 1
 fi
 
@@ -156,20 +239,15 @@ while (( lo < hi )); do
   first_half=("${candidates[@]:lo:$((mid - lo + 1))}")
   subset="$(IFS=' '; echo "${first_half[*]}")"
   if run_subset_then_target "$subset"; then
-    # first half passes → polluter in second half
     lo=$((mid + 1))
   else
-    # first half fails → polluter in first half
     hi=$mid
   fi
-  echo "range [$lo, $hi] (${#candidates[@]} candidates total)"
+  echo "range [$lo, $hi]"
 done
 
 polluter="${candidates[$lo]}"
 
-# --------------------------------------------------------------------
-# Report
-# --------------------------------------------------------------------
 cat <<EOF
 
 ================================================================
@@ -179,21 +257,21 @@ minimal reproduction:
 EOF
 
 case "$runner" in
-  jest)    echo "  pnpm exec jest --runInBand $polluter $target" ;;
-  vitest)  echo "  pnpm exec vitest run $polluter $target" ;;
-  pytest)  echo "  pytest $polluter $target -q" ;;
-  cargo)   echo "  cargo test $polluter && cargo test $target" ;;
-  gotest)  echo "  go test -run '$(basename $polluter)|$(basename $target)' ./..." ;;
-  rspec)   echo "  bundle exec rspec $polluter $target" ;;
-  mvn)     echo "  mvn -q test -Dtest=\"$polluter,$target\"" ;;
-  gradle)  echo "  ./gradlew test --tests $polluter --tests $target" ;;
+  jest)    echo "  $JS_EXEC jest --runInBand $polluter && $JS_EXEC jest --runInBand $target" ;;
+  vitest)  echo "  $JS_EXEC vitest run --no-file-parallelism $polluter && $JS_EXEC vitest run --no-file-parallelism $target" ;;
+  pytest)  echo "  pytest -p no:randomly $polluter && pytest -p no:randomly $target" ;;
+  cargo)   echo "  cargo test $polluter -- --test-threads=1 && cargo test $target -- --test-threads=1" ;;
+  gotest)  echo "  go test -shuffle=off -p 1 -run '$polluter' ./... && go test -shuffle=off -p 1 -run '$target' ./..." ;;
+  rspec)   echo "  bundle exec rspec --order defined $polluter $target" ;;
+  mvn)     echo "  mvn test -Dtest=\"$polluter\" && mvn test -Dtest=\"$target\"" ;;
+  gradle)  echo "  ./gradlew test --tests $polluter && ./gradlew test --tests $target" ;;
 esac
 
 cat <<EOF
 
 next action: read $polluter and identify what shared state it mutates
   (in-memory cache, global singleton, module-level config, on-disk file).
-  the polluter's teardown is incomplete. either add per-test cleanup,
+  the polluter's teardown is incomplete. either add per-test cleanup
   or isolate the shared resource (fresh instance per test).
 
 see references/bisection-strategies.md § Test-pollution bisection for the

--- a/skills/debug-systematic/skills/debug-systematic/scripts/find-polluter.sh
+++ b/skills/debug-systematic/skills/debug-systematic/scripts/find-polluter.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# find-polluter.sh — multi-runner test-pollution binary search
+#
+# Given a test that passes alone but fails when run after other tests, binary-search
+# the pre-test list to find the smallest subset that triggers the failure.
+#
+# Usage:
+#   bash find-polluter.sh --target <test-id> [--runner auto|jest|vitest|pytest|cargo|gotest|rspec|mvn|gradle] [--candidates <file>]
+#
+# Auto-detects the test runner from the project's manifest files. If multiple runners
+# are present (e.g., a monorepo), pass --runner explicitly.
+#
+# Exits 0 on success (polluter identified), 1 on no polluter found, 2 on usage error,
+# 3 on runner-not-detected.
+
+set -euo pipefail
+
+target=""
+runner="auto"
+candidates_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)     target="$2"; shift 2 ;;
+    --runner)     runner="$2"; shift 2 ;;
+    --candidates) candidates_file="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$target" ]]; then
+  echo "error: --target is required" >&2
+  exit 2
+fi
+
+# --------------------------------------------------------------------
+# Auto-detect test runner from project manifests
+# --------------------------------------------------------------------
+detect_runner() {
+  if [[ -f package.json ]]; then
+    if grep -qE '"(jest|ts-jest)"\s*:' package.json 2>/dev/null; then echo jest; return
+    elif grep -qE '"vitest"\s*:' package.json 2>/dev/null; then echo vitest; return
+    fi
+  fi
+  [[ -f pyproject.toml || -f pytest.ini || -f setup.cfg ]] && { echo pytest; return; }
+  [[ -f Cargo.toml ]] && { echo cargo; return; }
+  [[ -f go.mod ]] && { echo gotest; return; }
+  [[ -f Gemfile ]] && { echo rspec; return; }
+  [[ -f pom.xml ]] && { echo mvn; return; }
+  [[ -f build.gradle || -f build.gradle.kts ]] && { echo gradle; return; }
+  echo none
+}
+
+if [[ "$runner" == "auto" ]]; then
+  runner="$(detect_runner)"
+fi
+
+if [[ "$runner" == "none" ]]; then
+  echo "error: no test-runner manifest found (package.json / pyproject.toml / Cargo.toml / go.mod / Gemfile / pom.xml / build.gradle)" >&2
+  exit 3
+fi
+
+# --------------------------------------------------------------------
+# Build the list of candidate pre-tests
+# --------------------------------------------------------------------
+list_all_tests() {
+  case "$runner" in
+    jest|vitest)
+      # enumerate test files by convention
+      find . -type f \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.spec.ts' -o -name '*.spec.js' \) -not -path './node_modules/*' | sort ;;
+    pytest)
+      # pytest --collect-only -q prints test ids
+      pytest --collect-only -q 2>/dev/null | grep -v '^$' | head -n -2 ;;
+    cargo)
+      # cargo test -- --list lists tests in format "<name>: test"
+      cargo test --no-run 2>/dev/null >/dev/null
+      cargo test -- --list 2>/dev/null | grep ': test$' | sed 's/: test$//' ;;
+    gotest)
+      # go test enumerates via go test -list
+      go test -list '.*' ./... 2>/dev/null | grep -v '^ok\|^PASS\|^FAIL' ;;
+    rspec)
+      bundle exec rspec --dry-run --format documentation 2>/dev/null | grep -E '^\s+it ' ;;
+    mvn)
+      find . -name '*Test.java' -not -path '*/target/*' | sort ;;
+    gradle)
+      find . -name '*Test.kt' -o -name '*Test.java' | grep -v build/ | sort ;;
+    *) echo "error: unknown runner: $runner" >&2; exit 2 ;;
+  esac
+}
+
+# --------------------------------------------------------------------
+# Run a subset of tests plus the target; return 0 if target passes
+# --------------------------------------------------------------------
+run_subset_then_target() {
+  local subset="$1"
+  case "$runner" in
+    jest)    pnpm exec jest --runInBand $subset "$target" >/dev/null 2>&1 ;;
+    vitest)  pnpm exec vitest run $subset "$target" >/dev/null 2>&1 ;;
+    pytest)  pytest $subset "$target" -q >/dev/null 2>&1 ;;
+    cargo)
+      # cargo test runs in arbitrary order; to impose order, use separate invocations
+      # subset first (ignore failures), then target
+      for t in $subset; do cargo test "$t" >/dev/null 2>&1 || true; done
+      cargo test "$target" >/dev/null 2>&1 ;;
+    gotest)  go test -run "$(echo $subset $target | tr ' ' '|')" ./... >/dev/null 2>&1 ;;
+    rspec)   bundle exec rspec $subset "$target" >/dev/null 2>&1 ;;
+    mvn)     mvn -q test -Dtest="$(echo $subset $target | tr ' ' ',')" >/dev/null 2>&1 ;;
+    gradle)  ./gradlew test $(for t in $subset "$target"; do echo --tests "$t"; done) >/dev/null 2>&1 ;;
+  esac
+}
+
+# --------------------------------------------------------------------
+# Load candidates
+# --------------------------------------------------------------------
+if [[ -n "$candidates_file" ]]; then
+  mapfile -t candidates < "$candidates_file"
+else
+  mapfile -t candidates < <(list_all_tests | grep -v -F "$target")
+fi
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  echo "no candidate pre-tests found" >&2
+  exit 1
+fi
+
+echo "runner: $runner"
+echo "target: $target"
+echo "candidates: ${#candidates[@]}"
+
+# Baseline: does the target pass alone?
+if ! run_subset_then_target ""; then
+  echo "target fails in isolation — not a pollution issue" >&2
+  exit 1
+fi
+
+# Confirm the full set triggers the failure
+full_set="$(IFS=' '; echo "${candidates[*]}")"
+if run_subset_then_target "$full_set"; then
+  echo "target passes after full candidate set — no polluter found" >&2
+  exit 1
+fi
+
+# --------------------------------------------------------------------
+# Binary search
+# --------------------------------------------------------------------
+echo "bisecting ${#candidates[@]} candidates..."
+
+lo=0
+hi=$((${#candidates[@]} - 1))
+
+while (( lo < hi )); do
+  mid=$(( (lo + hi) / 2 ))
+  first_half=("${candidates[@]:lo:$((mid - lo + 1))}")
+  subset="$(IFS=' '; echo "${first_half[*]}")"
+  if run_subset_then_target "$subset"; then
+    # first half passes → polluter in second half
+    lo=$((mid + 1))
+  else
+    # first half fails → polluter in first half
+    hi=$mid
+  fi
+  echo "range [$lo, $hi] (${#candidates[@]} candidates total)"
+done
+
+polluter="${candidates[$lo]}"
+
+# --------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------
+cat <<EOF
+
+================================================================
+polluting test identified: $polluter
+
+minimal reproduction:
+EOF
+
+case "$runner" in
+  jest)    echo "  pnpm exec jest --runInBand $polluter $target" ;;
+  vitest)  echo "  pnpm exec vitest run $polluter $target" ;;
+  pytest)  echo "  pytest $polluter $target -q" ;;
+  cargo)   echo "  cargo test $polluter && cargo test $target" ;;
+  gotest)  echo "  go test -run '$(basename $polluter)|$(basename $target)' ./..." ;;
+  rspec)   echo "  bundle exec rspec $polluter $target" ;;
+  mvn)     echo "  mvn -q test -Dtest=\"$polluter,$target\"" ;;
+  gradle)  echo "  ./gradlew test --tests $polluter --tests $target" ;;
+esac
+
+cat <<EOF
+
+next action: read $polluter and identify what shared state it mutates
+  (in-memory cache, global singleton, module-level config, on-disk file).
+  the polluter's teardown is incomplete. either add per-test cleanup,
+  or isolate the shared resource (fresh instance per test).
+
+see references/bisection-strategies.md § Test-pollution bisection for the
+fix recipe once you've identified the shared-state mutation.
+================================================================
+EOF
+
+exit 0


### PR DESCRIPTION
## Summary

Language-agnostic systematic debugging skill ported from `obra/superpowers/systematic-debugging`, upgraded to be significantly more capable: 7-language coverage, explicit integration with this pack's discipline skills (`think-deeper`, `do-brainstorm`, `check-completion`), and 16-runtime ask-user-tool portability.

## Context

Ported obra's 11-file systematic-debugging skill into this pack. Research (obra source + local-repo conventions + adjacent skills) was done in plan mode; design approved; implementation followed the approved plan verbatim.

## Workflow

1. **Investigation** — symptom card + 10/10 deterministic repro + copy-pasteable evidence
2. **Pattern analysis** — ranked candidate mechanisms via `root-cause-tracing.md` backward trace
3. **Hypothesis testing** — falsification prediction stated before running the experiment
4. **Implementation** — narrowest fix + regression guard + route to `check-completion`

Gate: Iron Law ("no fix before root cause"). Escalation: **3 failed fixes → route to `do-brainstorm`** (architecture-shaped, not a bug).

## Files touched

- `skills/debug-systematic/README.md` (new)
- `skills/debug-systematic/skills/debug-systematic/SKILL.md` (252 lines, under 500 guard)
- 22 reference files:
  - 11 top-level: workflow-deep, root-cause-tracing, condition-based-waiting, defense-in-depth, bisection-strategies, instrumentation, escalation, integration, rationalizations, voice, cross-runtime
  - 7 waiting/<lang>.md (TS/Python/Rust/Go/Swift/Ruby/Java)
  - 4 pressure-tests/*.md (academic, financial, sunk-cost, authority)
- `scripts/find-polluter.sh` — multi-runner auto-detect (jest/vitest/pytest/cargo/gotest/rspec/mvn/gradle)
- `NAMING.md` — broadened `debug-` prefix definition to cover method-specific (not just tool-specific) variants; added `debug-systematic` to canonical list
- `README.md` — added alphabetical table row; bumped skill count 54 → 55

## What's advanced over obra

| Feature | obra | this port |
|---|---|---|
| Language coverage | TS/Jest only | 7 languages (hub + per-language drop-ins) |
| Integration with sibling skills | None | First-class decision matrix in SKILL.md routing to `think-deeper` / `do-brainstorm` / `check-completion` |
| Ask-user-tool portability | Implicit | 16-runtime table mirroring `enhance-prompt/ask-user-tools.md` |
| Rationalizations | 3 pressure scenarios | 15-row verbatim table + 4 full pressure scenarios as standalone references |
| Persuasion framing | Authority-adjacent | Authority + Commitment + Scarcity (Meincke et al. 2025 cited in `voice.md`) |
| Bisection strategies | `find-polluter.sh` (Jest only) | `scripts/find-polluter.sh` (8 runners auto-detected) + `bisection-strategies.md` covering git bisect, feature-flag, input-space |
| 3-fails escalation | Mentioned | Fully specified — Fail 1 re-opens Phase 2, Fail 2 re-opens Phase 1, Fail 3 routes to `do-brainstorm` with handoff template |

## Verification

- `python3 scripts/validate-skills.py` → 55 skills, all pass
- Orphan-reference check: zero orphans; every reference cited from SKILL.md
- Line budgets: SKILL.md 252 (cap 500); largest reference `workflow-deep.md` 309 (has Contents TOC per the 300-line threshold); all others ≤ 200

## Weaknesses / open questions

1. **RED baseline not run** — the 4 pressure-test scenarios are shipped as reference files but have not yet been run against a fresh agent via `enhance-skill-by-derailment`. Reviewer please flag if this is blocking.
2. **Overlap with `think-deeper/workflows/bug-tracing.md`** — `debug-systematic` covers much of the same ground but with a stronger discipline (Iron Law, 3-fails gate, pressure scenarios). Documented the boundary in SKILL.md's trigger section. May warrant a reciprocal routing edit on `think-deeper` in a follow-up PR.
3. **`debug-` prefix broadening** — `NAMING.md`'s `debug-` was scoped to tool-specific. Broadened to cover method-specific variants. Reviewer should confirm this broadening is acceptable vs. using a different prefix (e.g., `plan-root-cause`).
4. **Cross-skill duplication** — the 16-runtime ask-user-tool table is duplicated in `enhance-prompt` + `do-brainstorm` + (now) `debug-systematic`. Intentional (one-level-deep rule; each skill standalone). Three copies to keep in sync when new runtimes emerge.

## Follow-ups (not in scope)

- Add reciprocal routing in `think-deeper/workflows/bug-tracing.md` pointing at `debug-systematic` for runtime-failure cases
- Run `enhance-skill-by-derailment` against each pressure scenario post-merge; iterate on rationalizations/voice if any `[STUCK]`/`[BROKE]` markers surface
- Consider a `debug-flaky-test` sibling skill specifically for intermittent failures once `debug-systematic` has field feedback

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `debug-systematic`, a language-agnostic debugging skill with a 4-phase method, Iron Law gate, and 3-fails escalation, plus a multi-runner test-pollution bisector. Follow-up fixes harden the language-specific polling utilities, stabilize the bisector across runners, and align rules and references.

- New Features
  - `skills/debug-systematic`: 4 phases (Investigation → Pattern analysis → Hypothesis testing → Implementation) with Iron Law and 3-fails handoff; integrates with `think-deeper`, `do-brainstorm`, and `check-completion`.
  - References and drop-ins: 11+ docs (workflow deep dive, root-cause tracing, instrumentation, bisection) and condition-based waiting for 7 languages; cross-runtime ask-user tool lookup for 16 runtimes.
  - `scripts/find-polluter.sh`: auto-detects and supports jest/vitest/pytest/cargo/gotest/rspec/mvn/gradle.

- Bug Fixes
  - Polling utilities: correct falsy handling (null/None semantics), add helpers (`waitUntil`, async count), enforce timeouts and exception scoping; clock/interval safety across Rust/Go/Swift/Java.
  - Bisector: package-manager autodetect (pnpm/yarn/bun/npm), stable-order flags, robust candidate discovery for pytest/rspec/mvn/gradle, and clarified selector contract; docs updated with per-runner selector table and feature-flag pair-bisection note.
  - Consistency: clarify SKILL.md diagnostic edits vs. product fixes, align the 3-fails rule in `escalation.md`, update Fail-3 options in `cross-runtime.md`, and refine `debug-` prefix wording in `NAMING.md`.
  - Content fixes: add `next()` in middleware example, correct Postgres upsert syntax, and fix env-var naming in the financial outage scenario.

<sup>Written for commit 9a8e81928ed651a2ffb3113de13595724a657660. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

