### PR TITLE
🐛 fix(build-mcp-use-agent): correct factual errors against mcp-use@1.25.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ DERAILMENT_TEST_INVENTION/
 derail-notes/
 derailment-notes/
 derail-results/
+
+# Scratch audit output (per-skill fact-check inventories). Not shipped with the pack.
+violations/
+
+# Temporary holding area for files whose fate has not yet been decided.
+to-delete/
+
+# Session artifacts from AI coding tools.
+.continues-handoff.md
+*.claude-session*

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/SKILL.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/SKILL.md
@@ -55,7 +55,7 @@ Check for context: is there an existing application that could benefit from an a
 
 **If no context exists:** Ask the user up to 10 questions, each with 5+ concrete options:
 
-1. **What LLM provider?** (OpenAI `gpt-4o`, Anthropic `claude-3-5-sonnet-20241022`, Google `gemini-pro`, Groq `llama-3.3-70b-versatile`, other)
+1. **What LLM provider?** (OpenAI `gpt-4o`, Anthropic `claude-sonnet-4-6` or `claude-opus-4-7`, Google `gemini-2.5-flash` or `gemini-2.5-pro`, Groq `llama-3.3-70b-versatile`, other)
 2. **Initialization mode?** (Explicit — hand-built LLM and client, Simplified — `"provider/model"` string shorthand)
 3. **What MCP servers to connect?** (filesystem, database, custom stdio, remote HTTP/SSE, none yet)
 4. **Output format?** (plain text via `run()`, structured Zod schema, streaming steps, streaming tokens, pretty terminal)
@@ -63,7 +63,7 @@ Check for context: is there an existing application that could benefit from an a
 6. **Need observability?** (Langfuse auto-init, Langfuse custom endpoint, custom callbacks, none)
 7. **Execution environment?** (CLI script, HTTP handler, serverless function, Next.js route, REPL/chat loop)
 8. **Max steps?** (5 default, 10-20 for complex tasks, 30+ for code-mode workflows)
-9. **Tool restrictions?** (block dangerous tools via `disallowedTools`, narrow tool set via `toolsUsedNames`, no restrictions)
+9. **Tool restrictions?** (block dangerous tools via `disallowedTools`, inject extra tools via `additionalTools`, control resource/prompt surface via `exposeResourcesAsTools` / `exposePromptsAsTools`, no restrictions)
 10. **Advanced needs?** (code mode, server manager for multi-server routing, provider failover, none)
 
 Then build the agent using the quick start patterns below and the relevant references.
@@ -110,6 +110,8 @@ Use when you need full control over the model instance, `MCPClient`, callbacks, 
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
 
+// MCPClient accepts a second MCPClientOptions argument for codeMode,
+// onSampling, onElicitation, onNotification handlers. Omit it for plain agents.
 const client = new MCPClient({
   mcpServers: {
     filesystem: {
@@ -195,23 +197,35 @@ For the full options table with all defaults, read `references/guides/agent-conf
 |---|---|---|---|
 | `llm` | LangChain model or `"provider/model"` | required | The LLM to use (must support tool calling) |
 | `client` / `connectors` | `MCPClient` / `BaseConnector[]` | — | MCP server connection (explicit mode) |
-| `mcpServers` | server config record | — | Inline server config (simplified mode) |
+| `mcpServers` | server config record | — | Inline server config (simplified mode only) |
+| `llmConfig` | `LLMConfig` | — | Simplified mode only — `{ apiKey, temperature, maxTokens, topP, ... }` forwarded to the LLM constructor |
 | `maxSteps` | `number` | `5` | Cap on tool-call loops |
 | `autoInitialize` | `boolean` | `false` | Pre-connect sessions on construction |
 | `memoryEnabled` | `boolean` | `true` | Stateful conversation across turns |
 | `systemPrompt` | `string \| null` | `null` | Full prompt override |
+| `systemPromptTemplate` | `string \| null` | `null` | Override the default prompt template while keeping the tools/instructions scaffolding |
 | `additionalInstructions` | `string \| null` | `null` | Layer extra behavior on default prompt |
-| `disallowedTools` | `string[]` | `[]` | Block dangerous or irrelevant tools |
+| `disallowedTools` | `string[]` | `[]` | Block dangerous or irrelevant tools (real access filter) |
+| `additionalTools` | `StructuredToolInterface[]` | `[]` | Inject extra LangChain tools alongside MCP-sourced tools |
+| `exposeResourcesAsTools` | `boolean` | provider default | Expose MCP resources as callable tools |
+| `exposePromptsAsTools` | `boolean` | provider default | Expose MCP prompts as callable tools |
 | `useServerManager` | `boolean` | `false` | Multi-server routing (advanced) |
+| `serverManagerFactory` | `(client: MCPClient) => ServerManager` | default | Inject a custom `ServerManager` implementation |
+| `adapter` | `LangChainAdapter` | default | Override the MCP-tool → LangChain-tool adapter |
+| `observe` | `boolean` | `true` | Toggle observability manager wiring; set `false` to skip Langfuse even if env vars are set |
 | `callbacks` | `BaseCallbackHandler[]` | `[]` | Langfuse or custom callback hooks |
 | `verbose` | `boolean` | `false` | Debug logging |
+| `agentId` / `apiKey` / `baseUrl` | strings | — | Switch to **remote mode** — proxies run/stream to an mcp-use remote runtime instead of executing locally (no local LLM or client needed) |
+| `toolsUsedNames` | `string[]` | `[]` | Reporting field — seeds the post-run tools-used list. **Not** an access filter; use `disallowedTools` for that |
 
 ### `run()` signatures
 
 | Style | Example | When |
 |---|---|---|
-| Plain string | `await agent.run("Summarize...")` | Simple one-shot |
-| Object form | `await agent.run({ prompt, maxSteps, schema, tags, metadata, signal })` | Production, typed output, cancellation |
+| Plain string | `await agent.run("Summarize...")` | Simple one-shot (deprecated overload) |
+| Object form | `await agent.run({ prompt, maxSteps, manageConnector, externalHistory, schema, signal })` | Production, typed output, cancellation |
+
+`RunOptions` fields: `prompt` (required), `maxSteps`, `manageConnector` (defaults to `true` — pass `false` when the caller owns connector lifetime), `externalHistory` (override conversation history for this call), `schema` (Zod schema for typed output), `signal` (`AbortSignal`). Tags and metadata are **agent-wide**, not per-call — set them via `agent.setTags([...])` and `agent.setMetadata({...})` before calling `run()`.
 
 ### Streaming methods
 
@@ -230,13 +244,15 @@ Each step yielded by `stream()` represents one tool-call cycle. `step.observatio
 ```typescript
 interface AgentStep {
   action: {
-    tool: string;            // Tool selected by the agent
-    toolInput: Record<string, any>; // Arguments passed to the tool
-    log: string;             // LLM reasoning before tool selection
+    tool: string;     // Tool selected by the agent
+    toolInput: any;   // Arguments passed to the tool (any — could be string, object, etc.)
+    log: string;      // LLM reasoning text — often empty in tool-calling agents
   };
-  observation: string;       // Always "" at yield time
+  observation: string;  // Always "" at yield time
 }
 ```
+
+`step.action.log` is often empty in tool-calling agents because the model emits the intent through structured tool calls rather than reasoning text. The underlying LangChain runtime sometimes attaches `messageLog: BaseMessage[]` and `toolCallId: string` to the same `action` object — they are not declared on mcp-use's `AgentStep`, so cast to `any` to inspect them. Prefer those for correlating tool calls with `on_tool_start` / `on_tool_end` events emitted by `streamEvents()`. Also: do not `JSON.stringify(step.action.toolInput)` blindly — when it's already a string the result is double-encoded.
 
 #### `streamEvents()` example
 
@@ -312,25 +328,50 @@ For advanced code-mode patterns, read `references/guides/advanced-patterns.md`.
 
 ### Companion packages
 
+`mcp-use@1.25.0` requires LangChain v1 and Zod v4 as peers. The full `mcp-use` surface includes: `MCPAgent`, `MCPClient`, `MCPSession`, `RemoteAgent`, connector classes (`StdioConnector`, `HttpConnector`, `BaseConnector`), `loadConfigFile`, `ServerManager`, `ObservabilityManager`, `Telemetry`, OAuth helpers (`BrowserOAuthClientProvider`, `onMcpAuthorization`, `probeAuthParams`), code-execution ancillaries (`BaseCodeExecutor`, `E2BCodeExecutor`, `VMCodeExecutor`), elicitation helpers (`accept`, `decline`, `reject`, `validate`), and `PROMPTS`.
+
+#### Declared peer dependencies
+
+| Package | Required version | Purpose |
+|---|---|---|
+| `@langchain/core` | `^1.1.0` | LangChain v1 core types and message classes |
+| `@langchain/openai` | `^1.2.0` | `ChatOpenAI` — pair with `OPENAI_API_KEY` |
+| `@langchain/anthropic` | `^1.3.0` | `ChatAnthropic` — pair with `ANTHROPIC_API_KEY` |
+| `langchain` | `^1.2.10` | LangChain v1 runtime |
+| `langfuse`, `langfuse-langchain` | `^3.38.6` | Observability (auto-init when env vars set) |
+| `zod` | **`^4.0.0`** | Structured-output schemas (Zod v4 required) |
+| `@e2b/code-interpreter` | `^2.2.0` | Code-execution sandbox |
+| `react`, `react-router` | `^18 || ^19`, `^7.12.0` | React widget exports |
+
+All `@langchain/*`, `langchain`, `langfuse`, `langfuse-langchain`, and `@e2b/code-interpreter` are marked optional in `peerDependenciesMeta` — install only the providers you actually use. `zod`, `react`, and `react-router` are strictly required.
+
+#### Optional LLM adapters (NOT peer-declared)
+
+| Package | Purpose | Note |
+|---|---|---|
+| `@langchain/google-genai` | `ChatGoogleGenerativeAI` — `GOOGLE_API_KEY` | Not a peer dep — install only if using Gemini |
+| `@langchain/groq` | `ChatGroq` — `GROQ_API_KEY` | Not a peer dep — install only if using Groq |
+
+Both must remain LangChain v1 compatible. The `"google/..."` and `"groq/..."` simplified-mode shorthands fail at runtime if the matching adapter is missing.
+
+#### Other helpers
+
 | Package | Purpose |
 |---|---|
-| `mcp-use` | `MCPAgent`, `MCPClient`, streaming helpers |
-| `@langchain/openai` | `ChatOpenAI` — pair with `OPENAI_API_KEY` |
-| `@langchain/anthropic` | `ChatAnthropic` — pair with `ANTHROPIC_API_KEY` |
-| `@langchain/google-genai` | `ChatGoogleGenerativeAI` — pair with `GOOGLE_API_KEY` |
-| `@langchain/groq` | `ChatGroq` — pair with `GROQ_API_KEY` |
-| `zod` | Structured output schemas |
-| `langfuse-langchain` | Custom Langfuse endpoint callbacks only |
 | `dotenv` | Local dev env loading |
+
+If your codebase is on LangChain v0.x or Zod v3, plan the upgrade before adopting `mcp-use@1.25.0` — peer-dep mismatches surface as runtime tool-calling failures and JSON-schema serialization bugs.
 
 ## Provider quick reference
 
-| Provider | Model | String shorthand | Package | Env var |
-|---|---|---|---|---|
-| OpenAI | `gpt-4o` | `"openai/gpt-4o"` | `@langchain/openai` | `OPENAI_API_KEY` |
-| Anthropic | `claude-3-5-sonnet-20241022` | `"anthropic/claude-3-5-sonnet-20241022"` | `@langchain/anthropic` | `ANTHROPIC_API_KEY` |
-| Google | `gemini-pro` | `"google/gemini-pro"` | `@langchain/google-genai` | `GOOGLE_API_KEY` |
-| Groq | `llama-3.3-70b-versatile` | `"groq/llama-3.3-70b-versatile"` | `@langchain/groq` | `GROQ_API_KEY` |
+| Provider | Model | String shorthand | Package | Peer? | Env var |
+|---|---|---|---|---|---|
+| OpenAI | `gpt-4o` | `"openai/gpt-4o"` | `@langchain/openai` | peer (optional) | `OPENAI_API_KEY` |
+| Anthropic | `claude-sonnet-4-6` | `"anthropic/claude-sonnet-4-6"` | `@langchain/anthropic` | peer (optional) | `ANTHROPIC_API_KEY` |
+| Google | `gemini-2.5-flash` | `"google/gemini-2.5-flash"` | `@langchain/google-genai` | NOT a peer dep | `GOOGLE_API_KEY` |
+| Groq | `llama-3.3-70b-versatile` | `"groq/llama-3.3-70b-versatile"` | `@langchain/groq` | NOT a peer dep | `GROQ_API_KEY` |
+
+`@langchain/google-genai` and `@langchain/groq` are not declared peers of `mcp-use@1.25.0`; install them separately if you use those providers. Anthropic models: prefer `claude-opus-4-7` for deep reasoning, `claude-sonnet-4-6` for general MCP-agent workloads. Verify Google and Groq model IDs against their respective consoles before shipping — model IDs are deprecated frequently.
 
 For full provider details, failover, and custom adapters, read `references/guides/llm-integration.md`.
 
@@ -385,6 +426,8 @@ For dynamic server switching and multi-server patterns, read `references/guides/
 | Manual `CallbackHandler` for basic Langfuse | Unnecessary boilerplate | Use env var auto-initialization |
 | Enabling `useServerManager` by default | Adds complexity to simple agents | Enable only for multi-server routing |
 | Forgetting `client.closeAllSessions()` | Orphaned server processes | Call in `finally` when you own the client |
+| Passing `tags` / `metadata` inside `RunOptions` | Not fields of `RunOptions` — TypeScript rejects them, Langfuse never receives them | Use `agent.setTags([...])` / `agent.setMetadata({...})` once, before `run()` |
+| Using `toolsUsedNames` to narrow allowed tools | It is a reporting field populated as the agent runs, not an access filter | Use `disallowedTools` to remove tools, `additionalTools` to add, `exposeResourcesAsTools` / `exposePromptsAsTools` for the resource/prompt surface |
 
 ## Do / Don't
 

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/agent-recipes.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/agent-recipes.md
@@ -1070,7 +1070,9 @@ main().catch((err) => {
 
 ## 10. Agent with Tool Restrictions
 
-Uses `setDisallowedTools()` to block specific tools at runtime. Demonstrates environment-based restrictions (e.g., blocking write operations in production) and dynamic restriction changes during agent lifecycle.
+Uses `setDisallowedTools()` to block specific tools. Demonstrates environment-based restrictions (e.g., blocking write operations in production) and how to apply restriction changes during the agent lifecycle.
+
+> **Important — restrictions are bound at `initialize()` time.** `setDisallowedTools()` only updates the stored list; the bound `AgentExecutor` and tool list are not rebuilt. If the agent is already initialized (e.g., a previous `run()` ran), you MUST call `await agent.initialize()` after `setDisallowedTools()` for the change to take effect. Source code logs `"Agent already initialized. Changes will take effect on next initialization."` in this case.
 
 ---
 
@@ -1079,9 +1081,13 @@ Uses `setDisallowedTools()` to block specific tools at runtime. Demonstrates env
  * Recipe 10 — Agent with Tool Restrictions
  *
  * Shows how to restrict which tools an agent can use:
- *   - setDisallowedTools(tools) — block a list of tool names
+ *   - setDisallowedTools(tools) — set the disallowed list
  *   - getDisallowedTools()      — inspect current restrictions
  *   - Environment-based restrictions (prod vs dev)
+ *
+ * IMPORTANT: setDisallowedTools() must be called BEFORE the first run()
+ * (or initialize()), OR followed by an explicit initialize() call to
+ * rebuild the executor's tool bindings.
  *
  * Requirements:
  *   OPENAI_API_KEY in environment
@@ -1117,7 +1123,8 @@ async function main(): Promise<void> {
     "move_file",
   ];
 
-  // Apply restrictions based on environment
+  // Apply restrictions BEFORE first initialize()/run() — these will be bound
+  // when the agent is initialized inside the first run() call.
   const blockedTools = isProduction ? prodBlockedTools : devBlockedTools;
   agent.setDisallowedTools(blockedTools);
 
@@ -1125,7 +1132,8 @@ async function main(): Promise<void> {
   console.log(`🚫 Blocked tools: ${agent.getDisallowedTools().join(", ")}\n`);
 
   try {
-    // Task 1: Read-only operation (should work in both environments)
+    // Task 1: Read-only operation (first run() — initializes the agent
+    // with the restrictions defined above)
     console.log("--- Task 1: Read-only operation ---\n");
     const readResult = await agent.run({
       prompt: "List the files in the current directory and read any README.md.",
@@ -1133,7 +1141,7 @@ async function main(): Promise<void> {
     });
     console.log(readResult);
 
-    // Task 2: Write operation (blocked in production)
+    // Task 2: Write operation (blocked in production by the bound list)
     console.log("\n--- Task 2: Attempting write operation ---\n");
     const writeResult = await agent.run({
       prompt: `Try to create a file called "test-output.txt" with the content
@@ -1142,10 +1150,14 @@ async function main(): Promise<void> {
     });
     console.log(writeResult);
 
-    // Dynamic restriction change — unlock write for a specific task
+    // Dynamic restriction change — unlock write for a specific task.
+    // The agent is ALREADY initialized at this point, so updating the
+    // disallowed list alone is a no-op. We must re-initialize to rebuild
+    // the bound LangChain tool list and AgentExecutor.
     if (isProduction) {
       console.log("\n--- Temporarily unlocking write for a specific task ---\n");
-      agent.setDisallowedTools([]); // Clear all restrictions
+      agent.setDisallowedTools([]);          // update internal list
+      await agent.initialize();              // REBUILD executor + tool bindings
       console.log(`🔓 Restrictions cleared: ${agent.getDisallowedTools().length} blocked tools`);
 
       const unlocked = await agent.run({
@@ -1154,8 +1166,9 @@ async function main(): Promise<void> {
       });
       console.log(unlocked);
 
-      // Re-apply restrictions
+      // Re-apply restrictions — again, must re-initialize for it to take effect.
       agent.setDisallowedTools(prodBlockedTools);
+      await agent.initialize();
       console.log(`\n🔒 Restrictions re-applied: ${agent.getDisallowedTools().join(", ")}`);
     }
   } finally {
@@ -1171,11 +1184,11 @@ main().catch((err) => {
 
 **Key takeaways:**
 
-- `setDisallowedTools([...])` blocks specific tool names — the agent will refuse to call them.
-- `getDisallowedTools()` returns the current list of blocked tools.
-- Use environment variables (`NODE_ENV`) to apply different restriction profiles.
-- Restrictions can be changed dynamically between `run()` calls.
-- Clearing restrictions with `setDisallowedTools([])` unlocks all tools.
+- `setDisallowedTools([...])` updates the stored list; the bound `AgentExecutor` is NOT rebuilt automatically. Call `await agent.initialize()` afterwards to apply changes on an already-initialized agent.
+- The simplest pattern is to call `setDisallowedTools()` once, BEFORE the first `run()` — the first run will initialize the agent with the restrictions in place.
+- `getDisallowedTools()` returns the current stored list (regardless of whether it has been bound to the executor yet).
+- Use environment variables (`NODE_ENV`) to choose a restriction profile at construction time.
+- Clearing restrictions with `setDisallowedTools([])` followed by `await agent.initialize()` unlocks all tools.
 
 ---
 
@@ -1251,6 +1264,8 @@ agent.setTags(["tag1", "tag2"])              // Add trace tags (deduplicates)
 agent.getTags()                              // Get current tags copy
 
 // Tool restrictions (also settable at construction via disallowedTools: [...])
-agent.setDisallowedTools(["tool1", "tool2"]) // Block tools at runtime (call initialize() after)
-agent.getDisallowedTools()                   // Get blocked list
+agent.setDisallowedTools(["tool1", "tool2"]) // Update stored list. NOTE: only takes effect at initialize() time —
+                                             // call BEFORE first run(), or follow with `await agent.initialize()`
+                                             // to rebuild the executor on an already-initialized agent.
+agent.getDisallowedTools()                   // Get current stored list
 ```

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/integration-recipes.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/integration-recipes.md
@@ -6,66 +6,71 @@ Examples of integrating MCPAgent with external frameworks and services. Each rec
 
 ## 1. Vercel AI SDK — Next.js API Route with Streaming
 
-Stream MCPAgent responses through a Next.js App Router API route using the Vercel AI SDK. This uses a manual adapter that bridges `agent.streamEvents({ prompt })` output to the Vercel AI SDK's `ReadableStream<string>` format. Note: prefer passing a `RunOptions` object `{ prompt, maxSteps?, schema?, signal? }` to `streamEvents()` — the plain-string form is deprecated. There is no official mcp-use/Vercel AI SDK integration package — this is a hand-written bridge.
+Stream MCPAgent responses through a Next.js App Router API route using the Vercel AI SDK. This recipe shows the pattern used in mcp-use's own [`examples/client/ai_sdk_example.ts`](https://github.com/mcp-use/mcp-use-ts/blob/main/packages/mcp-use/examples/client/ai_sdk_example.ts) — `streamEventsToAISDK` and `createReadableStreamFromGenerator` are exported directly from `mcp-use`. The frontend uses `useChat` from `@ai-sdk/react` (the legacy `'ai/react'` subpath was removed in AI SDK v5+).
+
+> **AI SDK version note:** mcp-use's `examples/client/ai_sdk_example.ts` uses `LangChainAdapter.toDataStreamResponse(...)` imported from the `ai` package — that path works on AI SDK `4.x`. In AI SDK `5.x` and `6.x` (current), `LangChainAdapter` was removed; the equivalent is `toUIMessageStream` (from `@ai-sdk/langchain@^2`) wrapped in `createUIMessageStreamResponse` (from `ai@^6`). Both variants are shown below — pick the one matching your installed `ai` version.
 
 ---
 
+### Variant A — AI SDK v6 + `@ai-sdk/langchain@^2` (current as of 2026)
+
 ```typescript
+// Install: npm install ai@^6 @ai-sdk/react@^3 @ai-sdk/langchain@^2 mcp-use
 // app/api/chat/route.ts
-import type { StreamEvent } from "@langchain/core/tracers/log_stream";
-import { createTextStreamResponse } from "ai";
+import { createUIMessageStreamResponse } from "ai";
+import { toUIMessageStream } from "@ai-sdk/langchain";
 import { MCPAgent, MCPClient } from "mcp-use";
 
-// Adapter: converts LangChain StreamEvents into plain text chunks
-// that the Vercel AI SDK createTextStreamResponse can consume.
-async function* streamEventsToAISDK(
-  events: AsyncGenerator<StreamEvent, void, void>,
-  options?: { includeToolCalls?: boolean }
-): AsyncGenerator<string, void, void> {
-  for await (const event of events) {
-    // Emit LLM token chunks
-    // Note: chunk property may be 'text' or 'content' depending on LLM provider
-    if (event.event === "on_chat_model_stream") {
-      const text = event.data?.chunk?.text || event.data?.chunk?.content;
-      if (typeof text === "string" && text.length > 0) {
-        yield text;
-      }
-    }
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const lastMessage = messages[messages.length - 1]?.content ?? "";
 
-    // Optionally emit tool invocation markers so the frontend
-    // can render tool call / tool result boundaries.
-    if (options?.includeToolCalls) {
-      if (event.event === "on_tool_start") {
-        const name = event.name ?? "unknown_tool";
-        const input = JSON.stringify(event.data?.input ?? {});
-        yield `\n[tool_call: ${name}] ${input}\n`;
-      }
-      if (event.event === "on_tool_end") {
-        const output = JSON.stringify(event.data?.output ?? {});
-        yield `\n[tool_result] ${output}\n`;
-      }
-    }
-  }
-}
-
-// Convert an async generator into a ReadableStream for the Response.
-function createReadableStreamFromGenerator(
-  gen: AsyncGenerator<string, void, void>
-): ReadableStream<string> {
-  return new ReadableStream<string>({
-    async start(controller) {
-      try {
-        for await (const chunk of gen) {
-          controller.enqueue(chunk);
-        }
-      } catch (err) {
-        controller.error(err);
-      } finally {
-        controller.close();
-      }
+  const client = new MCPClient({
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp/data"],
+      },
     },
   });
+
+  const agent = new MCPAgent({
+    llm: "openai/gpt-4o",
+    client,
+    maxSteps: 20,
+  });
+
+  try {
+    // streamEvents() yields LangChain StreamEvent objects.
+    // toUIMessageStream auto-converts them into the UI-message-chunk
+    // protocol that @ai-sdk/react's useChat consumes.
+    const events = agent.streamEvents({ prompt: lastMessage });
+    return createUIMessageStreamResponse({ stream: toUIMessageStream(events) });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: "Agent execution failed" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  } finally {
+    await agent.close();
+  }
 }
+```
+
+### Variant B — AI SDK v4 + `LangChainAdapter` from `ai` (matches mcp-use's official example verbatim)
+
+```typescript
+// Install: npm install ai@^4 mcp-use
+// app/api/chat/route.ts
+import { LangChainAdapter } from "ai";
+// streamEventsToAISDK and createReadableStreamFromGenerator are exported
+// directly from mcp-use (see packages/mcp-use/src/agents/utils/ai_sdk.ts).
+import {
+  MCPAgent,
+  MCPClient,
+  streamEventsToAISDK,
+  createReadableStreamFromGenerator,
+} from "mcp-use";
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
@@ -88,16 +93,10 @@ export async function POST(req: Request) {
 
   try {
     const events = agent.streamEvents({ prompt: lastMessage });
-    const textStream = streamEventsToAISDK(events, {
-      includeToolCalls: true,
-    });
+    const textStream = streamEventsToAISDK(events);
     const readable = createReadableStreamFromGenerator(textStream);
-
-    return createTextStreamResponse({
-      status: 200,
-      headers: { "X-Agent-Id": "mcp-use" },
-      stream: readable,
-    });
+    // Returns a Response in the data-stream protocol useChat understands.
+    return LangChainAdapter.toDataStreamResponse(readable);
   } catch (error) {
     return new Response(
       JSON.stringify({ error: "Agent execution failed" }),
@@ -109,12 +108,15 @@ export async function POST(req: Request) {
 }
 ```
 
-**Frontend usage with `useChat`:**
+> **About the text-stream path** — the `createTextStreamResponse({ textStream })` helper from `ai` is still exported in v6 and accepts a `ReadableStream<string>`, but it produces plain text suitable only for `useCompletion`. It is NOT consumed correctly by `useChat`, which expects the UI-message-chunk protocol. Use Variant A or B above for `useChat`-paired backends.
+
+**Frontend usage with `useChat` (AI SDK v5+):**
 
 ```typescript
+// Install: npm install @ai-sdk/react ai
 // app/page.tsx
 "use client";
-import { useChat } from "ai/react";
+import { useChat } from "@ai-sdk/react";
 
 export default function ChatPage() {
   const { messages, input, handleInputChange, handleSubmit, isLoading } =
@@ -142,46 +144,114 @@ export default function ChatPage() {
 
 ## 2. Langfuse Observability
 
-Attach Langfuse tracing to every MCPAgent run for cost tracking, latency monitoring, and per-request trace filtering. Pass a `CallbackHandler` via the `callbacks: [handler]` constructor option. Uses `agent.setMetadata()` and `agent.setTags()` to enrich traces with arbitrary key-value data and tag strings.
+Attach Langfuse tracing to every MCPAgent run for cost tracking, latency monitoring, and per-request filtering.
+
+> **mcp-use auto-initializes a Langfuse handler from environment variables.** When `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are set (and `MCP_USE_LANGFUSE` is not `"false"`), mcp-use dynamically loads `langfuse-langchain` and registers a `LoggingCallbackHandler` through its internal `ObservabilityManager`. You do NOT need to pass `callbacks: [...]` manually for the common case. The recommended pattern is env vars + `agent.setMetadata()` + `agent.setTags()`. Pass a manual `CallbackHandler` only when you need per-request `traceId`/`userId` binding — and disable the auto-init first to avoid duplicate traces.
 
 ---
 
-```typescript
-// observability.ts
-import { CallbackHandler as LangfuseHandler } from "langfuse-langchain";
-import { MCPAgent, MCPClient } from "mcp-use";
-import { Logger } from "mcp-use";
-import { randomUUID } from "node:crypto";
+### Sub-recipe A — Zero-config auto-init (recommended default)
 
-// Enable framework-level debug logging alongside Langfuse traces.
+This matches mcp-use's own [`examples/client/observability.ts`](https://github.com/mcp-use/mcp-use-ts/blob/main/packages/mcp-use/examples/client/observability.ts).
+
+```typescript
+// .env:
+//   LANGFUSE_PUBLIC_KEY=pk-...
+//   LANGFUSE_SECRET_KEY=sk-...
+//   LANGFUSE_HOST=https://cloud.langfuse.com   # or your self-hosted URL
+//   MCP_USE_LANGFUSE=true                       # optional; auto-init is on by default
+
+import { config } from "dotenv";
+import { Logger, MCPAgent, MCPClient } from "mcp-use";
+
+config();
+
+// Optional — see what env vars Langfuse will pick up.
 Logger.setDebug(true);
 
-// Reusable function that creates a Langfuse callback handler
-// scoped to a single request trace.
+async function main() {
+  const client = new MCPClient({
+    mcpServers: {
+      everything: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      },
+    },
+  });
+
+  // No callbacks needed — mcp-use auto-detects env vars and registers the handler.
+  const agent = new MCPAgent({
+    llm: "openai/gpt-4o",
+    client,
+    maxSteps: 15,
+  });
+
+  // Enrich every trace this agent emits.
+  agent.setMetadata({
+    feature: "web-search",
+    costCenter: "product-team",
+    environment: process.env.NODE_ENV ?? "development",
+  });
+  agent.setTags(["production", "web-search"]);
+
+  try {
+    const result = await agent.run({
+      prompt: "Search for the latest TypeScript 5.6 features and summarize them",
+      maxSteps: 15,
+    });
+    console.log("Result:", result);
+  } finally {
+    // In serverless, flush traces before the function exits.
+    await agent.flush();
+    await agent.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+### Sub-recipe B — Per-request manual handler (when you need `traceId`/`userId` binding)
+
+Use this only when you need a deterministic `traceId` or `userId` scoped to a single run (e.g. correlating a trace with a specific HTTP request). To prevent double-tracing, you MUST disable the auto-init by setting `MCP_USE_LANGFUSE=false`.
+
+```typescript
+// Required env:
+//   LANGFUSE_PUBLIC_KEY=pk-...
+//   LANGFUSE_SECRET_KEY=sk-...
+//   LANGFUSE_HOST=https://cloud.langfuse.com   # or your self-hosted URL
+//   MCP_USE_LANGFUSE=false                      # disable ambient auto-init
+
+import { CallbackHandler as LangfuseHandler } from "langfuse-langchain";
+import { MCPAgent, MCPClient } from "mcp-use";
+import { randomUUID } from "node:crypto";
+
 function createLangfuseHandler(traceId: string, userId?: string) {
   return new LangfuseHandler({
     publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
     secretKey: process.env.LANGFUSE_SECRET_KEY!,
-    baseUrl: process.env.LANGFUSE_BASE_URL ?? "https://cloud.langfuse.com",
+    // mcp-use reads LANGFUSE_HOST (with LANGFUSE_BASEURL — note: no underscore
+    // between BASE and URL — as the only documented fallback). LANGFUSE_BASE_URL
+    // is NOT a recognized env var.
+    baseUrl: process.env.LANGFUSE_HOST ?? "https://cloud.langfuse.com",
     traceId,
     userId,
     sessionId: traceId,
-    metadata: {
-      environment: process.env.NODE_ENV ?? "development",
-    },
+    metadata: { environment: process.env.NODE_ENV ?? "development" },
   });
 }
 
-// Per-request traced agent execution
 async function runTracedAgent(prompt: string, userId?: string) {
   const traceId = randomUUID();
   const langfuseHandler = createLangfuseHandler(traceId, userId);
 
   const client = new MCPClient({
     mcpServers: {
+      // The Brave Search reference server lives under @modelcontextprotocol.
+      // Note: as of late 2024 it is marked deprecated on npm — replace with
+      // a community-maintained or self-hosted equivalent if it stops working.
       brave: {
         command: "npx",
-        args: ["-y", "@anthropic/mcp-server-brave"],
+        args: ["-y", "@modelcontextprotocol/server-brave-search"],
         env: { BRAVE_API_KEY: process.env.BRAVE_API_KEY! },
       },
     },
@@ -191,18 +261,16 @@ async function runTracedAgent(prompt: string, userId?: string) {
     llm: "openai/gpt-4o",
     client,
     maxSteps: 15,
-    callbacks: [langfuseHandler],
+    callbacks: [langfuseHandler],   // explicit per-request handler
   });
 
-  // Enrich the trace with metadata and tags for filtering
-  // in the Langfuse dashboard.
+  // Per-run metadata + tags for filtering.
   agent.setMetadata({
     traceId,
     userId: userId ?? "anonymous",
     feature: "web-search",
     costCenter: "product-team",
   });
-
   agent.setTags([
     "production",
     "web-search",
@@ -222,15 +290,13 @@ async function runTracedAgent(prompt: string, userId?: string) {
   }
 }
 
-// Example: run with observability
 async function main() {
   const { result, traceId } = await runTracedAgent(
     "Search for the latest TypeScript 5.6 features and summarize them",
     "user-42"
   );
-
   console.log("Result:", result);
-  console.log(`View trace: https://cloud.langfuse.com/trace/${traceId}`);
+  console.log(`View trace: ${process.env.LANGFUSE_HOST ?? "https://cloud.langfuse.com"}/trace/${traceId}`);
 }
 
 main().catch(console.error);
@@ -242,7 +308,8 @@ main().catch(console.error);
 - Use the `costCenter` metadata field to attribute spend.
 - The `userId` on the handler links every span to a user timeline.
 - Latency breakdown per tool call is automatic — each MCP tool invocation appears as a child span under the agent trace.
-- Set `LANGFUSE_BASE_URL` to your self-hosted instance if not using Langfuse Cloud.
+- Set `LANGFUSE_HOST` (not `LANGFUSE_BASE_URL`) to point at a self-hosted instance — e.g. `export LANGFUSE_HOST=https://langfuse.internal.example.com`. mcp-use reads `LANGFUSE_HOST` first and falls back to `LANGFUSE_BASEURL` (no underscore between `BASE` and `URL`).
+- Set `MCP_USE_LANGFUSE=false` if you want only the manual per-request handler to run, with no ambient auto-init.
 
 ---
 
@@ -474,9 +541,11 @@ router.post("/agent/stream", async (req: Request, res: Response) => {
 
   const client = new MCPClient({
     mcpServers: {
-      weather: {
+      // The Everything reference server is actively maintained and ships
+      // a broad sample of tools, resources, and prompts — useful for demos.
+      everything: {
         command: "npx",
-        args: ["-y", "@anthropic/mcp-server-weather"],
+        args: ["-y", "@modelcontextprotocol/server-everything"],
       },
     },
   });
@@ -960,7 +1029,11 @@ async function dynamicServerDemo() {
         '   serverName: "brave-search"',
         '   serverConfig: {',
         '     command: "npx",',
-        '     args: ["-y", "@anthropic/mcp-server-brave"],',
+        // The official Brave Search reference server lives under
+        // @modelcontextprotocol — there is NO @anthropic/mcp-server-* npm scope.
+        // Note: this package is marked deprecated on npm as of late 2024;
+        // substitute a community-maintained equivalent if it stops working.
+        '     args: ["-y", "@modelcontextprotocol/server-brave-search"],',
         `     env: { "BRAVE_API_KEY": "${process.env.BRAVE_API_KEY}" }`,
         "   }",
         "3. Use the newly added brave-search server to look up",

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/advanced-patterns.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/advanced-patterns.md
@@ -69,7 +69,6 @@ interface SimplifiedModeOptions {
   // plus all CommonAgentOptions fields above (except client/connectors)
 }
 ```
-```
 
 ### Options table
 
@@ -97,13 +96,27 @@ interface SimplifiedModeOptions {
 
 ### MCPAgent public methods
 
+> **Awaitable vs generator-returning methods.** `run()` and lifecycle methods return a `Promise` and must be `await`ed. The streaming methods (`stream`, `streamEvents`, `prettyStreamEvents`) return `AsyncGenerator` objects **synchronously** — do **not** `await` the call itself; consume the generator with `for await`. The two groups are listed together below; check the Return Type column.
+
+#### Awaitable methods
+
 | Method | Signature | Return Type | Description |
 |---|---|---|---|
-| `run` | `run(prompt: string)` or `run({ prompt, schema?, maxSteps?, signal? })` | `Promise<string>` or `Promise<T>` | Execute a prompt; plain string form is deprecated but works. |
+| `run` | `run(prompt: string)` or `run({ prompt, schema?, maxSteps?, signal?, manageConnector?, externalHistory? })` | `Promise<string>` or `Promise<T>` | Execute a prompt; plain string form is deprecated but works. |
+| `initialize` | `initialize(): Promise<void>` | `Promise<void>` | Async setup; called automatically when `autoInitialize: true` or when `manageConnector` is true at runtime. |
+
+#### Streaming methods (return generators synchronously — do not `await` the call)
+
+| Method | Signature | Return Type | Description |
+|---|---|---|---|
 | `stream` | `stream(prompt: string)` or `stream({ prompt, schema?, maxSteps?, signal? })` | `AsyncGenerator<AgentStep, string \| T, void>` | Yield step objects; generator return value is the final result. |
 | `streamEvents` | `streamEvents(prompt: string)` or `streamEvents({ prompt, schema?, maxSteps?, signal? })` | `AsyncGenerator<StreamEvent, void, void>` | Yield raw LangChain events; plain string form is deprecated. |
 | `prettyStreamEvents` | `prettyStreamEvents(prompt: string)` or `prettyStreamEvents({ prompt, maxSteps?, schema? })` | `AsyncGenerator<void, string, void>` | Formatted, colored CLI output. Plain-string form is deprecated; prefer the options object. |
-| `initialize` | `initialize(): Promise<void>` | `Promise<void>` | Async setup; called automatically when `autoInitialize: true` or when `manageConnector` is true at runtime. |
+
+#### Other methods
+
+| Method | Signature | Return Type | Description |
+|---|---|---|---|
 | `setDisallowedTools` | `setDisallowedTools(tools: string[]): void` | `void` | Update restricted tools at runtime. Changes take effect on next `initialize()` call. |
 | `getDisallowedTools` | `getDisallowedTools(): string[]` | `string[]` | Retrieve current restricted tool list. |
 | `getConversationHistory` | `getConversationHistory(): BaseMessage[]` | `BaseMessage[]` | Returns copy of current conversation history. |
@@ -119,14 +132,14 @@ interface SimplifiedModeOptions {
 
 | Method | Signature | Return Type | Description |
 |---|---|---|---|
-| `createAllSessions` | `createAllSessions(): Promise<void>` | `Promise<void>` | Connect all configured MCP servers upfront. |
+| `createAllSessions` | `createAllSessions(autoInitialize?: boolean)` | `Promise<Record<string, MCPSession>>` | Connect all configured MCP servers upfront; resolves to a map of server name → `MCPSession`. Pass `false` to skip auto-initialization. |
 | `closeAllSessions` | `closeAllSessions(): Promise<void>` | `Promise<void>` | Gracefully close all active server sessions. |
 
 ---
 
 ## LLM integration
 
-All four supported providers share the same constructor shape: `{ model, temperature, apiKey }`. The `apiKey` is optional when the corresponding environment variable is set.
+Each of the four providers below accepts a `{ model, temperature, apiKey }` core, and `apiKey` is optional when the corresponding environment variable is set. Beyond that core, each provider exposes its own options — for example `safetySettings` and `maxOutputTokens` (Google), `thinking` (Anthropic v4+), and `maxTokens` vs `maxOutputTokens` (OpenAI vs Google). For anything past the basics, check the matching `@langchain/<provider>` README.
 
 ```typescript
 // OpenAI
@@ -139,10 +152,10 @@ const llm = new ChatOpenAI({
 ```
 
 ```typescript
-// Anthropic
+// Anthropic (current generation as of April 2026)
 import { ChatAnthropic } from "@langchain/anthropic";
 const llm = new ChatAnthropic({
-  model: "claude-3-5-sonnet-20241022",
+  model: "claude-sonnet-4-6",   // or "claude-opus-4-7" for hardest reasoning
   temperature: 0.7,
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
@@ -152,7 +165,7 @@ const llm = new ChatAnthropic({
 // Google Gemini
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 const llm = new ChatGoogleGenerativeAI({
-  model: "gemini-pro",
+  model: "gemini-2.5-pro",      // or "gemini-2.0-flash" for lower latency
   temperature: 0.7,
   apiKey: process.env.GOOGLE_API_KEY,
 });
@@ -162,13 +175,15 @@ const llm = new ChatGoogleGenerativeAI({
 // Groq
 import { ChatGroq } from "@langchain/groq";
 const llm = new ChatGroq({
-  model: "llama-3.1-70b-versatile",
+  model: "llama-3.3-70b-versatile",
   temperature: 0.7,
   apiKey: process.env.GROQ_API_KEY,
 });
 ```
 
 All LLM instances are passed directly to `MCPAgent` as `llm`. Tool calling, structured output, and streaming are available for any provider that supports these features through LangChain's unified interface.
+
+> Model IDs drift. If you see `model_not_found` / `404`, check the provider's current model list (Anthropic, Google AI Studio, Groq) — the snapshots above were current as of April 2026.
 
 ---
 
@@ -501,42 +516,56 @@ await agent.close();
 
 ### Streaming to Vercel AI SDK (Next.js)
 
-`mcp-use` does not export a Vercel AI SDK adapter. Write a local helper to bridge `streamEvents` to `createTextStreamResponse`.
+`mcp-use` exports three Vercel AI SDK helpers from the package root (re-exported via `./src/agents/utils/index.js`):
+
+- `streamEventsToAISDK(events)` — yields plain text chunks from `on_chat_model_stream` events.
+- `streamEventsToAISDKWithTools(events)` — same, plus surface tool start/end markers in the output.
+- `createReadableStreamFromGenerator(gen)` — wrap an `AsyncGenerator<string>` as a `ReadableStream<string>`.
+
+Use them directly instead of writing a local bridge helper:
 
 ```typescript
-import type { StreamEvent } from "@langchain/core/tracers/log_stream";
+import {
+  streamEventsToAISDK,
+  // streamEventsToAISDKWithTools,  // alternative — adds 🔧 / ✅ tool markers
+} from "mcp-use";
 import { createTextStreamResponse } from "ai";
 import { MCPAgent, MCPClient } from "mcp-use";
+import { ChatOpenAI } from "@langchain/openai";
 
-// Local helper — not exported from mcp-use
-async function* streamEventsToText(
-  events: AsyncIterable<StreamEvent>
-): AsyncGenerator<string> {
-  for await (const event of events) {
-    if (event.event === "on_chat_model_stream") {
-      const text = event.data?.chunk?.text || event.data?.chunk?.content;
-      if (typeof text === "string" && text.length > 0) {
-        yield text;
-      }
-    }
-  }
-}
+const client = new MCPClient({ mcpServers: { /* ... */ } });
+const agent = new MCPAgent({ llm: new ChatOpenAI({ model: "gpt-4o" }), client });
 
 export async function POST(req: Request) {
   const { prompt } = await req.json();
-  const events = agent.streamEvents(prompt);
-  return createTextStreamResponse(streamEventsToText(events));
+  const events = agent.streamEvents({ prompt });
+  return createTextStreamResponse(streamEventsToAISDK(events));
 }
 ```
 
+Pick `streamEventsToAISDKWithTools` when you want the user to see `🔧 tool_name` and `✅` markers around tool calls in the streamed output; pick `streamEventsToAISDK` for raw text only.
+
 ### Streaming with persistence
 
+When you need to persist events as they arrive (DB writes, logs, audit trail), inline the loop and re-use the same `createTextStreamResponse` plumbing:
+
 ```typescript
+import { createTextStreamResponse } from "ai";
+import { MCPAgent, MCPClient } from "mcp-use";
+import { ChatOpenAI } from "@langchain/openai";
+
+const client = new MCPClient({ mcpServers: { /* ... */ } });
+const agent = new MCPAgent({ llm: new ChatOpenAI({ model: "gpt-4o" }), client });
+
+function persistEvent(event: unknown) {
+  // your logging / DB code
+}
+
 export async function POST(req: Request) {
   const { prompt } = await req.json();
 
   const stream = (async function* () {
-    for await (const event of agent.streamEvents(prompt)) {
+    for await (const event of agent.streamEvents({ prompt })) {
       persistEvent(event);   // write to DB / log
       if (event.event === "on_chat_model_stream") {
         const text = event.data?.chunk?.text || event.data?.chunk?.content;

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/memory-management.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/memory-management.md
@@ -48,19 +48,21 @@ import { ChatOpenAI } from "@langchain/openai";
 | Method | Signature | Return | Purpose |
 |---|---|---|---|
 | `clearConversationHistory()` | `(): void` | `void` | Clear all stored messages (system message preserved if present) |
-| `getConversationHistory()` | `(): Message[]` | `Message[]` | Returns a copy of the current conversation history as an array of message objects |
+| `getConversationHistory()` | `(): BaseMessage[]` | `BaseMessage[]` | Returns a copy of the current conversation history. `BaseMessage` (re-exported from `mcp-use/agents`) is a union of `AIMessage \| HumanMessage \| ToolMessage \| SystemMessage` from `langchain`. |
 
 ### `run` method signature
 
 `run` accepts either an options object (preferred) or a plain string (deprecated):
 
 ```typescript
-// Options object — preferred form
+// Options object — preferred form (matches the published RunOptions interface)
 async run<T = string>(options: {
-  prompt: string;           // user query
-  schema?: ZodSchema<T>;    // optional Zod schema for structured typed output
-  maxSteps?: number;        // override constructor maxSteps for this call only
-  signal?: AbortSignal;     // cancel the run via AbortController
+  prompt: string;                  // user query
+  maxSteps?: number;               // override constructor maxSteps for this call only
+  manageConnector?: boolean;       // auto-initialize/close MCP connectors for this call
+  externalHistory?: BaseMessage[]; // override agent memory for this call only (see below)
+  schema?: ZodSchema<T>;           // optional Zod schema for structured typed output
+  signal?: AbortSignal;            // cancel the run via AbortController
 }): Promise<T>
 
 // Plain string — still works but deprecated
@@ -69,7 +71,39 @@ await agent.run("Summarize the project");
 
 When `schema` is provided, the return value is typed according to the Zod schema. When omitted, the return is a `string`.
 
-Memory state is controlled by the constructor `memoryEnabled` option, not by a per-call flag. To get a stateless result from a stateful agent, use a separate agent instance with `memoryEnabled: false`.
+Memory state is controlled by the constructor `memoryEnabled` option, not by a per-call flag. To get a stateless result from a stateful agent, either use a separate agent instance with `memoryEnabled: false`, or pass `externalHistory` (see next section) to override the buffer for one call without mutating it.
+
+### `externalHistory` — per-call history override
+
+`externalHistory` is a first-class field on `RunOptions` (and accepted by `stream`, `streamEvents`, and `prettyStreamEvents` too). When supplied, it temporarily replaces the agent's internal `conversationHistory` for that single call only — the agent's stored buffer is **not mutated**.
+
+```typescript
+import { HumanMessage, AIMessage } from "langchain";
+
+const result = await agent.run({
+  prompt: "Continue that plan",
+  externalHistory: [
+    new HumanMessage("What's our plan?"),
+    new AIMessage("Step 1: Gather inputs..."),
+  ],
+});
+// agent.getConversationHistory() is unchanged after this call
+```
+
+Use it to:
+
+- Inject saved or replayed history without touching the live agent buffer
+- Run a one-off stateless call from a stateful agent
+- Drive memory entirely from an external store while keeping `memoryEnabled` semantics
+
+Behavior summary:
+
+| `memoryEnabled` | `externalHistory` | History used for the call | Buffer after the call |
+|---|---|---|---|
+| `true` | omitted | internal `conversationHistory` | grows by user + assistant messages |
+| `true` | provided | `externalHistory` only | unchanged |
+| `false` | omitted | none | none |
+| `false` | provided | `externalHistory` only | none |
 
 ---
 
@@ -122,6 +156,9 @@ const agent = new MCPAgent({
 
 await agent.run("Summarize the repository");
 await agent.run("Now list the top 5 risks from that summary");
+
+// Canonical cleanup — closes every active MCP server session.
+await client.closeAllSessions();
 ```
 
 ---
@@ -134,13 +171,17 @@ Use `memoryEnabled: false` to make every `run` independent.
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
 
+const client = new MCPClient({ mcpServers: {} });
+
 const agent = new MCPAgent({
   llm: new ChatOpenAI({ model: "gpt-4.1" }),
-  client: new MCPClient({ mcpServers: {} }),
+  client,
   memoryEnabled: false,
 });
 
 const response = await agent.run("Explain the token budget for this single request only");
+
+await client.closeAllSessions();
 ```
 
 ---
@@ -173,7 +214,7 @@ If you need durable state across sessions, store it explicitly in your own syste
 
 ## Inspecting memory
 
-Use `getConversationHistory()` to view the memory buffer. It returns a copy of the stored `Message[]` array.
+Use `getConversationHistory()` to view the memory buffer. It returns a copy of the stored `BaseMessage[]` array (from LangChain core, re-exported as `BaseMessage` from `mcp-use/agents`).
 
 ```typescript
 const history = agent.getConversationHistory();
@@ -289,6 +330,9 @@ Use memory to coordinate longer flows. Each pattern below assumes `memoryEnabled
 await agent.run("Draft a one‑page migration plan");
 await agent.run("Now add rollout phases and rollback criteria");
 await agent.run("Review for missing risks");
+
+// Canonical cleanup once the multi-turn flow is complete.
+await client.closeAllSessions();
 ```
 
 ### Pattern 2: Progressive constraints
@@ -664,15 +708,24 @@ Yes. Memory is global to the agent instance.
 
 ### Can I disable memory temporarily?
 
-`memoryEnabled` is a constructor option, not a per-call option. To get a stateless single call, create a separate agent with `memoryEnabled: false`:
+`memoryEnabled` is a constructor option, not a per-call option. You have two options for a stateless single call:
 
 ```typescript
+// Option A — pass externalHistory: [] (or any explicit history) to override the buffer for one call
+const result = await agent.run({
+  prompt: "One-off stateless query",
+  externalHistory: [],
+});
+// agent.getConversationHistory() is unchanged
+
+// Option B — create a separate agent with memoryEnabled: false sharing the same client
 const statelessAgent = new MCPAgent({ llm, client, memoryEnabled: false });
 const result = await statelessAgent.run({ prompt: "One-off stateless query" });
-await statelessAgent.close();
+// Cleanup at the application level — closes all sessions on the shared client
+await client.closeAllSessions();
 ```
 
-If you need both stateful and stateless behavior from the same session, maintain two agent instances pointing to the same `MCPClient`.
+If you need both stateful and stateless behavior from the same session, maintain two agent instances pointing to the same `MCPClient` and clean up via `await client.closeAllSessions()` once.
 
 ---
 

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/observability.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/observability.md
@@ -29,8 +29,11 @@ When observability is enabled, mcp-use automatically captures:
 export LANGFUSE_PUBLIC_KEY="pk-lf-..."
 export LANGFUSE_SECRET_KEY="sk-lf-..."
 
-# Optional: specify a custom Langfuse host
+# Optional: specify a custom Langfuse host. mcp-use reads LANGFUSE_HOST first
+# and falls back to LANGFUSE_BASEURL (the standard Langfuse SDK env var name)
+# if LANGFUSE_HOST is unset. Set whichever your existing config uses.
 export LANGFUSE_HOST="https://your-langfuse.com"
+# export LANGFUSE_BASEURL="https://your-langfuse.com"   # accepted as fallback
 
 # Set to "false" to disable Langfuse even when env vars are present
 export MCP_USE_LANGFUSE="false"

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/structured-output.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/structured-output.md
@@ -34,7 +34,11 @@ import { z } from "zod";
 | `prompt` | `string` | – | Natural‑language instruction to the agent |
 | `schema` | `z.ZodSchema<T>` | `undefined` | Validates and types the final response |
 | `maxSteps` | `number` | agent default | Override tool‑calling steps for this run |
-| `stream` | `boolean` | `false` | If `true`, returns a streaming iterator instead of a resolved value |
+| `manageConnector` | `boolean` | `undefined` | Auto-initialize/close MCP connectors for this call |
+| `externalHistory` | `BaseMessage[]` | `undefined` | Per-call history override (does not mutate agent buffer) |
+| `signal` | `AbortSignal` | `undefined` | Cancel the run via `AbortController` |
+
+> **`run()` does not stream.** There is no `stream` boolean on `RunOptions` — `run()` always returns a resolved `Promise`. To stream, call `agent.stream()`, `agent.streamEvents()`, or `agent.prettyStreamEvents()` instead. They return `AsyncGenerator` objects you consume with `for await`.
 
 ### Return type
 
@@ -536,9 +540,9 @@ for await (const event of agent.streamEvents({ prompt: "Produce JSON only", sche
 - Both `stream()` and `streamEvents()` accept either a plain `string` prompt (deprecated but supported) or a `RunOptions` object `{ prompt, schema?, maxSteps?, signal? }`.
 - The system retries formatting up to **3 times** before throwing an error.
 - Use `.describe()` on Zod fields to give the agent guidance on what each field should contain.
-- Call `client.closeAllSessions()` when done.
+- Call `await client.closeAllSessions()` at the application level when done — this is the canonical cleanup and matches the official examples.
 - Use `agent.clearConversationHistory()` to reset memory between runs.
-- Use `await agent.close()` to clean up background processes when finished.
+- `agent.close()` is a superset of `client.closeAllSessions()` (it also resets internal agent state). Pick **one** of the two — calling both in sequence is redundant and will attempt session cleanup twice.
 
 
 ---
@@ -551,18 +555,21 @@ These methods manage agent state and resources; they are not specific to structu
 // Reset conversation memory between independent runs
 agent.clearConversationHistory();
 
-// Clean up background processes (MCP server subprocesses, etc.)
-await agent.close();
-
-// Close all active MCP server sessions
+// Canonical cleanup at the application level — closes all active MCP server sessions
 await client.closeAllSessions();
+
+// Alternative: agent.close() is a superset of closeAllSessions() that also
+// resets agent state. Pick ONE; calling both is redundant.
+// await agent.close();
 ```
 
 | Method | On | Purpose |
 |---|---|---|
 | `clearConversationHistory()` | `MCPAgent` | Wipes stored conversation memory |
-| `close()` | `MCPAgent` | Cleans up resources (e.g., spawned background processes) |
-| `closeAllSessions()` | `MCPClient` | Terminates all active MCP server sessions |
+| `closeAllSessions()` | `MCPClient` | Canonical cleanup — terminates all active MCP server sessions. Use when you own the `MCPClient` lifecycle (most common; matches official examples). |
+| `close()` | `MCPAgent` | Superset of `client.closeAllSessions()` that also resets internal agent state. Use when you own only the agent and want a single-method cleanup. |
+
+> Pick **one** of `client.closeAllSessions()` or `agent.close()` per shutdown — they are not complementary. Calling both will attempt session cleanup twice.
 
 ---
 

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/patterns/anti-patterns.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/patterns/anti-patterns.md
@@ -229,7 +229,9 @@ app.post("/query", async (req, res) => {
 ```
 
 ```typescript
-// ✅ GOOD — create a fresh agent per request to isolate conversations
+// ✅ GOOD (simple) — fresh agent AND fresh client per request: isolates conversation,
+// but spawns a new stdio subprocess on every request. Fine for one-shot CLIs and dev;
+// expensive (~50-200ms per request, plus extra OS process per stdio server) for HTTP services.
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
 import express from "express";
@@ -248,7 +250,7 @@ const serverConfig = {
 const app = express();
 
 app.post("/query", async (req, res) => {
-  const client = new MCPClient(serverConfig);
+  const client = new MCPClient(serverConfig);   // spawns subprocess per request
   const agent = new MCPAgent({
     llm: new ChatOpenAI({ model: "gpt-4o" }),
     client,
@@ -263,9 +265,59 @@ app.post("/query", async (req, res) => {
     res.status(500).json({ error: "Agent execution failed" });
   } finally {
     await agent.close();
+    await client.closeAllSessions();   // tear down the subprocess for this request
   }
 });
 ```
+
+```typescript
+// ✅ GOOD (production) — share ONE MCPClient at module scope, create a fresh MCPAgent
+// per request. Each request gets its own conversation state and tool-execution context,
+// but the expensive stdio subprocesses (and any backend pools they hold open) survive.
+import { MCPAgent, MCPClient } from "mcp-use";
+import { ChatOpenAI } from "@langchain/openai";
+import express from "express";
+
+// At module scope — spawn MCP servers ONCE for the lifetime of the process
+const client = new MCPClient({
+  mcpServers: {
+    database: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-postgres"],
+      env: { DATABASE_URL: process.env.DATABASE_URL! },
+    },
+  },
+});
+
+const app = express();
+
+app.post("/query", async (req, res) => {
+  // Per-request — cheap; no process spawn, just a new agent on top of the shared client
+  const agent = new MCPAgent({
+    llm: new ChatOpenAI({ model: "gpt-4o" }),
+    client,                          // SHARED — no respawn
+    memoryEnabled: false,            // still isolate conversation state per request
+    maxSteps: 10,
+  });
+
+  try {
+    const result = await agent.run({ prompt: req.body.prompt });
+    res.json({ result });
+  } catch (err) {
+    res.status(500).json({ error: "Agent execution failed" });
+  } finally {
+    await agent.close();             // closes this agent only; client stays alive
+  }
+});
+
+// On process shutdown — release the shared subprocesses
+process.on("SIGTERM", async () => {
+  await client.closeAllSessions();
+  process.exit(0);
+});
+```
+
+> **Why two variants?** `new MCPClient(...)` followed by `agent.run()` triggers `child_process.spawn()` for every stdio server in the config (`@modelcontextprotocol/server-postgres` here). Spawning per HTTP request adds ~50-200ms of process-startup latency and forks an OS process per server per request — under load (e.g., 100 RPS × 3 servers ≈ 300 forks/s) this becomes the dominant cost. The shared-client variant trades a small amount of code complexity (module-level state + SIGTERM handler) for a large drop in p99 latency and lets backend MCP servers reuse their connection pools. For URL-based (SSE/HTTP) MCP servers no subprocess is spawned, so the simple variant is fine — but for stdio servers always prefer the shared-client pattern in production.
 
 ---
 
@@ -753,7 +805,7 @@ const agent = new MCPAgent({
 });
 
 try {
-  const result = await agent.run("Search the web and save results to /data/results.md");
+  const result = await agent.run({ prompt: "Search the web and save results to /data/results.md" });
   console.log(result);
 } finally {
   await agent.close();
@@ -780,7 +832,7 @@ const agent = new MCPAgent({
 });
 
 try {
-  const result = await agent.run("Search the web and save results to /data/results.md");
+  const result = await agent.run({ prompt: "Search the web and save results to /data/results.md" });
   console.log(result);
 } finally {
   await agent.close();
@@ -1075,7 +1127,7 @@ const client = new MCPClient({
 });
 
 const agent = new MCPAgent({
-  llm: new ChatAnthropic({ model: "claude-3-5-sonnet-20241022" }),
+  llm: new ChatAnthropic({ model: "claude-sonnet-4-6" }),
   client,
   maxSteps: 10,
 });
@@ -1107,7 +1159,7 @@ const client = new MCPClient({
 });
 
 const agent = new MCPAgent({
-  llm: new ChatAnthropic({ model: "claude-3-5-sonnet-20241022" }),
+  llm: new ChatAnthropic({ model: "claude-sonnet-4-6" }),
   client,
   maxSteps: 10,
 });
@@ -1119,6 +1171,8 @@ try {
   await agent.close();
 }
 ```
+
+> **Note — model IDs drift.** As of April 2026, `claude-sonnet-4-6` is current. Always check https://docs.anthropic.com/en/docs/about-claude/models before pinning a model — retired IDs return `model_not_found` from the provider API.
 
 ### 17. Mixing Simplified and Explicit Mode — TypeScript Type Violation
 
@@ -1162,10 +1216,12 @@ const agentSimplified = new MCPAgent({
   maxSteps: 10,
 });
 
-// Other valid simplified mode strings:
-// llm: "anthropic/claude-3-5-sonnet-20241022"
-// llm: "groq/llama-3.1-70b-versatile"
-// llm: "google/gemini-pro"
+// Other valid simplified mode strings (April 2026 — verify against provider catalogs):
+// llm: "anthropic/claude-sonnet-4-6"
+// llm: "groq/llama-3.3-70b-versatile"
+// llm: "google/gemini-2.5-pro"
+// llm: "openai/gpt-4o-mini"
+// Model names drift — if you get model_not_found, update against the provider's current catalog.
 
 try {
   const result = await agentSimplified.run({ prompt: "List files" });
@@ -1224,7 +1280,7 @@ const client = new MCPClient({
     },
     shell: {
       command: "npx",
-      args: ["-y", "@modelcontextprotocol/server-shell"],
+      args: ["-y", "mcp-shell-server"],   // community shell-capable MCP server (no @modelcontextprotocol/server-shell exists)
     },
   },
 });
@@ -1268,8 +1324,8 @@ const agent = new MCPAgent({
     "delete_file",
     "move_file",
     "write_file",       // read-only access only
-    "execute_command",
-    "run_shell",
+    "run_command",      // mcp-shell-server's command-execution tool
+    "execute_command",  // common alias used by other shell-capable servers
   ],
 });
 
@@ -1395,9 +1451,31 @@ try {
 ```
 
 ```typescript
-// ✅ GOOD — enable verbose mode and use callbacks for production observability
+// ✅ GOOD — enable verbose mode and use callbacks for production observability.
+// MCPAgent's `callbacks` option is typed as `BaseCallbackHandler[]` from
+// @langchain/core. Extend the abstract class and set `name` — passing a plain
+// object literal fails strict TypeScript and makes Langfuse / OTel group every
+// trace under "unknown_handler".
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+
+class AgentObservabilityHandler extends BaseCallbackHandler {
+  name = "agent-observability";   // required — used by LangChain tracing and observability platforms
+
+  async handleLLMStart(_llm: unknown, prompts: string[]) {
+    console.log(`[LLM] Starting with ${prompts.length} prompt(s)`);
+  }
+  async handleToolStart(tool: { name: string }, input: string) {
+    console.log(`[Tool] ${tool.name} called with: ${input.slice(0, 100)}`);
+  }
+  async handleLLMError(err: Error) {
+    console.error(`[LLM Error] ${err.message}`);
+  }
+  async handleToolError(err: Error) {
+    console.error(`[Tool Error] ${err.message}`);
+  }
+}
 
 const client = new MCPClient({
   mcpServers: {
@@ -1413,22 +1491,7 @@ const agent = new MCPAgent({
   client,
   maxSteps: 15,
   verbose: true, // logs each step, tool call, and LLM interaction
-  callbacks: [
-    {
-      handleLLMStart: async (_llm: any, prompts: string[]) => {
-        console.log(`[LLM] Starting with ${prompts.length} prompt(s)`);
-      },
-      handleToolStart: async (tool: any, input: string) => {
-        console.log(`[Tool] ${tool.name} called with: ${input.slice(0, 100)}`);
-      },
-      handleLLMError: async (err: Error) => {
-        console.error(`[LLM Error] ${err.message}`);
-      },
-      handleToolError: async (err: Error) => {
-        console.error(`[Tool Error] ${err.message}`);
-      },
-    },
-  ],
+  callbacks: [new AgentObservabilityHandler()],
 });
 
 try {
@@ -1566,9 +1629,17 @@ try {
 ```
 
 ```typescript
-// ✅ GOOD — decompose into focused agents, each with minimal server access
+// ✅ GOOD — decompose into focused agents, each with minimal server access.
+// Use a Zod schema with run({ prompt, schema }) to get a typed, validated result.
+// Calling JSON.parse on a plain run() result is unsafe — LLMs often wrap JSON in
+// prose ("Here are the files: ```json [...] ```"), which throws SyntaxError.
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
+import { z } from "zod";
+
+const DeprecatedFilesSchema = z.object({
+  files: z.array(z.string()).describe("Absolute paths of files with deprecated API usage"),
+});
 
 async function analyzeDeprecations(): Promise<string[]> {
   const client = new MCPClient({
@@ -1581,10 +1652,13 @@ async function analyzeDeprecations(): Promise<string[]> {
   });
   const agent = new MCPAgent({ llm: new ChatOpenAI({ model: "gpt-4o" }), client, maxSteps: 15 });
   try {
+    // Schema overload: run<T>(options: RunOptions<T>) → Promise<T>
+    // mcp-use retries the LLM up to 3x until output validates against the schema.
     const result = await agent.run({
-      prompt: "Read all TypeScript files in /project/src and list any deprecated API usages. Return as JSON array of file paths.",
+      prompt: "Read all TypeScript files in /project/src and list any files using deprecated APIs.",
+      schema: DeprecatedFilesSchema,
     });
-    return JSON.parse(result);
+    return result.files;
   } finally {
     await agent.close();
   }
@@ -1668,3 +1742,145 @@ try {
   console.log("Cleanup complete");
 }
 ```
+
+---
+
+## Remote Agents and OAuth
+
+mcp-use 1.x exports three first-party features that previously had no anti-pattern guidance: `RemoteAgent` (cloud-managed agent execution), `BrowserOAuthClientProvider` + `onMcpAuthorization` (browser OAuth for MCP servers like Linear or Slack). These are real public exports — confirmed in `dist/index.d.ts` of the published `mcp-use@1.25.0` tarball:
+
+```typescript
+export { BrowserOAuthClientProvider, onMcpAuthorization, probeAuthParams } from "./src/auth/index.js";
+export { RemoteAgent } from "./src/agents/remote.js";
+```
+
+### 24. Forgetting `apiKey` When Constructing a `RemoteAgent`
+
+```typescript
+// ❌ BAD — no apiKey: the first run() returns a cryptic 401 from the runtime
+import { RemoteAgent } from "mcp-use";
+
+const agent = new RemoteAgent({
+  agentId: "agent_abc",
+  baseUrl: "https://runtime.mcp-use.com",
+  // apiKey omitted — RemoteAgent constructor accepts this, but the runtime rejects every call
+});
+
+await agent.run({ prompt: "List my open tasks" });
+// → 401 Unauthorized — buried inside an mcp-use error stack
+```
+
+```typescript
+// ✅ GOOD — always pass apiKey from a server-side env var; never inline secrets
+import { RemoteAgent } from "mcp-use";
+
+const apiKey = process.env.MCP_USE_API_KEY;
+if (!apiKey) {
+  throw new Error("MCP_USE_API_KEY is required for RemoteAgent");
+}
+
+const agent = new RemoteAgent({
+  agentId: "agent_abc",
+  apiKey,
+  baseUrl: "https://runtime.mcp-use.com",
+});
+
+try {
+  const result = await agent.run({ prompt: "List my open tasks" });
+  console.log(result);
+} finally {
+  await agent.close();
+}
+```
+
+> RemoteAgent's `run()` and `stream()` accept the same `RunOptions` object form as MCPAgent — `{ prompt, maxSteps, schema, ... }`. The positional-string overload exists but is `@deprecated` (verified in `dist/src/agents/remote.d.ts`).
+
+### 25. Re-creating `BrowserOAuthClientProvider` Per Request
+
+`BrowserOAuthClientProvider` is a browser-only OAuth helper that stores tokens, code verifiers, and PKCE state in `localStorage`. It expects to be instantiated once per (server URL, browser session) and reused — every fresh constructor call resets cached metadata and may trigger a new authorization round-trip when the SDK calls back through it.
+
+```typescript
+// ❌ BAD — instantiating the provider inside every component / handler
+// triggers a fresh consent loop each time the user clicks "connect"
+import { BrowserOAuthClientProvider } from "mcp-use";
+
+function ConnectButton() {
+  // New provider object every render — token cache is invalidated as soon as state changes
+  const provider = new BrowserOAuthClientProvider("https://mcp.example.com", {
+    clientName: "My App",
+    callbackUrl: "https://app.example.com/oauth/callback",
+  });
+
+  return <button onClick={() => provider.redirectToAuthorization(/* ... */)}>Connect</button>;
+}
+```
+
+```typescript
+// ✅ GOOD — hoist the provider to module scope (or memoize per server URL)
+// so cached tokens, client info, and code verifiers persist across renders.
+import { BrowserOAuthClientProvider } from "mcp-use";
+
+// One provider per remote MCP server URL — re-used for the lifetime of the tab.
+const linearAuthProvider = new BrowserOAuthClientProvider("https://mcp.linear.app", {
+  clientName: "My App",
+  clientUri: "https://app.example.com",
+  callbackUrl: "https://app.example.com/oauth/callback",
+});
+
+function ConnectButton() {
+  return (
+    <button onClick={async () => {
+      // Provider keeps OAuth state in localStorage between clicks
+      const tokens = await linearAuthProvider.tokens();
+      if (!tokens) {
+        await linearAuthProvider.redirectToAuthorization(/* URL from MCP SDK */);
+      }
+    }}>
+      Connect Linear
+    </button>
+  );
+}
+```
+
+> `BrowserOAuthClientProvider` is browser-only — it relies on `localStorage` and `window.location`. Don't import it from server code; on Node it will throw at first method call. For server-side OAuth, drive the MCP SDK's `auth()` helper directly with your own provider implementation.
+
+### 26. Forgetting to Mount `onMcpAuthorization` on the OAuth Callback Page
+
+`onMcpAuthorization` is the callback handler the OAuth provider redirects to with `?code=...&state=...` query params. It exchanges the code for tokens and persists them via the same storage prefix the `BrowserOAuthClientProvider` uses. If you never call it on the callback URL, the redirect lands but tokens are never stored — the next `provider.tokens()` returns `undefined` and the consent loop repeats forever.
+
+```typescript
+// ❌ BAD — callback page just renders "Connecting…" but never finishes the OAuth flow
+// pages/oauth/callback.tsx
+export default function CallbackPage() {
+  return <div>Connecting…</div>;
+  // The ?code= param is silently discarded; tokens never get saved.
+}
+```
+
+```typescript
+// ✅ GOOD — call onMcpAuthorization() on mount; it reads ?code= / ?state= from the URL,
+// exchanges them with the MCP server, and writes tokens to localStorage under the same
+// storageKeyPrefix that BrowserOAuthClientProvider uses. Then redirect or notify opener.
+// pages/oauth/callback.tsx
+import { useEffect, useState } from "react";
+import { onMcpAuthorization } from "mcp-use";
+
+export default function CallbackPage() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    onMcpAuthorization()
+      .then(() => {
+        // Tokens are now persisted. Close the popup or navigate back.
+        window.opener?.postMessage({ type: "mcp-oauth-complete" }, window.location.origin);
+        window.close();
+      })
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) return <div>OAuth failed: {error}</div>;
+  return <div>Connecting…</div>;
+}
+```
+
+> `onMcpAuthorization()` returns `Promise<void>` and must run on the page registered as the provider's `callbackUrl`. It cannot be called from a server route or a different origin — the storage it writes to is scoped to the browser's `localStorage` for that origin.

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/patterns/production-patterns.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/patterns/production-patterns.md
@@ -234,7 +234,7 @@ The `maxSteps` parameter controls how many LLM reasoning + tool-call cycles the 
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
 
-// Guideline: default maxSteps is 5 — always set explicitly for non-trivial tasks
+// default maxSteps is 5 — far too low for most tasks; always set explicitly
 // simple lookup = 5-10, multi-step = 15-30, complex workflows = 30-50
 
 // Simple: single tool call, direct answer
@@ -1136,6 +1136,7 @@ interface AgentConfig {
   maxSteps: number;
   verbose: boolean;
   memoryEnabled: boolean;
+  observabilityEnabled: boolean;
   mcpFilesystemRoot: string;
   rateLimitRpm: number;
 }
@@ -1182,6 +1183,7 @@ function loadConfig(): AgentConfig {
     maxSteps: optionalInt("AGENT_MAX_STEPS", 20),
     verbose: optionalBool("AGENT_VERBOSE", false),
     memoryEnabled: optionalBool("AGENT_MEMORY", true),
+    observabilityEnabled: optionalBool("AGENT_OBSERVABILITY", true),
     mcpFilesystemRoot: required("AGENT_FS_ROOT"),
     rateLimitRpm: optionalInt("AGENT_RATE_LIMIT_RPM", 30),
   };
@@ -1232,6 +1234,7 @@ function createAgentFromConfig(config: AgentConfig): { agent: MCPAgent; client: 
     maxSteps: config.maxSteps,
     verbose: config.verbose,
     memoryEnabled: config.memoryEnabled,
+    observe: config.observabilityEnabled,  // explicit opt-out via AGENT_OBSERVABILITY=false
   });
 
   return { agent, client };
@@ -1272,6 +1275,7 @@ main().catch(console.error);
 | `AGENT_MAX_STEPS` | No | `20` | Max reasoning steps |
 | `AGENT_VERBOSE` | No | `false` | Enable verbose logging |
 | `AGENT_MEMORY` | No | `true` | Enable conversation memory |
+| `AGENT_OBSERVABILITY` | No | `true` | Auto-emit traces to Langfuse / configured platform; set `false` to opt out |
 | `AGENT_FS_ROOT` | **Yes** | — | Root directory for filesystem MCP server |
 | `AGENT_RATE_LIMIT_RPM` | No | `30` | Max requests per minute |
 
@@ -1281,6 +1285,7 @@ main().catch(console.error);
 - Use sensible defaults for everything except security-sensitive values (API keys, filesystem roots).
 - Never log API keys or secrets — only log the structure of the config.
 - For production, consider using `dotenv` for local development and real env vars in deployment.
+- `observe` defaults to `true`, so every agent emits traces if Langfuse / OTel env vars are set. For high-throughput batch jobs or cost-sensitive deployments, pass `observe: false` explicitly to opt out — this is the only way to silence the auto-init "ObservabilityManager: Observability disabled" debug log on initialize.
 
 ---
 

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/troubleshooting/common-errors.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/troubleshooting/common-errors.md
@@ -86,15 +86,16 @@ console.log("Provider package loaded successfully");
 ```
 3. If using a monorepo, make sure the package is installed in the correct workspace.
 
-**Prevention:** Add the provider package to your `dependencies` (not `devDependencies`) so it is always available in production. Pin the version to avoid breaking changes:
+**Prevention:** Add the provider package to your `dependencies` (not `devDependencies`) so it is always available in production. Pin to current stable versions — note that `mcp-use` jumped from the `0.1.x` line directly to `1.x` (no `0.6.x` ever existed on npm), so any range like `^0.6.0` will fail to install:
 ```json
 {
   "dependencies": {
-    "mcp-use": "^0.6.0",
-    "@langchain/openai": "^0.5.0"
+    "mcp-use": "^1.25.0",
+    "@langchain/openai": "^1.4.0"
   }
 }
 ```
+Verify the current latest with `npm view mcp-use version` before committing — versions drift over time.
 
 ---
 
@@ -239,7 +240,7 @@ const agent = new MCPAgent({
 });
 ```
 
-**Prevention:** Monitor your API usage dashboards. Set billing alerts. Use `gpt-4o-mini` or `claude-3-5-haiku` for tasks that do not require top-tier reasoning. Batch requests where possible rather than making many small agent runs.
+**Prevention:** Monitor your API usage dashboards. Set billing alerts. Use `gpt-4o-mini` or `claude-haiku-4-5` for tasks that do not require top-tier reasoning. Batch requests where possible rather than making many small agent runs.
 
 ---
 
@@ -250,15 +251,17 @@ const agent = new MCPAgent({
 **Cause:** Default timeout settings in the HTTP client are too short for the request payload size. Provider-side load spikes can also cause slowdowns beyond the timeout threshold.
 
 **Fix:**
-1. Increase the timeout via explicit mode configuration:
+1. Increase the timeout via explicit mode configuration. In `@langchain/openai@1.x`, the canonical placement is under `configuration: { ... }` (forwarded to the underlying `openai` SDK client). The top-level `timeout` and `maxRetries` are still accepted as backwards-compatible aliases, but `configuration` is the form you want for new code:
 ```typescript
 import { MCPAgent, MCPClient } from "mcp-use";
 import { ChatOpenAI } from "@langchain/openai";
 
 const llm = new ChatOpenAI({
   model: "gpt-4o",
-  timeout: 120_000, // 120 seconds
-  maxRetries: 3,
+  configuration: {
+    timeout: 120_000,   // 120 seconds — forwarded to the OpenAI SDK
+    maxRetries: 3,      // forwarded to the OpenAI SDK
+  },
 });
 
 const client = new MCPClient({
@@ -471,38 +474,52 @@ const result2 = await agent.run({ prompt: `Analyze these files: ${result1}` });
 
 ### Error: "Agent not initialized — call initialize() first"
 
-**When:** You call `agent.run()` or `agent.stream()` on an agent that has not been initialized, when `autoInitialize` is set to `false`.
+**When:** You call `agent.run({ prompt, manageConnector: false })` (or `stream` / `streamEvents` / `prettyStreamEvents` with `manageConnector: false`) on an agent that was never initialized, AND `autoInitialize` is left at its default of `false`.
 
-**Cause:** `autoInitialize` defaults to `false`. When it is `false`, you must call `await agent.initialize()` before any run calls. Setting `autoInitialize: true` makes the agent initialize automatically on the first `run()` call. If you leave the default and forget to initialize, you get this error.
+**Cause:** Normal `agent.run({ prompt })` usage **never** triggers this error: `run` delegates to `stream`, whose default `manageConnector` is `true`, which auto-initializes on first call. The error only fires when **all three** of these are simultaneously true:
+1. You explicitly pass `manageConnector: false` in the `RunOptions` (opting out of automatic init), AND
+2. `autoInitialize: false` (the default), AND
+3. You never called `await agent.initialize()` manually.
 
 **Fix:**
-1. Either set `autoInitialize: true` to initialize automatically on first `run()`:
+1. The simplest fix is to drop `manageConnector: false` and let the default (`true`) handle initialization automatically:
 ```typescript
 import { MCPAgent } from "mcp-use";
 
 const agent = new MCPAgent({
   llm: "openai/gpt-4o",
-  autoInitialize: true,  // initialize automatically on first run()
   mcpServers: { /* ... */ },
 });
 
+// No `manageConnector: false` — the agent auto-initializes on first run.
 const result = await agent.run({ prompt: "Hello" });
 ```
-2. Or explicitly initialize before calling run (this is the default behavior):
+2. If you intentionally pass `manageConnector: false` (e.g. to share lifecycle across multiple runs), call `initialize()` once up-front:
 ```typescript
 import { MCPAgent } from "mcp-use";
 
-// autoInitialize defaults to false — must call initialize() manually
 const agent = new MCPAgent({
   llm: "openai/gpt-4o",
   mcpServers: { /* ... */ },
 });
 
 await agent.initialize();
-const result = await agent.run({ prompt: "Hello" });
+const r1 = await agent.run({ prompt: "Task 1", manageConnector: false });
+const r2 = await agent.run({ prompt: "Task 2", manageConnector: false });
+await agent.close();
+```
+3. Or set `autoInitialize: true` so the agent initializes on first call even when `manageConnector: false`:
+```typescript
+const agent = new MCPAgent({
+  llm: "openai/gpt-4o",
+  autoInitialize: true,            // fallback init when manageConnector is false
+  mcpServers: { /* ... */ },
+});
+
+const result = await agent.run({ prompt: "Hello", manageConnector: false });
 ```
 
-**Prevention:** `autoInitialize` defaults to `false`. Either always call `await agent.initialize()` before `run()`, or set `autoInitialize: true` to have the agent initialize on first use.
+**Prevention:** Hitting this error almost always means `manageConnector: false` was set somewhere in the call. Audit your call sites for that flag. Default `run({ prompt })` usage initializes automatically — if you have not opted out, look elsewhere for the bug.
 
 ---
 
@@ -683,7 +700,7 @@ const SimpleSchema = z.object({
 });
 ```
 2. Break complex outputs into multiple agent runs with simpler schemas.
-3. Use `gpt-4o` or `claude-sonnet-4` — they have the best structured output adherence.
+3. Use `gpt-4o` or `claude-sonnet-4-5` — they have the best structured output adherence.
 
 **Prevention:** Design schemas with the LLM's capabilities in mind. Test with the cheapest model first — if `gpt-4o-mini` can handle it, any model can.
 
@@ -929,12 +946,29 @@ mcpServers: {
 ```bash
 npm install @modelcontextprotocol/server-filesystem
 ```
-Then use the local installation:
+Then use the package's direct JS entry (resolved against the current working directory). Do **not** point `node` at `node_modules/.bin/<name>` — `.bin` entries are shebang-script symlinks on Unix and `.cmd` wrappers on Windows, so `node` will throw `SyntaxError: Unexpected token` on the first line:
 ```typescript
+import path from "node:path";
+
 mcpServers: {
   filesystem: {
     command: "node",
-    args: ["node_modules/.bin/mcp-server-filesystem", "/tmp"],
+    args: [
+      path.resolve(
+        process.cwd(),
+        "node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
+      ),
+      "/tmp",
+    ],
+  },
+}
+```
+Or, simpler: keep `npx` but pass `--no-install` so it uses the locally installed copy without touching the registry:
+```typescript
+mcpServers: {
+  filesystem: {
+    command: "npx",
+    args: ["--no-install", "@modelcontextprotocol/server-filesystem", "/tmp"],
   },
 }
 ```
@@ -1001,7 +1035,7 @@ async function runWithRecovery(config: any, prompt: string) {
 }
 ```
 
-**Prevention:** Stress-test your MCP server with large payloads and concurrent requests. Set memory limits and add global error handlers in the server process. Use `useServerManager: true` in the agent config if available for automatic reconnection.
+**Prevention:** Stress-test your MCP server with large payloads and concurrent requests. Set memory limits and add global error handlers in the server process. To handle mid-task crashes, use the recovery pattern shown above — catch `EPIPE` / connection errors from `agent.run()` and recreate the agent (which re-spawns the server process via a fresh `initialize()` call). Note that `useServerManager: true` provides **dynamic server selection** (the LLM picks which configured server to connect to via management tools), not automatic reconnection of crashed processes.
 
 ---
 
@@ -1115,13 +1149,27 @@ const agent = new MCPAgent({
   },
 });
 ```
-2. For SSE-based (remote) servers:
+2. For remote servers, declare both the URL and the `transport` explicitly. mcp-use defaults to Streamable HTTP (`transport: "http"`) — pass `transport: "sse"` only when targeting a legacy SSE server:
 ```typescript
-const agent = new MCPAgent({
+// Modern Streamable HTTP server (recommended for new code)
+const httpAgent = new MCPAgent({
   llm: "openai/gpt-4o",
   mcpServers: {
-    remoteServer: {
-      url: "http://localhost:3001/sse",   // SSE endpoint
+    modernServer: {
+      url: "https://mcp.example.com/mcp",
+      transport: "http",                  // default — this is the current MCP standard
+      headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
+    },
+  },
+});
+
+// Legacy SSE server (older reference servers)
+const sseAgent = new MCPAgent({
+  llm: "openai/gpt-4o",
+  mcpServers: {
+    legacyServer: {
+      url: "http://localhost:3001/sse",
+      transport: "sse",                   // required — without this, mcp-use tries Streamable HTTP
     },
   },
 });
@@ -1276,34 +1324,49 @@ import type { MCPAgentOptions } from "mcp-use";
 **Cause:** The `callbacks` option expects LangChain-compatible callback handlers. Passing a plain object or incorrect structure causes runtime errors when the agent tries to invoke callback methods.
 
 **Fix:**
-1. Use the correct callback handler structure (simplified mode shown; works the same in explicit mode):
+1. Use the correct callback handler structure. The `callbacks` option is typed as `BaseCallbackHandler[]` — `BaseCallbackHandler` is an **abstract class** (not an interface), so subclass it instead of passing a plain object literal (which fails under `strict: true` with `Property 'name' is missing`):
 ```typescript
 import { MCPAgent } from "mcp-use";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+
+class AgentCallbacks extends BaseCallbackHandler {
+  name = "agent-callbacks";
+
+  async handleLLMStart(_llm: unknown, prompts: string[]) {
+    console.log("LLM started with", prompts.length, "prompts");
+  }
+  async handleLLMEnd(_output: unknown) {
+    console.log("LLM finished");
+  }
+  async handleToolStart(tool: { name: string }, _input: string) {
+    console.log("Tool called:", tool.name);
+  }
+  async handleToolEnd(output: string) {
+    console.log("Tool result:", output.substring(0, 100));
+  }
+}
 
 const agent = new MCPAgent({
   llm: "openai/gpt-4o",
   mcpServers: { /* ... */ },
-  callbacks: [
-    {
-      handleLLMStart: async (llm: any, prompts: string[]) => {
-        console.log("LLM started with", prompts.length, "prompts");
-      },
-      handleLLMEnd: async (output: any) => {
-        console.log("LLM finished");
-      },
-      handleToolStart: async (tool: any, input: string) => {
-        console.log("Tool called:", tool.name);
-      },
-      handleToolEnd: async (output: string) => {
-        console.log("Tool result:", output.substring(0, 100));
-      },
-    },
-  ],
+  callbacks: [new AgentCallbacks()],
 });
 ```
-2. Each callback method is optional — only implement the ones you need.
+2. Each callback method is optional — only override the ones you need.
+3. If you want a plain-object form for minimal boilerplate, cast it explicitly. Note that handlers without a `name` get grouped as `unknown_handler` in observability platforms like Langfuse:
+```typescript
+import type { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 
-**Prevention:** Define callbacks as a separate typed object and validate its shape before passing it to the agent constructor.
+callbacks: [
+  {
+    handleLLMStart: async (_llm, prompts: string[]) => {
+      console.log("LLM started with", prompts.length, "prompts");
+    },
+  } as unknown as BaseCallbackHandler,
+],
+```
+
+**Prevention:** Subclass `BaseCallbackHandler` and set a `name` property — this satisfies strict TypeScript and gives observability tools a clear handler identity.
 
 ---
 
@@ -1461,18 +1524,29 @@ const agent = new MCPAgent({
 
 **Step 2: Enable debug-level logging**
 
-For even more detail, enable the mcp-use logger's debug mode:
+For even more detail, enable the mcp-use logger's debug mode. `setDebug` accepts either a boolean or a numeric level (`0` silent, `1` info, `2` debug):
 
 ```typescript
 import { MCPAgent, Logger } from "mcp-use";
 
+// Quick: turn on debug logs (equivalent to Logger.setDebug(2))
 Logger.setDebug(true);
+
+// Or use the richer API for finer control:
+//   level:  "silent" | "error" | "warn" | "info" | "http" | "verbose" | "debug" | "silly"
+//   format: "minimal" | "detailed" | "emoji"
+Logger.configure({ level: "debug", format: "minimal" });
+
+// To silence in production:
+// Logger.configure({ level: "warn" });
 
 const agent = new MCPAgent({
   llm: "openai/gpt-4o",
   mcpServers: { /* ... */ },
 });
 ```
+
+Use `Logger.configure({ format: "minimal" })` in CI environments — emoji-formatted logs can break some log aggregators.
 
 **Step 3: Inspect the tool discovery**
 
@@ -1533,21 +1607,31 @@ const agent = new MCPAgent({
 
 **Step 7: Use prettyStreamEvents for visual debugging**
 
-The `prettyStreamEvents` method formats and displays all events in a human-readable way:
+The `prettyStreamEvents` method formats and displays all events in a human-readable way. It returns an `AsyncGenerator<void, string, void>` — you must iterate it with `for await`. Writing `await agent.prettyStreamEvents(...)` silently does nothing because awaiting an async-generator expression returns the generator object without running its body:
 
 ```typescript
-await agent.prettyStreamEvents({ prompt: "List files in /tmp" });
+// ✅ Correct — iterate the async generator
+for await (const _ of agent.prettyStreamEvents({ prompt: "List files in /tmp" })) {
+  // prettyStreamEvents yields void; pretty-printed output goes to stdout as a side effect
+}
 ```
 
 **Step 8: Check Node.js version and dependencies**
 
-Ensure you are running a supported Node.js version and all dependencies are up to date:
+Ensure you are running a supported Node.js version and all dependencies are up to date. `mcp-use@1.25.0` declares `"engines": { "node": "^20.19.0 || >=22.12.0" }` — Node 18.x and 21.x are NOT supported, and Node 20.x must be at least `20.19.0`:
 
 ```bash
-node --version          # Should be >= 18.0.0
+node --version          # mcp-use@1.25.0 requires ^20.19.0 || >=22.12.0
 npm list mcp-use        # Check installed version
 npm outdated mcp-use    # Check for updates
 ```
+
+A more precise check:
+```bash
+node -e "const [maj, min] = process.versions.node.split('.').map(Number); console.log((maj === 20 && min >= 19) || maj >= 22 ? 'OK: ' + process.versions.node : 'UPGRADE REQUIRED: ' + process.versions.node);"
+```
+
+If you see unexpected errors, confirm the engine constraint with `cat node_modules/mcp-use/package.json | grep -A1 engines`.
 
 **Step 9: Verify network connectivity**
 


### PR DESCRIPTION
## Summary

Multi-agent fact-check audit caught 55 verified errors in the `build-mcp-use-agent` skill. Five parallel Opus reviewers cross-checked every claim against the published `mcp-use@1.25.0` npm tarball at `/tmp/mcp-use-check/package/dist/`, then directly applied fixes to the skill files. Validation passes (`scripts/validate-skills.py` → 42 skills, all green).

## Why now

The skill drifted from upstream: model IDs aged out (`gemini-pro`, `claude-3-5-sonnet-20241022`), peer-dep version pins were undocumented (LangChain v1, Zod v4), and the `RunOptions` object form (primary API since v1.20.0) was misrepresented as fictional. Earlier audit attempts produced 105 candidate findings, but discovered mid-audit that GitHub `main` was lagging behind the published npm tarball — ~35 claims had to be retracted before fixes could begin. This PR is the corrective implementation phase, with every claim re-verified against the tarball before editing.

## What changed

10 files touched, +781 / −253 lines.

### `SKILL.md` (491 lines, under the 500-line limit) — 13 fixes
- Default models refreshed: `claude-sonnet-4-6`, `claude-opus-4-7`, `gemini-2.5-pro`, `gemini-2.5-flash`, `llama-3.3-70b-versatile`
- Companion-packages table split into **declared peer deps** (LangChain v1, Zod v4, `@langchain/core`, `@langchain/openai`, `@langchain/anthropic`) vs **NOT-peer optional adapters** (`@langchain/google-genai`, `@langchain/groq`)
- New constructor options documented: `observe`, `systemPromptTemplate`, `additionalTools`, `adapter`, `serverManagerFactory`, `agentId`/`apiKey`/`baseUrl`, `exposeResourcesAsTools`, `exposePromptsAsTools`, `toolsUsedNames`
- Public exports enumerated: `RemoteAgent`, `loadConfigFile`, `BrowserOAuthClientProvider`, `onMcpAuthorization`, `probeAuthParams`, `ServerManager`, `ObservabilityManager`, `Telemetry`, connector classes, code executors, elicitation helpers
- `toolsUsedNames` corrected: it is a **tools-used report**, NOT an access filter (line 66 questionnaire item 9)
- `tags` / `metadata` correctly scoped to agent-wide `setTags()` / `setMetadata()` setters, not per-call `RunOptions`
- `manageConnector` documented in object-form examples

### `references/guides/*` — 13 fixes
- **memory-management.md**: `BaseMessage[]` not `Message[]`; `externalHistory` documented as first-class `RunOptions` field; `client.closeAllSessions()` is the canonical cleanup
- **structured-output.md**: removed fictional `stream: boolean` option from `run()`; clarified `agent.close()` vs `client.closeAllSessions()` relationship
- **observability.md**: `LANGFUSE_BASEURL` documented as fallback alongside `LANGFUSE_HOST`
- **advanced-patterns.md**: `createAllSessions()` returns `Promise<Record<string, MCPSession>>` not `Promise<void>`; `LangChainAdapter` IS exported; streaming methods return `AsyncGenerator` directly (NOT `Promise<AsyncGenerator>`); per-provider constructor differences documented; dangling backtick fixed

### `references/patterns/*` — 10 fixes
- **production-patterns.md**: `maxSteps` default is 5 (was claimed as different); `observe: false` opt-out documented
- **anti-patterns.md**: outdated model IDs replaced; `JSON.parse(agent.run())` rewritten to use `run<T>({ prompt, schema })`; `BaseCallbackHandler` shape corrected to require `extends`; fictional `@modelcontextprotocol/server-shell` swapped for real `mcp-shell-server`; per-request `MCPClient` cost callout added; deprecated positional `agent.run("string")` swapped to object form; **new sections 24–26 added covering OAuth/RemoteAgent/onMcpAuthorization** (anti-patterns and correct usage)

### `references/troubleshooting/common-errors.md` — 12 fixes
- Version pin: `mcp-use@^1.25.0` (not non-existent `^0.6.0`)
- Filesystem server path corrected to `dist/index.js` resolution
- SSE config shape: explicit `transport: "http"` / `transport: "sse"` variants
- `Logger.setDebug` + `Logger.configure` signatures correct
- `BaseCallbackHandler` subclass with required `name` field
- `prettyStreamEvents` requires `for await`, not `await`
- Models updated: `claude-sonnet-4-5`, `claude-haiku-4-5`
- "Agent not initialized" scenario corrected to the narrow case where it actually fires
- Node engines: `^20.19.0 || >=22.12.0` (was `>=18.0.0`)
- `useServerManager: true` clarified — does NOT auto-reconnect; provides dynamic server selection only

### `references/examples/*` — 7 fixes
- **agent-recipes.md**: `setDisallowedTools()` requires re-`initialize()` call to take effect on already-initialized agent (init-time binding)
- **integration-recipes.md**: 
  - `useChat` import: `@ai-sdk/react` (not deprecated `ai/react`)
  - Vercel AI SDK recipe rewritten with two variants: `ai@^6` + `@ai-sdk/langchain@^2` using `createUIMessageStreamResponse({ stream: toUIMessageStream(events) })`, and `ai@^4` matching mcp-use's own `examples/client/ai_sdk_example.ts`
  - Fictional `@anthropic/mcp-server-*` packages replaced with real `@modelcontextprotocol/server-brave-search` / `server-everything`
  - `LANGFUSE_HOST` (not `LANGFUSE_BASE_URL`); `LANGFUSE_BASEURL` documented as fallback
  - Langfuse manual-handler recipe annotated to require `MCP_USE_LANGFUSE=false` to avoid duplicate traces with built-in auto-init

## Files touched

| File | Lines |
|---|---|
| `SKILL.md` | 491 |
| `references/guides/memory-management.md` | 811 |
| `references/guides/structured-output.md` | 706 |
| `references/guides/observability.md` | 206 |
| `references/guides/advanced-patterns.md` | 800 |
| `references/patterns/production-patterns.md` | 1959 |
| `references/patterns/anti-patterns.md` | 1886 (+216 for new sections 24–26) |
| `references/troubleshooting/common-errors.md` | 1698 |
| `references/examples/agent-recipes.md` | 1271 |
| `references/examples/integration-recipes.md` | 1173 |

## Verification

- [x] Each fix re-verified against `/tmp/mcp-use-check/package/dist/src/` before editing (no GitHub-main-only claims)
- [x] `python3 scripts/validate-skills.py` → 42 skills, all green
- [x] `SKILL.md` stays under 500 lines (491)
- [x] No `<` / `>` in frontmatter, no `claude` / `anthropic` in skill names
- [x] All `references/` files explicitly routed from `SKILL.md`

Not verified:
- [ ] Runtime smoke test against a real `mcp-use@1.25.0` agent — code paths in examples are paper-verified against the tarball types only

## Risks / open items

1. **`clientInfo` on `MCPClient`** — appears in live Manufact docs but not in the 1.25.0 tarball's `client.d.ts`. Possibly unreleased or docs-only; left as-is in the skill (skill doesn't claim to expose it).
2. **`OAuthHelper`, `LINEAR_OAUTH_CONFIG`, `createOAuthMCPConfig`** — referenced in skill but not located in the tarball's `auth/` subdir. Deeper scan against the runtime js may be needed; not changed in this PR.
3. **`@langchain/openai` v1 `timeout` option** — existed in v0.x; v1 types accept it under `configuration: {}` but unverified for top-level pass-through. Skill now shows the `configuration` form as primary.
4. **AI SDK v6 recipe** uses `createUIMessageStreamResponse({ stream: toUIMessageStream(events) })` — verified against `ai@6.0.168` types but no runtime test in this PR.

## Follow-ups (not in scope)

- Smoke-test the recipe code against a real `mcp-use@1.25.0` install
- Resolve the `OAuthHelper` / `clientInfo` discrepancies between tarball and live docs (file an upstream issue if they exist)
- Re-audit when `mcp-use` 1.26+ ships
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the `build-mcp-use-agent` docs and examples to match `mcp-use@1.25.0`, fixing API shapes, model IDs, and recipes so users can copy-paste working code. Validation passes for all skills.

- **Bug Fixes**
  - Updated model IDs and provider shorthands (e.g., `claude-sonnet-4-6`, `gemini-2.5-pro`, `llama-3.3-70b-versatile`).
  - Fixed `RunOptions` and `run()` docs: object form is primary; added `manageConnector`, `externalHistory`, `signal`; tags/metadata via `agent.setTags()`/`agent.setMetadata()`; `toolsUsedNames` is reporting-only.
  - Clarified streaming: `stream`/`streamEvents`/`prettyStreamEvents` return `AsyncGenerator` (do not `await` the call itself).
  - Added/clarified constructor options: `observe`, `systemPromptTemplate`, `additionalTools`, `exposeResourcesAsTools`/`exposePromptsAsTools`, `serverManagerFactory`, `adapter`, remote mode via `agentId`/`apiKey`/`baseUrl`.
  - Observability: prefer `LANGFUSE_HOST` with `LANGFUSE_BASEURL` fallback; auto-init behavior; how to disable via `MCP_USE_LANGFUSE=false`.
  - Vercel AI SDK recipes: AI SDK v6 path (`createUIMessageStreamResponse` + `@ai-sdk/langchain`’s `toUIMessageStream`) and AI SDK v4 path (`LangChainAdapter.toDataStreamResponse`); frontend uses `@ai-sdk/react`.
  - Replaced fictional packages and paths with real ones (`@modelcontextprotocol/server-*`, `mcp-shell-server`); corrected SSE/HTTP config and `createAllSessions` return type; `BaseCallbackHandler` subclassing shown.
  - Memory/troubleshooting: `BaseMessage[]` history, `externalHistory` override, canonical cleanup via `client.closeAllSessions()` (or `agent.close()`, not both), `setDisallowedTools()` requires `initialize()` to apply after first run; Node engines `^20.19.0 || >=22.12.0`; pin `mcp-use@^1.25.0`; OpenAI timeout via `configuration`.
  - `.gitignore` now ignores audit scratch and session artifacts: `violations/`, `to-delete/`, `.continues-handoff.md`, `*.claude-session*`.

- **Dependencies**
  - Peers: LangChain v1 (`langchain`, `@langchain/core`, `@langchain/openai`, `@langchain/anthropic`) and `zod@^4`. Optional adapters `@langchain/google-genai` and `@langchain/groq` are NOT peers; install only if used.
  - Documented exports now listed (e.g., `RemoteAgent`, `BrowserOAuthClientProvider`, `onMcpAuthorization`, `probeAuthParams`, `ServerManager`, `ObservabilityManager`, code executors).
  - Provider shorthands require the matching adapter to be installed (e.g., `"google/..."` needs `@langchain/google-genai`).

<sup>Written for commit eff3af9d404da2fab6fcbc785a28bac0de994b39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


