### PR TITLE
🐛 fix(build-mcp-use-agent): address remaining 4 review findings on PR #48

### DIFF
--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/SKILL.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/SKILL.md
@@ -207,8 +207,8 @@ For the full options table with all defaults, read `references/guides/agent-conf
 | `additionalInstructions` | `string \| null` | `null` | Layer extra behavior on default prompt |
 | `disallowedTools` | `string[]` | `[]` | Block dangerous or irrelevant tools (real access filter) |
 | `additionalTools` | `StructuredToolInterface[]` | `[]` | Inject extra LangChain tools alongside MCP-sourced tools |
-| `exposeResourcesAsTools` | `boolean` | provider default | Expose MCP resources as callable tools |
-| `exposePromptsAsTools` | `boolean` | provider default | Expose MCP prompts as callable tools |
+| `exposeResourcesAsTools` | `boolean` | `true` | Expose MCP resources as callable tools |
+| `exposePromptsAsTools` | `boolean` | `true` | Expose MCP prompts as callable tools |
 | `useServerManager` | `boolean` | `false` | Multi-server routing (advanced) |
 | `serverManagerFactory` | `(client: MCPClient) => ServerManager` | default | Inject a custom `ServerManager` implementation |
 | `adapter` | `LangChainAdapter` | default | Override the MCP-tool → LangChain-tool adapter |

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/agent-recipes.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/agent-recipes.md
@@ -1185,6 +1185,7 @@ main().catch((err) => {
 **Key takeaways:**
 
 - `setDisallowedTools([...])` updates the stored list; the bound `AgentExecutor` is NOT rebuilt automatically. Call `await agent.initialize()` afterwards to apply changes on an already-initialized agent.
+- **Simplified-mode hazard**: in **simplified mode** (passing `mcpServers` config to `MCPAgent` rather than a constructed `MCPClient`), each call to `agent.initialize()` constructs a NEW `MCPClient` and overwrites `this.client` without closing the old one. Repeatedly re-initializing in simplified mode leaks stdio child processes and connections — only the most recent client is closed by `agent.close()`. **For long-running servers that re-initialize, use explicit mode**: construct your own `MCPClient` once, pass it via `client:`, and call `await client.close()` at shutdown. Re-initialize binds new tools without spawning new connections. Source: `mcp-use@1.25.0` `dist/src/browser.js:1683-1690`.
 - The simplest pattern is to call `setDisallowedTools()` once, BEFORE the first `run()` — the first run will initialize the agent with the restrictions in place.
 - `getDisallowedTools()` returns the current stored list (regardless of whether it has been bound to the executor yet).
 - Use environment variables (`NODE_ENV`) to choose a restriction profile at construction time.

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/integration-recipes.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/examples/integration-recipes.md
@@ -6,7 +6,7 @@ Examples of integrating MCPAgent with external frameworks and services. Each rec
 
 ## 1. Vercel AI SDK — Next.js API Route with Streaming
 
-Stream MCPAgent responses through a Next.js App Router API route using the Vercel AI SDK. This recipe shows the pattern used in mcp-use's own [`examples/client/ai_sdk_example.ts`](https://github.com/mcp-use/mcp-use-ts/blob/main/packages/mcp-use/examples/client/ai_sdk_example.ts) — `streamEventsToAISDK` and `createReadableStreamFromGenerator` are exported directly from `mcp-use`. The frontend uses `useChat` from `@ai-sdk/react` (the legacy `'ai/react'` subpath was removed in AI SDK v5+).
+Stream MCPAgent responses through a Next.js App Router API route using the Vercel AI SDK. This recipe shows the pattern used in mcp-use's own examples (see the `examples/` directory under `libraries/typescript/packages/mcp-use/` in the canonical [`mcp-use/mcp-use`](https://github.com/mcp-use/mcp-use) repo) — `streamEventsToAISDK` and `createReadableStreamFromGenerator` are exported directly from `mcp-use`. The frontend uses `useChat` from `@ai-sdk/react` (the legacy `'ai/react'` subpath was removed in AI SDK v5+).
 
 > **AI SDK version note:** mcp-use's `examples/client/ai_sdk_example.ts` uses `LangChainAdapter.toDataStreamResponse(...)` imported from the `ai` package — that path works on AI SDK `4.x`. In AI SDK `5.x` and `6.x` (current), `LangChainAdapter` was removed; the equivalent is `toUIMessageStream` (from `@ai-sdk/langchain@^2`) wrapped in `createUIMessageStreamResponse` (from `ai@^6`). Both variants are shown below — pick the one matching your installed `ai` version.
 
@@ -152,7 +152,7 @@ Attach Langfuse tracing to every MCPAgent run for cost tracking, latency monitor
 
 ### Sub-recipe A — Zero-config auto-init (recommended default)
 
-This matches mcp-use's own [`examples/client/observability.ts`](https://github.com/mcp-use/mcp-use-ts/blob/main/packages/mcp-use/examples/client/observability.ts).
+This matches the observability pattern shipped in mcp-use's own examples (canonical [`mcp-use/mcp-use`](https://github.com/mcp-use/mcp-use) repo, `libraries/typescript/packages/mcp-use/examples/`).
 
 ```typescript
 // .env:

--- a/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/patterns/anti-patterns.md
+++ b/skills/build-mcp-use-agent/skills/build-mcp-use-agent/references/patterns/anti-patterns.md
@@ -1805,7 +1805,12 @@ try {
 import { BrowserOAuthClientProvider } from "mcp-use";
 
 function ConnectButton() {
-  // New provider object every render — token cache is invalidated as soon as state changes
+  // New provider object every render — instance state lost on each render:
+  // - PKCE pendingCodeVerifier (instance field, NOT localStorage) — current auth flow breaks
+  // - _cachedMetadata / _refreshPromise / _lastOriginalResource (instance) — refresh dedup is reset
+  // - fetch interceptor state — repeated install/uninstall churn
+  // (Tokens themselves are safe — they live in localStorage keyed on serverUrl hash and survive
+  //  re-instantiation. The cost is in-flight auth/refresh state, not the cached token.)
   const provider = new BrowserOAuthClientProvider("https://mcp.example.com", {
     clientName: "My App",
     callbackUrl: "https://app.example.com/oauth/callback",


### PR DESCRIPTION
# 🐛 fix(build-mcp-use-agent): address remaining 4 review findings on PR #48

## Summary

Round 2 of the do-review pass on the merged PR #48. PR #48 + the follow-up PR #49 already landed the 2 🔴 blockers (streaming `createReadableStreamFromGenerator` adapter, Node version check `(maj === 22 && min >= 12)` arithmetic) and the structured-output `RunOptions` table mismatch. This PR closes the remaining four 🟡 Important findings.

## Context

The do-review pass on PR #48 surfaced 7 actionable findings (2 🔴 + 5 🟡). The first three were fixed in the merged round 1. The remaining four were deferred and are addressed here as a single follow-up commit so each fix is independently auditable.

## The 4 fixes

### 1. SKILL.md — `exposeResourcesAsTools` / `exposePromptsAsTools` defaults

- **Files**: `skills/build-mcp-use-agent/skills/build-mcp-use-agent/SKILL.md:210–211`
- **Before**: column showed `provider default` for both rows.
- **After**: column shows `true`.
- **Source**: verified in `mcp-use@1.25.0` `dist/src/browser.js`:
  ```js
  exposeResourcesAsTools = true;
  exposePromptsAsTools = true;
  // ...
  this.exposeResourcesAsTools = options.exposeResourcesAsTools ?? true;
  this.exposePromptsAsTools = options.exposePromptsAsTools ?? true;
  ```

### 2. Stale `mcp-use-ts` repo links replaced with canonical `mcp-use/mcp-use`

- **Files**: `references/examples/integration-recipes.md:9, 155`
- **Before**: links pointed at `https://github.com/mcp-use/mcp-use-ts/blob/main/packages/mcp-use/examples/client/{ai_sdk_example.ts,observability.ts}`.
- **After**: prose references to `mcp-use/mcp-use` repo's `libraries/typescript/packages/mcp-use/examples/` directory.
- **Reason**: `mcp-use/mcp-use-ts` has been stale since `2025-12-08` per `gh api repos/mcp-use/mcp-use-ts`. The canonical repo is the actively pushed monorepo `mcp-use/mcp-use`. The specific `ai_sdk_example.ts` and `observability.ts` files are not at the same path upstream — keeping the prose reference avoids broken-link rot.

### 3. Simplified-mode `agent.initialize()` client leak warning

- **Files**: `references/examples/agent-recipes.md` (key takeaways block, ~L1188)
- **Before**: no warning about repeated `initialize()` calls in simplified mode.
- **After**: explicit hazard note — repeated `agent.initialize()` in simplified mode constructs a NEW `MCPClient` and overwrites `this.client` without closing the old one, leaking stdio child processes. Recommend explicit mode (own the `MCPClient` lifecycle) for long-running re-init flows.
- **Source**: verified in `mcp-use@1.25.0` `dist/src/browser.js:1683-1690`.

### 4. `BrowserOAuthClientProvider` anti-pattern rationale corrected

- **Files**: `references/patterns/anti-patterns.md` (§25, ~L1808)
- **Before**: comment claimed "token cache is invalidated as soon as state changes".
- **After**: explicit list of what IS lost on per-render instantiation:
  - PKCE `pendingCodeVerifier` (instance field, not localStorage) — current auth flow breaks.
  - `_cachedMetadata` / `_refreshPromise` / `_lastOriginalResource` (instance) — refresh dedup is reset.
  - Fetch interceptor state — repeated install/uninstall churn.
  - Tokens themselves are safe — they live in localStorage keyed on serverUrl hash and survive re-instantiation.
- **Source**: verified in `mcp-use@1.25.0` `dist/src/auth/browser-provider.d.ts` (token methods: `saveTokens`, `tokens()`, `invalidateCredentials`, `clearStorage` — only the latter two clear cached tokens; constructor does not).
- **Remedy unchanged**: hoist provider construction to module scope.

## Verification

```bash
$ git diff --stat origin/main..HEAD
 skills/build-mcp-use-agent/skills/build-mcp-use-agent/SKILL.md     | 4 ++--
 .../build-mcp-use-agent/references/examples/agent-recipes.md       | 1 +
 .../build-mcp-use-agent/references/examples/integration-recipes.md | 4 ++--
 .../build-mcp-use-agent/references/patterns/anti-patterns.md       | 7 ++++++-
 4 files changed, 11 insertions(+), 5 deletions(-)
```

## Test plan

- [x] `python3 scripts/validate-skills.py` — runs as part of CI.
- [x] No skill-name renames, no new files, no deletions.
- [x] Diff is content-only, single-purpose, single commit.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four documentation issues in `build-mcp-use-agent` to match current `mcp-use` behavior and add a warning to prevent client leaks during simplified agent re-inits.

- **Bug Fixes**
  - Set `exposeResourcesAsTools` and `exposePromptsAsTools` defaults to `true` in SKILL.md.
  - Replaced stale `mcp-use-ts` links with canonical `mcp-use/mcp-use` examples directory refs.
  - Added warning: repeated `agent.initialize()` in simplified mode creates a new `MCPClient` and can leak processes; recommend explicit mode for long-running re-inits.
  - Corrected `BrowserOAuthClientProvider` anti-pattern rationale: tokens persist in localStorage; the real risk is instance state loss (PKCE verifier, refresh dedup, interceptor churn); keep the provider hoisted.

<sup>Written for commit fac79e70c16a33cc1f54f728cddc000074e8b84d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

