### PR TITLE
🐛 fix(build-mcp-use-agent): apply review fixups for PR #48

### DIFF
--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/advanced-patterns.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/advanced-patterns.md
@@ -527,6 +527,7 @@ Use them directly instead of writing a local bridge helper:
 ```typescript
 import {
   streamEventsToAISDK,
+  createReadableStreamFromGenerator,
   // streamEventsToAISDKWithTools,  // alternative — adds 🔧 / ✅ tool markers
 } from "mcp-use";
 import { createTextStreamResponse } from "ai";
@@ -539,7 +540,11 @@ const agent = new MCPAgent({ llm: new ChatOpenAI({ model: "gpt-4o" }), client })
 export async function POST(req: Request) {
   const { prompt } = await req.json();
   const events = agent.streamEvents({ prompt });
-  return createTextStreamResponse(streamEventsToAISDK(events));
+  // createTextStreamResponse expects a ReadableStream<string>, not an AsyncGenerator —
+  // wrap with createReadableStreamFromGenerator before passing.
+  return createTextStreamResponse({
+    textStream: createReadableStreamFromGenerator(streamEventsToAISDK(events)),
+  });
 }
 ```
 

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/structured-output.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/guides/structured-output.md
@@ -49,9 +49,9 @@ import { z } from "zod";
 
 | Method | Parameters | Returns |
 |---|---|---|
-| `run` | `{ prompt: string; schema?: z.ZodSchema<T>; maxSteps?: number; signal?: AbortSignal }` | `Promise<T>` (typed if `schema` provided, else `string`) |
-| `stream` | `{ prompt: string; maxSteps?: number; schema?: z.ZodSchema<T>; signal?: AbortSignal }` or plain `string` | `AsyncGenerator<AgentStep, string \| T, void>` |
-| `prettyStreamEvents` | `{ prompt: string; maxSteps?: number; schema?: z.ZodSchema<T> }` | `AsyncGenerator<void, string, void>` |
+| `run` | `{ prompt: string; schema?: z.ZodSchema<T>; maxSteps?: number; manageConnector?: boolean; externalHistory?: BaseMessage[]; signal?: AbortSignal }` | `Promise<T>` (typed if `schema` provided, else `string`) |
+| `stream` | `{ prompt: string; maxSteps?: number; schema?: z.ZodSchema<T>; manageConnector?: boolean; externalHistory?: BaseMessage[]; signal?: AbortSignal }` or plain `string` | `AsyncGenerator<AgentStep, string \| T, void>` |
+| `prettyStreamEvents` | `{ prompt: string; maxSteps?: number; schema?: z.ZodSchema<T>; manageConnector?: boolean; externalHistory?: BaseMessage[] }` | `AsyncGenerator<void, string, void>` |
 | `streamEvents` | `{ prompt: string; schema?: z.ZodSchema<T>; maxSteps?: number; signal?: AbortSignal }` or plain `string` | `AsyncGenerator<StreamEvent, void, void>` |
 | `clearConversationHistory` | `()` | `void` |
 | `close` | `()` | `Promise<void>` |

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/troubleshooting/common-errors.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/troubleshooting/common-errors.md
@@ -1628,7 +1628,7 @@ npm outdated mcp-use    # Check for updates
 
 A more precise check:
 ```bash
-node -e "const [maj, min] = process.versions.node.split('.').map(Number); console.log((maj === 20 && min >= 19) || maj >= 22 ? 'OK: ' + process.versions.node : 'UPGRADE REQUIRED: ' + process.versions.node);"
+node -e "const [maj, min] = process.versions.node.split('.').map(Number); console.log((maj === 20 && min >= 19) || (maj === 22 && min >= 12) || maj >= 23 ? 'OK: ' + process.versions.node : 'UPGRADE REQUIRED: ' + process.versions.node);"
 ```
 
 If you see unexpected errors, confirm the engine constraint with `cat node_modules/mcp-use/package.json | grep -A1 engines`.


### PR DESCRIPTION
## Summary

Applies the three Cubic-flagged correctness fixes to `build-mcp-use-agent` that arrived after PR #48 was already merged. Each fix is the second-pass do-review finding from PR #48's review thread.

## Fixes

1. **`structured-output.md:48-50`** — full method reference table now lists `manageConnector` and `externalHistory` on `run`/`stream`/`prettyStreamEvents` to match the run-options table at lines 32–37 (which PR #48 added).

2. **`common-errors.md:1631`** — Node version check no longer prints OK for unsupported Node 22.0–22.11. The package's `engines` field is `^20.19.0 || >=22.12.0`, so the previous `(maj === 20 && min >= 19) || maj >= 22` would falsely pass for early Node 22.x. Fixed to `(maj === 20 && min >= 19) || (maj === 22 && min >= 12) || maj >= 23`.

3. **`advanced-patterns.md:528-543`** — wrap `streamEventsToAISDK(events)` with `createReadableStreamFromGenerator(...)` before passing to `createTextStreamResponse`. The AI SDK helper expects a `ReadableStream<string>`, not an `AsyncGenerator<string>`. Also pass via `{ textStream }` per the AI SDK signature. The companion code in `integration-recipes.md` was already correct; this aligns the two recipes.

## Verification

- [x] `python3 scripts/validate-skills.py` → 41 skills, all green
- [x] All three fixes manually traced against `mcp-use@1.25.0` source / Anthropic AI SDK v6 docs
- [x] No skill content changed beyond the three lines flagged in review

## Why a separate PR

PR #48 was merged before these fixups landed on the head branch. Rather than amend a merged commit (which would force-push history), this is a clean follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to PR #48 that applies three review fixes to `build-mcp-use-agent` docs and examples. Aligns method options, corrects Node version check, and fixes streaming usage with the `ai` SDK.

- **Bug Fixes**
  - structured-output.md: add `manageConnector` and `externalHistory` to `run`/`stream`/`prettyStreamEvents` tables to match the options reference.
  - common-errors.md: tighten Node check to `^20.19.0 || >=22.12.0` so Node 22.0–22.11 no longer show OK.
  - advanced-patterns.md: wrap `streamEventsToAISDK(events)` with `createReadableStreamFromGenerator` and pass via `{ textStream }` to `createTextStreamResponse` to provide a `ReadableStream<string>` as required.

<sup>Written for commit 14568c4bfd0a4fae36909de28ae0db8ff90a4e5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

