### PR TITLE
🐛 fix(run-codex-review): align with codex plugin reality + harden ten-phase flow

### DIFF
--- a/skills/run-codex-review/skills/run-codex-review/SKILL.md
+++ b/skills/run-codex-review/skills/run-codex-review/SKILL.md
@@ -5,11 +5,37 @@ description: "Use skill if you are running parallel per-branch /codex:review fix
 
 # Prepare and Run Codex Review
 
-The job: turn a messy repo into a clean per-branch decomposition; converge each branch through Codex's per-round review loop with `/do-review`-evaluated worker sub-agents; open a comprehensive PR per branch via a sub-agent that uses `/ask-review`; trigger `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh` on each PR as a last check; wait adaptively (900s base + 5-min extensions if bots still talking + 3-min quiet to terminate, capped at 30 min) for external review bots (Copilot, Greptile, Devin); dispatch a `/do-review` evaluator sub-agent per PR over all gathered streams; have the main agent apply the evaluator's accepted subset directly using `/do-review` in its own context; merge foundation→leaf on the private fork only; tidy. End state: every branch DONE-merged or surfaced (CAP-REACHED / BLOCKED / FAILED), no stale worktrees, manifest deleted, `audit-review-state.py` exits 0.
+The job: turn a messy repo into a clean per-branch decomposition; converge each branch through Codex's per-round review loop with `/do-review`-evaluated worker sub-agents; open a comprehensive PR per branch via a sub-agent that uses `/ask-review`; trigger `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh` on each PR as a last check; wait adaptively (900s base + 5-min extensions if bots still talking + 3-min quiet to terminate, capped at 30 min) for external review bots (Copilot, Greptile, Devin, cubic-dev-ai); dispatch a `/do-review` evaluator sub-agent per PR over all gathered streams; have the main agent apply the evaluator's accepted subset directly using `/do-review` in its own context; merge foundation→leaf on the private fork only; tidy. End state: every branch DONE-merged or surfaced (CAP-REACHED / BLOCKED / FAILED), no stale worktrees, manifest deleted, `audit-review-state.py` exits 0.
 
 This skill **layers on top of** `run-repo-cleanup`. Read that skill's `SKILL.md` first; its references and scripts are canonical for diff-walk, conventional commits, fork safety, worktrees, merge ordering. This skill adds: commit redistribution on committed history; the two-level coordinator+worker inner loop; `/ask-review`-based PR creation by sub-agent; `/codex:resc` orchestration with adaptive wait; multi-source review evaluation via `/do-review` sub-agents; main-agent direct apply; review-aware cleanup.
 
 Every sub-agent in this skill is dispatched per **`~/MISSION_PROTOCOL.md`** — Context Block → Mission Objective → Research & Tool Guidance → BSV Definition of Done → Verification → Failure Protocol → Handback. See `references/mission-protocol-integration.md`. Brief discipline is the lever; without it, parallel sub-agents drift toward mediocre.
+
+## Slash commands vs shell commands — invocation matrix
+
+This skill drives four slash commands. They are NOT shell programs. The codex plugin (`openai-codex/codex`) marks `/codex:review`, `/codex:status`, `/codex:result` as `disable-model-invocation: true` — **sub-agents physically cannot call them via `Skill(...)`**. `/codex:resc` requires the `Agent` tool which is not available to forked general-purpose sub-agents.
+
+Read this matrix once and stop guessing.
+
+| Command | Main agent | Worker / PR-Creator / Evaluator sub-agent |
+|---|---|---|
+| `/codex:review` | User-typed slash in chat for ad-hoc reviews. **For Phase 3 programmatic loops, dispatch the wrapper instead** (see worker row). | **`scripts/run-codex-review.py --branch X --base Y --worktree Z`**. The wrapper discovers `codex-companion.mjs` automatically (env-var first, then version-glob fallback), invokes it, normalizes the JSON output, and writes the round log. Sub-agents call the wrapper; the wrapper calls the companion script. |
+| `/codex:resc` | (a) `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <n>` typed as slash for 1-2 PRs. (b) **`scripts/trigger-codex-rescue.py --pr <n> --branch <b> --worktree <wt> --prompt-file <p>`** for programmatic loops with N PRs. Both paths run `codex-companion.mjs task --background` internally. | Not available. Phase 6 trigger is main-agent-only (the slash uses the `Agent` tool; the wrapper queues a Codex worker that forked sub-agents can't see). |
+| `/ask-review` | `Skill(skill="ask-review", args="…")` | `Skill(skill="ask-review", args="…")` — used by PR-Creator sub-agents in Phase 5. |
+| `/do-review` | `Skill(skill="do-review", args="…")` — Phase 8 main-agent direct apply. | **Not used in Phase 3 worker briefs.** Decisions are pre-made before worker dispatch (see invariant 11 + Phase 3 worker brief). Workers are appliers, not evaluators. |
+
+**Forbidden in every context:**
+
+- `codex review …` from Bash — there is no such CLI surface; the underlying `codex` binary has no `--background` flag.
+- Any "shim" wrapping the codex binary because a flag is "missing".
+- `node …/codex-companion.mjs review …` invoked DIRECTLY from a sub-agent brief or main-agent loop — that's what the wrapper is for. The wrapper does discovery, normalization, manifest-update, and round-log path computation. Calling the companion script directly bypasses all of that.
+- Reading `scripts/run-codex-review.py` thinking it's a stub — **it isn't**. It's the canonical wrapper. Production traces of agents writing `/tmp/codex-review-runner.py` parallel implementations were a workaround for an earlier broken version; that version has been rewritten.
+
+**Plugin discovery (handled inside the wrapper, documented for transparency):**
+
+1. `${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs` — set by Claude Code when the plugin is loaded.
+2. Latest semver-sorted version under `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs` — fallback for environments without the env var.
+3. If neither resolves: wrapper exits 127 with install instructions (https://github.com/openai/codex-plugin-cc).
 
 ## Pinned Defaults
 
@@ -23,23 +49,47 @@ Fill these once per project. If any cell is blank, ask — do not guess.
 | max rounds per branch (Phase 3) | `20` |
 | 3-consecutive-all-rejected → DONE | yes |
 | worktree path scheme | `../<repo>-wt-<branch-slug>` |
-| manifest path | `/tmp/codex-review-manifest.json` |
-| round-log dir | `/tmp/codex-review-rounds/` |
+| manifest path | `<repo-root>/.codex-review-manifest.json` (gitignored). **Never `/tmp/...`** — concurrent skill sessions in different repos clobber each other when both default to `/tmp/codex-review-manifest.json`. |
+| round-log dir | `<repo-root>/.codex-review-rounds/` (gitignored). Same reasoning. |
 | PR body cap (Phase 5, hard) | **50,000 chars (max only; no min)** |
-| Codex rescue invocation (Phase 6) | `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh` |
+| Codex rescue invocation (Phase 6) | Two first-class paths: (a) `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <n>` typed as slash directive in chat, OR (b) `scripts/trigger-codex-rescue.py --pr <n> --branch <b> --worktree <wt> --prompt-file <p>` for programmatic loops (wraps `codex-companion.mjs task --background --write --fresh --effort xhigh`). |
+| Single-owner repo mode | If `git remote -v` shows only `origin` and no `upstream`, treat origin as both source and target. Fork-safety invariant becomes vacuous. **Auto-detect in Phase 0; do not ask the user.** |
+| Manifest path collision | Default is repo-local; collisions across sessions are structurally impossible. If a stale `/tmp/codex-review-manifest.json` exists from an older skill version, ignore it. |
 | Wait base (Phase 6) | `900 s` (15 min) |
 | Wait quiet window | `180 s` (3 min) |
 | Wait extension | `300 s` (5 min) |
 | Wait total cap | `1800 s` (30 min) |
+| Codex review wall-clock cap (Phase 3 per-round) | `1500 s` (25 min). Codex can hang on remote tools (codebase-search APIs, etc.); the wrapper enforces this and exits non-zero with `terminal_reason: "review-hang past wall-clock cap"`. Main agent retries once, then marks the round FAILED. |
+| Phase 5 PR-Creator parallelism cap | `4 simultaneous`. GitHub's GraphQL budget is shared with `gh pr create` body uploads; opening 9+ in parallel exhausts it. Throttle batches; PR-Creator brief MUST instruct the sub-agent to use REST (`gh api repos/<owner>/<repo>/pulls -f title=… -f body=@<file> -f base=… -f head=…`) not `gh pr create` (which uses GraphQL). |
 | Mission protocol | `~/MISSION_PROTOCOL.md` |
 | run-repo-cleanup root | `<install-path>/run-repo-cleanup/` |
 | this skill root | `<install-path>/run-codex-review/` |
 
 Repo-local `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` wins over anything here.
 
+## Authorization rule (read this once, do not re-litigate)
+
+If the user's prompt named the full flow ("execute full skill flow", "run all phases", "do the whole pipeline", "full rigor", or invoked `/run-codex-review` without scoping), authorization is **persistent across all 10 phases**. Proceed phase-to-phase **without checkpoint, without option menus, without cost-warning prefaces, without asking "how would you like to proceed"**.
+
+Exception — pause **only** if:
+- A genuinely destructive operation requires confirmation that local context cannot resolve (e.g., a force-push the user did not authorize, a non-fast-forward push to a branch with prior history main agent did not write).
+- A skill invariant has been violated and there is no clean recovery (e.g., codex plugin unavailable; manifest collision that auto-namespacing did not catch).
+- The user typed a stop signal (`stop`, `pause`, `wait`, etc.) since the last action.
+
+Never pause to:
+- Estimate cost or wall-time ("this will take 4-7 hours and burn many tokens"). The user already authorized.
+- Present an option menu (Full / Phase-N-only / Foundation-only / Pause). The flow is already chosen.
+- Ask "would you like me to proceed?" The answer was given when the skill was invoked.
+- Justify a deviation. Either follow the skill or hand back BLOCKED with `terminal_reason` and one sentence on what you'd do differently.
+
+End-of-phase reports must be **one sentence**: "Phase X complete; entering X+1." Verbose state tables, per-branch summaries, and decision menus belong only in the **Final Deliverable** at the end of Phase 9.
+
 ## Non-Negotiable Invariants
 
-1. `origin` = private fork. `upstream` = read-only. Every mutating `gh` call passes `--repo <fork-owner>/<fork-repo>` explicitly. (See `skills/run-repo-cleanup/references/fork-safety.md`.)
+1. **Repo-mode auto-detected, not asked.** Two modes:
+    - **Two-remote** (origin = private fork, upstream = canonical): every mutating `gh` call passes `--repo <fork-owner>/<fork-repo>` explicitly; never push to upstream. (See `skills/run-repo-cleanup/references/fork-safety.md`.)
+    - **Single-owner** (only `origin`, no upstream): origin is the target; `gh` calls still pass `--repo <owner>/<repo>` for explicitness, but the "never touch upstream" rule is vacuously satisfied.
+    Detect from `git remote -v` in Phase 0. **Do not present options or ask the user when the detection is unambiguous.**
 2. Read every diff before staging. No `git commit -am`. (See `skills/run-repo-cleanup/references/diff-walk-discipline.md`.)
 3. Never `rm` an unknown file. Quarantine to `to-delete/` first. (See `skills/run-repo-cleanup/references/to-delete-folder.md`.)
 4. **One worktree per branch. One coordinator per worktree. One fresh worker per round.** No two agents mutate the same branch concurrently.
@@ -49,12 +99,21 @@ Repo-local `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` wins over anything here
 8. **Never push to upstream. Never touch `main` directly.**
 9. **Subagents fix; main agent merges.** Main agent never opens PRs in this workflow either — the PR-Creator sub-agent does.
 10. Granularity at the **concern boundary**, not arbitrary. Don't over-split a coherent commit; don't under-split a mixed one.
-11. **Never apply review feedback as-is.** Every Codex inner-loop, codex-rescue, copilot, greptile, devin item passes through a `/do-review` evaluator (sub-agent in Phase 3 + Phase 7; main-agent direct in Phase 8). Direct-apply is forbidden. (See `references/review-evaluation-protocol.md`.)
+11. **Never apply review feedback as-is — but the evaluator is NOT the worker.** Every Codex/copilot/greptile/devin item passes through `/do-review` evaluation. The role split:
+    - **Phase 3**: main agent runs the classifier on the round-log JSON, then evaluates each major item using `Skill(do-review)` in main's own context (one decision per item). Workers receive PRE-DECIDED accepted-fix specs and apply them mechanically. **Worker briefs do not mention `/do-review`** — that framing causes decision-only failure (workers produce excellent decision JSON but never apply or push).
+    - **Phase 7**: dedicated Evaluator sub-agent runs `/do-review` on every PR review item from all sources.
+    - **Phase 8**: main agent applies the evaluator's accepted subset directly using `/do-review` in own context.
+    Direct-apply without prior `/do-review` evaluation is forbidden in every phase. But pushing eval onto Phase 3 workers is also forbidden — workers are appliers, not evaluators.
 12. **Every sub-agent brief follows MISSION_PROTOCOL Mission Brief Skeleton.** Soft language banned. BSV Definition of Done. Ceilings, not floors. (See `~/MISSION_PROTOCOL.md` and `references/mission-protocol-integration.md`.)
 13. **PR creator MUST be a sub-agent.** Main agent never opens PRs in this skill's workflow. PR-Creator uses `/ask-review` skill (Skill tool) — hand-rolling the body is forbidden.
 14. **PR body ≤ 50,000 chars (hard cap; max only, no min).** Comprehensive ≠ verbose. The body must contain at least 3 explicit reviewer questions.
 15. **Codex rescue triggered immediately after PR creation.** Always `--background --fresh --model gpt-5.5 --effort xhigh`. It runs as Codex's own background sub-agent (not a Claude Agent we dispatch).
 16. **Wait window is 900s base + adaptive end + 1800s total cap.** Don't merge before the window closes and the evaluator runs.
+17. **Use the right invocation surface per context.** Each command has explicit valid paths; do not guess.
+   - **Phase 3 codex review** (per round, per branch): call `scripts/run-codex-review.py --branch X --base Y --worktree Z`. The wrapper discovers `codex-companion.mjs` (env-var first, then version-glob), invokes it synchronously, normalizes output, writes the round log. `/codex:review` is `disable-model-invocation: true` so sub-agents cannot dispatch the slash command — the wrapper IS their path. Main agent uses the wrapper too in programmatic loops.
+   - **Phase 6 codex rescue** (per PR): two first-class paths from main agent — (a) `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <n>` typed as slash directive for 1-2 PRs, OR (b) `scripts/trigger-codex-rescue.py --pr <n> --branch <b> --worktree <wt> --prompt-file <p>` for programmatic loops with N PRs. The wrapper internally calls `codex-companion.mjs task --background --write --fresh --effort xhigh` — same code path the slash command runs. Sub-agents cannot trigger rescue (no `Agent` tool in forked context).
+   - `/ask-review`, `/do-review` are model-invocable → both main and sub-agents call via `Skill(...)`.
+   - **Never** invoke `codex` directly from Bash (no `--background` CLI flag exists). **Never** invoke `node …/codex-companion.mjs …` directly from a brief — the wrappers do that, plus discovery, normalization, manifest update, and round-log path computation. **Never** write a parallel `/tmp/codex-review-runner.py` — that's what the production wrapper now does. **Never** invent a slash-command path that contradicts this matrix.
 
 ## The Ten Phases
 
@@ -85,12 +144,17 @@ Repo-local `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` wins over anything here
                  30 min total cap); gather all review streams
                               │
        Phase 7 — Evaluator sub-agent uses /do-review on all streams
-                 (codex-rescue, copilot, greptile, devin); returns
+                 (codex-rescue, copilot, copilot-pull-request-reviewer, greptile, devin, cubic-dev-ai); returns
                  accepted / rejected / ambiguous decisions JSON
                               │
-       Phase 8 — Main agent direct: read evaluator's JSON, apply accepted
-                 items via /do-review skill in own context, push, merge
-                 (or BLOCKED if ambiguous; surface for human)
+       Phase 8a — Main agent direct: read evaluator's JSON, apply accepted
+                 items, validate, push (or BLOCKED if ambiguous; surface).
+                 Apply order across PRs is irrelevant. /do-review re-eval
+                 is opt-in; the evaluator's JSON is the authority.
+                              │
+       Phase 8b — Foundation→leaf strict serial merge: wait CI green per PR;
+                 merge; rebase remaining leaves onto new main with
+                 --force-with-lease. Foundation must succeed first.
                               │
        Phase 9 — Tidy & final audit (fresh subagent re-verifies)
                               │
@@ -108,17 +172,23 @@ Each phase has a checkpoint. Don't skip forward. If you find yourself tempted to
 1. `python3 skills/run-repo-cleanup/scripts/audit-state.py` — base audit.
 2. `python3 skills/run-repo-cleanup/scripts/list-worktrees.py` — enumerate.
 3. `python3 <this-skill>/scripts/audit-review-state.py` — review-loop wrapper. Detects: orphan `*-wt-*` worktrees, stale `/tmp/codex-review-manifest.json`, in-flight Codex background jobs from prior runs, branches with stale round logs.
-4. `python3 skills/run-repo-cleanup/scripts/init-to-delete.py` if `.gitignore` is missing the patterns.
-5. Verify remotes per `skills/run-repo-cleanup/references/fork-safety.md`.
-6. Verify `~/MISSION_PROTOCOL.md` is present and current. Every sub-agent dispatch depends on it.
-7. Verify the `/ask-review` and `/do-review` skills are registered. Both are required.
+4. **Auto-detect repo mode** from `git remote -v`:
+   - Only `origin` exists → **single-owner mode**. Set `manifest.repo_mode = "single-owner"`. Skip the fork-safety options dialog. Do NOT ask the user about fork semantics.
+   - Both `origin` and `upstream` exist → **two-remote mode**. Verify per `skills/run-repo-cleanup/references/fork-safety.md`.
+5. **Pin manifest path repo-local.** This session's manifest is `<repo-root>/.codex-review-manifest.json`; round-log dir is `<repo-root>/.codex-review-rounds/`. Add both to `.gitignore` if not already there. **Do NOT use `/tmp/...`** — concurrent skill sessions across repos clobber each other when both default to /tmp. Pass `--manifest <repo-root>/.codex-review-manifest.json` to every script invocation. If a stale `/tmp/codex-review-manifest.json` exists from an older skill version, leave it alone — do not delete, do not edit.
+6. `python3 skills/run-repo-cleanup/scripts/init-to-delete.py` if `.gitignore` is missing the patterns.
+7. Verify `~/MISSION_PROTOCOL.md` is present and current. Every sub-agent dispatch depends on it.
+8. Verify the `codex:review`, `codex:resc`, `ask-review`, and `do-review` skills are registered (`Skill(...)` callable). All four are required. If any is missing, surface to the user and stop — do not invent a shim.
 
-**Gate**: enter Phase 1 only when (a) no in-progress git op, (b) `origin` verified as the fork, (c) `.gitignore` includes `to-delete/` + agent artifacts, (d) no orphan review state from a prior session, (e) MISSION_PROTOCOL + ask-review + do-review available.
+**Gate**: enter Phase 1 only when (a) no in-progress git op, (b) repo mode auto-detected (single-owner or two-remote), (c) manifest path resolved (namespaced if a collision was detected), (d) `.gitignore` includes `to-delete/` + agent artifacts, (e) no orphan review state from a prior session, (f) MISSION_PROTOCOL + the four required skills available.
 
 **Red flags**:
-- "I'll just start fresh and ignore the prior session's manifest." → No. Either resume or clean up explicitly.
+- "I'll just start fresh and ignore the prior session's manifest." → No. Either resume or namespace this session's manifest. Do not delete the other session's state.
+- "I'll rebuild the manifest by hand because it has stale entries." → No. Auto-namespace and proceed.
 - "audit-state.py is enough; skip audit-review-state." → No. Orphan review state is invisible to the base audit.
 - "I'll skip the MISSION_PROTOCOL check; the briefs will work without it." → No. The protocol IS the brief discipline.
+- "There's no upstream — let me ask the user how to set up fork semantics." → No. Single-owner mode is auto-detected. Proceed.
+- "Let me run `codex --help` to confirm the CLI is ready." → No. Slash commands are not shell programs. The dispatch surface for sub-agents is `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs"` (existence check is enough); for main agent the dispatch surface is the user-typed slash. Do not probe the underlying CLI.
 
 ---
 
@@ -150,72 +220,92 @@ Each phase has a checkpoint. Don't skip forward. If you find yourself tempted to
 **Think first**: *Each branch needs its own physical workspace before any review starts. Each must have a remote ref on `origin` for Codex to review against.*
 
 ```bash
-python3 <this-skill>/scripts/spawn-review-worktrees.py --branches feat/a feat/b docs/c --execute
+python3 <this-skill>/scripts/spawn-review-worktrees.py --branches feat/a feat/b docs/c --execute --prep-deps
 ```
 
 For each branch the script: creates `../<repo>-wt-<slug>` (or reuses if present and clean), pushes to `origin` with `-u` (refuses if remote != `origin`), appends an entry to the manifest. Verify with `python3 skills/run-repo-cleanup/scripts/list-worktrees.py`.
 
-**Gate**: every branch has a worktree, every branch is at `origin/<branch>`, manifest written.
+**Pre-flight worktree dependencies (`--prep-deps`).** If the project requires installed deps (`node_modules`, `.venv`, etc.) for the build/test that Phases 3 and 8 will run, install them in each worktree NOW — not lazily mid-Phase-3 or mid-Phase-8. The flag detects the package manager from repo files (`pnpm-lock.yaml` → `pnpm install`; `package-lock.json` → `npm ci`; `bun.lockb` → `bun install`; `requirements.txt` → `pip install -r requirements.txt`; `Cargo.toml` → no-op, cargo handles it; etc.) and runs the corresponding install in every newly-created worktree. Default is OFF; flip to ON for any repo whose validate command needs an install step. Production trace showed a worktree throwing `error TS2307: Cannot find module 'fs'` on first build because deps were never installed — `--prep-deps` makes that moment unreachable.
+
+**Gate**: every branch has a worktree, every branch is at `origin/<branch>`, manifest written, deps installed (when `--prep-deps` was used).
 
 **Red flags**:
 - "I'll review from the main worktree and switch branches." → No. Sub-agents will collide.
 - "I'll push later, just before opening the PR." → No. Codex needs a remote ref now.
+- "Skip `--prep-deps`; workers will install lazily as needed." → Acceptable for repos where the validate command works without an install step (Rust, Go, plain-Python). Forbidden for npm/pnpm/bun/pip projects that the validate command needs `node_modules`/`.venv` for — Phase 8 surprise costs more than upfront install.
 
 ---
 
-## Phase 3 — Parallel inner loop (coordinator + per-round worker)
+## Phase 3 — Parallel inner loop (main agent coordinates; appliers apply)
 
-**Think first**: *Each branch is independent. Each gets a coordinator sub-agent that drives the loop; per round it dispatches a fresh worker sub-agent that uses `/do-review` to evaluate Codex's items before applying. The main agent dispatches and watches; it does not edit during the loop.*
+**Think first**: *Main agent IS the coordinator across all branches. It dispatches per-round APPLIER sub-agents in parallel — one per branch, fresh each round. Decisions about each Codex item are made by main agent BEFORE worker dispatch, using `Skill(do-review)` in main's own context. Workers receive pre-decided fix specs and execute mechanically. They do not evaluate.*
 
-For each branch in the manifest, **main agent dispatches one coordinator sub-agent** (parallel across branches) per the brief in `references/parallel-subagent-protocol.md`. The coordinator runs the loop; per round it dispatches a fresh worker.
+The coordinator-as-subagent pattern in older versions of this skill is dropped: in practice, sub-agents that need to live for hours (one per branch × convergence loop) are unreliable in Claude Code. Main agent owns the round-cadence directly and dispatches short-lived, single-purpose appliers.
 
-**Coordinator brief skeleton** (full template in `parallel-subagent-protocol.md`):
-- Context: branch, worktree, manifest path, MISSION_PROTOCOL pointer, worker brief template location.
-- Mission: drive `<branch>`'s manifest entry to a terminal state with full round history.
-- DoD: status ∈ {DONE, CAP-REACHED, BLOCKED, FAILED}; rounds match round_history; terminal_reason set; remote tip matches manifest's head_sha_current.
-
-**Coordinator's loop** (canonical pseudocode in `references/per-branch-fix-loop.md`):
+**Per-round flow main agent runs** (parallel across all branches in flight):
 
 ```
 round = 1
-all_rejected_streak = 0
+per branch: all_rejected_streak = 0
 
-while round <= 20:
-    run-codex-review.py → review JSON
+while any branch has round <= 20 and not in terminal state:
+
+    # 1. Launch codex review for every active branch in parallel.
+    #    Sub-agents cannot Skill(codex:review) — disable-model-invocation.
+    #    Use the wrapper script (it bridges to codex-companion.mjs review --json).
+    for branch in active_branches:
+        bg: python3 <this-skill>/scripts/run-codex-review.py \
+              --branch <b> --base <base> --worktree <wt> \
+              --output <rounds-dir>/<slug>.<round>.json
+
+    # 2. As each review completes:
     classify-review-feedback.py → exit 0 (≥1 major) or 1 (no major)
 
     if classifier exit 1:
-        manifest.status = "DONE"; terminal_reason = "no major in round <N>"; break
+        manifest.status = "DONE"; terminal_reason = "no major in round <N>"; continue
 
-    # Dispatch FRESH worker sub-agent for THIS round
-    Agent(prompt=worker_brief_for_round, subagent_type="general-purpose")
+    # 3. Main agent EVALUATES each major item with Skill(do-review)
+    #    in own context. Produces decisions JSON: per item, accepted/rejected/ambiguous.
+    decisions = []
+    for item in major_items:
+        cited_code = read(<worktree>/<file>, around <line>, ±25 lines)
+        decision = Skill(do-review, args="--item <body> --code <cited_code>")
+        decisions.append(decision)
 
-    # Worker uses /do-review on every major item, applies accepted, pushes
-    # Hands back: { accepted: N, rejected: M, ambiguous: K }
+    # 4. Per branch: dispatch ONE applier sub-agent with the decisions baked in.
+    #    Worker brief is in references/parallel-subagent-protocol.md.
+    #    Worker DoD is BINARY: commits pushed to origin/<branch>; tests pass.
+    #    Worker brief NEVER mentions /do-review (decisions are pre-made).
+    Agent(prompt=applier_brief_with_decisions, subagent_type="general-purpose")
 
-    if worker.failed:
-        manifest.status = "FAILED"; break
+    # 5. Worker hands back: { applied: N, pushed: bool, validation: pass/fail }.
+    if not worker.pushed:
+        manifest.status = "FAILED"; terminal_reason = "applier failed to push"
+        continue
 
-    if worker.ambiguous and persistent_ambiguity:
-        manifest.status = "BLOCKED"; break
-
-    if worker.accepted == 0 and worker.rejected > 0:
+    if all decisions were rejected (worker.applied == 0, worker.rejected > 0):
         all_rejected_streak += 1
         if all_rejected_streak >= 3:
-            manifest.status = "DONE"; terminal_reason = "3 consecutive all-rejected; Codex stuck"; break
+            manifest.status = "DONE"; terminal_reason = "3 consecutive all-rejected; Codex stuck"
+            continue
     else:
         all_rejected_streak = 0
 
-    round += 1
+    round += 1  # for this branch
 
-if round > 20:
+per branch: if round > 20:
     manifest.status = "CAP-REACHED"
 ```
 
-**Worker brief skeleton** (full template in `parallel-subagent-protocol.md`):
-- Context: branch, worktree, round number, round JSON path, classifier output, prior round summaries.
-- Mission: every major item has a decision (accepted / rejected / ambiguous via `/do-review`); accepted items are committed (one concern per commit) and pushed; round log updated.
-- DoD: every item has a decision; `git diff --cached` empty; validation exits 0; `git push origin <branch>` succeeded.
+**Why the role split (read this once, do not re-litigate):**
+
+If the worker brief says "evaluate via `/do-review`, then apply", workers stop at the evaluation step ~100% of the time. The /do-review framing pulls them into evaluator-mode and "Verdict: apply" feels like the deliverable. Splitting evaluation (main agent) from application (worker, with explicit fix specs and binary push DoD) makes workers reliably push. This is empirically verified across multiple runs.
+
+**Applier brief skeleton** (full template in `parallel-subagent-protocol.md`):
+- Context: branch, worktree, round number, base ref, prior rounds' commit SHAs.
+- Mission: apply N pre-decided fixes (each spelled out with file:line + intended code shape), one concern per commit, validate, push.
+- Hard constraints: NEVER invoke `/do-review`. NEVER propose alternative fixes. NEVER stop at "Verdict: apply" — apply is the deliverable.
+- DoD (binary, verifiable): N new commits on `origin/<branch>`; `git -C <wt> rev-parse origin/<branch>` matches local HEAD; validation passes; `git -C <wt> log <base>..HEAD --oneline` shows the new commits.
 
 Main agent monitors with:
 
@@ -225,16 +315,30 @@ python3 <this-skill>/scripts/loop-status.py --watch
 
 Live table: branch, rounds, last status, state. **No editing while sub-agents are running.**
 
-**Gate**: every branch in the manifest in a terminal state (`DONE` / `CAP-REACHED` / `BLOCKED` / `FAILED`).
+**Gate**: every branch in the manifest in a terminal state.
+
+### Convergence taxonomy (the only valid terminal states)
+
+| State | Meaning | When set | PR? |
+|---|---|---|---|
+| `DONE` | No major items in the latest round (classifier exit 1). | Round N classifier returned no major. | Yes — open PR. |
+| `CONVERGED-AT-CAP` | Configured `max_rounds_per_branch` exhausted **with at least one round of fixes pushed**. Remaining items go in PR body as known-deferred. | Round counter ≥ cap; `len(round_history) ≥ 1`; latest classifier still exit 0 but Applier ran successfully. | Yes — open PR with deferred items in body. |
+| `CAP-REACHED` | 20-round hard cap (or configured cap) hit with **no convergence at all** (every round still has major items, no progress). | Round counter ≥ 20; same classifier outcome round-after-round. | No — surface for human (likely needs branch split). |
+| `BLOCKED` | Persistent ambiguous items, oscillation, contradictions; safe automated convergence not possible. | 3+ rounds of all-rejected (Codex stuck) reclassifies as `DONE`; persistent ambiguous reclassifies as `BLOCKED`. | No — surface. |
+| `FAILED` | Tooling crash past retry budget, codex plugin unavailable, Applier failed to push. | Any infrastructure gate that the retries did not recover. | No — surface. |
+
+**Do not invent additional states.** If a situation does not fit any of the five above, the skill is wrong (file an issue) — do NOT invent `DONE-PRAGMATIC`, `READY-ENOUGH`, or similar. Pick `BLOCKED` if you genuinely cannot pick from the taxonomy, with a `terminal_reason` describing the mismatch.
 
 **Red flags**:
-- "Let me check progress mid-loop and skip --background once." → No.
-- "Good enough after 3 rounds; ship it." → No (the classifier + worker decide).
+- "Let me check progress mid-loop." → No. Workers update the manifest atomically; read it.
+- "Good enough after 3 rounds; ship it." → No (the classifier decides DONE).
 - "Let me have one worker fix two rounds." → No (workers are fresh per round).
-- "Let me have the coordinator do the work itself." → No (coordinator orchestrates; worker acts).
-- "I'll skip /do-review for the obvious items." → No. Direct-apply violates invariant 11.
+- "Let me write the worker brief telling it to `/do-review` each item itself." → **No.** The /do-review framing causes systematic decision-only failure (verified across runs). Main agent evaluates; worker applies.
+- "I'll dispatch a coordinator subagent per branch like the older docs said." → No. Main agent IS the coordinator. The coordinator subagent role was dropped; sub-agents that live for hours are unreliable.
+- "I'll skip /do-review evaluation for the obvious items." → No. Direct-apply (without prior decision) violates invariant 11.
 - "The classifier is being noisy, let me bypass it." → No — adjust `major-vs-minor-policy.md` if the policy is wrong.
-- "I'll skip the validation step before re-review." → No. Codex can't tell your syntax error from a real bug.
+- "I'll skip the worker's validation step before push." → No. Codex can't tell your syntax error from a real bug.
+- "Round-2 found new items but I'm tired; let me invent DONE-PRAGMATIC and ship." → No. Apply round-2 fixes; if budget is binding, set `CONVERGED-AT-CAP` per the convergence taxonomy and proceed to PR — do not invent off-spec terminal states.
 
 ---
 
@@ -257,7 +361,9 @@ Once every branch is terminal, the main agent:
 
 **Think first**: *Each PR is opened by a fresh sub-agent dispatched by the main agent. The sub-agent uses the `/ask-review` skill to author a comprehensive body that explicitly asks the right reviewer questions. Body is capped at 50,000 chars (max only; no min). Main agent NEVER opens PRs in this workflow.*
 
-Process branches sequentially in foundation→leaf order from manifest.merge_order.
+**Throttling**: dispatch ≤4 PR-Creators in parallel. Opening 9+ in parallel exhausts GitHub's GraphQL budget (verified in production traces). The PR-Creator brief MUST instruct the sub-agent to use **REST endpoints for body uploads** (`gh api repos/<owner>/<repo>/pulls -f title=… -f body=@<file> -f base=… -f head=…`), NOT `gh pr create` (which uses GraphQL). When a handback says "rate-limited", check `gh api rate_limit --jq '.resources.graphql.reset'` for the Unix-timestamp reset; if main agent is in `/loop` dynamic mode, `ScheduleWakeup(delaySeconds=<reset_in - now + 60>, ...)`; otherwise queue that branch's redispatch behind the next batch.
+
+Process branches sequentially in foundation→leaf order from manifest.merge_order, but dispatch the PR-Creators in parallel batches of 4.
 
 For each `DONE` branch:
 
@@ -270,7 +376,15 @@ For each `DONE` branch:
    - Verifies body length ≤ 50,000 chars (`wc -c`).
    - Verifies body contains at least 3 explicit reviewer questions.
    - Saves body to `/tmp/pr-body-<branch-slug>.md`.
-   - Opens PR: `gh pr create --repo <fork-owner>/<repo> --base <base> --head <branch> --title "..." --body-file <path>`.
+   - **Opens PR via REST endpoint** (avoids GraphQL rate-limit blast in parallel dispatches):
+     ```bash
+     gh api -X POST repos/<fork-owner>/<repo>/pulls \
+            -f title="<title>" \
+            -f head="<branch>" \
+            -f base="<base>" \
+            -F body=@/tmp/pr-body-<branch-slug>.md
+     ```
+     **Do NOT use `gh pr create`** — it uses GraphQL by default, which has a separate ~5000/hour budget that's quickly exhausted by parallel PR creation (verified in production: 9 parallel `gh pr create` saturates GraphQL while REST core is barely touched). The REST endpoint above uses the core budget. Both produce equivalent PRs.
    - Verifies URL is on fork: `gh pr view <number> --repo <fork>/<repo> --json url,baseRefName`.
    - Updates manifest entry: `pr_number`, `pr_url`, `pr_title`, `pr_body_path`, `pr_body_chars`, `pr_explicit_questions`, `pr_opened_at`.
    - Hands back to main agent.
@@ -288,15 +402,25 @@ For each `DONE` branch:
 
 ## Phase 6 — Codex rescue + adaptive review window
 
-**Think first**: *Hand the PR link to Codex's own background sub-agent (`/codex:resc`). Then wait — adaptively — for codex-rescue + external bots (Copilot, Greptile, Devin) to land their reviews. The wait pattern: 900s base + 5-min extensions if bots are still talking + terminate on 3-min quiet + 30-min safety cap.*
+**Think first**: *Hand the PR link to Codex's own background sub-agent (`/codex:resc`). Then wait — adaptively — for codex-rescue + external bots (Copilot, Greptile, Devin, cubic-dev-ai) to land their reviews. The wait pattern: 900s base + 5-min extensions if bots are still talking + terminate on 3-min quiet + 30-min safety cap.*
 
 For each PR opened in Phase 5, sequentially:
 
-1. **Trigger codex rescue**:
+1. **Trigger codex rescue.** Two sanctioned paths (pick by context):
+
+   **A. Interactive (1-2 PRs):** type `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <number>` in chat.
+
+   **B. Programmatic loop (N PRs in parallel — Phase 6 default):**
    ```bash
-   python3 <this-skill>/scripts/trigger-codex-rescue.py --pr <number> --branch <b>
+   Bash(run_in_background=True):
+     cd <worktree-path> && \
+     node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task \
+          --write --fresh --effort xhigh \
+          "<comprehensive prompt for PR #<n>>"
    ```
-   This invokes `codex review --rescue --background --fresh --model gpt-5.5 --effort xhigh --pr <number>` inside the branch's worktree. Codex rescue is **Codex's own background sub-agent** (not a Claude Agent); we hand it the PR link and Codex's infrastructure spawns the review job. Manifest gets `rescue_review_id`, `rescue_started_at`, `rescue_status: "running"`.
+   This is the **same code path** `/codex:resc` runs internally; both invoke `codex-companion.mjs task`. In a programmatic loop, calling it directly is cleaner than typing N slash-command directives.
+
+   Codex rescue is **Codex's own background sub-agent** (not a Claude Agent we dispatch). Manifest gets `rescue_review_id`, `rescue_started_at`, `rescue_status: "running"`. NEVER invoke `codex review --rescue …` from Bash (no such CLI surface). NEVER write a "shim" — both invocation paths are first-class.
 
 2. **Wait + gather**:
    ```bash
@@ -351,69 +475,222 @@ For each PR:
 
 ---
 
-## Phase 8 — Main-agent direct apply + merge
+## Phase 8a — Main-agent direct apply (per-PR sequential; cross-PR order irrelevant)
 
-**Think first**: *The evaluator's structured output is in main agent's context. Re-dispatching to a sub-agent for apply would re-load context unnecessarily. Main agent applies directly using `/do-review` in own context — the user's principle: "do-review is healthier when answers come straight back".*
+**Think first**: *The evaluator's structured output is in main agent's context. Apply one PR at a time; main agent reads the evaluation JSON, applies each accepted item, validates, pushes. Apply order across PRs doesn't matter — each branch is its own worktree. Merge order is enforced in 8b.*
 
-For each PR:
+For each PR with `<repo>/.codex-review-rounds/pr-<n>.evaluation.json`:
 
-1. **Main agent reads** `<rounds-dir>/<slug>.pr-evaluation.json`.
-2. **For each accepted item** (deduplicated across sources):
-   - Read cited code (Read tool).
-   - Compose the fix per evaluator's rationale.
-   - Sanity-check via `/do-review` skill in main agent's context (Skill tool with `skill='do-review'`).
-   - Apply via Edit (with diff-walk discipline).
-   - `git diff --cached` (verify only intended hunks).
-   - `git commit -m "<emoji> <type>(<scope>): apply <source>'s <item-id>"`.
-3. **For each ambiguous item**: do NOT apply. Record in BLOCKED list for the PR.
-4. **After all accepted items applied**:
-   ```bash
-   git -C <worktree> push origin <branch>
+1. **Main agent reads** the evaluation JSON. Confirm:
+   - `accepted` count > 0 (else mark `apply_status: "skipped-no-accepted"` and proceed to next PR).
+   - `ambiguous` count > 0 → mark PR `BLOCKED` in manifest with `terminal_reason: "ambiguous: <item-id>: <evaluator's question>"`. **Skip apply for this PR's accepted items too** — partial-apply ships unreviewed code with a half-decided intent. Surface in deliverable, move to next PR.
+2. **For each accepted item** (deduplicated across sources, preserving the first-seen rationale):
+   - Read cited code at `<worktree>/<file>` around `<line>` (Read tool, ±25 lines for context).
+   - Apply the fix per evaluator's intended-shape via Edit.
+   - **If the intended-shape doesn't apply cleanly** (file moved, line shifted, current shape mismatch): DO NOT improvise. Record `apply_failed_after_evaluation: <item-id>` in manifest. Continue with remaining items. Surface at end of Phase 8a — the human decides re-evaluate or accept-as-known.
+   - **Stage by concern from the start**: `git -C <worktree> add <files-for-this-concern>`. Do NOT stage everything then `git restore --staged .` to peek and restage — that's wasted overhead per PR. Diff-walk per concern from the first add.
+   - `git -C <worktree> diff --cached` (verify only intended hunks).
+   - `git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject> (#<pr>)"`. Note the `(#<pr>)` suffix for traceability.
+3. **Commit-grouping rule**: tightly-coupled small fixes to the same file may share one commit IF the message lists each concern as a bullet. Example:
    ```
-   Wait for CI green.
-5. **If ambiguous list non-empty**: mark PR `BLOCKED` in manifest with `terminal_reason` citing the items. Surface in deliverable. Do NOT merge.
-6. **Else**: `gh pr merge <number> --repo <fork>/<repo> --squash` (or per repo policy).
-7. **Optional — fresh PR**: if accepted items are too divergent for in-place application (per `post-pr-review-protocol.md`'s rubric), open a new PR via Phase 5 redux for that branch.
+   🐛 fix(parsers/copilot): hardening pass (#47)
 
-After merge: `git fetch --all --prune`. If a sibling DONE branch overlaps the just-merged base, rebase it onto the new `main` (only safe because sibling has no review in flight at this point).
+   - Distinct sourceIds for inline tool requests
+   - toolName carry-through on execution_complete
+   - Dedup statSync in extractLastEventTimestamp
+   ```
+   For unrelated concerns, split into separate commits. **One concern per commit is the default**; combining is an exception that requires the bullets-in-message accountability.
+4. **Validate** before push: `pnpm run build && pnpm test` (or repo-equivalent per `AGENTS.md`/`CONTRIBUTING.md`). Three failure modes:
+   - **Build fails** (compile error, type error, syntax error from your edit) → revert the offending commit, mark item `apply_failed_validation`, surface — do not retry blindly with a different fix.
+   - **Test fails on a NEW assertion that the fix should pass** (real regression) → revert, mark item ambiguous, surface.
+   - **Test fails on an EXISTING assertion that asserts the OLD behavior the fix is intended to change** → this is a legitimate test-fixture update. Update the test (or fixture data) to match the new intended behavior in the SAME commit (or amend). Re-run validate. Do NOT revert. Example from production: a fix changed legacy session id format from `legacy:<basename>` to `legacy:<rel-path>` to disambiguate basename collisions across subdirectories. The existing test asserted the old format; updating the test fixture to match the new format was the correct response, not a revert.
 
-**Gate**: PR is `MERGED` (manifest field set), or `BLOCKED` with surfaced items.
+   When in doubt between "real regression" and "legitimate test-fixture update": **read the test's intent**. If the test was protecting against the regression the evaluator's accepted fix introduces, it's a real regression — revert. If the test was asserting an arbitrary detail of the OLD behavior that the evaluator explicitly intended to change (and the evaluator's rationale documents the change), it's a fixture update — update it.
+5. **Push**: `git -C <worktree> push origin <branch>` (no `--force`).
+6. **`/do-review` sanity-check is OPTIONAL and OFF by default.** The Evaluator already used `/do-review` in Phase 7; re-running per item in Phase 8 is double-eval. Reserve for the rare case where main agent's reading of the cited code disagrees with the evaluator's rationale — when borderline, sanity-check before push; otherwise skip.
 
-**Red flags**:
+Process PRs in any order in 8a (foundation-first OR leaves-first OR interleaved are all fine). Phase 8b enforces merge order.
+
+**Phase 8a gate**: every non-BLOCKED PR has new commits pushed; manifest has `apply_status: "applied"` per branch; ambiguous-flagged items recorded; `apply_failed_after_evaluation` items recorded for human surface.
+
+**Red flags (8a)**:
 - "Let me dispatch a sub-agent for apply too." → No. Phase 8 is main-agent direct.
-- "Apply ambiguous items just in case." → No. Ambiguous = human-in-the-loop.
+- "Apply ambiguous items just in case." → No. Ambiguous = human-in-the-loop. The whole PR is BLOCKED.
+- "Apply some accepted items even though others are ambiguous on the same PR." → No. Defer the entire PR.
 - "Re-trigger Codex review after apply." → No. Phase 8's commits are post-evaluator.
-- "Merge the BLOCKED PR anyway." → No. The classifier said major, the evaluator said ambiguous. Human decides.
+- "Phase 8 evaluator's intended-shape doesn't apply cleanly; let me improvise." → No. Mark `apply_failed_after_evaluation`, surface for human.
+- "Stage all files, peek with `git diff --cached`, then `git restore --staged .` to re-stage by concern." → No. Diff-walk per concern from the start.
+- "Re-do `/do-review` per item even when evaluator already accepted with high confidence." → No. Default-skip; the evaluator's JSON is the authority.
+
+---
+
+## Phase 8b — Merge in foundation→leaf strict serial
+
+**Think first**: *Apply is done. Now merge in dependency order. Foundation merges first; squash-merging foundation collapses N foundation commits into 1 squashed commit on main with a different SHA, which means leaves still carrying the original foundation commits will conflict on plain `git rebase origin/main` — they need `git rebase --onto` to skip the now-duplicated foundation history. After leaves are rebased and retargeted, they merge to main individually with CI-wait between.*
+
+### Step-by-step
+
+1. Order PRs per `manifest.merge_order` (foundation first, then sibling leaves in dependency order).
+2. **Capture foundation's pre-merge tip BEFORE merging foundation** (load-bearing for the leaf-rebase math below):
+   ```bash
+   foundation_tip=$(git -C <foundation-worktree> rev-parse HEAD)
+   # Persist in manifest for resilience across session restarts:
+   # manifest.foundation_pre_merge_tip = <sha>
+   ```
+3. **Foundation merge:**
+   - Wait CI green via `Bash(run_in_background=True)`:
+     ```bash
+     until [ "$(gh pr checks <foundation-pr> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+       sleep 30
+     done
+     gh pr checks <foundation-pr>
+     ```
+   - If any check is `failure` or `cancelled`: mark foundation `BLOCKED` and **STOP — do NOT merge any leaves; foundation is their base.** Surface foundation BLOCKED for human resolution.
+   - Else: `gh pr merge <foundation-pr> --repo <fork>/<repo> --squash --delete-branch` (the `--delete-branch` flag deletes the remote branch on merge, halving Phase 9 cleanup work).
+   - `git fetch --all --prune` to pull the new `origin/main`.
+4. **Retarget + rebase + push every leaf** (one batch, in parallel since leaves are siblings under foundation):
+   ```bash
+   for leaf_pr in <leaf-prs>; do
+       leaf_branch=$(gh pr view "$leaf_pr" --json headRefName --jq .headRefName)
+       leaf_worktree=<from-manifest>
+
+       # Retarget leaf's PR base from feat/handoff-foundation → main
+       gh pr edit "$leaf_pr" --base main
+
+       # Rebase leaf onto new main, SKIPPING the now-redundant foundation commits.
+       # Plain `git rebase origin/main` would re-apply foundation's originals on top of
+       # main's squashed equivalent → conflicts. --onto fast-forwards past the original
+       # foundation tip and replays only the leaf-specific commits.
+       git -C "$leaf_worktree" fetch origin
+       git -C "$leaf_worktree" rebase --onto origin/main "$foundation_tip" "$leaf_branch"
+       git -C "$leaf_worktree" push --force-with-lease origin "$leaf_branch"
+   done
+   ```
+5. **Merge each leaf in order** (sequential, NOT `--auto`; `--auto` queues but doesn't dequeue cleanly when stack still diverges in some repo configs):
+   ```bash
+   for leaf_pr in <leaf-prs-in-order>; do
+       # CI-wait per leaf
+       until [ "$(gh pr checks "$leaf_pr" --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+           sleep 30
+       done
+       gh pr checks "$leaf_pr"
+
+       # Check + merge
+       if any check is failure/cancelled:
+           mark leaf BLOCKED with terminal_reason: "CI failure: <check-name>"
+           continue   # do NOT halt for leaves; only foundation failure halts
+       else:
+           gh pr merge "$leaf_pr" --repo <fork>/<repo> --squash --delete-branch
+           git fetch --all --prune   # refresh main for next leaf's CI checks
+   done
+   ```
+
+### Auto-merge note
+
+`gh pr merge --auto` works for the **foundation** PR (single-step merge) but is unreliable for the **leaf** PRs — when a leaf is queued for auto-merge before its rebase is fully ready or when the squashed foundation diverges the stack, `--auto` silently waits forever or no-ops. **Use sequential merge without `--auto` for leaves.** Each leaf merges only after its rebase + force-push lands and CI passes.
+
+### When --delete-branch can't run
+
+If the repo policy requires PRs to be merged via web UI or branch-protection rules block `--delete-branch`, drop the flag and let Phase 9 handle remote-branch cleanup explicitly:
+```bash
+gh pr merge "$leaf_pr" --squash
+# Phase 9 will: gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<leaf-branch>
+```
+
+### Phase 8b hard exit gate
+
+**Phase 8b does NOT exit until every non-BLOCKED PR is MERGED.** Manifest field `merged_at` set per branch. `gh pr list --repo <fork>/<repo>` shows ONLY:
+- BLOCKED branches (`terminal_reason` set), or
+- `apply_failed_after_evaluation` branches (surfaced for human).
+
+If `gh pr list` still shows a PR that is neither BLOCKED nor `apply_failed_after_evaluation`, **8b is incomplete — re-attempt the merge for that PR**. In `/loop` dynamic mode, `ScheduleWakeup(delaySeconds=600)` and re-check on the next firing. Do NOT proceed to Phase 9 with un-resolved PRs.
+
+**Red flags (8b)**:
+- "Merge foundation before its CI is green." → No. Foundation merges only when CI is green.
+- "Skip CI-wait, just merge fast." → No. CI-wait is mandatory in 8b.
+- "Foundation CI failed — merge the leaves anyway." → No. Foundation is their base. Halt all leaf merges.
+- "Merge the BLOCKED PR anyway." → No. Human decides.
+- "After merging foundation, plain `git rebase origin/main` the leaves." → No. Plain rebase replays foundation's originals on top of the squashed equivalent → conflicts. Use `git rebase --onto origin/main <foundation_pre_merge_tip> <leaf>`.
+- "Skip capturing `foundation_pre_merge_tip` — I'll figure it out later." → No. Once foundation merges, the local foundation worktree's HEAD may move and `git log` may show only the squash. Capture the tip BEFORE merging foundation.
+- "Skip retargeting leaves to main; let GitHub auto-figure-out the new base." → No. The `--base` field on a PR is independent of the rebased branch. Retarget explicitly with `gh pr edit <leaf-pr> --base main`.
+- "Use `gh pr merge --auto` to chain all leaf merges in one shot." → No. Auto-merge is unreliable for divergent stacks. Sequential explicit merge with CI-wait between.
+- "Force-push leaves with `--force` instead of `--force-with-lease`." → No. `--force-with-lease` is the safety mechanism (refuses if remote moved unexpectedly). Plain `--force` can clobber concurrent activity.
+- "Open a fresh PR for the apply_failed_after_evaluation items." → Acceptable but optional; surface for human first. Don't auto-cycle.
 
 ---
 
 ## Phase 9 — Tidy & final audit
 
-**Think first**: *What state did I start in? Have I returned to it, plus the intended delta — nothing more, nothing less?*
+**Think first**: *What state did I start in? Have I returned to it, plus the intended delta — nothing more, nothing less? No stale worktree, no stale local branch, no stale remote branch, no stale temp file.*
 
-1. Cleanup worktrees:
+### Cleanup steps (do all four; the audit fails if any is skipped)
+
+1. **Worktrees** — remove every review worktree:
    ```bash
    python3 <this-skill>/scripts/cleanup-worktrees.py --base main --execute
    ```
-   Refuses worktrees whose branch is not merged unless `--force-abandon <branch>` is passed.
-2. Retire merged branches:
+   The script enumerates every `<repo>-wt-*` worktree and runs `git worktree remove <path>`. Refuses worktrees whose branch is not merged unless `--force-abandon <branch>` is passed.
+
+2. **Local branches** — delete every merged review branch:
    ```bash
    python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --execute
    ```
-3. **Dispatch a fresh subagent** for an independent re-audit (per `skills/run-repo-cleanup/references/post-pr-verification.md`). The subagent runs read-only:
-   - `python3 skills/run-repo-cleanup/scripts/audit-state.py` — must exit 0.
-   - `python3 <this-skill>/scripts/audit-review-state.py` — must exit 0.
-   - `git worktree list` — only main.
-   - `git branch -vv` — only `main` and any open-PR (BLOCKED) branches.
-   - `gh pr list --repo <fork>/<repo>` — matches expected.
-   - `gh pr list --repo <upstream>/<upstream-repo> --author @me` — empty.
-4. Delete `/tmp/codex-review-manifest.json` and `/tmp/codex-review-rounds/`.
+   The script runs `git branch -d <name>` for each branch fully merged into `main`. Branches that are NOT merged (BLOCKED, `apply_failed_after_evaluation`) are skipped — those stay around for human follow-up.
 
-**Gate**: subagent reports TIDY. `audit-review-state.py` exits 0.
+3. **Remote branches** — only needed for branches that weren't deleted by `gh pr merge --delete-branch` in 8b. For BLOCKED / failed branches, leave them on origin so the human can resume:
+   ```bash
+   # Only run for branches we created and that survived 8b without --delete-branch.
+   # The retire-merged-branches.py script handles this when run with --remote.
+   python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --remote --execute
+   ```
 
-**Red flags**:
+4. **Temp files** — every brief and manifest gets cleaned up:
+   ```bash
+   rm -f <repo>/.codex-review-manifest.json{,.lock}
+   rm -rf <repo>/.codex-review-rounds/
+   rm -f /tmp/applier-brief-*.md
+   rm -f /tmp/evaluator-brief-*.md
+   rm -f /tmp/evaluator-brief-template.md
+   rm -f /tmp/pr-creator-brief-*.md
+   rm -f /tmp/pr-creator-brief-template.md
+   rm -f /tmp/applier-brief-template*.md
+   ```
+   (Legacy `/tmp/codex-review-manifest.json{,.lock}` from older skill runs may also exist; remove if present and pointing at the same `repo_root`. Leave alone if pointing elsewhere — that's a different session's state.)
+
+### Independent re-audit (mandatory)
+
+Dispatch a **fresh subagent** for an independent re-audit (per `skills/run-repo-cleanup/references/post-pr-verification.md`). The subagent runs read-only:
+
+- `python3 skills/run-repo-cleanup/scripts/audit-state.py` → must exit 0.
+- `python3 <this-skill>/scripts/audit-review-state.py` → must exit 0.
+- `git worktree list` → ONLY main; no `*-wt-*` review worktrees.
+- `git branch -vv` → ONLY `main` and any open-PR (BLOCKED / `apply_failed_after_evaluation`) branches.
+- `git for-each-ref refs/heads/feat/* refs/heads/fix/* refs/heads/chore/* refs/heads/docs/*` → ONLY un-merged BLOCKED ones (or empty).
+- `gh pr list --repo <fork>/<repo>` → matches expected (only BLOCKED / `apply_failed_after_evaluation` PRs, or empty).
+- `gh api repos/<fork>/<repo>/branches --jq '.[].name' | grep -vE '^(main|<BLOCKED-list>)$'` → empty.
+- `gh pr list --repo <upstream>/<upstream-repo> --author @me` → empty (single-owner mode skips this check).
+- Repo-local `.codex-review-manifest.json` and `.codex-review-rounds/` → don't exist.
+- `/tmp/{applier,evaluator,pr-creator}-brief-*.md` → don't exist.
+
+### Phase 9 hard gate (the "no stale anything" exit condition)
+
+Phase 9 does NOT exit until ALL of:
+1. Every non-BLOCKED branch is **MERGED** to main (verify in manifest + `gh pr list`).
+2. Every review **worktree** is removed (`git worktree list` shows only main).
+3. Every merged **local branch** is deleted (`git branch -vv` shows only main + BLOCKED).
+4. Every merged **remote branch** is deleted (`gh api repos/.../branches` shows only main + BLOCKED).
+5. Every **temp brief / manifest / round-log** is cleaned (no `.codex-review-*` files in repo; no `*-brief-*.md` in `/tmp/`).
+6. Independent re-audit subagent reports **TIDY**.
+
+If any of (1)-(5) fails, Phase 9 is incomplete. In `/loop` dynamic mode, retry with `ScheduleWakeup(delaySeconds=600)` if the failure is transient (CI still pending on a leaf, GitHub rate-limit blocking branch deletion). If the failure is structural (BLOCKED PR with ambiguous items), surface the exact list and stop — the human takes over.
+
+**Red flags (Phase 9)**:
 - "I'll clean up next time." → No. Tidy is binary.
 - "I'll keep the worktrees in case." → No. Stale worktrees are debris.
+- "Local branches deleted; remote branches don't matter — they're on the fork." → No. Stale remote branches accumulate on every run; future runs see them as "in-flight" and refuse to spawn worktrees with the same name.
+- "Just `git worktree remove --force <path>` everything." → No. The skill's `cleanup-worktrees.py` refuses unmerged worktrees by default to protect un-pushed work; bypass with `--force-abandon <branch>` only when explicitly intended.
+- "Skip the independent re-audit; I'll just trust my own state." → No. The audit subagent is fresh-context; it catches state drift main agent's context can mask.
+- "Skip cleaning `/tmp/{applier,evaluator,pr-creator}-brief-*.md` — they're tiny." → No. Future runs may create briefs with the same names and read stale data; clean now, not later.
 
 ---
 
@@ -458,41 +735,90 @@ Full recipes: `references/failure-recovery.md`.
 
 ## Final Deliverable
 
+The wrap-up at end of Phase 9. **Phase 9 cannot exit until every section below is producible from manifest state** — this is the "all merged or surfaced" hard exit gate the user requires.
+
 ```markdown
-## Per-branch summary
-| Branch | Worktree | Concern | Rounds | Phase 3 status | PR | Phase 7 (a/r/x) | Merged | Notes |
-|---|---|---|---:|---|---|---|---|---|
+## 🎉 Full skill flow complete — N PRs merged to main (or M surfaced as BLOCKED)
 
-## Per-PR review breakdown
-| PR | codex-rescue (a/r/x) | copilot (a/r/x) | greptile (a/r/x) | devin (a/r/x) | Total accepted | Total ambiguous |
-|---|---|---|---|---|---:|---:|
+### Final state on <fork-owner>/<repo>
 
-## Tidy audit
+<output of: git log --oneline origin/main~N..origin/main>
+
+E.g.:
+a12dd4e fix(antigravity): protobuf sessions + RPC + cache (#51)
+cf8d3cd feat(parsers/gemini): JSONL + rewind reconciliation (#52)
+…
+3f15720 feat(handoff): structured timeline + verbosity controls (#53)
+
+### Per-branch summary
+| Branch | Concern | Rounds | Phase 3 status | PR | Phase 7 (a/r/x) | Phase 8a apply | Merged at | Notes |
+|---|---|---:|---|---|---|---|---|---|
+
+### Per-PR review breakdown
+| PR | codex-rescue (a/r/x) | copilot (a/r/x) | copilot-pr-reviewer (a/r/x) | greptile (a/r/x) | devin (a/r/x) | cubic-dev-ai (a/r/x) | Total accepted | Total ambiguous |
+|---|---|---|---|---|---|---|---:|---:|
+
+### What ran across all 10 phases
+| Phase | What happened |
+|---|---|
+| 0 | Pre-flight audit — all scripts present, MISSION_PROTOCOL loaded, /ask-review + /do-review available; manifest path repo-local. |
+| 1 | Decomposed N-file dirty tree into M per-concern branches. |
+| 2 | M worktrees spawned with --prep-deps, M branches pushed, manifest emitted. |
+| 3 | K rounds × M codex reviews; main agent evaluated, dispatched M appliers per round; J fixes applied across rounds. |
+| 4 | Merge order computed: foundation, then leaves. |
+| 5 | M PR-Creators (throttled ≤4) opened PRs via REST `gh api repos/.../pulls`. |
+| 6 | M codex:rescue jobs + M Monitors armed; external bots landed reviews; adaptive 900s base + 3-min quiet windows closed cleanly per PR. |
+| 7 | M Evaluator sub-agents used /do-review over gathered streams; produced decisions JSON (≈X items: A accepted, R rejected, U ambiguous). |
+| 8a | Main agent direct-applied accepted decisions across M worktrees; validated build+tests; pushed N commits. |
+| 8b | Captured foundation_pre_merge_tip; squash-merged foundation with --delete-branch; rebased leaves with `git rebase --onto`; retargeted leaves to main; merged sequentially with CI-wait. |
+| 9 | M worktrees removed, M local branches deleted, M remote branches deleted (mostly via --delete-branch in 8b), manifest + round-logs + briefs cleaned; final audit: TIDY. |
+
+### Loop tools that kept this autonomous
+- **Monitor** (M instances): per-PR comment poller; emitted one event per new bot/human comment; terminated on `[PR-N-DONE quiet]` or `[PR-N-DONE cap]`.
+- **ScheduleWakeup** (X fires): cache-aware 1200-1800s fallback tickers covering the 900s adaptive-wait floor.
+- **Agent run_in_background=true** (~K dispatches): appliers, PR-Creators, Evaluators — each fired a handback notification on completion.
+- **Bash run_in_background=true** (~K launches): per-branch codex review jobs, codex:rescue invocations, CI-wait pollers.
+
+### Lessons captured during execution (only include genuinely novel learnings; not boilerplate)
+
+### Tidy audit
 <output from audit-state.py + audit-review-state.py — both must show CLEAN>
+- git worktree list → only main
+- git branch -vv → only main + any BLOCKED branches
+- gh pr list → only BLOCKED branches (or empty)
 
-## Per-branch round history (appendix)
-### feat/foo (DONE in 4 rounds)
+### Per-branch round history (appendix)
+### feat/foo (DONE in 4 rounds, merged as #42)
 - Round 1: 3 major (3 accepted) → committed + pushed
 - Round 2: 1 major (1 accepted) → committed + pushed
 - Round 3: 1 major (0 accepted, 1 rejected) → all-rejected round
 - Round 4: no major → DONE
+- Phase 8a fixes: abc123, def456 (merged as squash 2026-04-26T11:40:00Z)
 
-### feat/foo PR #42 — MERGED
-- codex-rescue:  5 items (3 accepted, 2 rejected)
-- copilot:       8 items (1 accepted, 6 rejected, 1 ambiguous)
-- greptile:     12 items (4 accepted, 7 rejected, 1 ambiguous)
-- devin:         3 items (1 accepted, 2 rejected)
-- Cross-source contradictions: 0
-- Phase 8 commits: abc123, def456
-- Merged via squash at 2026-04-26T11:40:00Z
-
-### feat/bar (CAP-REACHED at 20 rounds)
+### feat/bar (CONVERGED-AT-CAP at 20 rounds, merged as #43 with deferred items in PR body)
 - 20 rounds, 8 accepted, 14 rejected, 0 ambiguous
-- Remaining major items in last round: <description>
-- Recommendation: split into 2 branches, re-run per concern.
+- Remaining major items in last round: <listed in PR body>
+
+### feat/baz (BLOCKED — surfaced for human; NOT merged)
+- terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
+- Suggested human action: <e.g. split into 2 branches, re-run per concern>
 ```
 
 The format is rendered from manifest entries; see `references/branch-decomposition-ledger.md`.
+
+### "All merged or surfaced" hard exit gate
+
+The Final Deliverable can be produced ONLY when every branch in the manifest reaches a terminal state:
+
+| Terminal state | Acceptable for clean exit? |
+|---|---|
+| `MERGED` (with `merged_at` timestamp) | ✅ yes — happy path |
+| `BLOCKED` (with `terminal_reason` set) | ✅ yes — surfaced for human; clean exit |
+| `apply_failed_after_evaluation` (with item list) | ✅ yes — surfaced for human; clean exit |
+| `CAP-REACHED` (no fixes pushed) | ✅ yes — surfaced for human |
+| `IN-LOOP` / `SPAWNED` / unset / `applying` | ❌ NO — incomplete; re-attempt or surface the specific blocker |
+
+If any branch is in an incomplete state when Phase 9 audit runs, **the audit fails**. Re-attempt the merge for that branch (in `/loop` mode, ScheduleWakeup 600s and re-check). Do NOT produce the Final Deliverable until every branch is terminal.
 
 ## Smell Test — forbidden internal thoughts
 
@@ -522,17 +848,45 @@ If any of these fires, stop and re-run `python3 <this-skill>/scripts/audit-revie
 - "The evaluator is overhead; just apply what the bots say."
 - "Auto-resolve the cross-source contradiction."
 
-**Phase 8:**
-- "Let me dispatch a sub-agent for the apply step too."
-- "Apply the ambiguous items just in case."
-- "Re-trigger Codex review after apply."
-- "Merge the BLOCKED PR anyway."
+**Phase 7-8:**
+- "Let me dispatch a sub-agent for the apply step too." → No. Phase 8a is main-agent direct.
+- "Apply the ambiguous items just in case." → No. Ambiguous = the WHOLE PR is BLOCKED; do not apply any items.
+- "Half-apply: ship the accepted items, defer the ambiguous ones." → No. Defer the entire PR to keep apply intent coherent.
+- "Re-trigger Codex review after apply." → No. Phase 8a's commits are post-evaluator.
+- "Merge the BLOCKED PR anyway." → No. Human decides.
+- "Skip CI-wait, just push and move on to the next PR." → No in 8b — CI-wait gates merge. Within 8a (apply), pushing without CI-wait is fine; merging without CI-wait is forbidden.
+- "Foundation CI failed — let me merge the leaves anyway." → No. Foundation is their base; halt all leaf merges and surface foundation BLOCKED.
+- "Combine 9 PRs' commits into one mega-commit at merge time." → No. One PR = one (or N concern-scoped) commits squashed at merge. Cross-PR squashing destroys per-concern audit trail.
+- "Re-do `/do-review` per item in Phase 8 even when the evaluator already accepted." → No (default). The evaluator's JSON is the authority; re-eval is opt-in for borderline confidence cases only.
+- "Stage all files first, peek with `git diff --cached`, then `git restore --staged .` to re-stage by concern." → No. Diff-walk per concern from the first `git add`. Two extra git ops × 9 PRs = wasted overhead.
+- "Phase 8 evaluator's intended-shape doesn't apply cleanly; let me improvise the fix." → No. Mark `apply_failed_after_evaluation`, continue with remaining items, surface for human.
+- "Force-push leaves after foundation merge without rebasing first." → No. `git fetch && git rebase origin/main` per leaf, then `--force-with-lease` (NOT plain `--force`).
+- "After Evaluator returns ambiguous, retry the evaluation with a different prompt." → No. Ambiguous means the evaluator couldn't decide; another eval pass won't help. Surface for human.
+- "All decisions are accepted/rejected; ambiguous handling won't fire." → It might. Read every PR's evaluation.json; if `ambiguous` count > 0, that PR is BLOCKED.
 
 **Cross-phase:**
 - "I'll start fresh and ignore the prior session's manifest."
 - "I'll write the brief later — this dispatch is simple."
 - "Soft DoD ('clean code') — agents understand."
 - "I can skip the failure protocol — the agent will figure it out."
+- "I'll just run `codex --help` to verify the CLI flags." → No. Slash commands are not shell programs.
+- "Let me write a shim because `codex review --background` doesn't exist." → No. The `--background`/`--fresh`/`--effort` are slash-command arguments, not CLI flags. Re-read `references/codex-review-contract.md`.
+- "I'll dispatch a coordinator subagent per branch like the older docs said." → No. Main agent IS the coordinator (the older per-branch coordinator subagent was dropped; long-lived sub-agents drift). The current pattern is main-agent-coordinator + per-round Applier sub-agents. Read `references/parallel-subagent-protocol.md` "Coordinator role".
+- "Let me run a smoke test before fanning out." → No. The skill prescribes Phase 3 dispatch in parallel from round 1. Smoke tests are not in the workflow.
+- "Re-confirming the user's defaults — fork mode, max rounds, decomposition." → No. Defaults are pinned. Auto-detect and proceed. Only ask when a destructive choice is genuinely ambiguous.
+- "I'll just rebuild the manifest by hand because it has stale entries." → No. Phase 0 auto-namespaces it.
+- "Let me invoke `codex-companion.mjs` directly since the slash command is awkward." → No. The companion script is plugin-internal and forbidden.
+- "Let me run `codex login status` / `codex --version` / `codex doctor` / any health probe before dispatching." → **No.** Slash-command dispatch is the only valid test. Underlying-CLI probes assume a default provider/auth configuration that may not apply — users with custom backends, alternate auth, or non-default providers commonly see probes report "not logged in" while the real flow works. Trust the user's environment; if `Skill(codex:review)` actually fails at dispatch time, hand back FAILED with `terminal_reason` and surface to the user. Never present a multi-option auth-resolution menu (A/B/C…) for an environment the user didn't ask you to configure.
+- "Let me `ls <worktree>/node_modules` (or any dependency check) before dispatching workers." → No. Workers own their worktree setup — they run their own `npm install` / `pnpm install` / equivalent before validation. Pre-checking from main agent is over-stepping and assumes one specific package manager / project layout.
+- "I'll write a small shim that wraps `node codex-companion.mjs review`." → No. The wrapper script `scripts/run-codex-review.py` exists for this purpose. Sub-agents call it; do not invent parallel scripts.
+- "Decision point: how would you like to proceed? Option A / B / C / D." → **No.** If the user's prompt authorized full flow, this is a stall. Proceed to the next phase. (See "Authorization rule".)
+- "Before dispatching N parallel coordinators (which will run for several hours), let me do one smoke test on a single branch first." → No. The skill's Phase 0 already validates the dispatch surface (verifying skills are registered, manifest collision detected, repo mode auto-detected). Smoke tests beyond that are unsanctioned deviations and signal cost-anxiety.
+- "I'm proposing a small deviation from the skill's two-level pattern." → No deviation. Main agent IS the coordinator (the older two-level pattern was dropped because long-lived coordinator subagents drift). Read `references/parallel-subagent-protocol.md` "Coordinator role" — main agent owns the cadence directly.
+- "Phase 3 is taking forever; let me invent `DONE-PRAGMATIC` to ship round-2 work without round-3 verification." → No. The taxonomy is `DONE` / `CONVERGED-AT-CAP` / `CAP-REACHED` / `BLOCKED` / `FAILED`. If you ran out of round budget, set `CONVERGED-AT-CAP` and surface remaining items in the PR body. Inventing states forks the skill.
+- "Round-2 found new items refining round-1 fixes — is the loop converging?" → Yes, that's normal. 6/8 branches in production runs need round-2. Convergence in 3-6 rounds is expected (per `references/major-vs-minor-policy.md`).
+- "Let me write the worker brief asking it to evaluate via `/do-review` then apply." → **No.** This is the highest-leverage failure pattern: workers stop at decision-only and never push. Decisions stay with main agent (Phase 3 step 3 of the loop). Workers receive pre-decided fix specs and apply mechanically. (See invariant 11 + `references/parallel-subagent-protocol.md` "Mission Brief: Applier" — note especially the "Why no `/do-review` in this brief" subsection.)
+- "Let me write 7 separate applier briefs, one per branch, via 7 `Write` tool calls." → **No.** Mandatory: write ONE template with `{{PLACEHOLDER}}` slots; render N briefs from template + decisions JSON in ONE Python invocation. Hand-writing N briefs burns thousands of tokens and drifts copy-paste errors. (See `references/parallel-subagent-protocol.md` "Brief templating".)
+- "I'll inline the comment-poller bash command directly in N separate `Monitor` calls." → No. Render N Monitor commands from one parameterized poller (or use `scripts/await-pr-reviews.py --pr <n>` which encapsulates the poll logic). The poller logic is ~40 lines; duplicating it 9× across briefs is unmaintainable.
 
 ## How to Think — meta-cognition per phase
 
@@ -559,15 +913,17 @@ See `references/thinking-steering.md` for full red-flag list. See `skills/run-re
 | 0 | `skills/run-repo-cleanup/scripts/init-to-delete.py` | reused | Idempotent `to-delete/` setup. |
 | 1 | `scripts/redistribute-commits.py` | new | Split mixed-concern commits via interactive rebase + backup ref. |
 | 2 | `scripts/spawn-review-worktrees.py` | new | Create worktrees, push to fork, emit manifest. |
-| 3 | `scripts/run-codex-review.py` | new | Wrap `/codex:review --background`; normalize output to JSON. |
+| 3 | `scripts/run-codex-review.py` | rewritten | Spawns `node codex-companion.mjs review --json` (or `adversarial-review --json`) synchronously; auto-discovers the codex plugin path version-agnostic; normalizes output to the round-log JSON schema; writes `<rounds-dir>/<slug>.<round>.json`; updates manifest. `--mode review\|adversarial` flag. |
 | 3 | `scripts/classify-review-feedback.py` | new | Apply major/minor policy; produce `{major[], minor[]}`. |
 | 3 | `scripts/loop-status.py` | new | Live table of branch round status (read-only). |
 | 4 | `skills/run-repo-cleanup/scripts/suggest-merge-order.py` | reused | Foundation→leaf heuristic. |
 | 5 | `/ask-review` skill (Skill tool) | external | Author comprehensive PR body. |
-| 6 | `scripts/trigger-codex-rescue.py` | new | Trigger `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh`. |
+| 6 | `scripts/trigger-codex-rescue.py` | rewritten | Spawns `node codex-companion.mjs task --background --write --fresh --model gpt-5.5 --effort xhigh --prompt-file <p> --json`; auto-discovers the plugin path; captures `jobId` + `logFile` to manifest. Optional `--wait` blocks on `status --wait` until terminal. |
 | 6 | `scripts/await-pr-reviews.py` | new | Adaptive 900s wait + gather all review streams. |
 | 7 | `/do-review` skill (Skill tool) | external | Evaluator's primary instrument. |
-| 8 | `/do-review` skill (Skill tool) | external | Main agent's apply-time instrument. |
+| 8a | `scripts/apply-evaluator-decisions.py` | new | Reads `<repo>/.codex-review-rounds/pr-<n>.evaluation.json`; prints ordered apply queue (ambiguous items at top with BLOCKED warning, then accepted items with `file:line:intended-shape:rationale`). Read-only; does NOT modify worktree, commit, or push. Reduces Phase 8a main-agent overhead from ~10 tool calls to ~5 per PR. |
+| 8a | `/do-review` skill (Skill tool) | external | OPTIONAL Phase 8a sanity-check (off by default; opt-in for borderline confidence items). |
+| 8b | `gh pr merge` (gh CLI) | external | Merge in foundation→leaf order with CI-wait gate. |
 | 9 | `scripts/cleanup-worktrees.py` | new | Remove review worktrees; refuses unmerged unless `--force-abandon`. |
 | 9 | `skills/run-repo-cleanup/scripts/retire-merged-branches.py` | reused | Delete merged local + remote branches. |
 
@@ -577,6 +933,7 @@ All new scripts: Python 3 stdlib only, dry-run by default where mutating, paired
 
 | File | Type | One-liner |
 |---|---|---|
+| `references/event-driven-orchestration.md` | new | Pinned spec for Monitor / ScheduleWakeup / Bash run_in_background / Agent run_in_background usage in Phases 3-8. Read before any parallel dispatch. |
 | `references/mission-protocol-integration.md` | new | How every sub-agent dispatch in this skill complies with `~/MISSION_PROTOCOL.md`. |
 | `references/codex-review-contract.md` | new | What `/codex:review --background` returns; how to invoke; how to read. |
 | `references/per-branch-fix-loop.md` | new | Phase 3 coordinator + worker pattern; round counter; 20-cap; state machine. |
@@ -608,4 +965,4 @@ External: `~/MISSION_PROTOCOL.md` (the brief-writing doctrine).
 
 ## Bottom Line
 
-Audit → decompose → worktree-per-branch → push to fork → parallel inner loop with coordinator + per-round `/do-review`-evaluating worker (cap 20) → main agent dispatches PR-Creator sub-agent that uses `/ask-review` to author body (≤ 50k, ≥ 3 reviewer questions) → trigger `/codex:resc` and adaptive 900s wait for external bots → evaluator sub-agent uses `/do-review` on all gathered streams → main agent applies accepted items directly via `/do-review` in own context → merge or BLOCKED → tidy. Every sub-agent brief follows MISSION_PROTOCOL. Every review item passes through `/do-review`. Direct-apply forbidden. PR creation is sub-agent-only. Fork-only, ever. One discipline, sixteen invariants, zero exceptions.
+Audit → decompose → worktree-per-branch → push to fork → parallel inner loop with coordinator + per-round `/do-review`-evaluating worker (cap 20) → main agent dispatches PR-Creator sub-agent that uses `/ask-review` to author body (≤ 50k, ≥ 3 reviewer questions) → trigger `/codex:resc` and adaptive 900s wait for external bots → evaluator sub-agent uses `/do-review` on all gathered streams → main agent applies accepted items directly via `/do-review` in own context → merge or BLOCKED → tidy. Every sub-agent brief follows MISSION_PROTOCOL. Every review item passes through `/do-review`. Direct-apply forbidden. PR creation is sub-agent-only. Fork-only, ever. One discipline, seventeen invariants, zero exceptions.

--- a/skills/run-codex-review/skills/run-codex-review/SKILL.md
+++ b/skills/run-codex-review/skills/run-codex-review/SKILL.md
@@ -5,9 +5,9 @@ description: "Use skill if you are running parallel per-branch /codex:review fix
 
 # Prepare and Run Codex Review
 
-The job: turn a messy repo into a clean per-branch decomposition; converge each branch through Codex's per-round review loop with `/do-review`-evaluated worker sub-agents; open a comprehensive PR per branch via a sub-agent that uses `/ask-review`; trigger `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh` on each PR as a last check; wait adaptively (900s base + 5-min extensions if bots still talking + 3-min quiet to terminate, capped at 30 min) for external review bots (Copilot, Greptile, Devin, cubic-dev-ai); dispatch a `/do-review` evaluator sub-agent per PR over all gathered streams; have the main agent apply the evaluator's accepted subset directly using `/do-review` in its own context; merge foundation→leaf on the private fork only; tidy. End state: every branch DONE-merged or surfaced (CAP-REACHED / BLOCKED / FAILED), no stale worktrees, manifest deleted, `audit-review-state.py` exits 0.
+The job: turn a messy repo into a clean per-branch decomposition; converge each branch through Codex's per-round review loop driven by **main agent as coordinator** (with per-round Applier sub-agents and main-agent `/do-review` evaluation); open a comprehensive PR per branch via a sub-agent that uses `/ask-review`; trigger codex rescue on each PR (`/codex:resc` slash for chat, or `scripts/trigger-codex-rescue.py` wrapping `codex-companion.mjs task --background` for programmatic loops); wait adaptively (900s base + 5-min extensions if bots still talking + 3-min quiet to terminate, capped at 30 min) for external review bots (Copilot, Greptile, Devin, cubic-dev-ai, copilot-pull-request-reviewer); dispatch a `/do-review` Evaluator sub-agent per PR over all gathered streams; have the main agent apply the evaluator's accepted subset directly via Edit + per-concern commits (Phase 8a); merge foundation→leaf with `git rebase --onto` mechanics for squash-merged stacks (Phase 8b); tidy. End state: every branch MERGED or surfaced (BLOCKED / CONVERGED-AT-CAP / CAP-REACHED / FAILED), no stale worktrees, no stale local/remote branches, manifest deleted, `audit-review-state.py` exits 0.
 
-This skill **layers on top of** `run-repo-cleanup`. Read that skill's `SKILL.md` first; its references and scripts are canonical for diff-walk, conventional commits, fork safety, worktrees, merge ordering. This skill adds: commit redistribution on committed history; the two-level coordinator+worker inner loop; `/ask-review`-based PR creation by sub-agent; `/codex:resc` orchestration with adaptive wait; multi-source review evaluation via `/do-review` sub-agents; main-agent direct apply; review-aware cleanup.
+This skill **layers on top of** `run-repo-cleanup`. Read that skill's `SKILL.md` first; its references and scripts are canonical for diff-walk, conventional commits, fork safety, worktrees, merge ordering. This skill adds: commit redistribution on committed history; the **main-agent-coordinator + per-round Applier** inner loop with `/do-review` evaluation in main's context; `/ask-review`-based PR creation by sub-agent; codex-rescue orchestration with adaptive wait; multi-source review evaluation via Evaluator sub-agents; main-agent direct apply (Phase 8a) followed by foundation→leaf serial merge (Phase 8b); review-aware cleanup with hard exit gate.
 
 Every sub-agent in this skill is dispatched per **`~/MISSION_PROTOCOL.md`** — Context Block → Mission Objective → Research & Tool Guidance → BSV Definition of Done → Verification → Failure Protocol → Handback. See `references/mission-protocol-integration.md`. Brief discipline is the lever; without it, parallel sub-agents drift toward mediocre.
 
@@ -92,8 +92,8 @@ End-of-phase reports must be **one sentence**: "Phase X complete; entering X+1."
     Detect from `git remote -v` in Phase 0. **Do not present options or ask the user when the detection is unambiguous.**
 2. Read every diff before staging. No `git commit -am`. (See `skills/run-repo-cleanup/references/diff-walk-discipline.md`.)
 3. Never `rm` an unknown file. Quarantine to `to-delete/` first. (See `skills/run-repo-cleanup/references/to-delete-folder.md`.)
-4. **One worktree per branch. One coordinator per worktree. One fresh worker per round.** No two agents mutate the same branch concurrently.
-5. **`/codex:review` always runs `--background`.** Never inline.
+4. **One worktree per branch. Main agent is the only coordinator (across all branches). One fresh Applier sub-agent per round per branch.** No two agents mutate the same branch concurrently. (The older "Coordinator sub-agent per worktree" pattern was dropped — long-lived sub-agents drift past harness session limits; main-agent-as-coordinator is empirically reliable. See `references/parallel-subagent-protocol.md` "Coordinator role".)
+5. **Codex review runs synchronously per round.** `codex-companion.mjs review` ignores `--background`; per-branch parallelism comes from concurrent subprocess invocations across branches, not from a background flag. (`task --background` IS honored — that's how Phase 6 codex rescue works; see Phase 6.)
 6. **20-round hard cap per branch.** Branches converge independently; one capping does not stop siblings.
 7. **Never `--force` push** a branch under active review. Stack commits on top.
 8. **Never push to upstream. Never touch `main` directly.**
@@ -348,7 +348,7 @@ Live table: branch, rounds, last status, state. **No editing while sub-agents ar
 
 Once every branch is terminal, the main agent:
 
-1. Reads `/tmp/codex-review-manifest.json`.
+1. Reads `<repo-root>/.codex-review-manifest.json` (the repo-local default; pass `--manifest <path>` if a custom location was used).
 2. Builds the deliverable's first table (Branch | Worktree | Concern | Rounds | Final status).
 3. Recomputes merge order with `python3 skills/run-repo-cleanup/scripts/suggest-merge-order.py --base main`. Override the heuristic for semantic dependencies; write the rationale into the manifest.
 4. Surfaces non-`DONE` branches: each with its remaining major feedback and a suggested human action.
@@ -526,95 +526,32 @@ Process PRs in any order in 8a (foundation-first OR leaves-first OR interleaved 
 
 ## Phase 8b — Merge in foundation→leaf strict serial
 
-**Think first**: *Apply is done. Now merge in dependency order. Foundation merges first; squash-merging foundation collapses N foundation commits into 1 squashed commit on main with a different SHA, which means leaves still carrying the original foundation commits will conflict on plain `git rebase origin/main` — they need `git rebase --onto` to skip the now-duplicated foundation history. After leaves are rebased and retargeted, they merge to main individually with CI-wait between.*
+**Think first**: *Apply is done. Now merge in dependency order with squash-merge-aware leaf rebases.*
 
-### Step-by-step
+The full merge recipe (foundation pre-merge tip capture, `git rebase --onto` for leaves, retargeting via `gh pr edit --base main`, sequential merge with CI-wait between, `--delete-branch` on merge) is documented in detail in **`references/post-pr-review-protocol.md` "Phase 8b — merge in foundation→leaf strict serial"**. Follow that recipe verbatim. Key points to keep in this skill body:
 
-1. Order PRs per `manifest.merge_order` (foundation first, then sibling leaves in dependency order).
-2. **Capture foundation's pre-merge tip BEFORE merging foundation** (load-bearing for the leaf-rebase math below):
-   ```bash
-   foundation_tip=$(git -C <foundation-worktree> rev-parse HEAD)
-   # Persist in manifest for resilience across session restarts:
-   # manifest.foundation_pre_merge_tip = <sha>
-   ```
-3. **Foundation merge:**
-   - Wait CI green via `Bash(run_in_background=True)`:
-     ```bash
-     until [ "$(gh pr checks <foundation-pr> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
-       sleep 30
-     done
-     gh pr checks <foundation-pr>
-     ```
-   - If any check is `failure` or `cancelled`: mark foundation `BLOCKED` and **STOP — do NOT merge any leaves; foundation is their base.** Surface foundation BLOCKED for human resolution.
-   - Else: `gh pr merge <foundation-pr> --repo <fork>/<repo> --squash --delete-branch` (the `--delete-branch` flag deletes the remote branch on merge, halving Phase 9 cleanup work).
-   - `git fetch --all --prune` to pull the new `origin/main`.
-4. **Retarget + rebase + push every leaf** (one batch, in parallel since leaves are siblings under foundation):
-   ```bash
-   for leaf_pr in <leaf-prs>; do
-       leaf_branch=$(gh pr view "$leaf_pr" --json headRefName --jq .headRefName)
-       leaf_worktree=<from-manifest>
-
-       # Retarget leaf's PR base from feat/handoff-foundation → main
-       gh pr edit "$leaf_pr" --base main
-
-       # Rebase leaf onto new main, SKIPPING the now-redundant foundation commits.
-       # Plain `git rebase origin/main` would re-apply foundation's originals on top of
-       # main's squashed equivalent → conflicts. --onto fast-forwards past the original
-       # foundation tip and replays only the leaf-specific commits.
-       git -C "$leaf_worktree" fetch origin
-       git -C "$leaf_worktree" rebase --onto origin/main "$foundation_tip" "$leaf_branch"
-       git -C "$leaf_worktree" push --force-with-lease origin "$leaf_branch"
-   done
-   ```
-5. **Merge each leaf in order** (sequential, NOT `--auto`; `--auto` queues but doesn't dequeue cleanly when stack still diverges in some repo configs):
-   ```bash
-   for leaf_pr in <leaf-prs-in-order>; do
-       # CI-wait per leaf
-       until [ "$(gh pr checks "$leaf_pr" --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
-           sleep 30
-       done
-       gh pr checks "$leaf_pr"
-
-       # Check + merge
-       if any check is failure/cancelled:
-           mark leaf BLOCKED with terminal_reason: "CI failure: <check-name>"
-           continue   # do NOT halt for leaves; only foundation failure halts
-       else:
-           gh pr merge "$leaf_pr" --repo <fork>/<repo> --squash --delete-branch
-           git fetch --all --prune   # refresh main for next leaf's CI checks
-   done
-   ```
-
-### Auto-merge note
-
-`gh pr merge --auto` works for the **foundation** PR (single-step merge) but is unreliable for the **leaf** PRs — when a leaf is queued for auto-merge before its rebase is fully ready or when the squashed foundation diverges the stack, `--auto` silently waits forever or no-ops. **Use sequential merge without `--auto` for leaves.** Each leaf merges only after its rebase + force-push lands and CI passes.
-
-### When --delete-branch can't run
-
-If the repo policy requires PRs to be merged via web UI or branch-protection rules block `--delete-branch`, drop the flag and let Phase 9 handle remote-branch cleanup explicitly:
-```bash
-gh pr merge "$leaf_pr" --squash
-# Phase 9 will: gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<leaf-branch>
-```
+- **Capture foundation's pre-merge tip BEFORE merging foundation** (`foundation_tip=$(git -C <foundation-worktree> rev-parse HEAD)`). Required for the `git rebase --onto origin/main <foundation_tip> <leaf>` math below.
+- **Foundation must succeed first.** If foundation CI fails, STOP — leaves are based on foundation; do not merge any of them. Surface foundation BLOCKED.
+- **Squash-merging foundation collapses N foundation commits into 1 commit on main with a different SHA.** Plain `git rebase origin/main` on leaves conflicts on every foundation hunk. Use `git rebase --onto origin/main <foundation_tip> <leaf-branch>` to skip the duplicated history.
+- **Retarget each leaf** (`gh pr edit <leaf-pr> --base main`) before merging — leaves were originally based on foundation.
+- **`gh pr merge --squash --delete-branch`** (the `--delete-branch` flag halves Phase 9 cleanup).
+- **`gh pr merge --auto` works for foundation, unreliable for leaves on divergent stacks.** Use sequential explicit merge with CI-wait between.
+- **`--force-with-lease`, NOT `--force`** when pushing rebased leaves.
 
 ### Phase 8b hard exit gate
 
-**Phase 8b does NOT exit until every non-BLOCKED PR is MERGED.** Manifest field `merged_at` set per branch. `gh pr list --repo <fork>/<repo>` shows ONLY:
-- BLOCKED branches (`terminal_reason` set), or
-- `apply_failed_after_evaluation` branches (surfaced for human).
+**Phase 8b does NOT exit until every non-BLOCKED PR is MERGED.** `gh pr list --repo <fork>/<repo>` should show ONLY BLOCKED or `apply_failed_after_evaluation` branches. If a PR is neither and isn't merged, 8b is incomplete — re-attempt the merge (in `/loop` mode, `ScheduleWakeup(delaySeconds=600)` and re-check). Do NOT proceed to Phase 9 with un-resolved PRs.
 
-If `gh pr list` still shows a PR that is neither BLOCKED nor `apply_failed_after_evaluation`, **8b is incomplete — re-attempt the merge for that PR**. In `/loop` dynamic mode, `ScheduleWakeup(delaySeconds=600)` and re-check on the next firing. Do NOT proceed to Phase 9 with un-resolved PRs.
+### Red flags (8b)
 
-**Red flags (8b)**:
-- "Merge foundation before its CI is green." → No. Foundation merges only when CI is green.
-- "Skip CI-wait, just merge fast." → No. CI-wait is mandatory in 8b.
-- "Foundation CI failed — merge the leaves anyway." → No. Foundation is their base. Halt all leaf merges.
+- "Merge foundation before CI green." → No. CI-wait is mandatory.
+- "Foundation CI failed — merge the leaves anyway." → No. Halt all leaf merges; surface foundation BLOCKED.
+- "Plain `git rebase origin/main` the leaves." → No. `--onto <foundation_tip>` is non-negotiable for squash-merged stacks.
+- "Skip capturing `foundation_pre_merge_tip`." → No. Capture BEFORE merging foundation; the local HEAD may move after.
+- "Skip retargeting leaves to main." → No. PR `--base` is independent of the rebased branch.
+- "Use `gh pr merge --auto` to chain leaf merges." → No. Sequential explicit merge with CI-wait between.
+- "Force-push leaves with `--force` instead of `--force-with-lease`." → No. `--force-with-lease` is the safety mechanism.
 - "Merge the BLOCKED PR anyway." → No. Human decides.
-- "After merging foundation, plain `git rebase origin/main` the leaves." → No. Plain rebase replays foundation's originals on top of the squashed equivalent → conflicts. Use `git rebase --onto origin/main <foundation_pre_merge_tip> <leaf>`.
-- "Skip capturing `foundation_pre_merge_tip` — I'll figure it out later." → No. Once foundation merges, the local foundation worktree's HEAD may move and `git log` may show only the squash. Capture the tip BEFORE merging foundation.
-- "Skip retargeting leaves to main; let GitHub auto-figure-out the new base." → No. The `--base` field on a PR is independent of the rebased branch. Retarget explicitly with `gh pr edit <leaf-pr> --base main`.
-- "Use `gh pr merge --auto` to chain all leaf merges in one shot." → No. Auto-merge is unreliable for divergent stacks. Sequential explicit merge with CI-wait between.
-- "Force-push leaves with `--force` instead of `--force-with-lease`." → No. `--force-with-lease` is the safety mechanism (refuses if remote moved unexpectedly). Plain `--force` can clobber concurrent activity.
 - "Open a fresh PR for the apply_failed_after_evaluation items." → Acceptable but optional; surface for human first. Don't auto-cycle.
 
 ---
@@ -623,74 +560,37 @@ If `gh pr list` still shows a PR that is neither BLOCKED nor `apply_failed_after
 
 **Think first**: *What state did I start in? Have I returned to it, plus the intended delta — nothing more, nothing less? No stale worktree, no stale local branch, no stale remote branch, no stale temp file.*
 
-### Cleanup steps (do all four; the audit fails if any is skipped)
+### Cleanup checklist (do ALL four; the hard gate fails if any is skipped)
 
-1. **Worktrees** — remove every review worktree:
-   ```bash
-   python3 <this-skill>/scripts/cleanup-worktrees.py --base main --execute
-   ```
-   The script enumerates every `<repo>-wt-*` worktree and runs `git worktree remove <path>`. Refuses worktrees whose branch is not merged unless `--force-abandon <branch>` is passed.
-
-2. **Local branches** — delete every merged review branch:
-   ```bash
-   python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --execute
-   ```
-   The script runs `git branch -d <name>` for each branch fully merged into `main`. Branches that are NOT merged (BLOCKED, `apply_failed_after_evaluation`) are skipped — those stay around for human follow-up.
-
-3. **Remote branches** — only needed for branches that weren't deleted by `gh pr merge --delete-branch` in 8b. For BLOCKED / failed branches, leave them on origin so the human can resume:
-   ```bash
-   # Only run for branches we created and that survived 8b without --delete-branch.
-   # The retire-merged-branches.py script handles this when run with --remote.
-   python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --remote --execute
-   ```
-
-4. **Temp files** — every brief and manifest gets cleaned up:
-   ```bash
-   rm -f <repo>/.codex-review-manifest.json{,.lock}
-   rm -rf <repo>/.codex-review-rounds/
-   rm -f /tmp/applier-brief-*.md
-   rm -f /tmp/evaluator-brief-*.md
-   rm -f /tmp/evaluator-brief-template.md
-   rm -f /tmp/pr-creator-brief-*.md
-   rm -f /tmp/pr-creator-brief-template.md
-   rm -f /tmp/applier-brief-template*.md
-   ```
-   (Legacy `/tmp/codex-review-manifest.json{,.lock}` from older skill runs may also exist; remove if present and pointing at the same `repo_root`. Leave alone if pointing elsewhere — that's a different session's state.)
+1. **Worktrees** — `python3 <this-skill>/scripts/cleanup-worktrees.py --base main --execute`. Removes every `<repo>-wt-*` worktree whose branch is merged. Refuses unmerged worktrees unless `--force-abandon <branch>`.
+2. **Local branches** — `python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --execute`. `git branch -d <name>` for each fully-merged branch; leaves BLOCKED / `apply_failed_after_evaluation` alone.
+3. **Remote branches** — only for branches that survived 8b without `--delete-branch`. Same script with `--remote --execute`.
+4. **Temp files** — `rm -f <repo>/.codex-review-manifest.json{,.lock} && rm -rf <repo>/.codex-review-rounds/ && rm -f /tmp/applier-brief-*.md /tmp/evaluator-brief-*.md /tmp/pr-creator-brief-*.md /tmp/*-brief-template*.md`. (Legacy `/tmp/codex-review-manifest.json{,.lock}` from older runs: remove only if its `repo_root` matches the current session's; leave alone if pointing elsewhere.)
 
 ### Independent re-audit (mandatory)
 
-Dispatch a **fresh subagent** for an independent re-audit (per `skills/run-repo-cleanup/references/post-pr-verification.md`). The subagent runs read-only:
+Dispatch a fresh sub-agent for read-only re-audit (per `skills/run-repo-cleanup/references/post-pr-verification.md`). The audit runs `audit-state.py` + `audit-review-state.py` + verifies: `git worktree list` shows only main; `git branch -vv` shows only main + BLOCKED branches; `gh pr list` shows only BLOCKED PRs; `gh api repos/<fork>/branches` shows only main + BLOCKED; `.codex-review-*` files absent; `/tmp/*-brief-*.md` absent.
 
-- `python3 skills/run-repo-cleanup/scripts/audit-state.py` → must exit 0.
-- `python3 <this-skill>/scripts/audit-review-state.py` → must exit 0.
-- `git worktree list` → ONLY main; no `*-wt-*` review worktrees.
-- `git branch -vv` → ONLY `main` and any open-PR (BLOCKED / `apply_failed_after_evaluation`) branches.
-- `git for-each-ref refs/heads/feat/* refs/heads/fix/* refs/heads/chore/* refs/heads/docs/*` → ONLY un-merged BLOCKED ones (or empty).
-- `gh pr list --repo <fork>/<repo>` → matches expected (only BLOCKED / `apply_failed_after_evaluation` PRs, or empty).
-- `gh api repos/<fork>/<repo>/branches --jq '.[].name' | grep -vE '^(main|<BLOCKED-list>)$'` → empty.
-- `gh pr list --repo <upstream>/<upstream-repo> --author @me` → empty (single-owner mode skips this check).
-- Repo-local `.codex-review-manifest.json` and `.codex-review-rounds/` → don't exist.
-- `/tmp/{applier,evaluator,pr-creator}-brief-*.md` → don't exist.
+### Phase 9 hard exit gate (the "no stale anything" condition)
 
-### Phase 9 hard gate (the "no stale anything" exit condition)
+Phase 9 does NOT exit until ALL six are true:
 
-Phase 9 does NOT exit until ALL of:
-1. Every non-BLOCKED branch is **MERGED** to main (verify in manifest + `gh pr list`).
-2. Every review **worktree** is removed (`git worktree list` shows only main).
-3. Every merged **local branch** is deleted (`git branch -vv` shows only main + BLOCKED).
-4. Every merged **remote branch** is deleted (`gh api repos/.../branches` shows only main + BLOCKED).
-5. Every **temp brief / manifest / round-log** is cleaned (no `.codex-review-*` files in repo; no `*-brief-*.md` in `/tmp/`).
-6. Independent re-audit subagent reports **TIDY**.
+1. Every non-BLOCKED branch is **MERGED** to main.
+2. Every review **worktree** is removed.
+3. Every merged **local branch** is deleted.
+4. Every merged **remote branch** is deleted.
+5. Every **temp brief / manifest / round-log** is cleaned.
+6. Independent re-audit sub-agent reports **TIDY**.
 
-If any of (1)-(5) fails, Phase 9 is incomplete. In `/loop` dynamic mode, retry with `ScheduleWakeup(delaySeconds=600)` if the failure is transient (CI still pending on a leaf, GitHub rate-limit blocking branch deletion). If the failure is structural (BLOCKED PR with ambiguous items), surface the exact list and stop — the human takes over.
+If any fails, Phase 9 is incomplete. In `/loop` dynamic mode, `ScheduleWakeup(delaySeconds=600)` and re-check on transient failures (CI still pending, rate-limit blocking branch deletion). On structural failures (BLOCKED PRs), surface the exact list and stop — human takes over.
 
-**Red flags (Phase 9)**:
+### Red flags (Phase 9)
+
 - "I'll clean up next time." → No. Tidy is binary.
-- "I'll keep the worktrees in case." → No. Stale worktrees are debris.
-- "Local branches deleted; remote branches don't matter — they're on the fork." → No. Stale remote branches accumulate on every run; future runs see them as "in-flight" and refuse to spawn worktrees with the same name.
-- "Just `git worktree remove --force <path>` everything." → No. The skill's `cleanup-worktrees.py` refuses unmerged worktrees by default to protect un-pushed work; bypass with `--force-abandon <branch>` only when explicitly intended.
-- "Skip the independent re-audit; I'll just trust my own state." → No. The audit subagent is fresh-context; it catches state drift main agent's context can mask.
-- "Skip cleaning `/tmp/{applier,evaluator,pr-creator}-brief-*.md` — they're tiny." → No. Future runs may create briefs with the same names and read stale data; clean now, not later.
+- "Local branches deleted; remote branches don't matter." → No. Stale remote branches accumulate; future runs see them as "in-flight" and refuse to spawn worktrees with the same name.
+- "`git worktree remove --force <path>` everything." → No. `cleanup-worktrees.py` refuses unmerged worktrees by default to protect un-pushed work; use `--force-abandon <branch>` only when explicitly intended.
+- "Skip the independent re-audit." → No. Fresh-context audit catches state drift main agent's own context can mask.
+- "Skip cleaning `/tmp/*-brief-*.md`." → No. Future runs may create briefs with the same names and read stale data.
 
 ---
 
@@ -735,76 +635,9 @@ Full recipes: `references/failure-recovery.md`.
 
 ## Final Deliverable
 
-The wrap-up at end of Phase 9. **Phase 9 cannot exit until every section below is producible from manifest state** — this is the "all merged or surfaced" hard exit gate the user requires.
+The wrap-up at end of Phase 9. **Phase 9 cannot exit until every section below is producible from manifest state** — this is the "all merged or surfaced" hard exit gate.
 
-```markdown
-## 🎉 Full skill flow complete — N PRs merged to main (or M surfaced as BLOCKED)
-
-### Final state on <fork-owner>/<repo>
-
-<output of: git log --oneline origin/main~N..origin/main>
-
-E.g.:
-a12dd4e fix(antigravity): protobuf sessions + RPC + cache (#51)
-cf8d3cd feat(parsers/gemini): JSONL + rewind reconciliation (#52)
-…
-3f15720 feat(handoff): structured timeline + verbosity controls (#53)
-
-### Per-branch summary
-| Branch | Concern | Rounds | Phase 3 status | PR | Phase 7 (a/r/x) | Phase 8a apply | Merged at | Notes |
-|---|---|---:|---|---|---|---|---|---|
-
-### Per-PR review breakdown
-| PR | codex-rescue (a/r/x) | copilot (a/r/x) | copilot-pr-reviewer (a/r/x) | greptile (a/r/x) | devin (a/r/x) | cubic-dev-ai (a/r/x) | Total accepted | Total ambiguous |
-|---|---|---|---|---|---|---|---:|---:|
-
-### What ran across all 10 phases
-| Phase | What happened |
-|---|---|
-| 0 | Pre-flight audit — all scripts present, MISSION_PROTOCOL loaded, /ask-review + /do-review available; manifest path repo-local. |
-| 1 | Decomposed N-file dirty tree into M per-concern branches. |
-| 2 | M worktrees spawned with --prep-deps, M branches pushed, manifest emitted. |
-| 3 | K rounds × M codex reviews; main agent evaluated, dispatched M appliers per round; J fixes applied across rounds. |
-| 4 | Merge order computed: foundation, then leaves. |
-| 5 | M PR-Creators (throttled ≤4) opened PRs via REST `gh api repos/.../pulls`. |
-| 6 | M codex:rescue jobs + M Monitors armed; external bots landed reviews; adaptive 900s base + 3-min quiet windows closed cleanly per PR. |
-| 7 | M Evaluator sub-agents used /do-review over gathered streams; produced decisions JSON (≈X items: A accepted, R rejected, U ambiguous). |
-| 8a | Main agent direct-applied accepted decisions across M worktrees; validated build+tests; pushed N commits. |
-| 8b | Captured foundation_pre_merge_tip; squash-merged foundation with --delete-branch; rebased leaves with `git rebase --onto`; retargeted leaves to main; merged sequentially with CI-wait. |
-| 9 | M worktrees removed, M local branches deleted, M remote branches deleted (mostly via --delete-branch in 8b), manifest + round-logs + briefs cleaned; final audit: TIDY. |
-
-### Loop tools that kept this autonomous
-- **Monitor** (M instances): per-PR comment poller; emitted one event per new bot/human comment; terminated on `[PR-N-DONE quiet]` or `[PR-N-DONE cap]`.
-- **ScheduleWakeup** (X fires): cache-aware 1200-1800s fallback tickers covering the 900s adaptive-wait floor.
-- **Agent run_in_background=true** (~K dispatches): appliers, PR-Creators, Evaluators — each fired a handback notification on completion.
-- **Bash run_in_background=true** (~K launches): per-branch codex review jobs, codex:rescue invocations, CI-wait pollers.
-
-### Lessons captured during execution (only include genuinely novel learnings; not boilerplate)
-
-### Tidy audit
-<output from audit-state.py + audit-review-state.py — both must show CLEAN>
-- git worktree list → only main
-- git branch -vv → only main + any BLOCKED branches
-- gh pr list → only BLOCKED branches (or empty)
-
-### Per-branch round history (appendix)
-### feat/foo (DONE in 4 rounds, merged as #42)
-- Round 1: 3 major (3 accepted) → committed + pushed
-- Round 2: 1 major (1 accepted) → committed + pushed
-- Round 3: 1 major (0 accepted, 1 rejected) → all-rejected round
-- Round 4: no major → DONE
-- Phase 8a fixes: abc123, def456 (merged as squash 2026-04-26T11:40:00Z)
-
-### feat/bar (CONVERGED-AT-CAP at 20 rounds, merged as #43 with deferred items in PR body)
-- 20 rounds, 8 accepted, 14 rejected, 0 ambiguous
-- Remaining major items in last round: <listed in PR body>
-
-### feat/baz (BLOCKED — surfaced for human; NOT merged)
-- terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
-- Suggested human action: <e.g. split into 2 branches, re-run per concern>
-```
-
-The format is rendered from manifest entries; see `references/branch-decomposition-ledger.md`.
+The full Final Deliverable template (per-branch summary, per-PR review breakdown across 6 bot sources, what-ran-across-all-10-phases table, loop-tools used, per-branch round-history appendix) lives in `references/branch-decomposition-ledger.md` "Final Deliverable template" — render it from manifest entries at end of Phase 9.
 
 ### "All merged or surfaced" hard exit gate
 
@@ -812,94 +645,69 @@ The Final Deliverable can be produced ONLY when every branch in the manifest rea
 
 | Terminal state | Acceptable for clean exit? |
 |---|---|
-| `MERGED` (with `merged_at` timestamp) | ✅ yes — happy path |
-| `BLOCKED` (with `terminal_reason` set) | ✅ yes — surfaced for human; clean exit |
-| `apply_failed_after_evaluation` (with item list) | ✅ yes — surfaced for human; clean exit |
-| `CAP-REACHED` (no fixes pushed) | ✅ yes — surfaced for human |
-| `IN-LOOP` / `SPAWNED` / unset / `applying` | ❌ NO — incomplete; re-attempt or surface the specific blocker |
+| `MERGED` (with `merged_at` timestamp) | ✅ happy path |
+| `BLOCKED` (with `terminal_reason` set) | ✅ surfaced for human; clean exit |
+| `apply_failed_after_evaluation` (with item list) | ✅ surfaced for human |
+| `CONVERGED-AT-CAP` (round budget hit; fixes pushed; deferred items in PR body) | ✅ surfaced; clean exit if PR is merged or BLOCKED |
+| `CAP-REACHED` (round budget hit; no fixes pushed) | ✅ surfaced for human |
+| `FAILED` (tooling crash past retry budget) | ✅ surfaced for human |
+| `IN-LOOP` / `SPAWNED` / unset / `applying` | ❌ incomplete; re-attempt or surface the specific blocker |
 
-If any branch is in an incomplete state when Phase 9 audit runs, **the audit fails**. Re-attempt the merge for that branch (in `/loop` mode, ScheduleWakeup 600s and re-check). Do NOT produce the Final Deliverable until every branch is terminal.
+If any branch is in an incomplete state when Phase 9 audit runs, **the audit fails**. Re-attempt the merge for that branch (in `/loop` mode, `ScheduleWakeup(delaySeconds=600)` and re-check). Do NOT produce the Final Deliverable until every branch is terminal.
 
 ## Smell Test — forbidden internal thoughts
 
-If any of these fires, stop and re-run `python3 <this-skill>/scripts/audit-review-state.py`:
+If any of these fires, stop and re-run `python3 <this-skill>/scripts/audit-review-state.py`. The full annotated list lives in `references/thinking-steering.md` "Forbidden inventions"; the highest-leverage entries are below.
 
-**Phase 3:**
-- "I'll just squash these reviews into one round."
-- "Good enough after 3 rounds, ship it."
-- "I'll skip /do-review for the obvious items."
-- "Let me have one worker fix two rounds."
-- "Let me have the coordinator do the work itself."
-- "I'll skip the validation step before re-review."
+**Phase 3 (loop discipline)**:
+- "Squash these reviews into one round" / "Good enough after 3 rounds, ship it" → no; classifier + main-agent decisions are the arbiters of DONE.
+- "Let me dispatch a Coordinator sub-agent per branch like the older docs said" → main agent IS the coordinator. Long-lived sub-agents drift past harness session limits.
+- "Let me write the worker brief asking it to `/do-review` then apply" → highest-leverage failure pattern. Workers stop at decision-only. Decisions stay with main agent; workers are appliers.
+- "Let me have one worker fix two rounds" → workers are fresh per round.
 
-**Phase 5:**
-- "I'll just open the PR myself."
-- "I'll hand-roll the body — /ask-review is overhead."
-- "Skip the explicit reviewer questions."
-- "The body is over 50k, let me trim by removing the per-commit section."
+**Phase 5-7 (PR + bots + evaluator)**:
+- "I'll open the PR myself" / "Hand-roll the body — `/ask-review` is overhead" → invariant 13: PR creator MUST be a sub-agent using `/ask-review`.
+- "Skip the wait" / "Wait less than 900s" → 900s base + adaptive end is the contract.
+- "Trust copilot blindly" / "The evaluator is overhead" → every item passes through `/do-review` evaluation.
 
-**Phase 6:**
-- "Skip the wait, merge fast."
-- "Run codex rescue inline."
-- "Wait less than 900s — the bots are fast."
+**Phase 7-8 (apply + merge)**:
+- "Apply the ambiguous items just in case" / "Half-apply: ship the accepted items, defer the ambiguous ones" → ambiguous = the WHOLE PR is BLOCKED.
+- "Skip CI-wait" → CI-wait is mandatory in 8b before any merge.
+- "Foundation CI failed — merge the leaves anyway" → foundation is their base; halt all leaf merges.
+- "Plain `git rebase origin/main` the leaves after foundation squash-merged" → no; `git rebase --onto origin/main <foundation_pre_merge_tip> <leaf>` is non-negotiable for squash-merged stacks.
+- "Skip retargeting leaves to main" / "Use `gh pr merge --auto` to chain leaf merges" → retarget via `gh pr edit --base main`; sequential explicit merge with CI-wait between.
+- "Stage everything, peek with `git diff --cached`, then `git restore --staged .`" → diff-walk per concern from the first `git add`.
+- "Phase 8a evaluator's intended-shape doesn't apply cleanly; let me improvise" → mark `apply_failed_after_evaluation`, continue, surface.
+- "Force-push leaves with `--force` instead of `--force-with-lease`" → use `--force-with-lease`.
 
-**Phase 7:**
-- "Trust copilot blindly because it's usually right."
-- "The evaluator is overhead; just apply what the bots say."
-- "Auto-resolve the cross-source contradiction."
+**Phase 9 (cleanup)**:
+- "I'll clean up next time" / "I'll keep the worktrees in case" → tidy is binary.
+- "Local branches deleted; remote branches don't matter" → stale remote branches accumulate; future runs see them as "in-flight".
+- "Skip the independent re-audit" → fresh-context audit catches state drift.
 
-**Phase 7-8:**
-- "Let me dispatch a sub-agent for the apply step too." → No. Phase 8a is main-agent direct.
-- "Apply the ambiguous items just in case." → No. Ambiguous = the WHOLE PR is BLOCKED; do not apply any items.
-- "Half-apply: ship the accepted items, defer the ambiguous ones." → No. Defer the entire PR to keep apply intent coherent.
-- "Re-trigger Codex review after apply." → No. Phase 8a's commits are post-evaluator.
-- "Merge the BLOCKED PR anyway." → No. Human decides.
-- "Skip CI-wait, just push and move on to the next PR." → No in 8b — CI-wait gates merge. Within 8a (apply), pushing without CI-wait is fine; merging without CI-wait is forbidden.
-- "Foundation CI failed — let me merge the leaves anyway." → No. Foundation is their base; halt all leaf merges and surface foundation BLOCKED.
-- "Combine 9 PRs' commits into one mega-commit at merge time." → No. One PR = one (or N concern-scoped) commits squashed at merge. Cross-PR squashing destroys per-concern audit trail.
-- "Re-do `/do-review` per item in Phase 8 even when the evaluator already accepted." → No (default). The evaluator's JSON is the authority; re-eval is opt-in for borderline confidence cases only.
-- "Stage all files first, peek with `git diff --cached`, then `git restore --staged .` to re-stage by concern." → No. Diff-walk per concern from the first `git add`. Two extra git ops × 9 PRs = wasted overhead.
-- "Phase 8 evaluator's intended-shape doesn't apply cleanly; let me improvise the fix." → No. Mark `apply_failed_after_evaluation`, continue with remaining items, surface for human.
-- "Force-push leaves after foundation merge without rebasing first." → No. `git fetch && git rebase origin/main` per leaf, then `--force-with-lease` (NOT plain `--force`).
-- "After Evaluator returns ambiguous, retry the evaluation with a different prompt." → No. Ambiguous means the evaluator couldn't decide; another eval pass won't help. Surface for human.
-- "All decisions are accepted/rejected; ambiguous handling won't fire." → It might. Read every PR's evaluation.json; if `ambiguous` count > 0, that PR is BLOCKED.
-
-**Cross-phase:**
-- "I'll start fresh and ignore the prior session's manifest."
-- "I'll write the brief later — this dispatch is simple."
-- "Soft DoD ('clean code') — agents understand."
-- "I can skip the failure protocol — the agent will figure it out."
-- "I'll just run `codex --help` to verify the CLI flags." → No. Slash commands are not shell programs.
-- "Let me write a shim because `codex review --background` doesn't exist." → No. The `--background`/`--fresh`/`--effort` are slash-command arguments, not CLI flags. Re-read `references/codex-review-contract.md`.
-- "I'll dispatch a coordinator subagent per branch like the older docs said." → No. Main agent IS the coordinator (the older per-branch coordinator subagent was dropped; long-lived sub-agents drift). The current pattern is main-agent-coordinator + per-round Applier sub-agents. Read `references/parallel-subagent-protocol.md` "Coordinator role".
-- "Let me run a smoke test before fanning out." → No. The skill prescribes Phase 3 dispatch in parallel from round 1. Smoke tests are not in the workflow.
-- "Re-confirming the user's defaults — fork mode, max rounds, decomposition." → No. Defaults are pinned. Auto-detect and proceed. Only ask when a destructive choice is genuinely ambiguous.
-- "I'll just rebuild the manifest by hand because it has stale entries." → No. Phase 0 auto-namespaces it.
-- "Let me invoke `codex-companion.mjs` directly since the slash command is awkward." → No. The companion script is plugin-internal and forbidden.
-- "Let me run `codex login status` / `codex --version` / `codex doctor` / any health probe before dispatching." → **No.** Slash-command dispatch is the only valid test. Underlying-CLI probes assume a default provider/auth configuration that may not apply — users with custom backends, alternate auth, or non-default providers commonly see probes report "not logged in" while the real flow works. Trust the user's environment; if `Skill(codex:review)` actually fails at dispatch time, hand back FAILED with `terminal_reason` and surface to the user. Never present a multi-option auth-resolution menu (A/B/C…) for an environment the user didn't ask you to configure.
-- "Let me `ls <worktree>/node_modules` (or any dependency check) before dispatching workers." → No. Workers own their worktree setup — they run their own `npm install` / `pnpm install` / equivalent before validation. Pre-checking from main agent is over-stepping and assumes one specific package manager / project layout.
-- "I'll write a small shim that wraps `node codex-companion.mjs review`." → No. The wrapper script `scripts/run-codex-review.py` exists for this purpose. Sub-agents call it; do not invent parallel scripts.
-- "Decision point: how would you like to proceed? Option A / B / C / D." → **No.** If the user's prompt authorized full flow, this is a stall. Proceed to the next phase. (See "Authorization rule".)
-- "Before dispatching N parallel coordinators (which will run for several hours), let me do one smoke test on a single branch first." → No. The skill's Phase 0 already validates the dispatch surface (verifying skills are registered, manifest collision detected, repo mode auto-detected). Smoke tests beyond that are unsanctioned deviations and signal cost-anxiety.
-- "I'm proposing a small deviation from the skill's two-level pattern." → No deviation. Main agent IS the coordinator (the older two-level pattern was dropped because long-lived coordinator subagents drift). Read `references/parallel-subagent-protocol.md` "Coordinator role" — main agent owns the cadence directly.
-- "Phase 3 is taking forever; let me invent `DONE-PRAGMATIC` to ship round-2 work without round-3 verification." → No. The taxonomy is `DONE` / `CONVERGED-AT-CAP` / `CAP-REACHED` / `BLOCKED` / `FAILED`. If you ran out of round budget, set `CONVERGED-AT-CAP` and surface remaining items in the PR body. Inventing states forks the skill.
-- "Round-2 found new items refining round-1 fixes — is the loop converging?" → Yes, that's normal. 6/8 branches in production runs need round-2. Convergence in 3-6 rounds is expected (per `references/major-vs-minor-policy.md`).
-- "Let me write the worker brief asking it to evaluate via `/do-review` then apply." → **No.** This is the highest-leverage failure pattern: workers stop at decision-only and never push. Decisions stay with main agent (Phase 3 step 3 of the loop). Workers receive pre-decided fix specs and apply mechanically. (See invariant 11 + `references/parallel-subagent-protocol.md` "Mission Brief: Applier" — note especially the "Why no `/do-review` in this brief" subsection.)
-- "Let me write 7 separate applier briefs, one per branch, via 7 `Write` tool calls." → **No.** Mandatory: write ONE template with `{{PLACEHOLDER}}` slots; render N briefs from template + decisions JSON in ONE Python invocation. Hand-writing N briefs burns thousands of tokens and drifts copy-paste errors. (See `references/parallel-subagent-protocol.md` "Brief templating".)
-- "I'll inline the comment-poller bash command directly in N separate `Monitor` calls." → No. Render N Monitor commands from one parameterized poller (or use `scripts/await-pr-reviews.py --pr <n>` which encapsulates the poll logic). The poller logic is ~40 lines; duplicating it 9× across briefs is unmaintainable.
+**Cross-phase (anti-stalls)**:
+- "Decision point: how would you like to proceed? Option A / B / C / D" → if user authorized full flow, this is a stall. Proceed.
+- "Before dispatching N parallel coordinators, let me do one smoke test first" → smoke tests are not in the workflow; Phase 0 already validates the dispatch surface.
+- "Let me run `codex --help` / `codex login status` / `codex doctor`" → never probe the underlying CLI; users with custom providers/auth see misleading "not logged in" probes while the real flow works.
+- "Let me `ls <worktree>/node_modules` before dispatching" → workers own their worktree setup.
+- "I'll write a shim that wraps `node codex-companion.mjs review`" → that's what `scripts/run-codex-review.py` is. Use it.
+- "I'll write 7 separate applier briefs via 7 `Write` calls" → mandatory: ONE template + render N from JSON in ONE Python invocation.
+- "Phase 3 is taking forever; let me invent `DONE-PRAGMATIC`" → taxonomy is fixed (`DONE`, `CONVERGED-AT-CAP`, `CAP-REACHED`, `BLOCKED`, `FAILED`). Use `CONVERGED-AT-CAP` for round-budget exhausted.
+- "I'll start fresh and ignore the prior session's manifest" / "I'll rebuild the manifest by hand" → Phase 0 auto-namespaces; do not delete or hand-edit other sessions' state.
 
 ## How to Think — meta-cognition per phase
 
 - **Phase 0**: *What surprises me? Are MISSION_PROTOCOL + ask-review + do-review available?*
 - **Phase 1**: *Can each branch be described in one sentence?*
 - **Phase 2**: *Worktree AND remote ref on origin for each branch?*
-- **Phase 3**: *Coordinator dispatched per branch; per round it dispatches a fresh worker that uses /do-review. Have I stepped back?*
+- **Phase 3**: *I am the coordinator across all branches. Per round per branch: codex review wrapper → classifier → /do-review per major item in my own context → dispatch fresh Applier with pre-decided fix specs. Have I stepped back from the worktrees while Appliers run?*
 - **Phase 4**: *Which branches are mergeable? What's the merge order rationale?*
-- **Phase 5**: *PR opened by sub-agent using /ask-review? Body ≤ 50k? ≥ 3 reviewer questions?*
-- **Phase 6**: *Codex rescue triggered? Wait window in progress with adaptive end?*
-- **Phase 7**: *Evaluator decided every item via /do-review? Cross-source contradictions flagged?*
-- **Phase 8**: *Applying directly via /do-review? Ambiguous items surfaced (BLOCKED), not silently merged?*
-- **Phase 9**: *Returned to clean state plus the intended delta?*
+- **Phase 5**: *PR opened by sub-agent using /ask-review? Body ≤ 50k? ≥ 3 reviewer questions? Throttled to ≤4 parallel?*
+- **Phase 6**: *Codex rescue triggered (wrapper or slash)? Wait window in progress with adaptive end?*
+- **Phase 7**: *Evaluator decided every item via /do-review? Cross-source contradictions flagged as ambiguous?*
+- **Phase 8a**: *Reading evaluator decisions; applying accepted items directly via Edit; ambiguous → BLOCKED for the whole PR?*
+- **Phase 8b**: *Captured `foundation_pre_merge_tip` BEFORE merging foundation? Using `git rebase --onto` for leaves? Sequential merge with CI-wait between?*
+- **Phase 9**: *Returned to clean state plus the intended delta? 0 stale worktrees / local branches / remote branches / temp files? Independent audit said TIDY?*
 
 See `references/thinking-steering.md` for full red-flag list. See `skills/run-repo-cleanup/references/agent-thinking-steering.md` for the general decompose/order/verify pattern. See `references/mission-protocol-integration.md` for brief-writing doctrine.
 

--- a/skills/run-codex-review/skills/run-codex-review/references/branch-decomposition-ledger.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/branch-decomposition-ledger.md
@@ -144,11 +144,11 @@ Transitions:
                  (created)
                     │
                     ▼
-                SPAWNED  ──(main agent dispatches coordinator)──▶  IN-LOOP
-                                                                    │
-            ┌──────────────────────────────────────────────┬────────┼──────────────────┐
-            ▼                                              ▼        ▼                  ▼
-          DONE                                        CAP-REACHED  BLOCKED          FAILED
+                SPAWNED  ──(main agent enters Phase 3 loop, round 1)──▶  IN-LOOP
+                                                                          │
+            ┌────────────────────────────┬──────────────────────┬────────┼─────────┬──────────┐
+            ▼                            ▼                      ▼        ▼         ▼          ▼
+          DONE              CONVERGED-AT-CAP              CAP-REACHED  BLOCKED  FAILED
             │                                                 │      │                │
             │ (Phase 5: PR-Creator dispatched)                └──────┴────────────────┘
             ▼                                                       (no further phases;

--- a/skills/run-codex-review/skills/run-codex-review/references/branch-decomposition-ledger.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/branch-decomposition-ledger.md
@@ -4,7 +4,7 @@ The manifest is the durable cross-process state for the entire skill. Every sub-
 
 ## File location
 
-Default: `/tmp/codex-review-manifest.json`. Override with `--manifest <path>` on every script. If the manifest needs to survive reboots, set the path to something under the repo (e.g. `<repo-root>/.codex-review/manifest.json`) and add it to `.gitignore`.
+Default: `<repo-root>/.codex-review-manifest.json` (the wrappers compute this from the worktree's git common-dir and add `.codex-review-manifest.json` next to it). Override with `--manifest <path>` on every script. The repo-local default keeps concurrent skill sessions across different repos from clobbering each other (older skill versions defaulted to `/tmp/codex-review-manifest.json` and concurrent sessions caused lost-update bugs in production). Add `.codex-review-manifest.json{,.lock}` and `.codex-review-rounds/` to `.gitignore`.
 
 ## Schema (top-level)
 
@@ -129,9 +129,10 @@ Notes on fields:
 |---|---|---|
 | `SPAWNED` | `spawn-review-worktrees.py` | Worktree created, branch pushed to origin, no coordinator dispatched yet. |
 | `IN-LOOP` | Main agent on Phase 3 dispatch | Coordinator owns this branch; rounds in progress. |
-| `DONE` | Coordinator | Last classifier output had `major == []`, OR 3 consecutive all-rejected rounds. Ready for Phase 5. |
-| `CAP-REACHED` | Coordinator | 20 rounds reached with major items still present. Surface for human; **no Phase 5**. |
-| `BLOCKED` | Coordinator OR evaluator (Phase 7) | Persistent ambiguity (worker-level or evaluator-level). Surface for human; **no merge**. |
+| `DONE` | Main agent (Phase 3 loop) | Last classifier output had `major == []`, OR 3 consecutive all-rejected rounds. Ready for Phase 5. |
+| `CONVERGED-AT-CAP` | Main agent (Phase 3 loop) | Configured `max_rounds_per_branch` exhausted with at least one round of fixes pushed; remaining items captured for the PR body. Ready for Phase 5; PR body documents the deferred items. |
+| `CAP-REACHED` | Main agent (Phase 3 loop) | 20 rounds reached with major items still present AND no successful round of pushed fixes (every round had failures). Surface for human; **no Phase 5**. |
+| `BLOCKED` | Main agent (Phase 3) OR evaluator (Phase 7) | Persistent ambiguity, oscillation, or contradictions. Surface for human; **no merge**. |
 | `FAILED` | Coordinator OR main agent OR any script | Tooling failure (codex, push, validation, evaluator) past retry budget. |
 | `PR-OPEN` | PR-Creator (Phase 5) | PR has been opened on the fork; pending Phase 6 wait + Phase 7 evaluation. |
 | `PR-EVALUATED` | Evaluator (Phase 7) | Evaluator's decisions JSON written; pending Phase 8 apply. |
@@ -264,3 +265,75 @@ After Phase 9 cleanup, a complete branch entry might look like:
 ```
 
 Every phase's contribution is visible. The trace is complete: one round of work → one round of review → one round of decision → final merged state.
+
+## Final Deliverable template
+
+Render at end of Phase 9 from manifest state. Each section maps to specific manifest fields — the template below shows where each value comes from. Phase 9 cannot exit until every section is producible.
+
+```markdown
+## 🎉 Full skill flow complete — N PRs merged to main (or M surfaced as BLOCKED)
+
+### Final state on <fork-owner>/<repo>
+<output of: git log --oneline origin/main~N..origin/main>
+
+E.g.:
+a12dd4e fix(antigravity): protobuf sessions + RPC + cache (#51)
+cf8d3cd feat(parsers/gemini): JSONL + rewind reconciliation (#52)
+…
+3f15720 feat(handoff): structured timeline + verbosity controls (#53)
+
+### Per-branch summary
+| Branch | Concern | Rounds | Phase 3 status | PR | Phase 7 (a/r/x) | Phase 8a apply | Merged at | Notes |
+|---|---|---:|---|---|---|---|---|---|
+
+### Per-PR review breakdown
+| PR | codex-rescue (a/r/x) | Copilot (a/r/x) | copilot-pull-request-reviewer (a/r/x) | greptile (a/r/x) | devin-ai-integration (a/r/x) | cubic-dev-ai (a/r/x) | Total accepted | Total ambiguous |
+|---|---|---|---|---|---|---|---:|---:|
+
+### What ran across all 10 phases
+| Phase | What happened |
+|---|---|
+| 0 | Pre-flight audit — all scripts present, MISSION_PROTOCOL loaded, /ask-review + /do-review available; manifest path repo-local. |
+| 1 | Decomposed N-file dirty tree into M per-concern branches. |
+| 2 | M worktrees spawned with `--prep-deps`, M branches pushed, manifest emitted. |
+| 3 | K rounds × M codex reviews; main agent evaluated, dispatched M Appliers per round; J fixes applied across rounds. |
+| 4 | Merge order computed: foundation, then leaves. |
+| 5 | M PR-Creators (throttled ≤4) opened PRs via REST `gh api repos/.../pulls`. |
+| 6 | M codex-rescue jobs + M Monitors armed; external bots landed reviews; adaptive 900s base + 3-min quiet windows closed cleanly per PR. |
+| 7 | M Evaluator sub-agents used /do-review over gathered streams; produced decisions JSON (≈X items: A accepted, R rejected, U ambiguous). |
+| 8a | Main agent direct-applied accepted decisions across M worktrees; validated build+tests; pushed N commits. |
+| 8b | Captured `foundation_pre_merge_tip`; squash-merged foundation with `--delete-branch`; rebased leaves with `git rebase --onto`; retargeted leaves to main; merged sequentially with CI-wait. |
+| 9 | M worktrees removed, M local branches deleted, M remote branches deleted (mostly via `--delete-branch` in 8b), manifest + round-logs + briefs cleaned; final audit: TIDY. |
+
+### Loop tools that kept this autonomous
+- **Monitor** (M instances): per-PR comment poller; emitted one event per new bot/human comment; terminated on `[PR-N-DONE quiet]` or `[PR-N-DONE cap]`.
+- **ScheduleWakeup** (X fires): cache-aware 1200-1800s fallback tickers covering the 900s adaptive-wait floor.
+- **Agent run_in_background=true** (~K dispatches): Appliers, PR-Creators, Evaluators — each fired a handback notification on completion.
+- **Bash run_in_background=true** (~K launches): per-branch codex review jobs, codex-rescue invocations, CI-wait pollers.
+
+### Lessons captured during execution
+(Only include genuinely novel learnings — not boilerplate. Examples: rate-limit pivot to REST, squash-merge `--onto` mechanic, brief-templating discipline, `/do-review` decision-only failure mode.)
+
+### Tidy audit
+<output from `audit-state.py` + `audit-review-state.py` — both must show CLEAN>
+- `git worktree list` → only main
+- `git branch -vv` → only main + any BLOCKED branches
+- `gh pr list` → only BLOCKED PRs (or empty)
+
+### Per-branch round history (appendix)
+
+#### feat/foo (DONE in 4 rounds, merged as #42)
+- Round 1: 3 major (3 accepted) → committed + pushed
+- Round 2: 1 major (1 accepted) → committed + pushed
+- Round 3: 1 major (0 accepted, 1 rejected) → all-rejected round
+- Round 4: no major → DONE
+- Phase 8a fixes: abc123, def456 (merged as squash 2026-04-26T11:40:00Z)
+
+#### feat/bar (CONVERGED-AT-CAP at 20 rounds, merged as #43 with deferred items in PR body)
+- 20 rounds, 8 accepted, 14 rejected, 0 ambiguous
+- Remaining major items in last round: <listed in PR body>
+
+#### feat/baz (BLOCKED — surfaced for human; NOT merged)
+- terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
+- Suggested human action: <e.g. split into 2 branches, re-run per concern>
+```

--- a/skills/run-codex-review/skills/run-codex-review/references/codex-review-contract.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/codex-review-contract.md
@@ -1,43 +1,68 @@
 # Codex Review Contract
 
-`/codex:review --background` is the per-branch reviewer in this skill. This file is the **single pinned spec** for how the skill calls it, parses it, and decides "no major feedback".
+`/codex:review` is the per-branch reviewer in this skill. It is a Claude Code slash command from the OpenAI Codex plugin (`openai-codex/codex`, source: https://github.com/openai/codex-plugin-cc). This file is the **single pinned spec** for how the skill invokes it, parses it, and decides "no major feedback".
 
-## Invocation forms
+## How callers invoke a codex review
 
-Two forms exist; both must run **inside the branch's worktree** so Codex sees the right HEAD:
+**Always through the wrapper, never directly.**
 
-1. **Slash command** (interactive Claude Code session):
-   ```
-   /codex:review --background
-   ```
-
-2. **Underlying CLI** (programmatic; what scripts call):
-   ```bash
-   codex review --background [--branch <b>] [--base main]
-   ```
-
-`scripts/run-codex-review.py` calls the CLI form. If the CLI signature in your environment differs, adjust `run-codex-review.py`'s `invoke_codex()` function — keep the rest of this contract identical.
-
-## Background-job lifecycle
-
-```
-launch  →  capture job id  →  poll  →  complete  →  fetch artifact  →  normalize JSON
+```bash
+python3 <this-skill>/scripts/run-codex-review.py \
+  --branch <branch> \
+  --base <base> \
+  --worktree <worktree-path>
 ```
 
-1. Launch returns a job id on stdout (e.g. `cdx-job-abc123`). Capture it; persist in manifest as `last_review_id`.
-2. Poll the job's status endpoint at `--poll-interval` (default 30s). Codex reports `running` / `completed` / `failed`.
-3. On `completed`, fetch the artifact (file path / API call / `gh` PR comment — depends on your Codex install).
-4. Normalize the artifact to the JSON schema below. Persist to `<rounds-dir>/<branch-slug>.<round>.json`.
+The wrapper does:
+1. Discover `codex-companion.mjs` automatically — env-var first (`${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs`), version-glob fallback (`~/.claude/plugins/cache/openai-codex/codex/<latest>/scripts/codex-companion.mjs`).
+2. Spawn `node codex-companion.mjs review --base <ref> --scope branch --json` synchronously inside the worktree.
+3. Parse the JSON envelope.
+4. Normalize to the round-log schema below.
+5. Write `<rounds-dir>/<slug>.<round>.json`.
+6. Update the manifest entry's `last_review_id`, `last_review_at`, `last_status`, `rounds`, `head_sha_current`, and append a `round_history` entry.
 
-If the job is still `running` after `--timeout` (default 1800s = 30 min), the wrapper marks the round `timeout` and returns exit 1; the subagent decides whether to retry the round (caps at 3 attempts).
+Sub-agents call the wrapper. Main agent (in programmatic loops) calls the wrapper. The wrapper is the contract; the underlying `codex-companion.mjs` invocation is the wrapper's implementation detail.
 
-## Normalized JSON schema
+### Why the wrapper matters
 
-Every round emits one file. Schema:
+`/codex:review` is `disable-model-invocation: true` in the plugin manifest — sub-agents physically cannot dispatch the slash command via `Skill(...)`. The slash itself runs `node codex-companion.mjs review` internally. Instead of every brief reinventing the discovery + invocation + parse + normalize chain (production traces showed agents writing 245-line `/tmp/codex-review-runner.py` shims session-after-session), `scripts/run-codex-review.py` does it once, version-agnostically, with a stable CLI surface.
+
+### Adversarial mode (structured findings, opt-in)
+
+`/codex:review` emits free-form text in `codex.stdout`; the wrapper regex-parses it. For projects that want pre-parsed findings with explicit severities (`critical | high | medium | low`), the wrapper supports `--mode adversarial`, which invokes `node codex-companion.mjs adversarial-review --json` instead. The `result.findings[]` array maps directly to round-log `items[]` — no regex needed.
+
+Default is `--mode review` (matches existing skill semantics). Switch to `--mode adversarial` when the regex parser misses items because Codex emitted unusual formatting.
+
+### Forbidden invocation paths
+
+| Forbidden | Why |
+|---|---|
+| `codex review …` from Bash | No such CLI surface — the underlying `codex` binary has no `--background` review flag. |
+| `Skill(skill="codex:review", ...)` from a sub-agent | `disable-model-invocation: true` in the plugin manifest. Will fail. |
+| `node …/codex-companion.mjs review …` directly from a sub-agent brief | The wrapper does that, plus discovery + normalization + manifest update + round-log path computation. Calling the companion script directly bypasses all of that. |
+| Inventing a "shim" because `codex --help` doesn't list `--background` | The flag belongs to the slash command, not the CLI. The wrapper handles it. |
+| Re-running `/codex:review` as user-typed text from a sub-agent | Sub-agents cannot type slash commands. They use the wrapper. |
+| Writing a parallel `/tmp/codex-review-runner.py` | That's what the production wrapper now does. Don't duplicate it. |
+
+### Plugin missing → surface, do not fabricate
+
+If the wrapper's discovery returns 127 (`codex-companion.mjs` not found at `${CLAUDE_PLUGIN_ROOT}/scripts/` or `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/`), the codex plugin is missing. The wrapper exits 127 with install instructions. Sub-agent hands back FAILED with `terminal_reason: "codex plugin unavailable"`. Main agent surfaces to the user and stops the skill. **Never** substitute a free-form `codex` Bash call or any other plugin's reviewer.
+
+## Synchronous execution (not background)
+
+Despite the legacy "—background" framing in earlier versions of this skill, the codex-companion `review` and `adversarial-review` subcommands ALWAYS run synchronously — `--background` is parsed but ignored. The wrapper invokes them with a wall-clock cap (default 1500s = 25 min) and returns when codex returns. Per-branch parallelism comes from concurrent subprocess invocations across branches, not from a background flag.
+
+If a single review hangs past the wall-clock cap (Codex can stall on remote tools like codebase-search APIs), the wrapper exits 1 with `terminal_reason: "review-hang past wall-clock cap"`. Caller retries once, then marks the round FAILED.
+
+(Note: `task --background` is different — it DOES honor the flag and runs out-of-band. That's how Phase 6 codex rescue works. See `scripts/trigger-codex-rescue.py` and `references/post-pr-review-protocol.md`.)
+
+## Normalized JSON schema (round-log)
+
+Every round emits one file at `<rounds-dir>/<slug>.<round>.json`:
 
 ```json
 {
-  "review_id": "cdx-job-abc123",
+  "review_id": "<codex thread id>",
   "branch": "feat/foo",
   "head_sha": "deadbeef1234...",
   "started_at": "2026-04-26T10:00:00Z",
@@ -46,7 +71,7 @@ Every round emits one file. Schema:
   "items": [
     {
       "id": "cdx-1",
-      "severity_raw": "high",
+      "severity_raw": "P1",
       "file": "src/foo.ts",
       "line": 42,
       "body": "Off-by-one in the slice — drops the last element."
@@ -55,16 +80,65 @@ Every round emits one file. Schema:
 }
 ```
 
-`severity_raw` is whatever Codex emits (`high|medium|low`, `error|warning|info`, etc.). The classifier (`classify-review-feedback.py`) maps it onto major/minor per `major-vs-minor-policy.md`. Don't pre-classify here — keep the wrapper's normalization mechanical.
+`severity_raw` is whatever Codex emits — the regex parser accepts `P1` / `P2` / `P3` / `P4` / `critical` / `high` / `medium` / `low` (case-insensitive). The adversarial-review path emits `critical | high | medium | low` directly. The classifier (`classify-review-feedback.py`) maps these onto major/minor per `major-vs-minor-policy.md`. **Don't pre-classify here** — keep the wrapper's normalization mechanical.
 
-If Codex's artifact is unstructured (free-text), `items` is `[]` and the classifier falls back to regex over `raw_text`. Mark `severity_raw: "unstructured"` in this case.
+If Codex's `codex.stdout` doesn't match the expected `[severity] Title — file:line` pattern (free-form prose with no item headers, or fully unrecognized format), `items` is `[]` and the classifier falls back to regex over `raw_text`.
+
+## codex-companion JSON envelopes (wrapper input)
+
+What `codex-companion.mjs review --json` emits to stdout:
+
+```json
+{
+  "review": "Review",
+  "target": { "mode": "branch", "label": "...", "baseRef": "main" },
+  "threadId": "...",
+  "sourceThreadId": "...",
+  "codex": {
+    "status": 0,
+    "stderr": "",
+    "stdout": "<free-form review text — `[Px] title — file:line` items>",
+    "reasoning": "<optional>"
+  }
+}
+```
+
+What `codex-companion.mjs adversarial-review --json` emits:
+
+```json
+{
+  "review": "Adversarial Review",
+  "result": {
+    "verdict": "approve|needs-attention",
+    "summary": "...",
+    "findings": [
+      {
+        "severity": "critical|high|medium|low",
+        "title": "...",
+        "body": "...",
+        "file": "src/foo.ts",
+        "line_start": 42,
+        "line_end": 42,
+        "confidence": 0.9,
+        "recommendation": "..."
+      }
+    ],
+    "next_steps": ["..."]
+  },
+  "rawOutput": "...",
+  "parseError": null,
+  "reasoningSummary": null
+}
+```
+
+The wrapper handles both shapes; callers don't need to care which mode produced the round-log.
 
 ## Detecting "no major feedback"
 
 The subagent decides DONE-vs-continue from the classifier's output, not from the raw artifact:
 
 ```bash
-python3 scripts/classify-review-feedback.py --review-json <round-json>
+python3 <this-skill>/scripts/classify-review-feedback.py --review-json <round-json>
 ```
 
 Exit code:
@@ -74,38 +148,32 @@ Exit code:
 
 Never decide DONE by eyeballing the raw text. The classifier is the single arbiter so the loop terminates the same way every time.
 
-## Always `--background`
-
-`--background` is non-negotiable. Inline mode blocks the subagent:
-
-| Mode | Effect |
-|---|---|
-| `--background` | Codex runs out-of-band. Subagent polls; can do other work in between. Per-branch parallelism works. |
-| inline | Subagent blocks until Codex returns. Other branches stall waiting. Defeats the whole skill. |
-
-If the user/environment disables `--background` mode, this skill cannot run as designed — fall back to `run-repo-cleanup` for serial cleanup.
-
 ## Failure modes and what the wrapper does
 
 | Failure | Wrapper behavior | Caller (subagent) action |
 |---|---|---|
-| codex CLI not installed | Exit 2 with stderr "codex not on PATH" | Cannot proceed; mark branch FAILED. |
-| Network failure mid-launch | Exit 2 with raw error in stderr | Retry round (max 3); else FAILED. |
-| Job stuck `running` past timeout | Exit 1; manifest marked `timeout` | Retry round (max 3); else FAILED. |
-| Job `completed` but artifact missing | Exit 2 with stderr explaining where it looked | Cannot recover; mark FAILED. |
-| Artifact present but malformed | Normalization writes `items: []`, `severity_raw: "unstructured"`; exit 0 | Classifier falls back to regex; loop continues normally. |
-| Branch HEAD changed mid-review (someone else pushed) | Wrapper warns; review may be stale | Discard the round, retry from current HEAD. |
+| Codex plugin not installed | Exit 127 with install instructions; manifest `last_status: "plugin-missing"` | Hand back FAILED with `terminal_reason: "codex plugin unavailable"`; main surfaces to user. |
+| Worktree not on the right branch | Exit 2; no manifest update | `git -C <wt> checkout <branch>`; retry. |
+| `codex-companion.mjs` exits non-zero with no stdout | Exit 2; manifest `last_status: "failed"` | Retry the round once. |
+| `codex-companion.mjs` exits non-zero but stdout has parseable JSON | Wrapper logs warning, normalizes anyway, exit 0 | Round log written; loop continues. |
+| Wall-clock timeout (Codex hung on a tool) | Exit 1; manifest `last_status: "timeout"`, `terminal_reason: "review-hang past wall-clock cap"` | Retry once; else mark FAILED. |
+| Output doesn't match expected JSON envelope | Exit 0 with `items: []`, raw text in `raw_text` | Classifier falls back to regex over `raw_text`. |
+| Branch HEAD changed mid-review (someone else pushed) | Not detected by wrapper; review may be stale | Discard the round, retry from current HEAD. |
 
 ## Read-only invariants
 
-`run-codex-review.py` itself is **mostly** read-only with respect to the repo — its only writes are the round-log file under `<rounds-dir>` and the manifest update. It does **not** push, commit, or modify the worktree. Pushing is the subagent's job after applying fixes.
+`run-codex-review.py` is read-only on the repo's content (no git mutations: no push, no commit, no checkout). Its only writes are:
+- `<rounds-dir>/<slug>.<round>.json` — the round log.
+- `<repo-root>/.codex-review-manifest.json` (or `--manifest <path>`) — the manifest entry update.
+
+Pushing fix commits is the Applier sub-agent's job in Phase 3, not the wrapper's.
 
 ## Adjusting the contract
 
-If your Codex installation deviates from the schema above:
+If a future Codex plugin version changes the JSON shape:
 
-1. Edit `scripts/run-codex-review.py`'s `normalize_review()` function to match Codex's actual output.
+1. Update `normalize_review()` in `scripts/run-codex-review.py` to match the new shape.
 2. Update this doc's Schema section in lock-step.
 3. Run `scripts/classify-review-feedback.py` against a sample normalized JSON to confirm the classifier still partitions correctly.
 
-Don't let the contract drift silently. The schema in this file is what the rest of the skill assumes.
+The wrapper's external CLI surface (`--branch`, `--base`, `--worktree`, `--mode`, `--output`, `--manifest`, `--rounds-dir`, `--timeout`, `--dry-run`) is stable across plugin upgrades — callers don't change.

--- a/skills/run-codex-review/skills/run-codex-review/references/event-driven-orchestration.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/event-driven-orchestration.md
@@ -1,0 +1,255 @@
+# Event-Driven Orchestration (Phases 3, 5, 6, 7)
+
+This skill is multi-hour and parallel. Main agent does NOT poll. It dispatches in parallel, sets up event sources (Monitor / Bash run_in_background / Agent run_in_background / ScheduleWakeup), goes idle, and reacts to notifications as they fire.
+
+This file is the **single pinned spec** for which event source to use in which phase. Failure mode: dispatching N parallel things and then sitting in a Bash poll loop checking each. That defeats the parallelism and burns tokens.
+
+## The four event sources
+
+| Source | What it pushes | Use for |
+|---|---|---|
+| `Bash` with `run_in_background: true` | One notification when the command exits | One-shot "tell me when X completes" — codex review wrapper finishes; rescue job exits; build completes |
+| `Agent` with `run_in_background: true` | One notification when the sub-agent hands back | Applier handback; PR-Creator handback; Evaluator handback |
+| `Monitor` | One notification per stdout line; ends when command exits, timeout fires, or `TaskStop` | Streams of events — new PR comments arriving over 30 min; new file changes; log error stream |
+| `ScheduleWakeup` (in `/loop` dynamic mode only) | Re-fires the `/loop` prompt after a delay | Idle-tick fallback when no signal exists to watch; pacing a self-driven loop |
+
+**Picking the right one is mechanical, not aesthetic:**
+
+- One notification ↔ Bash/Agent run_in_background.
+- Stream of notifications ↔ Monitor.
+- Sub-agent did the work ↔ Agent run_in_background (the dispatch IS the event source).
+- Long-running shell command did the work ↔ Bash run_in_background (the exit IS the event).
+- Want to wake yourself up later ↔ ScheduleWakeup (only valid in `/loop` dynamic mode; runtime clamps to [60, 3600]).
+
+Never sit in a `while true; do …; sleep N; done` loop **inside the main agent's turn**. That blocks the runtime and burns tokens. Either dispatch via Bash run_in_background (which IS the loop, just owned by the harness) or use Monitor (which streams).
+
+## Phase-by-phase canonical patterns
+
+### Phase 3 — codex review + applier loop
+
+**Per branch, per round, main agent runs:**
+
+```
+1. Bash(run_in_background=True): python3 scripts/run-codex-review.py --branch <b> ... --output <rounds-dir>/<slug>.<round>.json
+   → notification: "Background command 'codex review: <branch>' completed"
+
+2. (after notification) Read the round-log JSON, classify, evaluate per item via Skill(do-review) in own context.
+
+3. If accepted decisions exist:
+     Agent(run_in_background=True, prompt=<applier-brief-with-pre-decided-fixes>)
+     → notification: "Agent 'Applier: <branch>' completed"
+
+4. Repeat for round N+1 until terminal state.
+```
+
+**Anti-pattern**: launching 8 codex reviews via `Bash run_in_background`, then immediately launching 8 SEPARATE `Bash run_in_background` polling watchers (`until grep -qE "Reviewer (finished|failed)" ... ; do sleep 5; done`) to watch when each finishes. The codex review wrapper script itself exits when the review completes — the Bash run_in_background's own completion notification IS the signal you want. Don't double up.
+
+**Anti-anti-pattern**: if the wrapper script is missing or doesn't reliably exit on terminal state, fix the wrapper. Don't paper it over with a polling watcher.
+
+**Wall-clock cap**: codex reviews can hang on certain tools (e.g., remote codebase-search APIs returning slowly). The wrapper enforces `--timeout 1500s` by default; on hang it exits non-zero with `terminal_reason: "review-hang past wall-clock cap"`. Main agent treats as FAILED for that round; retries once; then surfaces.
+
+### Phase 5 — PR creation (rate-limit-aware)
+
+**N PRs to open. Pattern:**
+
+```
+1. Render N PR-Creator briefs from one template + per-branch JSON (see "Brief templating" in parallel-subagent-protocol.md). NEVER hand-write N separate briefs.
+
+2. Throttle to ≤4 simultaneous PR-Creator dispatches.
+   - GitHub's GraphQL budget is shared with `gh pr create` body uploads; opening 9 in parallel exhausts it.
+   - The PR-Creator brief MUST instruct the sub-agent to use REST endpoints (`gh api repos/<owner>/<repo>/pulls -f title=... -f body=@<file> -f base=... -f head=...`) — not `gh pr create` (which uses GraphQL by default).
+
+3. Dispatch first batch of 4 in parallel via Agent(run_in_background=True).
+   → 4 handback notifications fire as PRs open.
+
+4. As each handback lands, dispatch next from the queue.
+
+5. When a handback says "rate-limited", main agent waits for the reset (gh api rate_limit returns Unix timestamp) via ScheduleWakeup(delaySeconds=<reset_in - now + 60>) if in /loop, or by deferring that PR's redispatch to the next round of completions.
+```
+
+**Anti-pattern**: dispatching all N in parallel and hoping for the best. Verified failure mode in production: 1+ of N rate-limits, agent has to retry-with-different-strategy.
+
+**Anti-anti-pattern**: serializing all N. Phase 5 then becomes 9× ~5min = 45 min serial, when it could be ~3 batches × ~5min = 15 min throttled-parallel.
+
+### Phase 6 — codex rescue + adaptive review window
+
+**Per PR (after Phase 5 succeeded), main agent runs:**
+
+```
+1. Trigger codex rescue. In a programmatic loop, main agent invokes:
+     Bash(run_in_background=True):
+       node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task \
+         --write --fresh --effort xhigh \
+         "<comprehensive review prompt for PR #<n>>"
+
+   This IS the same code path the /codex:resc slash command runs internally —
+   /codex:resc dispatches a Codex sub-agent via the codex-companion.mjs task
+   subcommand. In a programmatic loop, calling it directly is sanctioned.
+
+   → notification: "Background command 'codex:rescue PR #<n>' completed"
+       when the rescue review finishes posting to the PR.
+
+2. Arm a Monitor (one per PR) that polls the PR's comments+reviews:
+
+     Monitor(
+       command='''
+         pr=<n>
+         repo="<owner>/<repo>"
+         start=$(date -u +%s)
+         seen_ids=""
+         last_event=$start
+         BASE_WAIT=900     # 15 min before first quiet-check
+         QUIET_WINDOW=180  # terminate on 3 min of no new comments after base wait
+         CAP=1800          # 30 min hard cap
+
+         emit_new_items() {
+           # Issue comments
+           while IFS=$'\\t' read id user body; do
+             [ -z "$id" ] && continue
+             echo "$seen_ids" | grep -q "i$id" && continue
+             seen_ids="$seen_ids i$id"
+             last_event=$(date -u +%s)
+             echo "PR #$pr [$user]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
+           done < <(gh api "repos/$repo/issues/$pr/comments" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.body)"' 2>/dev/null || true)
+           # Review comments
+           while IFS=$'\\t' read id user state body; do
+             [ -z "$id" ] && continue
+             echo "$seen_ids" | grep -q "r$id" && continue
+             seen_ids="$seen_ids r$id"
+             last_event=$(date -u +%s)
+             echo "PR #$pr REVIEW [$user $state]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
+           done < <(gh api "repos/$repo/pulls/$pr/reviews" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.state)\\t\\(.body // "")"' 2>/dev/null || true)
+         }
+
+         # Initial seed pass (don't emit pre-existing comments)
+         emit_new_items >/dev/null
+         seen_initialised=1
+
+         while true; do
+           emit_new_items
+           now=$(date -u +%s)
+           since_last=$((now - last_event))
+           total=$((now - start))
+           # Termination: past base wait + 3min quiet, OR hard cap
+           if [ $total -ge $BASE_WAIT ] && [ $since_last -ge $QUIET_WINDOW ]; then
+             echo "PR-$pr-DONE quiet (no new comments in ${since_last}s, total ${total}s)"
+             exit 0
+           fi
+           if [ $total -ge $CAP ]; then
+             echo "PR-$pr-DONE cap (${total}s elapsed)"
+             exit 0
+           fi
+           sleep 30
+         done
+       ''',
+       description="PR #<n> review comments (codex/copilot/copilot-pr-reviewer/greptile/devin/cubic/human)",
+       persistent=False,
+       timeout_ms=2700000,   # 45 min hard ceiling
+     )
+
+   Each new comment fires one notification. The terminal "PR-<n>-DONE …" line
+   fires the final notification, the script exits, the Monitor releases.
+
+3. When the Monitor terminates with PR-<n>-DONE, main agent has all gathered
+   review items. It dispatches a Phase 7 Evaluator sub-agent for that PR.
+```
+
+**Why this Monitor shape:**
+- One Monitor per PR keeps termination independent — PR-A finishing doesn't cancel PR-B's wait.
+- The seed pass populates `seen_ids` from existing comments without emitting them; only NEW arrivals fire notifications.
+- The 30-second poll interval respects GitHub rate limits (≤120 req/hour per PR for issues+reviews; well within budget).
+- Both `issues/<pr>/comments` (line-level) AND `pulls/<pr>/reviews` (review summaries) are polled — different bots use different surfaces (Copilot uses reviews, Devin uses comments, etc.).
+- `|| true` after the `gh api` calls absorbs transient API failures without killing the monitor.
+- The terminal `PR-<n>-DONE …` line is filterable downstream — main agent's reaction logic matches `^PR-\d+-DONE` to know "this PR is ready for Phase 7".
+
+**Anti-pattern: per-event Monitor.** Don't arm a Monitor that emits ONLY the success line — silence equals "still running" equals "running forever". The pattern above emits one notification per actual comment AND a terminal line.
+
+**Anti-pattern: skipping the base wait.** Bots often arrive at minute 13 (Greptile is famously slow). Quiet-detection starting at second 0 would terminate immediately on initial silence. The 900s base floor is non-negotiable.
+
+### Phase 7 — Evaluator dispatch (one per PR, parallel)
+
+After all Phase 6 Monitors terminate (or as each one terminates):
+
+```
+For each PR with completed Monitor:
+  Read the PR's gathered comments+reviews (gh api dump → JSON file).
+  Agent(run_in_background=True, prompt=<evaluator-brief-for-this-PR>)
+  → notification: "Agent 'Evaluator: PR #<n>' completed"
+
+Up to 9 Evaluators in parallel — they don't share rate limits with PR creation.
+```
+
+### Phase 8 — main agent direct apply
+
+**No event sources.** Main agent is the actor; it reads each PR's evaluator JSON, applies accepted items via Edit, validates, pushes, merges. Sequential per PR (foundation→leaf), since merges affect downstream branches' bases.
+
+The only event source in Phase 8 is **CI status** between push and merge:
+
+```
+After git push origin <branch>:
+  Bash(run_in_background=True):
+    until [ "$(gh pr checks <n> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+      sleep 30
+    done
+    gh pr checks <n>
+  → notification when all checks land terminal state.
+```
+
+## ScheduleWakeup as fallback ticker
+
+In `/loop` dynamic mode, `ScheduleWakeup` re-fires the `/loop` prompt after a delay. Use it as a **safety ticker**, not as the primary signal:
+
+```
+After dispatching all Phase 5 PR-Creators with run_in_background:
+  ScheduleWakeup(
+    delaySeconds=1200,   # 20 min — past 5-min cache TTL but amortized
+    prompt="<the same /loop prompt this skill was invoked under>",
+    reason="fallback wake in case any PR-Creator handback gets lost",
+  )
+```
+
+The actual handbacks SHOULD fire well before 1200s; ScheduleWakeup catches the case where the harness drops a notification (rare but happens). When it fires, main agent re-checks state via the manifest and proceeds.
+
+**Cache-window math** (load-bearing):
+- Anthropic prompt cache TTL = 5 min (300 s). Wake-ups past 300s read full conversation context uncached.
+- 60–270s = stays cached, cheap. Use for active polling near the action.
+- 300s = WORST OF BOTH — pay cache miss without amortization. Never pick this.
+- 1200–1800s = one cache miss buys a long wait. Use for idle ticks.
+
+Don't think in round-number minutes. Think in cache windows.
+
+## Combining sources — the canonical Phase 6 idle pattern
+
+After dispatching N parallel codex:rescue jobs and arming N Monitors:
+
+```
+1. Bash run_in_background × N → each emits "rescue job <n> finished"
+2. Monitor × N → each emits "PR #<n> [<user>]: <body>" per comment, then "PR-<n>-DONE …"
+3. ScheduleWakeup (1200s in /loop, OR no-op if not in /loop) → safety ticker
+4. Main agent ends turn.
+5. Notifications fire over the next 15-30 min:
+   - Rescue jobs complete (informational; the comment-poller catches their posted reviews)
+   - Comments arrive (informational; appended to gathered-reviews JSON)
+   - Monitor terminates with PR-<n>-DONE (signal to dispatch Phase 7 Evaluator for that PR)
+6. Main agent dispatches Evaluator on each "PR-<n>-DONE" event.
+7. Evaluator handbacks (Agent run_in_background) trigger Phase 8 apply for that PR.
+```
+
+Sub-100 lines of orchestration logic; main agent burns ~zero tokens during the wait windows.
+
+## Common mistakes from production traces
+
+| Mistake | Fix |
+|---|---|
+| 8 separate `Bash run_in_background` polling watchers (one per branch) duplicating the codex review wrapper's own completion signal | The wrapper's own exit IS the event. One Bash run_in_background per branch is enough. |
+| Monitor that only emits the success line | Filter must cover failure too. Emit on every terminal state (comment, error, timeout). Silence ≠ success. |
+| `Monitor(command='tail -f log | grep -m 1 "ready"')` for a single-event "tell me when ready" | Use Bash run_in_background with `until grep -q "ready" log; do sleep 0.5; done` instead. `tail -f` never exits on match; the monitor sits armed until timeout. |
+| Hand-rolling N comment-poller commands inline in N Monitor calls | Render a parameterized poller from a template; pass `--pr <n>` args. (See `scripts/await-pr-reviews.py`.) |
+| ScheduleWakeup(delaySeconds=300) | Worst of both worlds. Drop to 270 (cache-warm) or jump to 1200 (cache-miss-amortized). |
+| Sitting in a `while …; sleep …` loop in the main agent's own turn | Blocks the runtime. Use Bash run_in_background or Monitor. |
+| Per-PR Monitor + per-branch comment-poller-ALSO-as-Bash-run_in_background, doubling up | Pick one source per signal. Comments → Monitor. Rescue completion → Bash run_in_background. Don't duplicate. |
+| Verbose status tables every turn ("Live state", "Phase X complete") | One sentence per phase boundary. The Final Deliverable in Phase 9 is the place for tables. |
+
+## Bottom line
+
+`run_in_background` for one-shot completions. `Monitor` for streams. `Agent run_in_background` for sub-agent handbacks. `ScheduleWakeup` (in /loop only) for fallback ticks with cache-aware delays. Combine all four; sit idle; react. Phases 5-8 are 4-7 hours of wall-clock that should consume ~15 minutes of main agent's actual work.

--- a/skills/run-codex-review/skills/run-codex-review/references/event-driven-orchestration.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/event-driven-orchestration.md
@@ -103,22 +103,32 @@ Never sit in a `while true; do …; sleep N; done` loop **inside the main agent'
          CAP=1800          # 30 min hard cap
 
          emit_new_items() {
-           # Issue comments
+           # Issue comments — --paginate is REQUIRED. Default page is 30 items;
+           # PRs with 4+ active bots routinely cross 30 comments and the poller
+           # would silently miss everything past page 1 without it.
            while IFS=$'\\t' read id user body; do
              [ -z "$id" ] && continue
              echo "$seen_ids" | grep -q "i$id" && continue
              seen_ids="$seen_ids i$id"
              last_event=$(date -u +%s)
              echo "PR #$pr [$user]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
-           done < <(gh api "repos/$repo/issues/$pr/comments" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.body)"' 2>/dev/null || true)
-           # Review comments
+           done < <(gh api --paginate "repos/$repo/issues/$pr/comments" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.body)"' 2>/dev/null || true)
+           # Review comments — same --paginate requirement
            while IFS=$'\\t' read id user state body; do
              [ -z "$id" ] && continue
              echo "$seen_ids" | grep -q "r$id" && continue
              seen_ids="$seen_ids r$id"
              last_event=$(date -u +%s)
              echo "PR #$pr REVIEW [$user $state]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
-           done < <(gh api "repos/$repo/pulls/$pr/reviews" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.state)\\t\\(.body // "")"' 2>/dev/null || true)
+           done < <(gh api --paginate "repos/$repo/pulls/$pr/reviews" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.state)\\t\\(.body // "")"' 2>/dev/null || true)
+           # Inline review comments (line-level findings — Devin & cubic-dev-ai use these heavily)
+           while IFS=$'\\t' read id user body; do
+             [ -z "$id" ] && continue
+             echo "$seen_ids" | grep -q "p$id" && continue
+             seen_ids="$seen_ids p$id"
+             last_event=$(date -u +%s)
+             echo "PR #$pr INLINE [$user]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
+           done < <(gh api --paginate "repos/$repo/pulls/$pr/comments" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.body)"' 2>/dev/null || true)
          }
 
          # Initial seed pass (don't emit pre-existing comments)
@@ -142,7 +152,7 @@ Never sit in a `while true; do …; sleep N; done` loop **inside the main agent'
            sleep 30
          done
        ''',
-       description="PR #<n> review comments (codex/copilot/copilot-pr-reviewer/greptile/devin/cubic/human)",
+       description="PR #<n> review comments (codex/copilot/copilot-pull-request-reviewer/greptile/devin/cubic-dev-ai/human)",
        persistent=False,
        timeout_ms=2700000,   # 45 min hard ceiling
      )

--- a/skills/run-codex-review/skills/run-codex-review/references/failure-recovery.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/failure-recovery.md
@@ -27,18 +27,18 @@ Codex CLI crashed, push was rejected, validation kept failing past retry budget.
 2. Common causes:
    - **codex CLI not on PATH**: install / fix shell. Re-run `audit-review-state.py` to confirm the environment is sound.
    - **Push rejected (non-fast-forward)**: someone else pushed to the branch. `git fetch origin && git pull --rebase` (only on this branch in its worktree); resume from current HEAD.
-   - **Validation kept failing**: usually a syntax error introduced by the worker's last fix. Look at the diff of the last commit; the worker should have caught this and reverted; if not, manual revert + restart.
-3. Decide: redispatch the coordinator (resumes from `rounds + 1` if state is recoverable), or split-and-restart, or abandon.
-4. Never retry a `FAILED` round more than once at the wrapper level. Cap subagent-level retries at 3.
+   - **Validation kept failing**: usually a syntax error introduced by the Applier's last fix. Look at the diff of the last commit; the Applier should have caught this and reverted; if not, manual revert + restart.
+3. Decide: re-run the round (resumes from current `rounds`), or split-and-restart, or abandon.
+4. Never retry a `FAILED` round more than once at the wrapper level. Cap Applier-level retries at 3.
 
-### BLOCKED — coordinator-level
+### BLOCKED — main agent decision
 
-The coordinator marks BLOCKED when worker's `/do-review` evaluator marks items ambiguous in 2+ consecutive rounds, OR an oscillation pattern emerges.
+Main agent marks BLOCKED when its `/do-review` evaluation returns ambiguous items in 2+ consecutive rounds, OR an oscillation pattern emerges.
 
-**Trigger conditions** (coordinator sets BLOCKED on any of these):
-- Two consecutive rounds where worker emitted ambiguous items.
-- Same major item recurs after the worker (and `/do-review`) accepted it (oscillation: applied fix didn't satisfy Codex; second attempt also failed).
-- A major item requires a decision outside this branch's scope (worker marked it ambiguous with a question).
+**Trigger conditions** (main agent sets BLOCKED on any of these):
+- Two consecutive rounds where main-agent decisions emitted ambiguous items.
+- Same major item recurs after main-agent accepted it (oscillation: applied fix didn't satisfy Codex; second attempt also failed).
+- A major item requires a decision outside this branch's scope (main-agent marked it ambiguous with a question).
 
 **Recovery**:
 1. Read `terminal_reason` for the contradiction or oscillation cause.
@@ -48,23 +48,24 @@ The coordinator marks BLOCKED when worker's `/do-review` evaluator marks items a
    - Split the branch so the conflicting concerns separate.
 3. Document the decision in the manifest's `terminal_reason` for posterity.
 
-### Worker sub-agent crash mid-round
+### Applier sub-agent crash mid-round
 
-The worker dies before writing its handback. Coordinator detects via heartbeat (round-log mtime / manifest write timestamp).
-
-**Recovery**:
-1. Coordinator reads round-log file (if any) to determine partial state.
-2. Redispatch a fresh worker for the same round (rounds counter not incremented).
-3. After 2 worker redispatches without progress, mark FAILED for the branch.
-
-### Coordinator sub-agent crash
-
-Main agent detects via stale `updated_at` on the manifest entry.
+The Applier dies before writing its handback. Main agent detects via heartbeat (round-log mtime / manifest write timestamp).
 
 **Recovery**:
-1. Main agent reads manifest entry to determine state (which round was active).
-2. Redispatch the coordinator with the same brief; it resumes from `rounds + 1` (or from the current round if no round-log written).
-3. After 2 redispatches without progress, mark FAILED for the branch.
+1. Main agent reads round-log file (if any) to determine partial state.
+2. Redispatch a fresh Applier for the same round (rounds counter not incremented).
+3. After 2 Applier redispatches without progress, mark FAILED for the branch.
+
+### Main-agent session interrupted mid-loop
+
+Main agent IS the coordinator; if its session is interrupted (host reboot, fresh chat), the manifest carries enough state to resume.
+
+**Recovery**:
+1. Re-invoke the skill; Phase 0 audit detects the in-progress manifest.
+2. For each branch with `status: IN-LOOP` (or no terminal state set), main agent reads manifest entry to determine which round was active.
+3. Resume from `rounds + 1` (or re-run the current round if no round-log was written).
+4. After 2 resumes without progress on the same branch, mark FAILED for that branch.
 
 ### Lost worktree
 
@@ -76,7 +77,7 @@ git worktree prune                           # clean up dangling refs
 git worktree add <expected-path> <branch>    # recreate from manifest
 ```
 
-The coordinator resumes from `rounds + 1` because all round logs and state are external to the worktree (in `<rounds-dir>` and the manifest).
+Main agent resumes from `rounds + 1` because all round logs and state are external to the worktree (in `<rounds-dir>` and the manifest).
 
 If the branch itself is also lost (only existed locally, no `origin/<branch>`), it's gone. Mark `FAILED`; surface for human; recover from `backup/codex-review/<branch>/<timestamp>` ref if Phase 1 redistribution created one.
 
@@ -89,7 +90,7 @@ A worker's worktree shows uncommitted changes from a prior round failure.
 2. `git status` and `git diff` to inspect.
 3. If the changes are recoverable: complete the commit, push, resume.
 4. If not: `git stash push -u -m "phase-3-recovery-<branch>-<round>"`, restore from manifest's `head_sha_current`, re-classify the last round to decide whether to retry.
-5. If the worktree is irrecoverably mangled, `git worktree remove --force <path>`, recreate per "Lost worktree" recovery above. Mark the round failed; let the coordinator decide redispatch.
+5. If the worktree is irrecoverably mangled, `git worktree remove --force <path>`, recreate per "Lost worktree" recovery above. Mark the round failed; main agent decides redispatch.
 
 ---
 

--- a/skills/run-codex-review/skills/run-codex-review/references/mission-protocol-integration.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/mission-protocol-integration.md
@@ -179,30 +179,32 @@ Before sending any brief, ask:
 
 If any answer is no, revise the brief before dispatch. The brief is the lever — wrong brief = wrong work, no matter how capable the agent is.
 
-## The two-level pattern in Phase 3
+## Eval-vs-apply role split in Phase 3
 
-The coordinator dispatches a fresh worker per round. The coordinator's brief and the worker's brief are different:
+Main agent runs the convergence loop directly (it IS the coordinator across all branches; there is no Coordinator sub-agent). Per round per branch, main agent:
+1. Runs the codex review wrapper (Bash background).
+2. Runs the classifier.
+3. Evaluates each major item via `Skill(do-review)` in own context.
+4. Dispatches a fresh **Applier** sub-agent with the decisions baked in as pre-decided fix specs.
 
-- **Coordinator** orchestrates over time (loop counter, terminal-state decision, dispatch).
-- **Worker** acts in a moment (one round, one fix-set, one push).
+The Applier brief is the only brief in Phase 3. Its DoD is **binary**: "N pre-decided fixes applied; tests pass; commits pushed to `origin/<branch>`". The brief does NOT mention `/do-review` — that framing causes systematic decision-only failure.
 
-Both follow MISSION_PROTOCOL. The coordinator's DoD is "branch reaches terminal state with all rounds logged"; the worker's DoD is "this round's accepted items applied, validated, pushed".
-
-The two-level structure ensures:
-- Each round's worker is fresh (no stale context).
-- Each round's brief gets the full protocol treatment (no degraded discipline over time).
-- The coordinator owns the convergence decision, not any single worker.
-- Failure of one worker doesn't compound across rounds (next round = fresh worker).
+This eval-vs-apply split ensures:
+- Each round's Applier is fresh (no stale context).
+- Each round's brief gets the full MISSION_PROTOCOL treatment.
+- Decisions live with main agent (which has the cross-branch context); application lives with the short-lived Applier.
+- Workers reliably push (binary DoD) instead of stopping at "Verdict: apply" (which is what happens when the brief contains `/do-review`).
 
 ## Common sub-agent dispatch failures (skill-specific)
 
 | Failure | Brief defect |
 |---|---|
-| Worker over-applies items the user would have rejected | DoD didn't require evaluator-style accepted / rejected / ambiguous decision |
-| PR body has no reviewer questions | Brief didn't make "explicit questions ≥ 3" a BSV criterion |
-| PR body exceeds 50k chars | Brief didn't include the wc -c verification step |
-| Evaluator marks everything accepted | Brief didn't include the rejection criteria + ambiguous escape valve |
-| Coordinator never marks DONE despite no major items | Brief didn't make the classifier exit-1 condition a BSV terminal trigger |
+| Applier produces decision JSON but never pushes | Brief mentioned `/do-review` — pulled the agent into evaluator-mode. Remove `/do-review` from worker briefs entirely. |
+| Applier applies items main agent already rejected | Brief baked in items beyond the accepted subset. Filter before dispatch. |
+| PR body has no reviewer questions | PR-Creator brief didn't make "explicit questions ≥ 3" a BSV criterion |
+| PR body exceeds 50k chars | PR-Creator brief didn't include the `wc -c` verification step |
+| Evaluator marks everything accepted | Phase 7 brief didn't include the rejection criteria + ambiguous escape valve |
+| Loop never marks DONE despite no major items | Main agent's loop pseudocode skipped the classifier-exit-1 short-circuit |
 
 When you see one of these, fix the brief, not the agent.
 

--- a/skills/run-codex-review/skills/run-codex-review/references/mission-protocol-integration.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/mission-protocol-integration.md
@@ -30,12 +30,13 @@ Maximum **5,000 words** per brief — a ceiling, not a target.
 
 | Phase | Sub-agent | Brief lives in |
 |---|---|---|
-| 3 | Coordinator (per branch, parallel) | `parallel-subagent-protocol.md` |
-| 3 | Worker (per round, fresh) | `parallel-subagent-protocol.md` |
+| 3 | Applier (per round, per branch, fresh) | `parallel-subagent-protocol.md` |
 | 5 | PR-Creator (per DONE branch) | `parallel-subagent-protocol.md` |
 | 7 | Evaluator (per PR) | `parallel-subagent-protocol.md` |
 
-Phase 8 is **main-agent direct** — no sub-agent. Main agent invokes `/do-review` skill in its own context to apply the evaluator's accepted subset.
+Phase 3 has **no Coordinator sub-agent** — main agent IS the coordinator across all branches (older skill versions had a per-branch Coordinator subagent; long-lived sub-agents drifted past harness session limits in production runs and the pattern was dropped). Main agent runs the codex review wrapper, evaluates major items via `/do-review` in own context, and dispatches one fresh Applier sub-agent per round per branch with the pre-decided fix specs.
+
+Phase 8a is **main-agent direct apply** — main agent walks the Phase 7 Evaluator's decisions JSON and applies each accepted item via Edit + per-concern commits. Phase 8b (merge) is also main-agent direct, with `git rebase --onto` mechanics for squash-merged stacks.
 
 ## The mindset shift
 
@@ -63,8 +64,7 @@ Then identify the **heavy layers** (Framing / Discovery / Evidence / Execution /
 
 | Sub-agent | Ambiguity | Familiarity | Stakes | Heavy layers |
 |---|---|---|---|---|
-| Coordinator | Low | Familiar (the protocol is fixed) | Medium (one branch) | Execution + Verification |
-| Worker (per round) | Medium (Codex's items vary) | Unfamiliar (each round may touch new code) | Medium-High (real fixes) | Framing + Evidence + Execution + Verification |
+| Applier (per round, per branch) | Low (decisions are pre-made) | Unfamiliar (each round may touch new code) | Medium-High (real fixes pushed) | Framing + Execution + Verification |
 | PR-Creator | Low (the deliverable is fixed) | Unfamiliar (must read all changes) | Medium (PR is shared) | Discovery + Evidence + Execution + Verification |
 | Evaluator | Medium-High (multiple sources contradict) | Unfamiliar (PR's changes are new context) | High (decisions drive Phase 8 apply) | Framing + Evidence + Verification |
 
@@ -98,8 +98,8 @@ Where ceilings show up in this skill's briefs:
 
 | Where | Ceiling | Release valve |
 |---|---|---|
-| Worker brief | "Up to 20 rounds total per branch" | "Most branches converge in 3–6 rounds" |
-| Worker brief | "Up to 5 distinct fix approaches per major item" | "If the first approach lands cleanly, you're done with that item" |
+| Phase 3 loop (main agent) | "Up to 20 rounds total per branch" | "Most branches converge in 3–6 rounds" |
+| Applier brief | "Up to 5 distinct fix approaches per accepted item" | "If the first approach lands cleanly, you're done with that item" |
 | PR-Creator brief | "Body up to 50,000 characters" | "Coming in well under is fine; comprehensive ≠ verbose" |
 | PR-Creator brief | "Up to 10 explicit reviewer questions" | "3–5 sharp questions outperform 10 mediocre ones" |
 | Evaluator brief | "Up to 100 distinct review items across all sources" | "Group duplicates; one decision per logical item" |
@@ -113,19 +113,14 @@ Floors I deliberately do **not** set:
 
 ## The Five Layers — applied per sub-agent
 
-### Coordinator
-- **Framing**: light (the protocol is fixed).
-- **Discovery**: light (the protocol files are referenced).
-- **Evidence**: medium (read manifest, classifier output, round logs).
-- **Execution**: heavy (orchestrates the loop).
-- **Verification**: heavy (must show terminal state with evidence).
+(Phase 3 has no sub-agent for orchestration — main agent IS the coordinator. Only the per-round Applier is dispatched.)
 
-### Worker (per round)
-- **Framing**: medium-high (each round's items may have multiple interpretations).
-- **Discovery**: medium-high (must trace cited code).
-- **Evidence**: heavy (extract specific code citations, behavior, contracts).
-- **Execution**: heavy (apply fixes via diff-walk).
-- **Verification**: heavy (validate, push, confirm round-log update).
+### Applier (per round, per branch)
+- **Framing**: low (decisions are pre-made; brief contains the fix specs verbatim).
+- **Discovery**: low (the brief tells the Applier exactly which file:line and intended shape).
+- **Evidence**: light (Read cited code as a sanity check; diff-walk before staging).
+- **Execution**: heavy (apply fixes via Edit; commit per concern; validate; push).
+- **Verification**: heavy (commits exist on origin/<branch>; tests pass; round-log updated).
 
 ### PR-Creator
 - **Framing**: light (the deliverable is fixed: a comprehensive PR).
@@ -145,8 +140,8 @@ Floors I deliberately do **not** set:
 
 The `what_to_extract` mindset (from the protocol's Tool Intelligence section) applies here:
 
-- **Coordinator brief** specifies: extract status transitions, round numbers, terminal_reason text, head SHA after push.
-- **Worker brief** specifies: extract per-item decisions, per-item rationales, per-item commit SHAs (if accepted), validation output.
+- **Main agent's Phase 3 self-direction** specifies: extract status transitions, round numbers, terminal_reason text, head SHA after each round.
+- **Applier brief** specifies: extract per-fix commit SHAs, validation output, final pushed HEAD SHA, list of items that didn't apply cleanly (`apply_failed_after_evaluation`).
 - **PR-Creator brief** specifies: extract PR number, PR URL, body length, list of explicit reviewer questions.
 - **Evaluator brief** specifies: extract per-item decisions per source, deduplication map, cross-source contradictions.
 

--- a/skills/run-codex-review/skills/run-codex-review/references/parallel-subagent-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/parallel-subagent-protocol.md
@@ -2,30 +2,53 @@
 
 This file specifies the four sub-agent types this skill dispatches and the **mission brief template** for each. Every brief follows the MISSION_PROTOCOL skeleton (`~/MISSION_PROTOCOL.md` — see `mission-protocol-integration.md`).
 
+## Invocation matrix per brief
+
+The codex plugin marks `/codex:review` as `disable-model-invocation: true`. Sub-agents physically cannot call it via `Skill(...)` — they must invoke the underlying companion script via Bash. `/codex:resc` requires the `Agent` tool which forked sub-agents do not have. Use the matrix below in every brief:
+
+| Surface | Worker / PR-Creator / Evaluator | How to invoke from the brief |
+|---|---|---|
+| Codex review | Worker (Phase 3) | `python3 <this-skill>/scripts/run-codex-review.py --branch … --base … --worktree … --output …` (wrapper internally calls `codex-companion.mjs review --json`). |
+| Codex rescue | NOT for sub-agents | Phase 6 trigger is main-agent-only; sub-agents do not call it. |
+| `/ask-review` | PR-Creator (Phase 5) | `Skill(skill="ask-review", args="…")` — model-invocable. |
+| `/do-review` | Evaluator (Phase 7) | `Skill(skill="do-review", args="…")` — model-invocable. |
+| `/do-review` | Worker (Phase 3) | **Never.** Workers are appliers; decisions are pre-made before dispatch. See "Mission Brief: Worker" below. |
+
+**Forbidden in every brief:**
+
+- Direct shell invocation of `codex`, `codex review`, `codex review --background`, or any other `codex …` form (no such CLI flags exist).
+- Inventing a "shim" or wrapper because the codex CLI doesn't accept some flag.
+- Inventing a coordinator/worker pattern that diverges from the templates below.
+- Calling `Skill(codex:review)` or `Skill(codex:resc)` from a sub-agent context — both will fail; the plugin disables them.
+
+If `<this-skill>/scripts/run-codex-review.py` cannot find a working `codex-companion.mjs`, the codex plugin is missing. Sub-agent hands back FAILED with `terminal_reason: "codex plugin unavailable"`. Main agent surfaces to the user and stops.
+
 ## Sub-agent inventory
 
 | Phase | Sub-agent | Dispatched by | Lifecycle |
 |---|---|---|---|
-| 3 | **Coordinator** | Main agent | One per branch; lives entire convergence loop. |
-| 3 | **Worker** | Coordinator | Fresh per round; one round of work, then exits. |
+| 3 | **Applier** | Main agent | Fresh per round per branch; applies pre-decided fixes, validates, pushes, exits. |
 | 5 | **PR-Creator** | Main agent | One per DONE branch; opens the PR, then exits. |
 | 7 | **Evaluator** | Main agent | One per PR; reads gathered reviews, returns decisions JSON. |
 
-**Phase 8 is main-agent direct** — no sub-agent. Main agent uses `/do-review` skill in its own context.
+**Main agent is the coordinator across all branches** — it owns the round cadence, runs codex review wrappers in parallel, evaluates major items via `Skill(do-review)` in its own context, and dispatches per-round Appliers. Phase 8 is also main-agent direct.
+
+> **Why main-agent-as-coordinator (load-bearing):** older versions of this skill used a per-branch Coordinator sub-agent that held the convergence loop. In practice these long-lived sub-agents (5+ hours, dozens of rounds) drift, lose context, or hit harness session limits. Main agent is the only stable owner of the multi-hour cadence. Sub-agents are short-lived single-purpose appliers / PR-creators / evaluators.
 
 ## Ownership boundary (hard rule)
 
 ```
-1 worktree  =  1 coordinator  =  N rounds (cap 20)
-1 round     =  1 fresh worker
-1 DONE PR   =  1 PR-creator (then 1 codex rescue handoff, then 1 evaluator)
+1 worktree  =  1 branch  =  N rounds driven by main agent (cap 20)
+1 round-per-branch  =  1 fresh Applier sub-agent
+1 DONE PR  =  1 PR-Creator → 1 codex rescue (main-agent direct) → 1 Evaluator
 ```
 
-- A worker mutates ONLY files inside its branch's worktree path.
-- A worker NEVER touches another branch, another worktree, or the manifest entries of other branches.
-- A worker NEVER opens PRs, merges, or retires branches — those are PR-creator (5), main-agent (8), or cleanup-worktrees (9) jobs.
-- The main agent NEVER edits inside a worktree while a worker is running.
-- Branches A and B can have concurrent coordinators (parallel inner loops), but their workers are physically isolated by separate worktrees.
+- An Applier mutates ONLY files inside its branch's worktree path.
+- An Applier NEVER touches another branch, another worktree, or the manifest entries of other branches.
+- An Applier NEVER opens PRs, merges, or retires branches — those are PR-Creator (5), main-agent (8), or cleanup-worktrees (9) jobs.
+- An Applier does NOT run codex review or classify — main agent does that before the dispatch.
+- Main agent NEVER edits inside a worktree while an Applier is running.
+- Different branches can have concurrent Appliers (parallel rounds across branches), physically isolated by separate worktrees.
 
 ## Communication contract: manifest as message bus
 
@@ -63,274 +86,195 @@ def update_manifest_entry(manifest_path, branch, updates, history_entry=None):
 
 `os.replace` is atomic on POSIX. `flock` provides mutual exclusion across concurrent writers.
 
-## Heartbeat
+## Brief templating (mandatory for parallel dispatches)
 
-Liveness is inferred from manifest mtime + round-log mtime. If a coordinator has not updated its branch's `updated_at` in `--stale-minutes` (default 60), it's presumed crashed. Same for workers — round-log mtime is the heartbeat.
+When dispatching N parallel sub-agents (N appliers in Phase 3, N PR-Creators in Phase 5, N evaluators in Phase 7), **never hand-write N separate briefs via N `Write` tool calls**. That pattern burns thousands of tokens, drifts copy-paste errors across briefs, and adds 5+ minutes of wall-time per phase.
 
-The sub-agent doesn't write explicit heartbeats. Manifest writes ARE the heartbeat.
+**Mandatory pattern:**
 
----
+1. Write **one** template file with `{{PLACEHOLDER}}` slots, e.g. `/tmp/applier-brief-template.md`.
+2. Render N concrete briefs from the template + a per-branch decisions JSON in **one Python invocation**:
 
-## Mission Brief: Coordinator (Phase 3)
-
-Dispatched by main agent at the start of Phase 3. One coordinator per branch. Coordinators run in parallel across branches.
-
-### Skeleton (fill in `<...>`)
-
-```markdown
-# Mission: Drive branch `<branch>` to convergence
-
-## Context
-
-You are the coordinator for branch `<branch>` in worktree `<worktree-path>`. The
-run-codex-review skill is running on repo `<repo-root>`. The
-private fork is `<fork-owner-repo>`; upstream `<upstream-owner-repo>` is
-read-only — never push, never PR there.
-
-This branch holds one coherent concern: `<concern-one-liner>`.
-
-The skill follows `~/MISSION_PROTOCOL.md` for every sub-agent dispatch you make
-(workers, in your case).
-
-You live in the host harness as a sub-agent dispatched by the main agent. You
-own this branch end-to-end through Phase 3 only — Phases 5–8 are the main
-agent's job.
-
-What you must read before acting:
-- `<this-skill>/SKILL.md` — phase semantics and invariants.
-- `<this-skill>/references/per-branch-fix-loop.md` — the loop pseudocode you
-  implement.
-- `<this-skill>/references/review-evaluation-protocol.md` — what your workers
-  must do per round.
-- `skills/run-repo-cleanup/references/fork-safety.md` — origin vs upstream rules.
-- The manifest entry for `<branch>` at `<manifest-path>` — current rounds,
-  last_review_id, etc.
-
-Mental model after reading:
-- The convergence loop reviews → classifies → dispatches a fresh worker → waits
-  for handback → repeats. You orchestrate; workers act.
-- Terminal states: `DONE` (no major after a round), `CAP-REACHED` (20 rounds
-  with major still present), `BLOCKED` (oscillation or contradictory feedback),
-  `FAILED` (tooling crash past retry budget).
-- 3 consecutive all-rejected rounds = `DONE` (Codex stuck on items the worker
-  evaluator rejected).
-
-## Mission Objective
-
-Drive `<branch>`'s manifest entry to a terminal state with full round history.
-Every round produces a round-log file at `<rounds-dir>/<slug>.<round>.json`,
-the worker subagent's handback is recorded in `round_history`, and the
-manifest's `status` is one of {DONE, CAP-REACHED, BLOCKED, FAILED} when you
-exit.
-
-Hard constraints:
-- Never edit files in `<worktree-path>` directly. Workers do that.
-- 20-round hard cap.
-- Always invoke `/codex:review --background` (via the wrapper script). Never inline.
-- Never `--force` push.
-- Never push to upstream.
-- Always evaluate Codex's items via worker's `/do-review` — never apply directly
-  by skipping the worker.
-
-Known risks:
-- Codex CLI may rate-limit. The wrapper retries; you escalate after 3 failures.
-- A worker may crash. Its heartbeat (round-log mtime) tells you. Redispatch up
-  to 2 times; else FAILED.
-- Cross-source contradictions across rounds → BLOCKED with `terminal_reason`.
-
-Priority signal: correctness over speed. A FAILED branch is not a disaster — a
-silently-wrong DONE is.
-
-You own this mission. The destination is fixed; the path is yours.
-
-## Research & Tool Guidance
-
-- Use `<this-skill>/scripts/run-codex-review.py` for each round's review.
-- Use `<this-skill>/scripts/classify-review-feedback.py` to partition major/minor.
-- Dispatch each round's worker via the host's Agent tool (subagent_type =
-  "general-purpose" — needs Skill access for /do-review).
-- The worker's brief is the template later in this file under "Mission Brief:
-  Worker". Customize for the round.
-- After dispatch, wait for the worker's handback — it writes to
-  `<rounds-dir>/<slug>.<round>.json` and updates the manifest entry.
-- Use `loop-status.py` to inspect state (read-only).
-
-Ceilings (release valves applied):
-- Up to 20 rounds per branch (most branches converge in 3–6).
-- Up to 2 worker redispatches per round on transient failure.
-- Up to 3 codex CLI retries per round before failing the round.
-
-## Definition of Done
-
-- `<branch>`'s manifest entry has `status` ∈ {DONE, CAP-REACHED, BLOCKED, FAILED}.
-- `manifest[branch].rounds` matches `len(round_history)`.
-- Every entry in `round_history` has `{round, review_id, major_n, minor_n, completed_at}`.
-- `terminal_reason` is set, citing the trigger (e.g. "no major in round 4",
-  "20 rounds with 2 major remaining", "oscillation in round 6").
-- `<branch>`'s remote tip on `origin/<branch>` matches the worker's last
-  reported `head_sha_current`.
-
-You must achieve 100% of every criterion above before reporting completion.
-Partial completion = not complete. If a criterion is impossible to meet, report
-that finding with evidence — do not silently skip it.
-
-## Verification
-
-For DoD:
-- `python3 <this-skill>/scripts/loop-status.py --manifest <path>` — branch
-  appears with terminal state.
-- `git -C <worktree-path> log origin/<branch>..HEAD --oneline` — empty (all
-  commits pushed).
-- `wc -l < <rounds-dir>/<slug>.<round>.json` for each round entry exists.
-
-## Failure Protocol
-
-If blocked:
-1. What was attempted: round numbers, codex job ids, worker dispatches.
-2. What was discovered: any pattern (oscillation, contradictions, persistent
-   tooling failure).
-3. Why it failed: the specific blocker.
-4. What to try next: split branch / extend cap / human triage.
-
-Mark the manifest entry `status: FAILED` (or BLOCKED for semantic ambiguity)
-with `terminal_reason` citing the above. Never silently exit without updating
-the manifest.
-
-## Handback
-
-When you complete this mission, respond with:
-1. **Summary**: branch + terminal state + rounds used (one paragraph).
-2. **Changes**: list of round-log files written, last commit SHA pushed.
-3. **Evidence**: loop-status.py output showing terminal state.
-4. **Observations**: anything notable (oscillation patterns, classifier
-   misclassifications, codex flakiness).
+```python
+import json, pathlib
+template = pathlib.Path("/tmp/applier-brief-template.md").read_text()
+decisions = json.loads(pathlib.Path("<rounds-dir>/decisions.json").read_text())
+for branch_slug, payload in decisions.items():
+    body = template
+    for k, v in payload.items():
+        body = body.replace(f"{{{{{k}}}}}", v if isinstance(v, str) else json.dumps(v, indent=2))
+    pathlib.Path(f"/tmp/applier-brief-{branch_slug}.md").write_text(body)
+print(f"rendered {len(decisions)} briefs")
 ```
 
-### Tuning the coordinator brief
+Then dispatch:
 
-- For a small branch (1 commit, low complexity): the brief above is overkill.
-  You can trim Context to ~200 words. Don't trim DoD or Verification — those
-  are the contract.
-- For a complex branch (mixed concerns, large diff): expand the Known risks
-  section with specific pitfalls (e.g. "this branch touches the auth middleware
-  — false positives are common; trust the worker evaluator").
+```
+for branch_slug in decisions:
+    Agent(
+        prompt=f"Read /tmp/applier-brief-{branch_slug}.md and execute.",
+        subagent_type="general-purpose",
+        run_in_background=True,
+    )
+```
+
+**Why mandatory**: production trace showed an agent writing 7+5+9 = 21 briefs across Phases 3 and 5 via 21 separate Write calls. Each brief was 50-140 lines of mostly-identical text with per-branch decisions varying. Template + render in one shot is ~3 tool calls vs. 21; cuts orchestration cost by ~85%.
+
+**Brief content rules** (apply per template type):
+
+- Applier briefs: one template per round (`/tmp/applier-brief-template-r<N>.md`); placeholders for branch, worktree, base, prior-round commits, this-round decisions.
+- PR-Creator briefs: one template; placeholders for branch, worktree, base, status, round_history summary, concern.
+- Evaluator briefs: one template; placeholders for PR number, gathered-reviews JSON path, taxonomy reference.
+
+The template ITSELF must be revised when its corresponding "Mission Brief" template skeleton in this file changes. The two are versioned together.
+
+## Heartbeat
+
+Liveness is inferred from manifest mtime + round-log mtime. If an Applier has not updated its branch's `updated_at` in `--stale-minutes` (default 60), it's presumed crashed. The sub-agent doesn't write explicit heartbeats — manifest writes ARE the heartbeat.
 
 ---
 
-## Mission Brief: Worker (Phase 3, per round)
+## Coordinator role (main-agent self-direction)
 
-Dispatched by the coordinator at the start of each round (after `run-codex-review.py` produces the round JSON and `classify-review-feedback.py` returns major[] non-empty).
+There is **no Coordinator sub-agent** in this skill. Older drafts dispatched a per-branch Coordinator subagent that held the convergence loop; in production those long-lived sub-agents drift, lose context, or hit harness session limits. **Main agent is the coordinator across all branches** — it owns the round cadence directly.
+
+Main agent's coordinator self-direction (no brief — main reads this section as its own playbook):
+
+- **Per round across all active branches:**
+  1. In parallel, launch `python3 <this-skill>/scripts/run-codex-review.py --branch <b> --base <base> --worktree <wt> --output <rounds-dir>/<slug>.<round>.json` for every active branch via Bash background tasks.
+  2. As each review completes (Monitor or Bash run_in_background callbacks), run `python3 <this-skill>/scripts/classify-review-feedback.py --review-json <path>`.
+     - Exit 1 (no major) → mark branch DONE with `terminal_reason: "no major in round <N>"`.
+     - Exit 0 (≥1 major) → continue.
+  3. For each major item, read cited code (Read tool, ±25 lines around `file:line`), then call `Skill(skill="do-review", args="--item <body> --code <cited_code>")` in main's own context. Record decision per `references/review-evaluation-protocol.md`.
+  4. For each branch with at least one accepted decision: dispatch ONE Applier sub-agent with the brief in "Mission Brief: Applier" below. Pre-decided fixes baked in.
+  5. As Appliers hand back, update manifest's `round_history[<N>]` per branch.
+  6. Increment per-branch round counter; loop until all branches terminal.
+
+- **Terminal states** (`manifest.status`):
+  - `DONE` — no major after a round (classifier exit 1).
+  - `CONVERGED-AT-CAP` — `<this-skill>'s` configured `max_rounds_per_branch` exhausted with at least one round of fixes pushed; remaining items captured in PR body. (See SKILL.md "Convergence taxonomy".)
+  - `CAP-REACHED` — 20 rounds (or configured cap) with no convergence. Surface for human.
+  - `BLOCKED` — oscillation (3 consecutive all-rejected rounds → reclassify as DONE; persistent ambiguous items → BLOCKED) or cross-source contradictions.
+  - `FAILED` — tooling crash past retry budget; codex plugin unavailable; Applier failed to push.
+
+- **Non-negotiables:**
+  - Never edit inside a worktree while its Applier is running.
+  - Never `--force`. Never push to upstream.
+  - Decisions stay with main agent; appliers stay mechanical.
+  - Read the manifest, not the worktree, for state — Appliers update the manifest atomically.
+
+- **Cost / wall-time expectations** (do not be surprised; do not invent shortcuts):
+  - Each codex review wrapper call: ~3–15 minutes wall.
+  - Each Applier dispatch: ~3–10 minutes wall.
+  - Round per branch: ~10–25 minutes serial. With N parallel branches: same wall, N× quota.
+  - Typical convergence: 3–6 rounds per branch (per `references/major-vs-minor-policy.md`).
+  - Round-2+ commonly find new items (refinements of round-1 fixes). 6/8 branches in production runs needed round-2 fixes. **This is normal — do not invent `DONE-PRAGMATIC` to shortcut.**
+
+---
+
+## Mission Brief: Applier (Phase 3, per round)
+
+Dispatched by **main agent** (not by a coordinator subagent — that role was dropped) at the start of each round, after main agent has:
+1. Run the codex review wrapper for this branch.
+2. Run the classifier to partition major/minor.
+3. Evaluated each major item itself using `Skill(do-review)` in main's own context.
+4. Composed the per-item fix specs (file, line, intended code shape, rationale).
+
+The applier's job is **mechanical**: apply the pre-decided fixes, validate, push. It is not an evaluator. The brief MUST NOT mention `/do-review` — that framing pulls the agent into evaluator-mode and produces decision-only failure.
 
 ### Skeleton
 
 ```markdown
-# Mission: Apply round `<N>` of branch `<branch>`
+# Mission: Round <N> of `<branch>` — apply N pre-decided fixes, validate, push
+
+You are an APPLIER for branch `<branch>` in worktree `<worktree-path>`. The
+decisions below were made before this dispatch. Your only job is BINARY
+EXECUTION: apply, validate, push. **Anything short of pushed commits is FAILED.**
+
+This is NOT an evaluation task. Do NOT invoke `/do-review`. Do NOT propose
+alternative fixes. Do NOT produce decision JSON. Do NOT stop at "Verdict:
+apply" — apply IS the deliverable.
 
 ## Context
 
-You are the per-round worker for branch `<branch>` in worktree
-`<worktree-path>`, round `<N>` of up to 20. The coordinator (your dispatcher)
-expects a single round of work: evaluate this round's Codex items, apply the
-accepted subset, validate, push, hand back.
+- **Worktree**: `<worktree-path>`
+- **Branch**: `<branch>` (on `origin/<branch>`)
+- **Base**: `<base-ref>`
+- **Round**: <N> of up to 20. Prior rounds (if any): <commit SHAs>.
+- **You own this worktree's setup.** If validation needs `node_modules` /
+  `.venv` / build artifacts that don't exist yet, install them yourself
+  (`pnpm install`, `npm install`, `bun install`, `pip install -r ...`).
+  Main agent does NOT preflight dependencies.
 
-This is a FRESH dispatch — you have no prior context from earlier rounds. The
-coordinator's brief (which you are reading) carries everything you need.
+## Pre-decided fixes (apply each exactly)
 
-This round's Codex review JSON is at `<round-json-path>`. The classifier's
-output (which items are `major[]`, which are `minor[]`, which are
-`unclassified_treated_as_major[]`) is the input you must act on. The
-classifier's exit code was 0 (≥1 major), so you have work to do.
-
-Prior rounds in this branch's history (summary):
-<insert prior rounds' major_n / minor_n / decisions if available>
-
-You must read before acting:
-- `<round-json-path>` — Codex's review for this round.
-- `<this-skill>/references/review-evaluation-protocol.md` — accepted/rejected/ambiguous taxonomy.
-- `skills/run-repo-cleanup/references/diff-walk-discipline.md` — staging discipline.
-- `skills/run-repo-cleanup/references/conventional-commits.md` — commit format.
-
-Mental model after reading:
-- For each `major` item, evaluate it against the actual code in
-  `<worktree-path>` using the `/do-review` skill (Skill tool with
-  skill='do-review').
-- accepted → apply the fix, commit one concern at a time.
-- rejected → record reason; skip.
-- ambiguous → record question; do NOT apply; coordinator will surface.
-
-## Mission Objective
-
-For round `<N>` of branch `<branch>`: every `major` item in `<round-json-path>`
-has a decision (accepted / rejected / ambiguous), accepted items are
-applied + committed + pushed, validation passes, and the round-log JSON
-records all decisions.
-
-Hard constraints:
-- Use `/do-review` (Skill tool) to evaluate every `major` item before applying.
-- Never apply an item without a decision — never default to accepting.
-- One concern per commit. Conventional commits + gitmoji per
+### Fix 1: <one-line summary>
+- **File**: `<worktree-path>/<file>`
+- **Around line**: <line>
+- **Current shape** (verbatim from current code):
+  ```
+  <existing code excerpt>
+  ```
+- **Intended shape** (apply this; preserve indentation):
+  ```
+  <new code excerpt>
+  ```
+- **Rationale**: <why — main agent's evaluator decision summary>
+- **Commit message**: `<emoji> <type>(<scope>): <subject>` per
   `skills/run-repo-cleanup/references/conventional-commits.md`.
-- `git diff` before staging. `git diff --cached` before committing. No
-  `git commit -am`.
-- Validation BEFORE push (e.g. `python3 -m py_compile <changed-files>`,
-  `bun run type-check`, `cargo check`, or repo-local check).
+
+### Fix 2: …
+(repeat per item)
+
+## Hard constraints
+
+- One concern per commit. N fixes = N commits.
+- `git diff` before staging. `git diff --cached` before committing. No `git commit -am`.
+- Validate BEFORE push (e.g. `pnpm run build && pnpm test`, `bun run type-check`,
+  `cargo check`, or whatever the repo's `CONTRIBUTING.md` / `AGENTS.md` says).
 - Push to `origin/<branch>` only. Never `--force`. Never to upstream.
 - Stay inside `<worktree-path>`. Do not `cd` elsewhere.
 
-Known risks:
-- Codex sometimes loops on items the prior round's evaluator already rejected.
-  If this round contains an item that's identical to a prior-round rejected
-  item, mark it ambiguous (oscillation signal for the coordinator).
-- Codex's suggested fix may be technically correct but break a downstream
-  caller. The /do-review evaluator should catch this; if uncertain, mark
-  ambiguous.
+## Definition of Done (binary)
 
-Priority: correctness over volume. A round with 1 carefully-evaluated accept
-is better than a round with 5 sloppy accepts.
-
-You own this round. The coordinator orchestrates; you decide the per-item
-fate.
-
-## Research & Tool Guidance
-
-- Read `<round-json-path>` — find every item with id, severity_raw, file, line, body.
-- Use `/do-review` (Skill tool: skill='do-review') to evaluate. Pass it the
-  cited code from `<worktree-path>/<file>` around `<line>` (you may need to
-  read 20–50 lines of context).
-- For each item, decide per `references/review-evaluation-protocol.md`:
-  - accepted → produce the fix; apply via Edit tool inside the worktree.
-  - rejected → record `decision: rejected, reason: <why>`.
-  - ambiguous → record `decision: ambiguous, question: <what needs human>`.
-- Commit accepted fixes one concern at a time:
-  - `git -C <worktree> add <files-for-this-concern>`
-  - `git -C <worktree> diff --cached`
-  - `git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject>"`
-- Validate (language-appropriate fast check) before push.
-- Push: `git -C <worktree> push origin <branch>` (no `--force`).
-
-Ceilings:
-- Up to 5 distinct fix approaches per major item. If the first approach lands
-  cleanly, you're done with that item.
-- Up to 50 lines of cited code read per item. If the answer needs more, mark
-  ambiguous (the item is too entangled).
-- Up to 1 retry on validation failure (revert + retry once). After that,
-  rejected with `reason: "post-fix validation failed"`.
-
-## Definition of Done
-
-- Every `major` item has a decision in your round-log output: `accepted` /
-  `rejected` / `ambiguous`.
-- Every accepted item produced one or more commits with conventional + gitmoji
-  format.
-- `git diff --cached` returns empty (no leftover staged changes).
+- N new commits exist on local HEAD with conventional + gitmoji messages.
+- `git -C <worktree-path> diff --cached` returns empty.
 - Validation command exits 0.
-- `git push origin <branch>` succeeded (no rejection, no force).
-- Round-log JSON at `<rounds-dir>/<slug>.<N>.json` has been updated with
-  per-item decisions and final HEAD SHA.
-- Manifest entry's `last_classifier_summary`, `head_sha_current`, and
-  `round_history[<N>]` reflect this round's outcome.
+- `git -C <worktree-path> push origin <branch>` succeeded.
+- `git -C <worktree-path> rev-parse origin/<branch>` matches local HEAD.
+- Manifest entry updated: `head_sha_current`, `round_history[<N>]`.
 
-100% required. Partial = incomplete.
+Anything short of all of the above = FAILED. Hand back FAILED with
+`terminal_reason` naming the specific gate that did not pass.
+
+## Failure protocol
+
+- If a fix's intended shape doesn't apply cleanly (file moved, line shifted,
+  current shape mismatch): STOP, do NOT improvise. Hand back FAILED with
+  `terminal_reason: "fix N intended-shape mismatch — main agent re-evaluate"`.
+  Main agent will re-decide and re-dispatch.
+- If validation fails after a fix: revert the offending commit, hand back
+  FAILED with the validation output.
+- If push is rejected (non-fast-forward, hook failure): hand back FAILED with
+  the rejection output. NEVER `--force`.
+
+## Handback shape
+
+```json
+{
+  "applied": <N>,
+  "pushed": true | false,
+  "head_sha": "<sha>",
+  "validation_exit": 0 | <nonzero>,
+  "commit_shas": ["<sha1>", ...],
+  "terminal_reason": null | "<one-sentence>"
+}
+```
+```
+
+### Why no `/do-review` in this brief
+
+Empirically verified across multiple production runs: when the worker brief mentions `/do-review`, ~100% of dispatched workers stop after producing decision JSON without applying or pushing. The /do-review framing pulls the agent into evaluator-mode; "Verdict: apply" feels like the deliverable to the agent. Splitting evaluation (main agent) from application (worker, with explicit pre-decided fix specs and binary push DoD) is the empirical fix. Do not re-introduce eval framing into the worker brief.
 
 ## Verification
 

--- a/skills/run-codex-review/skills/run-codex-review/references/parallel-subagent-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/parallel-subagent-protocol.md
@@ -52,7 +52,7 @@ If `<this-skill>/scripts/run-codex-review.py` cannot find a working `codex-compa
 
 ## Communication contract: manifest as message bus
 
-All sub-agents in this skill report state via atomic writes to `/tmp/codex-review-manifest.json`. No chat-based handbacks for state.
+All sub-agents in this skill report state via atomic, lock-guarded writes to the repo-local manifest (`<repo-root>/.codex-review-manifest.json` by default; `--manifest <path>` to override). No chat-based handbacks for state. The wrapper scripts (`run-codex-review.py`, `trigger-codex-rescue.py`) implement the lock recipe below; sub-agents call the wrappers rather than rolling their own.
 
 ### Atomic write recipe
 

--- a/skills/run-codex-review/skills/run-codex-review/references/per-branch-fix-loop.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/per-branch-fix-loop.md
@@ -84,43 +84,51 @@ while round <= 20:
         cited_code = read(<worktree>/<item.file>, around <item.line>, ±25)
         decision = Skill(skill="do-review",
                          args=f"--item {item.body} --code {cited_code}")
-        # decision ∈ {accepted, rejected, ambiguous}
+        # decision is a string enum: "accepted" | "rejected" | "ambiguous"
         decisions.append(decision)
 
-    if all(d == "ambiguous" for d in decisions) and persistent_ambiguity():
-        manifest[branch].status = "BLOCKED"
-        terminal_reason = f"persistent ambiguous items in round {round}"
-        break
+    accepted  = [d for d in decisions if d == "accepted"]
+    rejected  = [d for d in decisions if d == "rejected"]
+    ambiguous = [d for d in decisions if d == "ambiguous"]
 
-    accepted = [d for d in decisions if d.kind == "accepted"]
-    rejected = [d for d in decisions if d.kind == "rejected"]
-
-    # 4. ALL-REJECTED-STREAK detection (skip Applier dispatch this round
-    #    since there are no fixes to apply).
-    if not accepted and rejected:
-        all_rejected_streak += 1
-        if all_rejected_streak >= 3:
-            manifest[branch].status = "DONE"
-            terminal_reason = ("3 consecutive all-rejected rounds; "
-                               "Codex stuck on items main agent rejected")
+    # 4. AMBIGUOUS GATE — even one ambiguous item BLOCKS the round.
+    #    Don't half-apply: ship-some + defer-some leaves an inconsistent state.
+    if ambiguous:
+        if persistent_ambiguity():
+            manifest[branch].status = "BLOCKED"
+            terminal_reason = f"persistent ambiguous items in round {round}"
             break
+        # Non-persistent ambiguous (one round): defer the entire round, retry
+        round += 1
+        continue
+
+    # 5. ALL-REJECTED-STREAK detection (skip Applier dispatch this round
+    #    since there are no fixes to apply).
+    if not accepted:
+        if rejected:
+            all_rejected_streak += 1
+            if all_rejected_streak >= 3:
+                manifest[branch].status = "DONE"
+                terminal_reason = ("3 consecutive all-rejected rounds; "
+                                   "Codex stuck on items main agent rejected")
+                break
         round += 1
         continue
     else:
         all_rejected_streak = 0
 
-    # 5. DISPATCH APPLIER — fresh sub-agent for this round.
+    # 6. DISPATCH APPLIER — fresh sub-agent for this round.
     #    Brief contains pre-decided fix specs; NO /do-review invocation.
     brief = build_applier_brief(branch, worktree, round, accepted)
     handback = Agent(prompt=brief, subagent_type="general-purpose")
 
-    # 6. INTERPRET HANDBACK (binary)
+    # 7. INTERPRET HANDBACK (binary)
     if not handback.pushed:
         manifest[branch].status = "FAILED"
         terminal_reason = f"applier failed to push round {round}: {handback.terminal_reason}"
         break
 
-    # 7. NEXT ROUND
+    # 8. NEXT ROUND
     round += 1
 
 if round > 20:

--- a/skills/run-codex-review/skills/run-codex-review/references/per-branch-fix-loop.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/per-branch-fix-loop.md
@@ -1,117 +1,143 @@
 # Per-Branch Fix Loop
 
-Phase 3 of the skill. The convergence loop that takes a branch from "ready for review" to "Codex has nothing major" via the **two-level sub-agent pattern**:
-
-- One **coordinator sub-agent** per branch (parallel across branches; lives the entire loop).
-- One **worker sub-agent** per round (fresh dispatch each round; uses `/do-review`).
-
-This file specifies the loop pseudocode, the round-counter persistence, the 20-cap rationale, the validation step, the push rules, and the state machine. Mission brief templates for both sub-agents are in `parallel-subagent-protocol.md`. Every brief is written per `~/MISSION_PROTOCOL.md` (see `mission-protocol-integration.md`).
-
-## The two-level pattern
+Phase 3 of the skill. The convergence loop that takes a branch from "ready for review" to "Codex has nothing major". **Main agent owns the loop directly** — there is no coordinator sub-agent. Sub-agents are short-lived per-round Appliers.
 
 ```
-                   main agent
+                   main agent (the coordinator)
                        │
-                       │ (Phase 3 dispatch — N parallel)
-                       ▼
+                       │ per round, per active branch:
+                       │   1. Bash-bg: run-codex-review.py
+                       │   2. classify-review-feedback.py
+                       │   3. for each major item: Skill(do-review) in own context → decision
+                       │   4. compose pre-decided fix specs
+                       │
+                       ▼ Agent dispatch (FRESH per round, per branch, parallel)
        ┌─────────────────────────────────────────────────┐
-       │   coordinator sub-agent  (per branch, lives the │
-       │   entire loop, drives convergence to terminal)  │
-       └────────────────────┬────────────────────────────┘
-                            │
-                            │ (per round, FRESH dispatch each time)
-                            ▼
-       ┌─────────────────────────────────────────────────┐
-       │   worker sub-agent  (one round of work,         │
-       │   evaluates via /do-review, applies, pushes,    │
-       │   hands back to coordinator)                    │
+       │   Applier sub-agent  (one round of work,        │
+       │   applies pre-decided fixes mechanically,       │
+       │   validates, pushes; binary push DoD;           │
+       │   never invokes /do-review)                     │
        └─────────────────────────────────────────────────┘
 ```
 
-The coordinator orchestrates over time (loop counter, terminal-state decision, dispatch). The worker acts in a moment (one round, one fix-set, one push). Both follow `~/MISSION_PROTOCOL.md`.
+Main agent orchestrates over time (loop counter, terminal-state decision, dispatch, evaluation). Applier acts in a moment (apply N pre-decided fixes, validate, push). Applier brief follows `~/MISSION_PROTOCOL.md` (see `mission-protocol-integration.md`); main-agent self-direction is documented in `parallel-subagent-protocol.md` "Coordinator role".
 
-## Why fresh worker per round
+## Why fresh Applier per round
 
 | Approach | Pros | Cons |
 |---|---|---|
-| Fresh worker per round (this skill) | Brief discipline applied every round; no stale context; per-round failure isolated | 2× dispatch overhead |
-| Long-lived worker per branch | Cheaper dispatch | Brief discipline degrades over rounds; round-N's mistakes contaminate round-N+1 |
+| Fresh Applier per round (this skill) | Brief discipline applied every round; no stale context; per-round failure isolated; binary push DoD | 2× dispatch overhead |
+| Long-lived worker per branch | Cheaper dispatch | Brief discipline degrades; round-N mistakes contaminate round-N+1 |
 
-The user's wording — *"after every review from Codex we invoke sub-agents… once the sub-agent finishes, we start another Codex review"* — explicitly codifies fresh-per-round. The two-level pattern is the only way to achieve that AND keep parallel branches AND comply with MISSION_PROTOCOL strictly per round.
+The user's wording — *"after every review from Codex we invoke sub-agents… once the sub-agent finishes, we start another Codex review"* — explicitly codifies fresh-per-round.
 
-## Pseudocode (canonical) — coordinator's loop
+## Why no Coordinator sub-agent
+
+Older drafts of this file dispatched a per-branch Coordinator sub-agent that held the convergence loop. Production runs revealed:
+
+- Coordinators that need to live for hours (5+ hours, 9 branches, 20 rounds) drift, lose context, or hit harness session limits.
+- Sub-sub-agent dispatch (Coordinator dispatching its own Worker per round) is brittle in Claude Code; depth-2 dispatch isn't a stable interface.
+- The worker brief framing that asked workers to `/do-review` then apply caused 100% decision-only failure across runs.
+
+The current pattern moves orchestration and decisions to main agent, leaves only mechanical apply to short-lived sub-agents. This is the empirically reliable shape.
+
+## Pseudocode (canonical) — main agent's per-branch loop
 
 ```python
+# Main agent runs this PER BRANCH, but executes branches in parallel via
+# Bash run_in_background for the codex-review steps and Agent dispatch for
+# the per-round Applier.
+
 round = 1
-all_rejected_streak = 0  # consecutive rounds where worker rejected ALL items
+all_rejected_streak = 0  # consecutive rounds where every decision was rejected
 
 while round <= 20:
-    # 1. REVIEW
-    # Coordinator triggers Codex via the wrapper (returns when review JSON is written).
-    rc_review = run("python3 scripts/run-codex-review.py --branch <b> --worktree <wt>")
+    # 1. REVIEW (parallel across branches — main agent kicks off all in
+    #    parallel via Bash run_in_background and gathers results).
+    rc_review = run("python3 scripts/run-codex-review.py "
+                    "--branch <b> --base <base> --worktree <wt> "
+                    "--output <rounds-dir>/<slug>.<round>.json")
     if rc_review == 1:
-        # timeout — retry once
-        rc_review = run(...)
+        rc_review = run(...)  # timeout — retry once
     if rc_review == 2:
         manifest[branch].status = "FAILED"
         terminal_reason = "codex review failed past retry budget"
         break
 
-    review_json = "/tmp/codex-review-rounds/<slug>.<round>.json"
+    review_json = "<rounds-dir>/<slug>.<round>.json"
 
     # 2. CLASSIFY
-    rc_class = run(f"python3 scripts/classify-review-feedback.py --review-json {review_json}")
+    rc_class = run(f"python3 scripts/classify-review-feedback.py "
+                   f"--review-json {review_json}")
     if rc_class == 1:
-        # No major items — Codex says clean
         manifest[branch].status = "DONE"
         terminal_reason = f"no major feedback (round {round})"
         break
     if rc_class == 2:
-        # malformed review JSON — retry the round once
-        retry round, else mark FAILED.
+        # malformed review JSON — retry the round once, else FAILED
+        ...
 
-    # 3. DISPATCH WORKER (fresh sub-agent for THIS round)
-    brief = build_worker_brief(branch, worktree, round, review_json, prior_round_summaries)
-    handback = Agent(prompt=brief, subagent_type="general-purpose")
-    # Wait for worker's handback. Worker has used /do-review, applied accepted, pushed.
+    # 3. EVALUATE — main agent decides each major item in own context.
+    #    NOT delegated to a sub-agent. Skill(do-review) runs in main.
+    decisions = []
+    for item in major_items:
+        cited_code = read(<worktree>/<item.file>, around <item.line>, ±25)
+        decision = Skill(skill="do-review",
+                         args=f"--item {item.body} --code {cited_code}")
+        # decision ∈ {accepted, rejected, ambiguous}
+        decisions.append(decision)
 
-    # 4. INTERPRET HANDBACK
-    if handback.status == "FAILED":
-        manifest[branch].status = "FAILED"
-        terminal_reason = f"worker FAILED round {round}: <reason>"
+    if all(d == "ambiguous" for d in decisions) and persistent_ambiguity():
+        manifest[branch].status = "BLOCKED"
+        terminal_reason = f"persistent ambiguous items in round {round}"
         break
 
-    decisions = handback.decisions  # {accepted, rejected, ambiguous}
-    if decisions.ambiguous:
-        # Coordinator's call: cap-1 ambiguous can pass; ≥2 or persistent -> BLOCKED
-        if persistent_ambiguity():
-            manifest[branch].status = "BLOCKED"
-            terminal_reason = f"ambiguous items in round {round}: {decisions.ambiguous}"
-            break
+    accepted = [d for d in decisions if d.kind == "accepted"]
+    rejected = [d for d in decisions if d.kind == "rejected"]
 
-    if decisions.accepted == 0 and len(decisions.rejected) > 0:
-        # All-rejected round (no accepts, ≥1 rejected, no ambiguous)
+    # 4. ALL-REJECTED-STREAK detection (skip Applier dispatch this round
+    #    since there are no fixes to apply).
+    if not accepted and rejected:
         all_rejected_streak += 1
         if all_rejected_streak >= 3:
             manifest[branch].status = "DONE"
-            terminal_reason = f"3 consecutive all-rejected rounds; Codex stuck on items the worker evaluator rejected"
+            terminal_reason = ("3 consecutive all-rejected rounds; "
+                               "Codex stuck on items main agent rejected")
             break
+        round += 1
+        continue
     else:
-        all_rejected_streak = 0  # reset
+        all_rejected_streak = 0
 
-    # 5. INCREMENT
+    # 5. DISPATCH APPLIER — fresh sub-agent for this round.
+    #    Brief contains pre-decided fix specs; NO /do-review invocation.
+    brief = build_applier_brief(branch, worktree, round, accepted)
+    handback = Agent(prompt=brief, subagent_type="general-purpose")
+
+    # 6. INTERPRET HANDBACK (binary)
+    if not handback.pushed:
+        manifest[branch].status = "FAILED"
+        terminal_reason = f"applier failed to push round {round}: {handback.terminal_reason}"
+        break
+
+    # 7. NEXT ROUND
     round += 1
 
 if round > 20:
-    manifest[branch].status = "CAP-REACHED"
-    terminal_reason = f"20 rounds; remaining major items in last review"
+    if any_round_pushed_fixes():
+        manifest[branch].status = "CONVERGED-AT-CAP"
+        terminal_reason = (f"{round-1} rounds applied; remaining items "
+                            "captured for PR body")
+    else:
+        manifest[branch].status = "CAP-REACHED"
+        terminal_reason = "20 rounds, no convergence"
 ```
 
 ## Round-counter persistence
 
-The round counter lives in the manifest entry's `rounds` field. `run-codex-review.py` increments it after each successful review write. The coordinator never increments it manually — every increment must correspond to a written round-log file at `<rounds-dir>/<slug>.<N>.json`.
+The round counter lives in the manifest entry's `rounds` field. `run-codex-review.py` increments it after each successful review write. Main agent never increments it manually — every increment must correspond to a written round-log file at `<rounds-dir>/<slug>.<N>.json`.
 
-If the coordinator restarts mid-loop (process crash, host reboot), it reads `rounds` from the manifest and resumes at `rounds + 1`.
+If main agent restarts mid-loop (host reboot, fresh session), it reads `rounds` from the manifest and resumes at `rounds + 1`.
 
 ## Why 20
 
@@ -121,13 +147,13 @@ If a branch genuinely needs >20 rounds, the right answer is **decompose**: split
 
 ## Why 3 consecutive all-rejected → DONE
 
-If the worker (using `/do-review`) decides every major item is a false positive for 3 rounds in a row, Codex is stuck on items the evaluator has already determined aren't real. Continuing the loop is wasted compute — Codex won't change its mind, and the worker won't change theirs.
+If main agent (using `/do-review` in own context) decides every major item is a false positive for 3 rounds in a row, Codex is stuck on items the evaluator has already determined aren't real. Continuing the loop is wasted compute — Codex won't change its mind, and main agent won't change its.
 
-The coordinator marks DONE with `terminal_reason: "3 consecutive all-rejected; Codex stuck on rejected items"`. Phase 5 proceeds to PR creation. The PR body should mention the persistent rejected items so the human reviewer knows the worker considered them and disagreed.
+Main agent marks DONE with `terminal_reason: "3 consecutive all-rejected; Codex stuck on rejected items"`. Phase 5 proceeds to PR creation. The PR body should mention the persistent rejected items so the human reviewer knows main agent considered them and disagreed.
 
-## Validation step (worker's responsibility)
+## Validation step (Applier's responsibility)
 
-Skip re-review if the worker broke the build. The classifier can't tell the difference between "Codex found a real bug" and "Codex found the syntax error the worker just introduced". The worker validates BEFORE pushing:
+Skip re-review if the Applier broke the build. The classifier can't tell the difference between "Codex found a real bug" and "Codex found the syntax error the Applier just introduced". The Applier validates BEFORE pushing:
 
 | Repo type | Validation |
 |---|---|
@@ -137,32 +163,34 @@ Skip re-review if the worker broke the build. The classifier can't tell the diff
 | Skills repo with validator | `python3 <repo-root>/scripts/validate-skills.py` |
 | Multi-language | the project's `Makefile` `lint` / `check` target |
 
-If validation fails, the worker reverts the bad commit, retries once, else FAILED for that round (worker hands back FAILED; coordinator marks branch FAILED).
+If validation fails, the Applier reverts the bad commit, retries once, else hands back FAILED. Main agent marks the branch FAILED.
 
 ## Push rules
 
 - Always to `origin`. The branch was pushed `-u` in Phase 2.
 - **Never `--force`** while a review is in flight — invalidates inline review attribution and breaks the round-log → review-id mapping.
 - Never push to upstream. Hard rule from `skills/run-repo-cleanup/references/fork-safety.md`.
-- If a push is rejected (non-fast-forward), someone else pushed to the branch. The worker stops; coordinator decides (typically FAILED).
+- If a push is rejected (non-fast-forward), someone else pushed to the branch. The Applier hands back FAILED; main agent decides (typically FAILED at branch level).
 
-## Per-round evaluation (the `/do-review` step)
+## Per-round evaluation (main agent's `/do-review` step)
 
-The worker's central act each round is **evaluation via `/do-review`** before applying. Per `references/review-evaluation-protocol.md`:
+Main agent's central act each round (step 3 of the loop pseudocode) is **per-item evaluation via `Skill(do-review)` in own context**. Per `references/review-evaluation-protocol.md`:
 
 ```
 For each major item from the classifier:
-  1. Read the cited code in the worktree.
-  2. Use /do-review skill (Skill tool: skill='do-review').
+  1. Main agent reads the cited code in the worktree (Read tool, ±25 lines).
+  2. Main agent calls Skill(skill="do-review", args="--item ... --code ...")
+     in own context (NOT delegated to a sub-agent — empirically causes
+     decision-only failure in dispatched sub-agents).
   3. Decide:
-     - accepted (real issue, valid fix) → apply via diff-walk
-     - rejected (false positive, stale, scope creep) → record reason
-     - ambiguous (needs human) → record question
+     - accepted (real issue, valid fix) → bake fix spec into Applier brief
+     - rejected (false positive, stale, scope creep) → record reason; Applier never sees it
+     - ambiguous (needs human) → record question; do not apply
 ```
 
 Default-when-uncertain: **ambiguous**. Never silently accept. Never silently reject.
 
-Direct-apply (skipping the evaluator) is forbidden by skill invariant 11. The worker brief enforces this in its DoD: "every major item has a decision".
+Direct-apply (skipping the evaluator) is forbidden by skill invariant 11. The pseudocode above enforces this — no major item ever reaches the Applier without a prior `accepted` decision from main agent.
 
 ## State machine
 
@@ -172,98 +200,108 @@ Direct-apply (skipping the evaluator) is forbidden by skill invariant 11. The wo
                           ▼
                        SPAWNED
                           │
-              (main agent dispatches coordinator)
+              (main agent enters Phase 3 loop; per-branch round 1)
                           │
                           ▼
                        IN-LOOP
                           │
           ┌───────────────┼─────────────────────┬───────────────────────┐
           ▼               ▼                     ▼                       ▼
-     classifier:     classifier:            worker hands back        worker hands
-     no major        ≥1 major               with all-rejected        back FAILED
+     classifier:     classifier:            main-agent decisions    Applier hands
+     no major        ≥1 major               all-rejected            back FAILED
           │               │                     │                       │
           ▼               ▼                     ▼                       ▼
-        DONE         dispatch worker      all_rejected_streak += 1    FAILED
+        DONE      main agent /do-review  all_rejected_streak += 1    FAILED
+                  per item, then              │
+                  dispatch Applier            ▼
+                          │              if streak >= 3:
+                          ▼                  DONE
+              (Applier applies + pushes)   else continue
                           │                     │
-                          ▼                     ▼
-              (worker applies + pushes)    if streak >= 3:
-                          │                       DONE
-              (handback to coordinator)         else continue
+              (handback: pushed:bool)           │
                           │                     │
                           ▼                     ▼
                     round += 1, loop      round += 1, loop
                           │
-                rounds == 20 with major
+                rounds == 20 with major still present
                           │
                           ▼
-                    CAP-REACHED
+            len(round_history) ≥ 1 with pushed fixes?
+                  yes / no
+                  ▼     ▼
+          CONVERGED-AT-CAP / CAP-REACHED
 
    Anywhere in IN-LOOP: persistent ambiguity (≥2 ambiguous items, or
-   ambiguous-then-recurring) → coordinator marks BLOCKED.
+   ambiguous-then-recurring across rounds) → main agent marks BLOCKED.
 ```
 
 ## Terminal states
 
-| State | Means | Auto-merged in Phase 5? |
+(See SKILL.md "Convergence taxonomy" — single source of truth. Summary:)
+
+| State | Means | PR? |
 |---|---|---|
-| `DONE` (no-major) | Last classifier output had `major == []` | yes (Phase 5 opens PR) |
-| `DONE` (3-all-rejected) | 3 consecutive rounds where worker rejected all major items | yes (Phase 5 opens PR; body mentions rejected items) |
-| `CAP-REACHED` | 20 rounds reached; ≥1 major still present after worker's evaluation | **no** — surface for human |
-| `BLOCKED` | Persistent ambiguity (worker can't decide; needs human) | **no** — surface for human |
-| `FAILED` | Tooling failure (codex crashed, push rejected, validation kept failing) past retry budget | **no** — surface for human |
+| `DONE` (no-major) | Last classifier output had `major == []` | yes |
+| `DONE` (3-all-rejected) | 3 consecutive rounds where main-agent rejected all major items | yes (PR body mentions rejected items) |
+| `CONVERGED-AT-CAP` | 20 rounds (or configured cap); ≥1 round of fixes pushed; remaining items deferred to PR body | yes |
+| `CAP-REACHED` | 20 rounds reached, no convergence at all (no rounds pushed fixes) | **no** — surface for human |
+| `BLOCKED` | Persistent ambiguity / contradictions | **no** — surface |
+| `FAILED` | Tooling crash past retry budget | **no** — surface |
 
 ## When to mark BLOCKED
 
-The coordinator marks `BLOCKED` when:
+Main agent marks `BLOCKED` when:
 
-- Worker reports ambiguous items in 2+ consecutive rounds, AND the items are roughly the same item recurring.
-- Worker reports ambiguous items where the question requires architectural input outside the branch's scope.
-- Two consecutive workers' decisions contradict on the same item ("apply Codex's fix" then "the prior fix made things worse, reject any further attempt").
+- `/do-review` returned ambiguous in 2+ consecutive rounds, AND the items are roughly the same recurring item.
+- `/do-review` returned ambiguous where the question requires architectural input outside the branch's scope.
+- Cross-round decision contradicts (round N said apply Codex's fix; round N+1 said the prior fix made things worse — reject any further attempt).
 
 In all cases, persist the ambiguity into the manifest's `terminal_reason` for human triage. Phase 5 will skip BLOCKED branches.
 
 ## Why per-round, not per-major-item
 
-The worker reviews → evaluates → applies ALL accepted items in one round → pushes → re-reviews. Per-item dispatches would be slower (one Codex call per fix) and would fragment commit history. One commit per accepted item per round is the right granularity: small enough to bisect, big enough to not flood the PR.
+Main agent evaluates ALL major items in one round, dispatches ONE Applier per branch per round to apply all accepted items, pushes once, re-reviews. Per-item dispatches would be slower (one Codex call per fix) and would fragment commit history. One commit per accepted item per round is the right granularity: small enough to bisect, big enough to not flood the PR.
 
-## Coordinator vs main agent
+## Failure recovery
 
-The main agent dispatches N coordinators in parallel (one per branch). Coordinators run their loops independently. The main agent does NOT enter coordinators' loops to check progress — it monitors via `loop-status.py` (read-only).
-
-If a coordinator crashes (heartbeat stale via manifest mtime), main agent:
+If an Applier crashes (heartbeat stale via manifest mtime), main agent:
 
 1. Reads manifest entry to determine state.
-2. Decides: redispatch the coordinator (resumes from `rounds + 1`) OR mark FAILED.
+2. Re-dispatches the Applier with the same brief (resumes from `rounds + 1`).
 3. After 2 redispatches without progress, mark FAILED for that branch.
 
-## Hard rules (coordinator + worker must enforce)
+## Hard rules
 
-- One coordinator per branch.
-- One fresh worker per round.
-- Always `--background` Codex review.
-- 20-round hard cap. Never raise.
+- Main agent IS the coordinator; no Coordinator sub-agent.
+- One fresh Applier per round per branch.
+- Codex review is invoked via `scripts/run-codex-review.py` (which internally calls `codex-companion.mjs review --json`).
+- 20-round hard cap. Never raise. Above 20 → `CONVERGED-AT-CAP` (if any rounds pushed fixes) or `CAP-REACHED` (if no rounds pushed at all).
 - Never `--force` push.
 - Never amend.
 - Never touch `main`.
 - Never push to upstream.
 - Never decide DONE without classifier exit 1 OR 3-all-rejected streak.
 - Never increment `rounds` without a corresponding round-log file.
-- Worker NEVER applies an item without `/do-review` evaluation.
-- Worker NEVER skips a major item without recording a decision.
-- Coordinator NEVER bypasses the worker (no direct edits to the worktree).
+- Main agent NEVER skips `/do-review` evaluation for an accepted item (invariant 11).
+- Applier NEVER invokes `/do-review` (decisions are pre-made; framing causes decision-only failure).
+- Applier NEVER skips an accepted item without recording a decision in the round-log JSON.
+- Main agent NEVER bypasses the Applier (no direct edits to the worktree during Phase 3).
 
 ## Anti-patterns
 
 | Anti-pattern | Why it fails |
 |---|---|
-| Coordinator does the work itself instead of dispatching workers | Brief discipline degrades; round-N stale context contaminates round-N+1 |
-| Worker applies items without `/do-review` evaluation | Direct-apply violates invariant 11; false positives ship |
-| Worker pushes without validating | Validation failures get classified as Codex bugs in next round |
-| Coordinator increments rounds without round-log file | Round counter drifts; can't bisect later |
+| Dispatching a Coordinator sub-agent per branch (older pattern) | Long-lived sub-agents drift; depth-2 dispatch is brittle in Claude Code |
+| Worker brief mentioning `/do-review` | Empirically causes 100% decision-only failure (sub-agents stop at "Verdict: apply") |
+| Main agent applies fixes itself instead of dispatching an Applier | The user's spec demands sub-agent application; also Phase 3 is parallel-N-branches, main agent can't apply N branches concurrently |
+| Applier pushes without validating | Validation failures get classified as Codex bugs in next round |
+| Round counter increments without a round-log file | Round counter drifts; can't bisect later |
 | `--force` push on a branch with active review | Invalidates round-log → review-id mapping |
 | Skip the 3-all-rejected check | Codex loops on rejected items forever; cap-reached triggers without progress |
 | Re-evaluate prior-round rejected items | The decision was made; don't re-litigate |
+| Inventing a `DONE-PRAGMATIC` state when round-budget is exhausted | Use `CONVERGED-AT-CAP` (taxonomy is closed) |
+| Asking the user "how should I proceed?" at the end of Phase 3 | The user authorized full flow; proceed to Phase 5 (see SKILL.md "Authorization rule") |
 
 ## Bottom line
 
-Phase 3 is parallel branches via coordinator sub-agents, each running a fresh-worker-per-round loop. Workers evaluate via `/do-review` before applying. Convergence is no-major OR 3-all-rejected. Cap is 20 rounds. Failure modes are well-defined. The brief discipline (per MISSION_PROTOCOL) is what separates a good convergence from a noisy one.
+Phase 3 is parallel branches under main agent's coordination, each running a fresh-Applier-per-round loop. Main agent evaluates via `/do-review` before dispatching the Applier; Applier applies the pre-decided fixes mechanically. Convergence is no-major OR 3-all-rejected. Cap is 20 rounds (`CONVERGED-AT-CAP` if any rounds applied fixes; `CAP-REACHED` if none did). Failure modes are well-defined. The brief discipline (per MISSION_PROTOCOL) plus the eval/apply role split is what separates a good convergence from a noisy one.

--- a/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
@@ -2,7 +2,7 @@
 
 Phases 6–8 of this skill. After a PR is opened (Phase 5), this protocol governs:
 - Triggering Codex rescue as the last automated check.
-- Waiting for external review bots (Copilot, Greptile, Devin, plus any humans).
+- Waiting for external review bots (Copilot, copilot-pull-request-reviewer, Greptile, Devin, cubic-dev-ai, plus any humans). Bot list expands over time as new code-review bots are installed on the repo; the comment-poller works against the GitHub API and surfaces whatever lands, so adding a new bot does not require skill changes.
 - Adaptive end condition: 900s base + extension if comments still flowing + termination on quiet.
 - Hand-off to Phase 7 evaluator sub-agent.
 - Phase 8 main-agent direct apply.
@@ -24,23 +24,39 @@ Codex rescue is **Codex's own background sub-agent**, not a Claude sub-agent we 
 python3 scripts/trigger-codex-rescue.py --pr <number> --branch <b>
 ```
 
-The script:
+There are two valid invocation paths for Phase 6 rescue from main agent. Pick by context:
+
+**A. Interactive context (chat directive):** Type `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <number>` in the chat. The slash command dispatches a Codex sub-agent via the `Agent` tool internally. Use this when main agent has a few PRs and you're not in a parallel loop.
+
+**B. Programmatic loop context (sanctioned for Phase 6 with N PRs):**
+
+```bash
+Bash(run_in_background=True):
+  cd <worktree-path> && \
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task \
+       --write --fresh --effort xhigh \
+       "<comprehensive review prompt for PR #<n>>"
+```
+
+This is the **same code path** the `/codex:resc` slash command runs internally — `/codex:resc`'s frontmatter dispatches a Codex sub-agent via `node codex-companion.mjs task`. In a programmatic loop where main agent dispatches N rescue jobs in parallel, the Bash invocation is cleaner than typing N slash-command directives. Both are sanctioned; the companion-script path is NOT a workaround.
+
+The `task` subcommand is the public interface for "run a Codex sub-agent on this prompt". `--write` means "post the review back to the PR thread"; `--fresh` means "no prior session bias"; `--effort xhigh` is the heaviest reasoning budget for one-shot last-check rescues.
+
+`scripts/trigger-codex-rescue.py` wraps this for batch use; it:
 1. Reads the manifest entry for `<branch>` to get `worktree_path`.
-2. Inside that worktree, invokes the Codex rescue CLI form:
-   ```
-   codex review --rescue --background --fresh --model gpt-5.5 --effort xhigh --pr <number>
-   ```
-   (Adjustment point in the script; the actual CLI form depends on your Codex install.)
-3. Captures the rescue job id from stdout.
+2. Inside that worktree, dispatches `node codex-companion.mjs task --write --fresh --effort xhigh "<prompt>"` via Bash run_in_background.
+3. Captures the resulting Codex job id.
 4. Writes `rescue_review_id` and `rescue_started_at` to the branch's manifest entry.
 5. Returns immediately (does not poll).
 
 ### Why "fresh" and "xhigh effort"
 
+These are arguments passed to the `/codex:resc` slash command, not shell flags:
+
 - **`--fresh`**: no prior session bias. Codex rescue evaluates the PR cold; it doesn't carry over the inner-loop's context.
 - **`--model gpt-5.5`**: stronger reasoning than the inner-loop's default model. The rescue is a last check; it deserves the heavier model.
 - **`--effort xhigh`**: Codex spends more compute. Acceptable here because rescue is one-shot per PR, not per round.
-- **`--background`**: Codex queues the job; we don't block waiting for it.
+- Background execution is governed by the codex plugin itself (rescue runs out-of-band by default); there is no `--background` argument to set explicitly.
 
 ## Phase 6 — adaptive review window
 
@@ -143,38 +159,72 @@ Key brief points:
 - **Verification**: `git status` in worktree returns empty (no drift); JSON has decisions for all items.
 - **Failure**: missing decision → mark ambiguous; stale citation → reject; can't determine → ambiguous (never silently accept).
 
-## Phase 8 — main-agent direct apply
+## Phase 8a — main-agent direct apply (per-PR sequential; cross-PR order irrelevant)
 
-After the evaluator sub-agent hands back, **main agent acts directly** (no further sub-agent). Use `/do-review` skill in main agent's context for sanity-checking each apply.
+After the evaluator sub-agent hands back, **main agent acts directly** (no further sub-agent). The evaluator's JSON is the authority; main agent applies each accepted item mechanically. **`/do-review` re-eval per item is OPTIONAL and OFF by default** — the evaluator already used /do-review in Phase 7; double-eval is rarely worth the cost. Reserve for borderline-confidence cases.
 
-### Apply flow
+### Apply flow (per PR)
 
 ```
-Read evaluator's output JSON.
-For each accepted item (deduplicated across sources):
-    1. Read cited code (Read tool) at <worktree>/<file>:<line> ± context.
-    2. Compose the fix per evaluator's rationale + Codex/source's suggested fix.
-    3. Sanity-check via /do-review skill (in main agent's context):
-       - Does the fix align with the evaluator's rationale?
-       - Does the fix introduce regressions?
-    4. Apply via Edit (with diff-walk discipline).
-    5. git add <files>.
-    6. git diff --cached (verify only intended hunks).
-    7. git commit -m "<emoji> <type>(<scope>): apply <source>'s <item-id>"
-       — or one commit per logical concern (better; matches inner-loop discipline).
+Read <repo>/.codex-review-rounds/pr-<n>.evaluation.json.
 
+# AMBIGUOUS GATE — read this FIRST, before any apply
 If ambiguous[] non-empty:
-    Mark PR BLOCKED in manifest with terminal_reason citing the items.
-    Surface in deliverable.
-    Do NOT merge.
-    Optional: open a fresh PR with the patches applied (if changes are too divergent for an in-place amendment).
+    Mark PR BLOCKED in manifest:
+      terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
+    DO NOT apply this PR's accepted items either —
+      partial-apply ships unreviewed code with half-decided intent.
+    Surface in deliverable. Do NOT merge.
+    Move to next PR.
 
-Else:
-    git push origin <branch>
-    Wait for CI green.
-    gh pr merge <number> --repo <fork>/<repo> --squash | --merge | --rebase
-       (per repo policy)
+# ACCEPTED ITEMS — only reached when ambiguous[] is empty
+For each accepted item (deduplicated across sources, first-seen rationale wins):
+    1. Read cited code at <worktree>/<file>:<line> ± 25 lines (Read tool).
+    2. Apply the evaluator's intended-shape fix via Edit.
+       If it doesn't apply cleanly (file moved, line shifted, current shape mismatch):
+         DO NOT improvise. Record `apply_failed_after_evaluation: <item-id>` in manifest.
+         Continue with remaining items. Surface at end of Phase 8a.
+    3. Stage by concern from the start:
+         git -C <worktree> add <files-for-this-concern>
+         (do NOT stage all then `git restore --staged .` to peek and restage)
+    4. git -C <worktree> diff --cached  # verify only intended hunks
+    5. git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject> (#<pr>)"
+       — Note the (#<pr>) suffix for traceability.
+       — One concern per commit by default.
+       — Multi-concern allowed IFF tightly coupled to same file AND
+         message lists each concern as a bullet (the bullets are the
+         accountability — they document the audit trail).
+
+# OPTIONAL sanity-check
+For borderline confidence items only (not by default):
+    Skill(skill="do-review", args="--item <body> --code <cited_code>")
+    If main agent disagrees with the evaluator's accept decision:
+      Mark item ambiguous; revert; surface — do not push the disagreement.
+
+# VALIDATE before push
+pnpm run build && pnpm test  # or repo-equivalent per AGENTS.md/CONTRIBUTING.md
+If validation fails:
+    Revert the offending commit. Mark item ambiguous. Surface — do not retry blindly.
+
+# PUSH (no merge yet)
+git -C <worktree> push origin <branch>   # NEVER --force
 ```
+
+Process PRs in any order in 8a. Foundation→leaf is enforced in 8b.
+
+### Phase 8a apply recipe (one-shot helper)
+
+A wrapper script encapsulates the repetitive bits:
+
+```bash
+python3 <this-skill>/scripts/apply-evaluator-decisions.py \
+  --pr <n> \
+  --worktree <worktree> \
+  --eval <repo>/.codex-review-rounds/pr-<n>.evaluation.json \
+  --print-queue
+```
+
+Output: ordered apply queue with ambiguous items at the top (BLOCKED warning), then accepted items each with `file:line:intended-shape:rationale`. Read-only — does NOT modify worktree, does NOT commit, does NOT push. Main agent walks the queue, applies via Edit, validates, commits, pushes — but the queue derivation is mechanical and offloaded to the script.
 
 ### Why main-agent direct, not sub-agent
 
@@ -185,17 +235,54 @@ The evaluator's structured output is already in main agent's context. Re-dispatc
 
 Main agent applying directly keeps the chain tight: evaluator decides → main agent applies. The user's stated principle: "do-review is healthier when answers come straight back".
 
-### Optional: open a fresh PR
+## Phase 8b — merge in foundation→leaf strict serial
 
-If the evaluator's accepted set is so large or divergent that amending the current PR would muddy its history, main agent has the option to:
+Apply is done; now merge in dependency order. Foundation merges first; each leaf rebases onto the new main between merges.
 
-1. Mark the current PR as "superseded by #<new>".
-2. Branch from main again.
-3. Cherry-pick the original branch's commits + apply the accepted items.
-4. Open a new PR with `/ask-review` (Phase 5 redux for this branch).
-5. Close the original PR.
+### Merge flow
 
-This is the user's "we'll ask for a new PR if needed" path. Use sparingly — most of the time, in-place commits are simpler.
+```
+Order PRs per manifest.merge_order (foundation first, then leaves).
+
+For each PR in order:
+    # CI-WAIT GATE
+    Bash(run_in_background=True):
+      until [ "$(gh pr checks <n> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+        sleep 30
+      done
+      gh pr checks <n>
+    # Notification fires when all checks land terminal state.
+
+    If any check is `failure` or `cancelled`:
+        Mark PR BLOCKED with terminal_reason: "CI failure: <check-name>"
+        Surface; do NOT merge; continue with next PR.
+        Exception: if THIS is foundation, STOP — do not merge any leaves.
+
+    Else:
+        gh pr merge <n> --repo <fork>/<repo> --squash
+          (or --merge / --rebase per repo policy from AGENTS.md)
+
+    After merge:
+        git fetch --all --prune
+        For every leaf PR not yet merged:
+            git -C <leaf-worktree> rebase origin/main
+            git -C <leaf-worktree> push --force-with-lease origin <leaf-branch>
+            (--force-with-lease, NOT --force; safe because no review is in flight
+             and Phase 1's backup ref preserves the original commits.)
+```
+
+### Foundation must succeed first
+
+Leaves are based on foundation. If foundation can't merge (CI fails, conflict): STOP — do not merge any leaves; surface foundation BLOCKED to the human. The human resolves foundation, then re-runs Phase 8b on the leaves.
+
+### Optional: open a fresh PR for `apply_failed_after_evaluation`
+
+If Phase 8a recorded items as `apply_failed_after_evaluation` (intended-shape didn't apply because file/line drifted), surface them at end of 8a. The human decides:
+
+1. Re-run Phase 7 evaluator with current code (preferred), OR
+2. Branch from main again, cherry-pick the original branch's commits + apply the failed items by hand, open a new PR (Phase 5 redux), close the original PR.
+
+Don't auto-cycle — surface and let the human pick.
 
 ## Failure modes
 
@@ -213,13 +300,31 @@ The Phase 7 evaluator handles a single source (or no source) gracefully. If the 
 
 `await-pr-reviews.py` terminates with `wait_terminated_by: "total_cap"`. The current state is gathered. Phase 7 evaluates what we have. Late-arriving comments after evaluation are surfaced for human attention but don't block merge — the bot will still see them on the merged commit if it cares.
 
-### Evaluator marks everything ambiguous
+### Evaluator marks anything ambiguous (the BLOCKED gate)
 
-Surface for human triage. Do not merge. Likely cause: PR is too broad or too cross-cutting; consider splitting in a follow-up.
+**An item marked `ambiguous` by the evaluator means**: real issue OR false positive can't be determined without human input.
+
+**Rule**: a single ambiguous item BLOCKS the entire PR. Do NOT half-apply (don't ship the accepted items and defer the ambiguous ones — that ships unreviewed code with a half-decided intent). Defer the entire PR.
+
+Per ambiguous item, main agent records:
+1. `manifest.pr.terminal_reason: "ambiguous: <item-id>: <evaluator's exact question>"`.
+2. Skip apply for that PR's accepted items too.
+3. Surface in final deliverable with the evaluator's exact question.
+4. Do NOT merge.
+
+If the evaluator marks **everything** ambiguous, surface the whole PR for human triage. Likely cause: PR is too broad or too cross-cutting; consider splitting in a follow-up.
 
 ### Evaluator's accepted fix breaks CI
 
-Phase 8 push fails CI. Revert the bad commit on the branch (don't force-push; commit a revert), mark the item ambiguous in the manifest with `terminal_reason: "post-apply CI failure: <details>"`, surface for human.
+Phase 8a push fails CI in 8b. Revert the bad commit on the branch (don't force-push; commit a revert), mark the item `apply_failed_validation` in the manifest with `terminal_reason: "post-apply CI failure: <details>"`, surface for human.
+
+### Phase 8a intended-shape doesn't apply cleanly (`apply_failed_after_evaluation`)
+
+The evaluator's `intended-shape` references a file:line that has drifted (file moved, line shifted, surrounding code refactored between Phase 7 and Phase 8a). DO NOT improvise a fix.
+
+Record `apply_failed_after_evaluation: <item-id>` in manifest. Continue with remaining items. Surface at end of Phase 8a. Human decides:
+1. Re-run Phase 7 evaluator with current code (preferred), OR
+2. Apply by hand and open a fresh PR (Phase 5 redux for that branch).
 
 ### Cross-source contradiction can't be resolved
 
@@ -271,7 +376,8 @@ The 900s+ wait exceeds the 5-minute prompt cache TTL. After the wait, the next a
 |---|---|
 | Skip Phase 6, merge fast | Loses the value of external review entirely. The whole skill exists to harvest reviewer feedback. |
 | Trust copilot's items blindly | Copilot is a reviewer like any other. Evaluator first. |
-| Run codex rescue inline (not `--background`) | Blocks the agent for 1–5 min. Defeats the parallel orchestration. |
+| Invoke codex rescue from Bash (`codex review --rescue …`) | There is no such CLI surface. Use `Skill(codex:resc, …)` — slash command, not shell. |
+| `node …/codex-companion.mjs task …` directly from a sub-agent brief | The wrapper does that, plus discovery + manifest update + (optional) status polling. Use the wrapper. |
 | Wait less than 900s by default | Bots that arrive at minute 13 are missed; their feedback is lost. |
 | Wait more than total_cap | Indefinite wait = dead session. Cap is the safety. |
 | Auto-merge after Phase 8 even with ambiguous items | Ambiguous means human-in-the-loop. Auto-merge defeats the gate. |

--- a/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
@@ -56,7 +56,8 @@ These are arguments passed to the `/codex:resc` slash command, not shell flags:
 - **`--fresh`**: no prior session bias. Codex rescue evaluates the PR cold; it doesn't carry over the inner-loop's context.
 - **`--model gpt-5.5`**: stronger reasoning than the inner-loop's default model. The rescue is a last check; it deserves the heavier model.
 - **`--effort xhigh`**: Codex spends more compute. Acceptable here because rescue is one-shot per PR, not per round.
-- Background execution is governed by the codex plugin itself (rescue runs out-of-band by default); there is no `--background` argument to set explicitly.
+- **`--background`**: codex-companion's `task` subcommand DOES honor `--background` (unlike `review`, which always runs synchronously). With `--background`, the wrapper returns `{ jobId, status: "queued", title, logFile }` immediately and the rescue review runs in a detached worker. The wrapper script `trigger-codex-rescue.py` always passes `--background`; without it the wrapper would block for the entire rescue duration (1-5 minutes per PR × N PRs serially).
+- **`--write`**: instructs Codex to post the rescue review back to the PR as a comment.
 
 ## Phase 6 — adaptive review window
 
@@ -237,39 +238,57 @@ Main agent applying directly keeps the chain tight: evaluator decides → main a
 
 ## Phase 8b — merge in foundation→leaf strict serial
 
-Apply is done; now merge in dependency order. Foundation merges first; each leaf rebases onto the new main between merges.
+Apply is done; now merge in dependency order. Foundation merges first; each leaf retargets to main and rebases with `--onto` to skip the squashed foundation commits before merging individually.
+
+### Why `--onto` (not plain `git rebase origin/main`)
+
+Squash-merging foundation collapses N foundation commits into 1 squashed commit on main with a different SHA. Plain `git rebase origin/main` on a leaf branch tries to re-apply both copies of foundation (the original N commits in leaf history AND the squashed commit on main) — git can't detect the equivalence and conflicts on every foundation hunk. `git rebase --onto origin/main <foundation_pre_merge_tip> <leaf>` fast-forwards past the original foundation tip and replays only the leaf-specific commits onto the new main.
 
 ### Merge flow
 
 ```
 Order PRs per manifest.merge_order (foundation first, then leaves).
 
-For each PR in order:
-    # CI-WAIT GATE
+# 0. Capture foundation's pre-merge tip BEFORE merging — required for --onto below.
+foundation_tip=$(git -C <foundation-worktree> rev-parse HEAD)
+manifest['foundation_pre_merge_tip']=$foundation_tip
+
+# 1. Merge foundation
+Wait CI green for foundation:
     Bash(run_in_background=True):
-      until [ "$(gh pr checks <n> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+      until [ "$(gh pr checks <foundation-pr> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
         sleep 30
       done
-      gh pr checks <n>
-    # Notification fires when all checks land terminal state.
+      gh pr checks <foundation-pr>
 
-    If any check is `failure` or `cancelled`:
-        Mark PR BLOCKED with terminal_reason: "CI failure: <check-name>"
-        Surface; do NOT merge; continue with next PR.
-        Exception: if THIS is foundation, STOP — do not merge any leaves.
+If any check is `failure` or `cancelled` for foundation:
+    STOP — do not merge any leaves. Surface foundation BLOCKED.
+Else:
+    gh pr merge <foundation-pr> --repo <fork>/<repo> --squash --delete-branch
+    git fetch --all --prune
 
+# 2. Retarget + rebase --onto + push every leaf (one batch, parallelizable across leaves)
+for leaf_pr in <leaf-prs>:
+    leaf_branch=$(gh pr view "$leaf_pr" --json headRefName --jq .headRefName)
+    leaf_worktree=<from manifest>
+
+    gh pr edit "$leaf_pr" --base main
+    git -C "$leaf_worktree" fetch origin
+    git -C "$leaf_worktree" rebase --onto origin/main "$foundation_tip" "$leaf_branch"
+    git -C "$leaf_worktree" push --force-with-lease origin "$leaf_branch"
+    # --force-with-lease (NOT --force); safe because Phase 1's backup ref
+    # preserves the original commits.
+
+# 3. Merge each leaf in order (sequential; NOT --auto)
+for leaf_pr in <leaf-prs-in-order>:
+    Wait CI green for leaf
+    If failure/cancelled: mark leaf BLOCKED; continue (do NOT halt; only foundation halts)
     Else:
-        gh pr merge <n> --repo <fork>/<repo> --squash
-          (or --merge / --rebase per repo policy from AGENTS.md)
-
-    After merge:
+        gh pr merge "$leaf_pr" --repo <fork>/<repo> --squash --delete-branch
         git fetch --all --prune
-        For every leaf PR not yet merged:
-            git -C <leaf-worktree> rebase origin/main
-            git -C <leaf-worktree> push --force-with-lease origin <leaf-branch>
-            (--force-with-lease, NOT --force; safe because no review is in flight
-             and Phase 1's backup ref preserves the original commits.)
 ```
+
+`--auto` works for foundation (single-step) but is unreliable for leaves on divergent stacks. Use sequential explicit merge with CI-wait between leaves.
 
 ### Foundation must succeed first
 

--- a/skills/run-codex-review/skills/run-codex-review/references/thinking-steering.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/thinking-steering.md
@@ -127,7 +127,7 @@ Asking is not failure. Wrong moves on these are irreversible.
 
 ## The decompose → step back → watch reflex
 
-The single most important shift from `run-repo-cleanup`'s flow to this one: **after Phase 2, the main agent stops editing.** Phase 3 dispatches coordinators; main agent monitors. Phase 5 dispatches PR-Creators; main agent waits. Phase 7 dispatches Evaluators; main agent waits. Only Phase 8 brings main agent back in as actor.
+The single most important shift from `run-repo-cleanup`'s flow to this one: **after Phase 2, the main agent stops editing files** but stays in the driver's seat for orchestration. Phase 3: main agent runs codex review wrappers, evaluates major items via `Skill(do-review)` in own context, dispatches per-round Appliers. Phase 5: main agent dispatches PR-Creators; waits. Phase 7: main agent dispatches Evaluators; waits. Phase 8: main agent applies the evaluator's accepted subset directly. Editing inside worktrees is sub-agent territory; orchestration is main agent's territory throughout.
 
 If you find yourself opening a worktree to "check on it" or "fix something quickly", you've already broken the protocol. The sub-agent's writes and yours can race. The classifier's exit code, the worker's handback, the evaluator's JSON — those are the only signals you should be acting on.
 
@@ -150,6 +150,28 @@ Before every Agent dispatch, run the brief discipline checklist (in `parallel-su
 - [ ] Brief ≤ 5,000 words.
 
 If any unchecked, revise. Cost: 1 minute. Saves: hours of wrong work.
+
+## Forbidden inventions
+
+Do **not**, under any phase, propose:
+
+- **A "smoke test" or pilot before Phase 3 fan-out.** The skill prescribes parallel dispatch from round 1. A smoke test is not in the workflow. If the codex plugin is unavailable, you find out at dispatch time and surface FAILED — you do not pre-test.
+- **Re-introducing a Coordinator sub-agent layer.** That pattern was tried; it does not work in production (long-lived sub-agents drift, depth-2 dispatch is brittle). Main agent IS the coordinator across all branches — see `parallel-subagent-protocol.md` "Coordinator role". If your instinct says "I should dispatch a coordinator subagent per branch", you are recreating the old pattern.
+- **Writing a custom MISSION_PROTOCOL brief inline** rather than instantiating one of the four templates in `parallel-subagent-protocol.md` (Coordinator / Worker / PR-Creator / Evaluator). If the brief feels off, fix the *template*; do not bypass it.
+- **A shim, wrapper, or fallback for any slash command.** `/codex:review`, `/codex:resc`, `/ask-review`, `/do-review` either exist (use them via `Skill(...)`) or do not (surface and stop). There is no third path.
+- **Confirming a pinned default with the user.** Defaults in the Pinned Defaults table are pinned. Auto-detect (repo mode, manifest path) or proceed. Only ask when a destructive choice is genuinely ambiguous and not derivable from local state.
+- **Reading `scripts/run-codex-review.py` or `scripts/trigger-codex-rescue.py` looking for the "real" invocation.** The wrappers ARE the active path: `run-codex-review.py` is what sub-agents call (it bridges to `codex-companion.mjs review --json` because `/codex:review` is `disable-model-invocation: true` for sub-agents). For main agent, `/codex:resc` is the slash command for Phase 6. Either way, do not invent a parallel script.
+- **Multi-question opening confirmations** ("OK to proceed with B1–B5? Max rounds 20? Codex CLI ready?"). The user's first prompt is the authorization. Detect what's detectable and execute.
+- **Pre-flight environment probing for tool reachability.** No `codex login status`, `codex --version`, `codex doctor`, `ls .../node_modules`, `command -v <tool>`, or other "is the environment ready" probes. Such probes assume a default configuration (one specific auth path, one package manager, one project layout) that often doesn't match the user's actual setup — users routinely run with custom providers, alternate auth, or atypical layouts where the probe reports "broken" while the real workflow runs fine. The slash-command dispatch and the worker's own validation step are the only valid tests; if they truly fail you hand back FAILED with `terminal_reason` and surface to the user. **Never** present a multi-option resolution menu (A/B/C…) to fix an environment configuration the user did not ask you to touch.
+- **Bridging plugin-internal scripts with a "small shim".** Shims are forbidden by invariant 17. The right path per surface is in the SKILL.md invocation matrix.
+- **End-of-phase option menus** ("Full Phase 5-8 / Phase 5 only / Foundation only / Pause"). The user authorized full flow at skill invocation. Proceed phase-to-phase without checkpoint. (See SKILL.md "Authorization rule".)
+- **Cost-and-time paralysis prefaces** ("multi-hour, multi-thousand-token operation"). The user knows; the user authorized. Stating it again is stalling, not transparency. Just execute.
+- **Verbose end-of-phase state tables.** The Final Deliverable in Phase 9 is the place for per-branch summaries. Mid-flight, one sentence: "Phase X complete; entering X+1."
+- **Inventing terminal states** like `DONE-PRAGMATIC`, `READY-ENOUGH`, `MOSTLY-DONE`. The taxonomy is fixed: `DONE`, `CONVERGED-AT-CAP`, `CAP-REACHED`, `BLOCKED`, `FAILED`. If reality doesn't fit, surface a real `BLOCKED` with `terminal_reason`.
+- **`/do-review` framing in worker briefs.** Empirically causes 100% decision-only failure. Decisions are made by main agent before dispatch; workers are appliers.
+- **Hand-rolled bash polling loops** (`until grep -qE "Reviewer (finished|failed)" …`) for codex review status. Use the wrapper script's exit code; use Monitor for terminal markers; use Bash `run_in_background` for the dispatch itself. Polling loops are a sign the wrapper contract is broken — fix the wrapper, don't paper it over.
+
+These inventions cost the user 10–15 minutes per session in the wild. Don't.
 
 ## The bottom line
 

--- a/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.md
@@ -1,0 +1,126 @@
+# apply-evaluator-decisions.py
+
+Print the ordered apply queue for one PR's Phase 8a main-agent direct apply. Read-only against the worktree. Reduces Phase 8a main-agent overhead from ~10 tool calls to ~5 per PR by offloading the queue derivation: dedup across sources, ambiguous-first BLOCKED gate, accepted items rendered with `file:line` + intended-shape + rationale + commit-message scaffold.
+
+## Usage
+
+```bash
+# Default: human-readable apply queue
+python3 scripts/apply-evaluator-decisions.py \
+    --pr 53 \
+    --worktree /Users/.../wt-feat-foo \
+    --eval /repo/.codex-review-rounds/pr-53.evaluation.json
+
+# Machine-readable (for downstream tooling)
+python3 scripts/apply-evaluator-decisions.py \
+    --pr 53 --worktree /path --eval /path/to.json --json
+```
+
+## Behavior
+
+1. Read `<eval-path>`, validate it's an object, check that `--pr` matches `payload.pr`.
+2. Group items by `decision` (`accepted | rejected | ambiguous`).
+3. Dedup accepted items by `(file, line_start, title-prefix-60)` — first source wins. Production traces show 4+ bots flagging the same issue with slightly different wording; main agent applies once.
+4. If ANY item is ambiguous: print BLOCKED gate first (the whole PR is blocked; main agent must not apply accepted items either). Exit 1.
+5. Else if no accepted items: print no-op message. Exit 3.
+6. Else: print apply queue with each item's `file:line`, current shape, intended shape, rationale, and commit-message scaffold (`(#<pr>)` suffix). Exit 0.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--pr <n>` | required | PR number; cross-checked against `payload.pr` to catch mistyped invocations. |
+| `--worktree <path>` | required | Worktree path. Informational — the script doesn't read worktree contents. |
+| `--eval <path>` | required | Path to `pr-<n>.evaluation.json` (the Phase 7 Evaluator's output). |
+| `--print-queue` | default | Human-readable queue. |
+| `--json` | off | Machine-readable JSON output (mutually exclusive with `--print-queue`). |
+
+## Exit codes
+
+| Code | Meaning | Caller (main-agent) action |
+|---|---|---|
+| `0` | Queue printed; PR has accepted items, zero ambiguous | Walk the queue, apply each, validate, push. |
+| `1` | PR is BLOCKED — at least one ambiguous item | Mark PR BLOCKED in manifest; surface; do NOT apply, do NOT merge. |
+| `2` | Evaluation file missing or malformed, OR --pr mismatches payload.pr | Investigate; do NOT apply blindly. |
+| `3` | No accepted items AND no ambiguous items | Phase 8a is a no-op for this PR; advance to Phase 8b. |
+
+## Expected `pr-<n>.evaluation.json` schema (Phase 7 Evaluator output)
+
+```json
+{
+  "pr": 53,
+  "branch": "feat/foo",
+  "totals": {"accepted": 5, "rejected": 4, "ambiguous": 1},
+  "items": [
+    {
+      "id": "<source>-<n>",
+      "decision": "accepted|rejected|ambiguous",
+      "source": "codex-rescue|copilot|cubic-dev-ai|devin|greptile|<human>",
+      "file": "src/foo.ts",
+      "line_start": 42,
+      "line_end": 42,
+      "title": "Off-by-one in slice",
+      "intended_shape": "slice(0)",
+      "current_shape": "slice(0, -1)",
+      "rationale": "clearly drops last element"
+    }
+  ]
+}
+```
+
+## Sample output (queue)
+
+```
+PR #53 — branch: feat/foo
+  totals: accepted=2 (deduped from 5 raw), rejected=4, ambiguous=0
+
+========================================================================
+APPLY QUEUE (in dedup-source order — apply each via Edit, commit per concern)
+========================================================================
+  [1/2] Off-by-one in slice
+    source:    codex-rescue
+    file:line: src/foo.ts:42
+    rationale: clearly drops last element
+    current shape:
+      slice(0, -1)
+    intended shape:
+      slice(0)
+    commit:    <emoji> <type>(<scope>): Off-by-one in slice (#53)
+  ...
+```
+
+## Sample output (BLOCKED)
+
+```
+========================================================================
+⚠  PR IS BLOCKED — DO NOT APPLY ACCEPTED ITEMS EITHER
+========================================================================
+Per Phase 8a invariant: a single ambiguous item BLOCKS the entire PR.
+Half-apply ships unreviewed code with a half-decided intent.
+
+  [AMBIGUOUS #1] <title>
+    source:    <source>
+    file:line: src/bar.ts:99
+    question:  <evaluator's question>
+
+Action: mark PR BLOCKED in manifest with terminal_reason citing the items above.
+Action: surface in deliverable. Action: do NOT merge.
+```
+
+## Read/write surface
+
+- **Reads**: `--eval` JSON file.
+- **Writes**: nothing. (Stdout only.)
+- **Does NOT**: modify the worktree, commit, push, comment on the PR, or call codex.
+
+## When to run
+
+- **Phase 8a, per PR**, after the Phase 7 Evaluator's handback. One invocation per PR.
+- Main agent walks the printed queue with Edit + git commands per item; this script does NOT do the walk.
+
+## See also
+
+- `scripts/run-codex-review.py` — Phase 3 wrapper (codex-companion review).
+- `scripts/trigger-codex-rescue.py` — Phase 6 wrapper (codex-companion task --background).
+- `references/post-pr-review-protocol.md` — full Phase 6 / 7 / 8 flow including the apply recipe.
+- `references/review-evaluation-protocol.md` — the rubric the Evaluator follows; defines the JSON shape this script consumes.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Print the ordered apply queue for a Phase 8a (main-agent direct apply).
+
+Reads the Phase 7 Evaluator's decisions JSON for one PR and prints:
+  - Ambiguous items first with a BLOCKED warning (Phase 8a must NOT apply
+    when any item is ambiguous; the whole PR is BLOCKED).
+  - Accepted items in source-deduped order with `file:line` + intended-shape
+    + rationale, ready for main agent to walk and apply via Edit.
+  - Rejected items as a footer (informational; main agent skips them).
+
+This script is **read-only**: it does NOT modify the worktree, does NOT commit,
+does NOT push. It exists so main agent can offload the queue derivation rather
+than re-deriving it inline per PR (which production traces showed costs ~5
+extra tool calls per PR × 9 PRs × multiple sessions).
+
+The expected `pr-<n>.evaluation.json` shape (produced by Phase 7 Evaluator):
+
+    {
+      "pr": 53,
+      "branch": "feat/foo",
+      "totals": {"accepted": 5, "rejected": 4, "ambiguous": 1},
+      "items": [
+        {
+          "id": "<source>-<n>",
+          "decision": "accepted|rejected|ambiguous",
+          "source": "codex-rescue|copilot|copilot-pull-request-reviewer|cubic-dev-ai|devin|greptile|<human>",
+          "file": "src/foo.ts",
+          "line_start": 42,
+          "line_end": 42,
+          "title": "...",
+          "intended_shape": "<the fix the evaluator approved>",
+          "rationale": "<why the evaluator accepted/rejected/marked ambiguous>",
+          "current_shape": "<excerpt of code as the evaluator saw it>"
+        }
+      ]
+    }
+
+Usage:
+    python3 apply-evaluator-decisions.py \\
+        --pr 53 \\
+        --worktree /path/to/wt \\
+        --eval /repo/.codex-review-rounds/pr-53.evaluation.json \\
+        --print-queue
+
+    # JSON output for downstream tools (one-line-per-item):
+    python3 apply-evaluator-decisions.py --pr 53 --worktree /path --eval /path --json
+
+Exit codes:
+    0  Queue printed; PR has accepted items to apply (and zero ambiguous).
+    1  PR is BLOCKED — at least one ambiguous item; main agent must NOT apply.
+    2  Evaluation file missing or malformed.
+    3  No accepted items AND no ambiguous items (PR done already).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def load_evaluation(path: Path) -> dict:
+    if not path.is_file():
+        raise FileNotFoundError(f"evaluation file not found: {path}")
+    try:
+        with path.open() as f:
+            payload = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"evaluation file is not valid JSON: {e}")
+    if not isinstance(payload, dict):
+        raise ValueError(f"evaluation file root must be an object, got {type(payload).__name__}")
+    return payload
+
+
+def dedupe_items(items: list[dict]) -> list[dict]:
+    """Deduplicate accepted items across review sources by (file, line, title-prefix).
+    Preserves the FIRST seen rationale (earliest source wins). Production traces
+    showed multiple bots flagging the same issue with slightly different wording;
+    main agent applies once.
+    """
+    seen: dict[tuple, dict] = {}
+    for item in items:
+        if item.get("decision") != "accepted":
+            continue
+        key = (
+            (item.get("file") or "").strip().lower(),
+            int(item.get("line_start") or item.get("line") or 0),
+            ((item.get("title") or "").strip().lower())[:60],
+        )
+        if key not in seen:
+            seen[key] = item
+    return list(seen.values())
+
+
+def render_human(payload: dict) -> tuple[str, int]:
+    """Render the apply queue for human / main-agent reading. Returns
+    (text, exit_code). exit_code semantics match the module docstring.
+    """
+    pr = payload.get("pr", "?")
+    branch = payload.get("branch", "?")
+    items = payload.get("items") or []
+
+    by_decision: dict[str, list[dict]] = defaultdict(list)
+    for item in items:
+        d = item.get("decision", "unknown")
+        by_decision[d].append(item)
+
+    ambiguous = by_decision.get("ambiguous", [])
+    accepted = dedupe_items(items)
+    rejected = by_decision.get("rejected", [])
+
+    out: list[str] = []
+    out.append(f"PR #{pr} — branch: {branch}")
+    out.append(f"  totals: accepted={len(accepted)} (deduped from {len(by_decision.get('accepted', []))} raw), "
+               f"rejected={len(rejected)}, ambiguous={len(ambiguous)}")
+    out.append("")
+
+    # Ambiguous goes FIRST so main agent sees the BLOCKED gate before the queue.
+    if ambiguous:
+        out.append("=" * 72)
+        out.append("⚠  PR IS BLOCKED — DO NOT APPLY ACCEPTED ITEMS EITHER")
+        out.append("=" * 72)
+        out.append("Per Phase 8a invariant: a single ambiguous item BLOCKS the entire PR.")
+        out.append("Half-apply ships unreviewed code with a half-decided intent.")
+        out.append("")
+        for i, item in enumerate(ambiguous, start=1):
+            out.append(f"  [AMBIGUOUS #{i}] {item.get('title', '<no title>')}")
+            out.append(f"    source:    {item.get('source', '?')}")
+            out.append(f"    file:line: {item.get('file', '?')}:"
+                       f"{item.get('line_start', item.get('line', '?'))}")
+            rationale = item.get("rationale", "").strip()
+            if rationale:
+                out.append(f"    question:  {rationale}")
+            out.append("")
+        out.append("Action: mark PR BLOCKED in manifest with terminal_reason citing the items above.")
+        out.append("Action: surface in deliverable. Action: do NOT merge.")
+        return "\n".join(out), 1  # exit 1 = BLOCKED
+
+    if not accepted:
+        out.append("No accepted items. PR is either DONE-after-eval (rejected-only)")
+        out.append("or there were no items to begin with. Phase 8a is a no-op for this PR.")
+        return "\n".join(out), 3
+
+    out.append("=" * 72)
+    out.append("APPLY QUEUE (in dedup-source order — apply each via Edit, commit per concern)")
+    out.append("=" * 72)
+    for i, item in enumerate(accepted, start=1):
+        out.append(f"  [{i}/{len(accepted)}] {item.get('title', '<no title>')}")
+        out.append(f"    source:    {item.get('source', '?')}")
+        out.append(f"    file:line: {item.get('file', '?')}:"
+                   f"{item.get('line_start', item.get('line', '?'))}"
+                   + (f"-{item['line_end']}" if item.get('line_end')
+                      and item.get('line_end') != item.get('line_start') else ""))
+        rationale = item.get("rationale", "").strip()
+        if rationale:
+            out.append(f"    rationale: {rationale}")
+        current = (item.get("current_shape") or "").rstrip()
+        intended = (item.get("intended_shape") or "").rstrip()
+        if current:
+            out.append(f"    current shape:")
+            for line in current.splitlines()[:8]:
+                out.append(f"      {line}")
+            if len(current.splitlines()) > 8:
+                out.append(f"      ... ({len(current.splitlines()) - 8} more lines)")
+        if intended:
+            out.append(f"    intended shape:")
+            for line in intended.splitlines()[:8]:
+                out.append(f"      {line}")
+            if len(intended.splitlines()) > 8:
+                out.append(f"      ... ({len(intended.splitlines()) - 8} more lines)")
+        commit_msg = (
+            f"<emoji> <type>(<scope>): {item.get('title', 'apply evaluator decision')[:60]} "
+            f"(#{pr})"
+        )
+        out.append(f"    commit:    {commit_msg}")
+        out.append("")
+
+    out.append("Reminders for main agent:")
+    out.append("  - Stage by concern from the start (do NOT `git add .` then `git restore --staged .`).")
+    out.append("  - Validate before push: `pnpm run build && pnpm test` (or repo-equivalent).")
+    out.append("  - If intended_shape doesn't apply cleanly: do NOT improvise — record")
+    out.append("    `apply_failed_after_evaluation: <id>` in manifest, continue, surface at end.")
+    out.append("  - One concern per commit by default; multi-concern only with bullets-in-message.")
+
+    if rejected:
+        out.append("")
+        out.append("-" * 72)
+        out.append(f"REJECTED ({len(rejected)}, informational — DO NOT apply):")
+        for item in rejected[:8]:
+            out.append(f"  - [{item.get('source', '?')}] {item.get('title', '<no title>')[:80]}")
+        if len(rejected) > 8:
+            out.append(f"  ... ({len(rejected) - 8} more rejected)")
+
+    return "\n".join(out), 0
+
+
+def render_json(payload: dict) -> tuple[str, int]:
+    """JSON-shaped output for downstream tooling. Returns (json_text, exit_code)."""
+    items = payload.get("items") or []
+    by_decision: dict[str, list[dict]] = defaultdict(list)
+    for item in items:
+        by_decision[item.get("decision", "unknown")].append(item)
+
+    ambiguous = by_decision.get("ambiguous", [])
+    accepted = dedupe_items(items)
+    rejected = by_decision.get("rejected", [])
+
+    if ambiguous:
+        exit_code = 1
+        status = "BLOCKED"
+    elif not accepted:
+        exit_code = 3
+        status = "NO-OP"
+    else:
+        exit_code = 0
+        status = "READY"
+
+    output = {
+        "pr": payload.get("pr"),
+        "branch": payload.get("branch"),
+        "status": status,
+        "totals": {
+            "accepted_raw": len(by_decision.get("accepted", [])),
+            "accepted_deduped": len(accepted),
+            "rejected": len(rejected),
+            "ambiguous": len(ambiguous),
+        },
+        "ambiguous": ambiguous,  # full items so caller can format BLOCKED messages
+        "queue": accepted,        # the order to walk
+        "rejected_titles": [
+            f"[{i.get('source', '?')}] {i.get('title', '')[:120]}" for i in rejected
+        ],
+    }
+    return json.dumps(output, indent=2), exit_code
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pr", type=int, required=True, help="PR number (informational)")
+    ap.add_argument("--worktree", required=True,
+                    help="Worktree path (informational; not actually read by this script)")
+    ap.add_argument("--eval", "--evaluation", dest="eval_path", required=True,
+                    help="Path to pr-<n>.evaluation.json from Phase 7")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--print-queue", action="store_true", default=True,
+                      help="(default) Human-readable apply queue")
+    mode.add_argument("--json", action="store_true",
+                      help="Machine-readable JSON output for downstream tooling")
+    args = ap.parse_args()
+
+    eval_path = Path(args.eval_path)
+    try:
+        payload = load_evaluation(eval_path)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    # Make sure the PR number in the file matches the CLI arg (catches mistyped --pr)
+    file_pr = payload.get("pr")
+    if file_pr is not None and int(file_pr) != args.pr:
+        print(f"ERROR: --pr={args.pr} but evaluation file is for PR #{file_pr} ({eval_path})",
+              file=sys.stderr)
+        return 2
+
+    if args.json:
+        text, exit_code = render_json(payload)
+    else:
+        text, exit_code = render_human(payload)
+
+    print(text)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/run-codex-review/skills/run-codex-review/scripts/audit-review-state.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/audit-review-state.py
@@ -3,15 +3,19 @@
 
 Detects:
   - Orphan worktrees matching <repo>-wt-* that aren't in the manifest.
-  - Stale or missing /tmp/codex-review-manifest.json.
+  - Stale or missing manifest at the repo-local default path.
   - Round logs whose mtime is older than --stale-minutes.
   - In-flight Codex jobs from prior runs (best-effort via manifest entries).
 
+Manifest defaults to the repo-local path `<repo-root>/.codex-review-manifest.json`
+(matches the wrappers). Override with `--manifest <path>` if you've placed the
+manifest elsewhere.
+
 Usage:
-    python3 audit-review-state.py
+    python3 audit-review-state.py                                 # repo-local defaults
     python3 audit-review-state.py --json
-    python3 audit-review-state.py --manifest /tmp/codex-review-manifest.json
-    python3 audit-review-state.py --rounds-dir /tmp/codex-review-rounds/
+    python3 audit-review-state.py --manifest /custom/path.json
+    python3 audit-review-state.py --rounds-dir /custom/rounds-dir/
     python3 audit-review-state.py --stale-minutes 60
 
 Exit codes:
@@ -31,8 +35,11 @@ import sys
 import time
 from pathlib import Path
 
-DEFAULT_MANIFEST = "/tmp/codex-review-manifest.json"
-DEFAULT_ROUNDS_DIR = "/tmp/codex-review-rounds/"
+# Defaults are computed lazily from the repo root when args are parsed —
+# see _resolve_default_paths() below. The /tmp legacy paths are checked
+# only as a fallback for older skill versions' state files.
+LEGACY_TMP_MANIFEST = "/tmp/codex-review-manifest.json"
+LEGACY_TMP_ROUNDS_DIR = "/tmp/codex-review-rounds/"
 DEFAULT_STALE_MINUTES = 60
 TERMINAL_STATES = {"DONE", "CAP-REACHED", "BLOCKED", "FAILED"}
 
@@ -252,8 +259,10 @@ def render(report: dict, audit_output: str, audit_rc: int) -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
-    ap.add_argument("--rounds-dir", default=DEFAULT_ROUNDS_DIR)
+    ap.add_argument("--manifest", default=None,
+                    help="Path to manifest. Default: <repo-root>/.codex-review-manifest.json (repo-local).")
+    ap.add_argument("--rounds-dir", default=None,
+                    help="Path to round-logs dir. Default: <repo-root>/.codex-review-rounds/")
     ap.add_argument("--stale-minutes", type=int, default=DEFAULT_STALE_MINUTES)
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
@@ -262,6 +271,21 @@ def main() -> int:
     if root is None:
         print("not inside a git repository", file=sys.stderr)
         return 2
+
+    # Repo-local defaults (matches the wrappers); fall back to legacy /tmp paths
+    # only if a stale manifest exists there.
+    if args.manifest is None:
+        repo_local = str(root / ".codex-review-manifest.json")
+        if Path(repo_local).is_file() or not Path(LEGACY_TMP_MANIFEST).is_file():
+            args.manifest = repo_local
+        else:
+            args.manifest = LEGACY_TMP_MANIFEST  # legacy, surface as actionable
+    if args.rounds_dir is None:
+        repo_local_rounds = str(root / ".codex-review-rounds")
+        if Path(repo_local_rounds).is_dir() or not Path(LEGACY_TMP_ROUNDS_DIR).is_dir():
+            args.rounds_dir = repo_local_rounds
+        else:
+            args.rounds_dir = LEGACY_TMP_ROUNDS_DIR
 
     audit_path = find_run_repo_cleanup_audit()
     audit_output, audit_rc = "", 0

--- a/skills/run-codex-review/skills/run-codex-review/scripts/loop-status.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/loop-status.md
@@ -41,8 +41,8 @@ Columns:
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--manifest <path>` | `/tmp/codex-review-manifest.json` | Source-of-truth manifest. |
-| `--rounds-dir <path>` | `/tmp/codex-review-rounds/` | Per-branch round-log directory. |
+| `--manifest <path>` | `<repo-root>/.codex-review-manifest.json` (repo-local default) | Source-of-truth manifest. |
+| `--rounds-dir <path>` | `<repo-root>/.codex-review-rounds/` | Per-branch round-log directory. |
 | `--stale-minutes <n>` | `60` | Heartbeat threshold for `STALE` flagging. |
 | `--watch` | off | Redraw on a timer. |
 | `--refresh <n>` | `10` | Seconds between redraws (only with `--watch`). |

--- a/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.md
@@ -1,27 +1,40 @@
 # run-codex-review.py
 
-Wrapper around `/codex:review --background` for one branch in one worktree. Launches the background review, polls to completion, fetches the artifact, normalizes to the JSON schema in `references/codex-review-contract.md`, writes the round log, and updates the manifest.
+Wrapper around `node codex-companion.mjs review --json` (or `adversarial-review --json`) for one branch in one worktree. Runs the review synchronously, normalizes output to the JSON schema in `references/codex-review-contract.md`, writes the round log, and updates the manifest.
 
 **This is the single entry point for "do one round of review on this branch".** Subagents call it once per round.
+
+The wrapper invokes the OpenAI Codex Claude Code plugin's companion script — it discovers `codex-companion.mjs` automatically (version-agnostic), so no per-environment adjustment is required.
 
 ## Usage
 
 ```bash
+# Default: native review (free-form text parsed via regex)
 python3 scripts/run-codex-review.py --branch feat/foo --worktree /Users/.../wt-feat-foo
+
+# Pick base branch
 python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --base canary
-python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --timeout 600
+
+# Wall-clock cap (Codex review can hang on remote tools)
+python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --timeout 1500
+
+# Adversarial mode — structured findings with severities critical|high|medium|low
+python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --mode adversarial
+
+# Dry-run prints the resolved codex-companion.mjs path + the planned invocation
 python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --dry-run
 ```
 
 ## Behavior
 
 1. Pre-flight: verify `--worktree` exists and is on `--branch`.
-2. `cd` into the worktree.
-3. Invoke the codex CLI form (see "Adjustment point" below).
-4. Parse the launch output for the background job id.
-5. Poll the job status every `--poll-interval` seconds until completion or `--timeout`.
-6. On completion: fetch the artifact, normalize to the schema, write `<rounds-dir>/<slug>.<round>.json`.
-7. Update the manifest entry's `last_review_id`, `last_review_at`, `last_status`, `rounds`, `head_sha_current`, and append a `round_history` entry.
+2. Discover `codex-companion.mjs` (env-var first, then `~/.claude/plugins/cache/openai-codex/codex/<latest>/`).
+3. Invoke `node codex-companion.mjs <review|adversarial-review> --base <ref> --scope branch --json` synchronously inside the worktree.
+4. Parse the JSON envelope:
+   - **`review` mode**: extract `codex.stdout` (free-form text) and regex-parse `[severity] Title — file:line` items.
+   - **`adversarial` mode**: read `result.findings[]` directly (structured; no regex).
+5. Write `<rounds-dir>/<slug>.<round>.json` with the round-log schema.
+6. Update the manifest entry's `last_review_id`, `last_review_at`, `last_status`, `rounds`, `head_sha_current`, and append a `round_history` entry.
 
 ## Flags
 
@@ -29,37 +42,31 @@ python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --dry-run
 |---|---|---|
 | `--branch <b>` | required | Branch under review. Must match the worktree's HEAD. |
 | `--worktree <path>` | required | Worktree directory; codex runs from here. |
-| `--base <ref>` | `main` | Base passed to the codex CLI (if it accepts one). |
-| `--manifest <path>` | `/tmp/codex-review-manifest.json` | Manifest to update. |
-| `--rounds-dir <path>` | `/tmp/codex-review-rounds/` | Round-log directory. |
-| `--timeout <n>` | `1800` (30 min) | Seconds to wait for the background job to complete. |
-| `--poll-interval <n>` | `30` | Seconds between status polls. |
-| `--dry-run` | off | Print the plan; don't invoke codex. |
+| `--base <ref>` | `main` | Base ref for the diff. |
+| `--mode review\|adversarial` | `review` | `review` = native (free-form text parsed); `adversarial` = adversarial-review (structured `findings[]`). |
+| `--manifest <path>` | `<repo-root>/.codex-review-manifest.json` | Manifest to update. Defaults to repo-local (no `/tmp` cross-repo collisions). |
+| `--rounds-dir <path>` | `<repo-root>/.codex-review-rounds/` | Round-log directory. Same defaulting logic. |
+| `--output <path>` | (computed) | Override the round-log output path. If unset, computed from `<rounds-dir>` + branch slug + round number. |
+| `--timeout <n>` | `1500` (25 min) | Wall-clock cap. On hang, exit 1 with `last_status: "timeout"` and `terminal_reason: "review-hang past wall-clock cap"`. |
+| `--dry-run` | off | Resolve `codex-companion.mjs` path, validate worktree state, print the intended invocation. Don't run codex. |
 
 ## Exit codes
 
 | Code | Meaning | Caller (subagent) action |
 |---|---|---|
 | `0` | Review available; round log written | Run `classify-review-feedback.py` next. |
-| `1` | Timeout (manifest marked `timeout`) | Retry the round (max 3); else mark FAILED. |
-| `2` | Codex/CLI failed (manifest marked `failed`) | Retry the round (max 3); else mark FAILED. |
+| `1` | Timeout (wall-clock cap; manifest marked `timeout`) | Retry the round once; else mark FAILED. |
+| `2` | Codex CLI failed (manifest marked `failed`) | Retry the round once; else mark FAILED. |
+| `127` | Codex plugin not installed | Surface to user; install via Claude Code plugin manager. |
 
-## Adjustment point — codex CLI form
+## Plugin discovery
 
-The exact CLI form depends on your Codex installation. Edit `invoke_codex()` in the script to match.
+The wrapper discovers `codex-companion.mjs` automatically:
 
-Default attempts (in order):
+1. **`${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs`** — set by Claude Code when the plugin is loaded in a live session.
+2. **Latest version under `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs`** — fallback for when the env var isn't set. Versions are sorted semver-ascending; the latest installed wins. Non-semver directory names sort first (so `1.0.4` beats `dev`).
 
-```python
-candidates = [
-    ["codex", "review", "--background", "--branch", branch, "--base", base],
-    ["codex", "review", "--background"],
-]
-```
-
-If your install uses a different form (e.g. `claude codex review`, `cdx review`, `gh codex`), update the list. The script picks the first form that doesn't return `127` (command not found).
-
-Same for the **status** poll (`codex review --status <id>`) and **fetch** (`codex review --fetch <id>`) — adjust if your install uses different subcommands.
+If neither path resolves, the wrapper exits with code 127 and a message pointing at https://github.com/openai/codex-plugin-cc.
 
 ## Schema of the round-log JSON
 
@@ -67,95 +74,115 @@ Per `references/codex-review-contract.md`:
 
 ```json
 {
-  "review_id": "cdx-job-abc123",
+  "review_id": "<codex thread id>",
   "branch": "feat/foo",
   "head_sha": "deadbeef1234...",
   "started_at": "2026-04-26T10:00:00Z",
   "finished_at": "2026-04-26T10:04:32Z",
   "raw_text": "<full Codex output verbatim>",
   "items": [
-    { "id": "...", "severity_raw": "...", "file": "...", "line": 42, "body": "..." }
+    { "id": "cdx-0", "severity_raw": "P1", "file": "src/foo.ts", "line": 42, "body": "..." }
   ]
 }
 ```
 
-`items` is populated when the artifact is structured JSON. When unstructured (free text), `items` is `[]` and the classifier scans `raw_text` instead.
+In `review` mode, `items[]` is populated by regex-parsing `codex.stdout`. Token recognized in the severity slot: `P1` / `P2` / `P3` / `P4` / `critical` / `high` / `medium` / `low` (case-insensitive).
 
-## Job-id parsing
+In `adversarial` mode, `items[]` is populated by mapping `result.findings[]`:
+- `severity_raw` ← `severity` (`critical | high | medium | low`)
+- `file` ← `file`
+- `line` ← `line_start`
+- `body` ← `title + body + recommendation` joined with blank lines
 
-The script tries these patterns on launch stdout (case-insensitive):
+## codex-companion.mjs JSON shapes
 
-```
-\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)
-\b(cdx[- ]?job[- ]?[A-Za-z0-9_-]+)
-\bbackground job[:=]\s*([A-Za-z0-9_-]+)
-```
-
-If none match, a synthetic id `cdx-job-unknown-<unix-ts>` is generated and a warning is printed. The synthetic id is still recorded in the manifest so the round-log filename is unique.
-
-## Polling loop
-
-```
-status = "running"
-while elapsed < timeout:
-    rc, out, _ = sh(["codex", "review", "--status", job_id])
-    if "completed" in out: status = "completed"; fetch; break
-    if "failed" in out:    status = "failed"; break
-    sleep(poll_interval)
+`review --json`:
+```json
+{
+  "review": "Review",
+  "target": { "mode": "branch", "label": "...", "baseRef": "main" },
+  "threadId": "...",
+  "codex": { "status": 0, "stdout": "<free-form text>", "stderr": "...", "reasoning": null }
+}
 ```
 
-If polling exceeds `--timeout`, the script returns exit 1 with `last_status: "timeout"` in the manifest. The subagent decides whether to retry (max 3 retries per round).
+`adversarial-review --json`:
+```json
+{
+  "review": "Adversarial Review",
+  "result": {
+    "verdict": "approve|needs-attention",
+    "summary": "...",
+    "findings": [
+      { "severity": "critical|high|medium|low", "title": "...", "body": "...",
+        "file": "src/foo.ts", "line_start": 42, "line_end": 42,
+        "confidence": 0.0, "recommendation": "..." }
+    ],
+    "next_steps": [...]
+  },
+  "rawOutput": "...",
+  "parseError": null
+}
+```
 
 ## Concurrency safety
 
-`run-codex-review.py` is invoked **once per round per branch** by exactly **one subagent**. No file-locking is needed for the round-log write (each round-log filename is unique by `slug.round.json`). Manifest updates use `tempfile + os.replace` for atomicity, but the protocol assumes one subagent per branch — concurrent invocations on the same branch are an error.
+`run-codex-review.py` is invoked **once per round per branch** by exactly **one subagent**. No file-locking on the round-log write (each round-log filename is unique by `slug.round.json`). Manifest updates use `tempfile + os.replace` for atomicity, but the protocol assumes one subagent per branch — concurrent invocations on the same branch are an error.
 
-## Sample output (success)
+Multiple branches can be reviewed in parallel: each branch's invocation is independent. Parallelism comes from concurrent subprocesses, not from a `--background` flag (the companion's `review` and `adversarial-review` subcommands ignore `--background` — they always run synchronously).
+
+## Sample output (success, native review)
 
 ```
-launching /codex:review --background in /Users/.../myrepo-wt-feat-foo ...
-  job id: cdx-job-7f8a9c; polling every 30s up to 1800s...
-  ✓ round log written: /tmp/codex-review-rounds/feat-foo.03.json
+running codex-companion review (sync) in /Users/.../wt-feat-foo ... timeout=1500s
+  ✓ round log written: /Users/.../repo/.codex-review-rounds/feat-foo.03.json (items=4)
   ✓ manifest updated: rounds=3
 ```
 
 ## Sample output (timeout)
 
 ```
-launching /codex:review --background in /Users/.../myrepo-wt-feat-foo ...
-  job id: cdx-job-7f8a9c; polling every 30s up to 1800s...
-✗ job cdx-job-7f8a9c timed out after 1800s
+running codex-companion review (sync) in /Users/.../wt-feat-foo ... timeout=1500s
+✗ codex review timed out after 1500s
 ```
 
-(exit 1; manifest `last_status: "timeout"`)
+(exit 1; manifest `last_status: "timeout"`, `terminal_reason: "review-hang past wall-clock cap"`)
+
+## Sample output (plugin missing)
+
+```
+codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin
+(https://github.com/openai/codex-plugin-cc) — expected at $CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs
+or at ~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs.
+```
+
+(exit 127; manifest `last_status: "plugin-missing"`)
 
 ## Failure modes
 
 | Failure | Wrapper behavior | Recovery |
 |---|---|---|
-| `codex` CLI not on PATH | Exit 2; `last_status: "failed"` | Install codex; resume. |
+| Plugin not installed | Exit 127; `last_status: "plugin-missing"` | Install plugin; resume. |
 | Worktree not on the right branch | Exit 2 with stderr; no manifest update | `git -C <wt> checkout <branch>`; retry. |
-| Network failure mid-launch | Exit 2; `last_status: "failed"` | Subagent retries (max 3). |
-| Job stuck `running` past timeout | Exit 1; `last_status: "timeout"` | Subagent retries OR raises timeout. |
-| Job `completed` but no artifact | Exit 2; `last_status: "failed"` | Investigate codex install; surface to human. |
-| Artifact malformed JSON | Exit 0; `items: []`, `raw_text` populated | Classifier falls back to regex; loop continues. |
-| Branch HEAD changed mid-review | Wrapper warns via raw_text comparison; review may be stale | Subagent discards round, retries from current HEAD. |
+| codex-companion ran but exited non-zero with no stdout | Exit 2; `last_status: "failed"` | Subagent retries once. |
+| codex-companion ran with non-zero exit but stdout has parseable JSON | Wrapper logs warning, normalizes anyway | Round log written; loop continues. |
+| Wall-clock timeout | Exit 1; `last_status: "timeout"` | Subagent retries once OR mark FAILED. |
+| Output doesn't match expected JSON envelope | Exit 0 with `items: []`, raw text in `raw_text` | Classifier falls back to regex over `raw_text`. |
+| Branch HEAD changed mid-review | Not detected by wrapper; review may be stale | Subagent discards round, retries from current HEAD. |
 
 ## When to run
 
 - Per round, by exactly one subagent per branch.
-- Never invoke twice in parallel on the same branch.
-- Never invoke from outside the branch's worktree.
+- Never invoke twice in parallel on the same branch (use a different worktree if you need parallel branches).
 
 ## Read/write surface
 
-- **Reads**: `<worktree>/...`, manifest, codex CLI status/fetch endpoints.
+- **Reads**: `<worktree>/...`, manifest, the codex-companion script.
 - **Writes**: `<rounds-dir>/<slug>.<round>.json` (new each round), manifest entry for this branch.
 - **Does NOT**: push, commit, modify the worktree, open PRs, edit other branches' entries.
 
-## Extending
+## See also
 
-- Replace `invoke_codex()`'s body with your codex CLI form. Keep the return contract `(rc, stdout, stderr)`.
-- Replace `parse_job_id()`'s patterns with your codex's launch-output convention.
-- Replace `poll_job()`'s status/fetch with your codex's polling contract.
-- Add a per-call `--policy <path>` flag if you want to override the classifier policy from this script (currently the classifier is invoked separately).
+- `scripts/trigger-codex-rescue.py` — the Phase 6 sibling that wraps `codex-companion.mjs task --background` for the rescue review on an open PR.
+- `references/codex-review-contract.md` — the round-log schema this wrapper produces.
+- `references/event-driven-orchestration.md` — how main agent dispatches this wrapper in parallel across N branches via `Bash run_in_background`.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python3
-"""Wrap /codex:review --background for one branch; normalize output to JSON.
+"""Wrap the OpenAI Codex Claude Code plugin's review for one branch; normalize
+output to the round-log JSON schema in references/codex-review-contract.md.
 
-Invokes the Codex CLI inside the branch's worktree, polls the background job
-to completion, fetches the review artifact, normalizes to the JSON schema in
-references/codex-review-contract.md, and writes the round log + manifest update.
-
-The exact codex CLI form is environment-dependent; see invoke_codex() for the
-adjustment point.
+Invokes `node codex-companion.mjs review --json` (or `adversarial-review --json`)
+inside the branch's worktree. The companion script ignores `--background` for
+review subcommands — it always runs synchronously. Each parallel coordinator
+runs its own subprocess; parallelism comes from concurrent invocations, not
+from background flags.
 
 Usage:
     python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt
     python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt --dry-run
     python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt \\
-        --timeout 1800 --poll-interval 30
+        --base main --timeout 1500 --mode review
+
+    # Adversarial mode (structured findings — no regex, severities are
+    # critical|high|medium|low):
+    python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt --mode adversarial
 
 Exit codes:
     0  review available; round log written
     1  timeout (manifest marked 'timeout'; caller decides retry)
     2  codex/CLI failed (manifest marked 'failed'; caller decides FAILED)
+  127  codex plugin not installed (caller surfaces FAILED)
 """
 
 from __future__ import annotations
@@ -29,15 +34,53 @@ import re
 import subprocess
 import sys
 import tempfile
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-DEFAULT_MANIFEST = "/tmp/codex-review-manifest.json"
-DEFAULT_ROUNDS_DIR = "/tmp/codex-review-rounds/"
-DEFAULT_TIMEOUT = 1800
-DEFAULT_POLL_INTERVAL = 30
+DEFAULT_TIMEOUT = 1500  # 25 min wall-clock cap; Codex review can hang on remote tools
+DEFAULT_MODE = "review"  # native (free-form parsed). "adversarial" → structured findings.
 
+
+# ─── codex-companion.mjs discovery (version-agnostic) ─────────────────────────
+
+def _find_codex_companion() -> Path:
+    """Discover the OpenAI Codex plugin's codex-companion.mjs.
+
+    Resolution order:
+      1. ${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs (env var set by Claude
+         Code harness when the plugin is loaded).
+      2. Latest installed version under
+         ~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs
+         (semver-sorted; latest wins; falls back to lex-sort for non-semver dirs).
+
+    Raises FileNotFoundError if neither resolves. Plugin source:
+      https://github.com/openai/codex-plugin-cc/tree/main/plugins/codex
+    """
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidate = Path(plugin_root) / "scripts" / "codex-companion.mjs"
+        if candidate.is_file():
+            return candidate
+
+    cache = Path.home() / ".claude" / "plugins" / "cache" / "openai-codex" / "codex"
+    if cache.is_dir():
+        def _key(p: Path) -> tuple:
+            m = re.match(r"^(\d+)\.(\d+)\.(\d+)", p.name)
+            return (1, int(m[1]), int(m[2]), int(m[3])) if m else (0, p.name)
+        for v in sorted((p for p in cache.iterdir() if p.is_dir()), key=_key, reverse=True):
+            candidate = v / "scripts" / "codex-companion.mjs"
+            if candidate.is_file():
+                return candidate
+
+    raise FileNotFoundError(
+        "codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin "
+        "(https://github.com/openai/codex-plugin-cc) — expected at "
+        "$CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs or at "
+        "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs."
+    )
+
+
+# ─── Generic helpers ──────────────────────────────────────────────────────────
 
 def sh(cmd, cwd=None, env=None, timeout=None):
     try:
@@ -79,6 +122,17 @@ def atomic_write(path: str, content: str):
         raise
 
 
+def repo_local_default(wt: Path, name: str) -> str:
+    """Repo-local default for state files; main agent's session may pass --manifest
+    explicitly. This default prevents cross-repo /tmp collisions."""
+    # Find repo root from the worktree path (handle the worktree's own .git file)
+    rc, out, _ = sh(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=wt)
+    if rc == 0 and out:
+        # git-common-dir points at the main checkout's .git directory; its parent is repo root
+        return str(Path(out).parent / name)
+    return f"/tmp/{name}"  # last-resort fallback
+
+
 def load_manifest(path: str) -> dict | None:
     if not os.path.isfile(path):
         return None
@@ -113,82 +167,143 @@ def get_round_for_branch(path: str, branch: str) -> int:
     return 0
 
 
-# ─── Codex invocation — adjustment point per environment ──────────────────────
+# ─── Codex invocation ─────────────────────────────────────────────────────────
 
-def invoke_codex(branch: str, base: str, wt: Path) -> tuple[int, str, str]:
-    """Launch /codex:review --background. Return (rc, stdout, stderr).
+def invoke_codex(branch: str, base: str, wt: Path, mode: str, timeout: int) -> tuple[int, str, str]:
+    """Spawn codex-companion.mjs <mode> --base <ref> --json synchronously.
 
-    Adjust the command form here to match the codex CLI in your environment.
-    Common forms (try in order):
-      - codex review --background --branch <b> --base <base>
-      - codex review --background
-      - claude codex review --background
+    The companion script's review and adversarial-review subcommands always run
+    foreground regardless of any --background flag. Returns (rc, stdout, stderr).
     """
-    candidates = [
-        ["codex", "review", "--background", "--branch", branch, "--base", base],
-        ["codex", "review", "--background"],
-    ]
-    for cmd in candidates:
-        rc, out, err = sh(cmd, cwd=wt, timeout=120)
-        if rc != 127:  # found and ran (even if it failed for other reasons)
-            return rc, out, err
-    return 127, "", "no codex CLI form succeeded; check codex install / PATH"
-
-
-def parse_job_id(stdout: str) -> str | None:
-    """Extract a background job id from launch stdout.
-
-    Adjust this regex to match what your codex CLI prints.
-    """
-    patterns = [
-        r"\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)",
-        r"\b(cdx[- ]?job[- ]?[A-Za-z0-9_-]+)",
-        r"\bbackground job[:=]\s*([A-Za-z0-9_-]+)",
-    ]
-    for pat in patterns:
-        m = re.search(pat, stdout, flags=re.IGNORECASE)
-        if m:
-            return m.group(1)
-    return None
-
-
-def poll_job(job_id: str, wt: Path, poll_interval: int, timeout: int) -> tuple[str, str]:
-    """Poll the codex job until completion. Returns (status, raw_artifact)."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        rc, out, err = sh(["codex", "review", "--status", job_id], cwd=wt, timeout=60)
-        if rc == 127:
-            return "failed", f"codex --status not available: {err}"
-        text = out.lower()
-        if "completed" in text or "done" in text or "finished" in text:
-            # fetch artifact
-            rc2, art, err2 = sh(["codex", "review", "--fetch", job_id], cwd=wt, timeout=120)
-            if rc2 == 0:
-                return "completed", art
-            return "failed", f"fetch failed: {err2}"
-        if "failed" in text or "cancelled" in text or "errored" in text:
-            return "failed", out
-        time.sleep(poll_interval)
-    return "timeout", ""
-
-
-def normalize_review(raw: str, review_id: str, branch: str, head: str,
-                     started_at: str, finished_at: str) -> dict:
-    """Best-effort normalization of the artifact to the schema in
-    references/codex-review-contract.md. If the artifact is structured JSON,
-    parse it. Otherwise treat as unstructured text and let the classifier
-    fall back to regex over raw_text.
-    """
-    items = []
-    parsed = None
     try:
-        parsed = json.loads(raw)
+        companion = _find_codex_companion()
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+
+    subcmd = "review" if mode == "review" else "adversarial-review"
+    cmd = [
+        "node", str(companion), subcmd,
+        "--base", base,
+        "--scope", "branch",
+        "--json",
+    ]
+    return sh(cmd, cwd=wt, timeout=timeout)
+
+
+# ─── Output normalization ─────────────────────────────────────────────────────
+
+# Severity tokens we recognize in free-form review output. Codex's native review
+# emits items as `[Px] Title — file:line` or `[severity] Title — file:line`.
+_SEV_TOKEN = r"P\d+|critical|high|medium|low"
+
+_FREEFORM_PATTERN = re.compile(
+    rf"^\s*\[(?P<sev>{_SEV_TOKEN})\]\s*"
+    r"(?P<title>.+?)\s*[—–-]+\s*"
+    r"(?P<file>[^\s:]+):(?P<line_start>\d+)(?:-(?P<line_end>\d+))?\s*$"
+    rf"(?P<body>(?:\n(?!\s*\[(?:{_SEV_TOKEN})\]).*)*)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def parse_freeform_items(text: str) -> list[dict]:
+    """Regex-parse Codex's free-form review text into items[].
+
+    Matches header lines like:
+        [P1] Title here — src/foo.ts:42
+        <body line 1>
+        <body line 2>
+
+        [P2] Next item — src/bar.ts:13-15
+        ...
+
+    Severity tokens: P1 / P2 / P3 / P4 / critical / high / medium / low.
+    """
+    items: list[dict] = []
+    for i, m in enumerate(_FREEFORM_PATTERN.finditer(text)):
+        items.append({
+            "id": f"cdx-{i}",
+            "severity_raw": m["sev"].lower(),
+            "file": m["file"],
+            "line": int(m["line_start"]),
+            "body": (m["body"] or "").strip() or m["title"].strip(),
+        })
+    return items
+
+
+def normalize_review(raw_json: str, branch: str, head: str,
+                     started_at: str, finished_at: str) -> dict:
+    """Convert codex-companion's --json output to the round-log schema.
+
+    Two input shapes:
+
+    1. review (native):
+        {
+          "review": "Review",
+          "target": {...}, "threadId": "...",
+          "codex": { "status": 0, "stdout": "<free-form text>", "stderr": "...", "reasoning": null }
+        }
+
+    2. adversarial-review (structured):
+        {
+          "review": "Adversarial Review",
+          "result": {
+            "verdict": "approve|needs-attention",
+            "summary": "...",
+            "findings": [{ "severity": "critical|high|medium|low",
+                           "title": "...", "body": "...",
+                           "file": "...", "line_start": N, "line_end": N,
+                           "confidence": 0.0..1.0,
+                           "recommendation": "..." }],
+            "next_steps": [...]
+          },
+          "rawOutput": "...", "parseError": null, ...
+        }
+
+    Output (round-log per references/codex-review-contract.md):
+        {
+          "review_id", "branch", "head_sha",
+          "started_at", "finished_at",
+          "raw_text", "items": [{ "id", "severity_raw", "file", "line", "body" }]
+        }
+    """
+    try:
+        payload = json.loads(raw_json)
     except (ValueError, TypeError):
-        parsed = None
-    if isinstance(parsed, dict) and isinstance(parsed.get("items"), list):
-        items = parsed["items"]
-    elif isinstance(parsed, list):
-        items = parsed
+        # Companion didn't emit valid JSON — degenerate path; pass raw text through
+        # so the classifier's regex fallback can still try.
+        return {
+            "review_id": "",
+            "branch": branch,
+            "head_sha": head,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "raw_text": raw_json,
+            "items": [],
+        }
+
+    review_id = str(payload.get("threadId") or "")
+
+    if payload.get("review") == "Adversarial Review":
+        result = payload.get("result") or {}
+        findings = result.get("findings") or []
+        items = []
+        for i, f in enumerate(findings):
+            title = (f.get("title") or "").strip()
+            body = (f.get("body") or "").strip()
+            recommendation = (f.get("recommendation") or "").strip()
+            combined = "\n\n".join(p for p in (title, body, recommendation) if p)
+            items.append({
+                "id": f"adv-{i}",
+                "severity_raw": str(f.get("severity") or "unknown").lower(),
+                "file": f.get("file") or "",
+                "line": int(f.get("line_start") or 0),
+                "body": combined or title,
+            })
+        raw_text = payload.get("rawOutput") or json.dumps(result, indent=2)
+    else:
+        # Native review — free-form text in codex.stdout.
+        raw_text = (payload.get("codex") or {}).get("stdout") or ""
+        items = parse_freeform_items(raw_text)
 
     return {
         "review_id": review_id,
@@ -196,28 +311,44 @@ def normalize_review(raw: str, review_id: str, branch: str, head: str,
         "head_sha": head,
         "started_at": started_at,
         "finished_at": finished_at,
-        "raw_text": raw,
+        "raw_text": raw_text,
         "items": items,
     }
 
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--branch", required=True)
     ap.add_argument("--worktree", required=True)
     ap.add_argument("--base", default="main")
-    ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
-    ap.add_argument("--rounds-dir", default=DEFAULT_ROUNDS_DIR)
+    ap.add_argument("--manifest",
+                    help="Path to the manifest JSON. Default: <repo-root>/.codex-review-manifest.json")
+    ap.add_argument("--rounds-dir",
+                    help="Directory for round-log JSON files. Default: <repo-root>/.codex-review-rounds/")
+    ap.add_argument("--output",
+                    help="Override round-log output path. If set, overrides --rounds-dir + --branch + round-N path computation.")
     ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT,
-                    help="seconds to wait for the background job to complete")
-    ap.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL)
-    ap.add_argument("--dry-run", action="store_true")
+                    help=f"Wall-clock cap in seconds. Default {DEFAULT_TIMEOUT}s. "
+                         "Codex review can hang on remote tools (codebase-search APIs etc.); "
+                         "on hang, exit non-zero with terminal_reason 'review-hang past wall-clock cap'.")
+    ap.add_argument("--mode", choices=["review", "adversarial"], default=DEFAULT_MODE,
+                    help="codex-companion subcommand. 'review' = native (free-form text parsed via regex; "
+                         "default). 'adversarial' = adversarial-review (structured findings; severities are "
+                         "critical|high|medium|low).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Resolve the codex-companion path, validate worktree state, print intended invocation. Don't run codex.")
     args = ap.parse_args()
 
     wt = Path(args.worktree)
     if not wt.is_dir():
         print(f"worktree not found: {wt}", file=sys.stderr)
         return 2
+
+    # Default manifest + rounds-dir to repo-local paths (avoids /tmp cross-repo collisions)
+    manifest_path = args.manifest or repo_local_default(wt, ".codex-review-manifest.json")
+    rounds_dir = args.rounds_dir or repo_local_default(wt, ".codex-review-rounds")
 
     # Pre-flight: branch is checked out in the worktree
     rc, branch_at_wt, _ = sh(["git", "symbolic-ref", "--short", "HEAD"], cwd=wt)
@@ -229,63 +360,75 @@ def main() -> int:
     started_at = utc_now_iso()
 
     if args.dry_run:
-        print(f"DRY-RUN: would invoke codex review --background in {wt}")
+        try:
+            companion = _find_codex_companion()
+        except FileNotFoundError as e:
+            print(f"DRY-RUN: {e}", file=sys.stderr)
+            return 127
+        subcmd = "review" if args.mode == "review" else "adversarial-review"
+        print(f"DRY-RUN: would invoke")
+        print(f"  node {companion} {subcmd} --base {args.base} --scope branch --json")
+        print(f"  cwd:         {wt}")
         print(f"  branch:      {args.branch}")
-        print(f"  base:        {args.base}")
         print(f"  head:        {head}")
-        print(f"  manifest:    {args.manifest}")
-        print(f"  rounds-dir:  {args.rounds_dir}")
-        print(f"  timeout:     {args.timeout}s, poll {args.poll_interval}s")
+        print(f"  manifest:    {manifest_path}")
+        print(f"  rounds-dir:  {rounds_dir}")
+        print(f"  timeout:     {args.timeout}s")
+        print(f"  mode:        {args.mode}")
         return 0
 
-    print(f"launching /codex:review --background in {wt} ...")
-    rc, out, err = invoke_codex(args.branch, args.base, wt)
-    if rc not in (0, 1):  # 0=ok, 1 sometimes used for "submitted with warnings"
-        print(f"✗ codex launch failed (rc={rc}): {err}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {"last_status": "failed"})
-        return 2
-
-    job_id = parse_job_id(out) or parse_job_id(err)
-    if not job_id:
-        # Heuristic: if codex returned 0 but no recognizable id, use a synthetic one
-        job_id = f"cdx-job-unknown-{int(time.time())}"
-        print(f"⚠  no recognizable job id in launch output; using synthetic: {job_id}")
-
-    print(f"  job id: {job_id}; polling every {args.poll_interval}s up to {args.timeout}s...")
-    status, raw = poll_job(job_id, wt, args.poll_interval, args.timeout)
+    print(f"running codex-companion {args.mode} (sync) in {wt} ... timeout={args.timeout}s")
+    rc, stdout, stderr = invoke_codex(args.branch, args.base, wt, args.mode, args.timeout)
     finished_at = utc_now_iso()
 
-    if status == "timeout":
-        print(f"✗ job {job_id} timed out after {args.timeout}s", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "last_review_id": job_id,
+    if rc == 127:
+        # Plugin missing — caller surfaces FAILED with the install instructions in stderr
+        print(stderr or "codex plugin unavailable", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {"last_status": "plugin-missing"})
+        return 127
+
+    if rc == 124:
+        print(f"✗ codex review timed out after {args.timeout}s", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {
             "last_review_at": finished_at,
             "last_status": "timeout",
+            "terminal_reason": "review-hang past wall-clock cap",
         })
         return 1
-    if status == "failed":
-        print(f"✗ job {job_id} failed: {raw[:200]}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "last_review_id": job_id,
-            "last_review_at": finished_at,
-            "last_status": "failed",
-        })
-        return 2
 
-    # status == "completed"
-    review = normalize_review(raw, job_id, args.branch, head, started_at, finished_at)
-    round_n = get_round_for_branch(args.manifest, args.branch) + 1
-    log_path = os.path.join(args.rounds_dir, f"{slug(args.branch)}.{round_n:02d}.json")
+    if rc != 0:
+        # Companion exited non-zero; could be a Codex error or a parser error.
+        # The JSON envelope might still be on stdout; if so, fall through to
+        # normalize. Otherwise mark failed.
+        if not stdout.strip():
+            print(f"✗ codex review failed (rc={rc}): {stderr[:500]}", file=sys.stderr)
+            update_manifest_entry(manifest_path, args.branch, {
+                "last_review_at": finished_at,
+                "last_status": "failed",
+            })
+            return 2
+        # Try to normalize; some Codex paths exit non-zero even on usable output
+        print(f"⚠  codex review exited rc={rc}; attempting to parse stdout anyway", file=sys.stderr)
+
+    review = normalize_review(stdout, args.branch, head, started_at, finished_at)
+    round_n = get_round_for_branch(manifest_path, args.branch) + 1
+
+    if args.output:
+        log_path = args.output
+    else:
+        log_path = os.path.join(rounds_dir, f"{slug(args.branch)}.{round_n:02d}.json")
+
     atomic_write(log_path, json.dumps(review, indent=2))
-    print(f"  ✓ round log written: {log_path}")
+    print(f"  ✓ round log written: {log_path} (items={len(review['items'])})")
 
     history_entry = {
         "round": round_n,
-        "review_id": job_id,
+        "review_id": review["review_id"],
         "completed_at": finished_at,
+        "items_found": len(review["items"]),
     }
-    update_manifest_entry(args.manifest, args.branch, {
-        "last_review_id": job_id,
+    update_manifest_entry(manifest_path, args.branch, {
+        "last_review_id": review["review_id"],
         "last_review_at": finished_at,
         "last_status": "reviewed",
         "rounds": round_n,

--- a/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.py
@@ -28,6 +28,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
@@ -143,18 +145,48 @@ def load_manifest(path: str) -> dict | None:
         return None
 
 
-def update_manifest_entry(path: str, branch: str, updates: dict, history_entry: dict | None = None):
-    manifest = load_manifest(path)
-    if manifest is None:
-        return
-    for entry in manifest.get("branches", []):
-        if entry.get("branch") == branch:
-            entry.update(updates)
-            entry["updated_at"] = utc_now_iso()
-            if history_entry is not None:
-                entry.setdefault("round_history", []).append(history_entry)
-            break
-    atomic_write(path, json.dumps(manifest, indent=2))
+@contextlib.contextmanager
+def _manifest_lock(manifest_path: str):
+    """Hold an fcntl.LOCK_EX on `<manifest>.lock` for the duration of a
+    read-modify-write. Required because parallel branches/PRs write to the
+    same manifest concurrently — without the lock, simultaneous writers
+    clobber each other and lose updates.
+
+    The lock file is created next to the manifest (not inside it) and is
+    safe to leave around between runs.
+    """
+    lock_path = manifest_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    with open(lock_path, "w") as lock_fp:
+        fcntl.flock(lock_fp, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fp, fcntl.LOCK_UN)
+
+
+def update_manifest_entry(path: str, branch: str, updates: dict, history_entry: dict | None = None) -> bool:
+    """Atomic read-modify-write under flock. Returns True iff the manifest
+    existed AND a branch entry matching `branch` was found and updated.
+    Callers should check the return value before reporting success.
+    """
+    with _manifest_lock(path):
+        manifest = load_manifest(path)
+        if manifest is None:
+            return False
+        found = False
+        for entry in manifest.get("branches", []):
+            if entry.get("branch") == branch:
+                entry.update(updates)
+                entry["updated_at"] = utc_now_iso()
+                if history_entry is not None:
+                    entry.setdefault("round_history", []).append(history_entry)
+                found = True
+                break
+        if not found:
+            return False
+        atomic_write(path, json.dumps(manifest, indent=2))
+        return True
 
 
 def get_round_for_branch(path: str, branch: str) -> int:
@@ -204,6 +236,27 @@ _FREEFORM_PATTERN = re.compile(
     re.MULTILINE | re.IGNORECASE,
 )
 
+# Map Codex's P1/P2/P3/P4 priority tokens to the severity labels the
+# classifier recognizes (`SEVERITY_MAJOR = {"critical","high","error","blocker","must-fix"}`
+# in classify-review-feedback.py). Without this mapping, P1 items lowercase
+# to "p1" — a token the classifier doesn't recognize as major — and a
+# branch with only P1 findings can be classified DONE. Verified against
+# classify-review-feedback.py:79.
+_PRIORITY_TO_SEVERITY = {
+    "p1": "critical",
+    "p2": "high",
+    "p3": "medium",
+    "p4": "low",
+}
+
+
+def _normalize_severity(token: str) -> str:
+    """Lowercase the matched severity token; map P1-P4 priorities to
+    critical/high/medium/low so the classifier recognizes them.
+    """
+    lower = token.lower()
+    return _PRIORITY_TO_SEVERITY.get(lower, lower)
+
 
 def parse_freeform_items(text: str) -> list[dict]:
     """Regex-parse Codex's free-form review text into items[].
@@ -216,13 +269,14 @@ def parse_freeform_items(text: str) -> list[dict]:
         [P2] Next item — src/bar.ts:13-15
         ...
 
-    Severity tokens: P1 / P2 / P3 / P4 / critical / high / medium / low.
+    Severity tokens: P1 / P2 / P3 / P4 (mapped to critical/high/medium/low) or
+    critical / high / medium / low (preserved as-is).
     """
     items: list[dict] = []
     for i, m in enumerate(_FREEFORM_PATTERN.finditer(text)):
         items.append({
             "id": f"cdx-{i}",
-            "severity_raw": m["sev"].lower(),
+            "severity_raw": _normalize_severity(m["sev"]),
             "file": m["file"],
             "line": int(m["line_start"]),
             "body": (m["body"] or "").strip() or m["title"].strip(),
@@ -377,14 +431,28 @@ def main() -> int:
         print(f"  mode:        {args.mode}")
         return 0
 
+    # Pre-resolve the companion path so we can distinguish "plugin missing"
+    # (codex-companion.mjs not on disk) from "node missing" (sh returns 127
+    # because `node` itself isn't on PATH).
+    try:
+        companion_path = _find_codex_companion()
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {"last_status": "plugin-missing"})
+        return 127
+
     print(f"running codex-companion {args.mode} (sync) in {wt} ... timeout={args.timeout}s")
     rc, stdout, stderr = invoke_codex(args.branch, args.base, wt, args.mode, args.timeout)
     finished_at = utc_now_iso()
 
     if rc == 127:
-        # Plugin missing — caller surfaces FAILED with the install instructions in stderr
-        print(stderr or "codex plugin unavailable", file=sys.stderr)
-        update_manifest_entry(manifest_path, args.branch, {"last_status": "plugin-missing"})
+        # node binary not on PATH (plugin path was already verified above)
+        print(f"✗ `node` not on PATH (codex-companion.mjs requires Node.js): {stderr[:500]}", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {
+            "last_status": "node-missing",
+            "last_error": "node not on PATH",
+            "last_review_at": finished_at,
+        })
         return 127
 
     if rc == 124:
@@ -396,19 +464,32 @@ def main() -> int:
         })
         return 1
 
+    # Decide whether stdout is parseable. Don't normalize if it doesn't look
+    # like the JSON envelope — that previously masked codex errors by writing
+    # an empty round-log marked "reviewed".
+    stdout_looks_jsonish = stdout.strip().startswith("{")
+
     if rc != 0:
-        # Companion exited non-zero; could be a Codex error or a parser error.
-        # The JSON envelope might still be on stdout; if so, fall through to
-        # normalize. Otherwise mark failed.
-        if not stdout.strip():
+        if not stdout_looks_jsonish:
             print(f"✗ codex review failed (rc={rc}): {stderr[:500]}", file=sys.stderr)
             update_manifest_entry(manifest_path, args.branch, {
                 "last_review_at": finished_at,
                 "last_status": "failed",
             })
             return 2
-        # Try to normalize; some Codex paths exit non-zero even on usable output
-        print(f"⚠  codex review exited rc={rc}; attempting to parse stdout anyway", file=sys.stderr)
+        # Some Codex paths exit non-zero even on usable JSON output; try to parse
+        print(f"⚠  codex review exited rc={rc}; stdout looks JSON-ish, attempting to parse", file=sys.stderr)
+
+    if not stdout_looks_jsonish:
+        # rc was 0 but stdout isn't a JSON envelope — degenerate path; surface
+        # the failure rather than write a stub round-log.
+        print(f"✗ codex review returned rc=0 but stdout is not a JSON envelope (first 200 chars: {stdout[:200]!r})", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {
+            "last_review_at": finished_at,
+            "last_status": "failed",
+            "last_error": "stdout-not-json",
+        })
+        return 2
 
     review = normalize_review(stdout, args.branch, head, started_at, finished_at)
     round_n = get_round_for_branch(manifest_path, args.branch) + 1
@@ -427,14 +508,22 @@ def main() -> int:
         "completed_at": finished_at,
         "items_found": len(review["items"]),
     }
-    update_manifest_entry(manifest_path, args.branch, {
+    manifest_updated = update_manifest_entry(manifest_path, args.branch, {
         "last_review_id": review["review_id"],
         "last_review_at": finished_at,
         "last_status": "reviewed",
         "rounds": round_n,
         "head_sha_current": head,
     }, history_entry=history_entry)
-    print(f"  ✓ manifest updated: rounds={round_n}")
+    if manifest_updated:
+        print(f"  ✓ manifest updated: rounds={round_n}")
+    else:
+        # Round-log is on disk; manifest didn't update. Common cause: --branch
+        # mistyped, or manifest doesn't have a branches[] entry for this branch.
+        # Don't claim success — surface so caller doesn't double-write rounds.
+        print(f"⚠  round-log written but manifest entry for branch '{args.branch}' "
+              f"not found at {manifest_path} (round counter not incremented)", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/skills/run-codex-review/skills/run-codex-review/scripts/spawn-review-worktrees.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/spawn-review-worktrees.py
@@ -178,6 +178,56 @@ def find_or_create_entry(manifest: dict, branch: str) -> dict:
     return entry
 
 
+# ─── Dependency installation per worktree ─────────────────────────────────────
+
+def detect_package_manager(wt: Path) -> tuple[str, list[str]] | None:
+    """Detect which package manager the project uses based on lockfile / config.
+    Returns (label, install command) or None when no install step is needed.
+
+    Detection order matters when multiple lockfiles coexist (e.g. pnpm + npm) —
+    prefer the more specific one. Cargo/Go are no-ops because their toolchains
+    handle vendoring transparently.
+    """
+    if (wt / "pnpm-lock.yaml").is_file():
+        return ("pnpm", ["pnpm", "install", "--frozen-lockfile"])
+    if (wt / "bun.lockb").is_file() or (wt / "bun.lock").is_file():
+        return ("bun", ["bun", "install", "--frozen-lockfile"])
+    if (wt / "yarn.lock").is_file():
+        return ("yarn", ["yarn", "install", "--frozen-lockfile"])
+    if (wt / "package-lock.json").is_file():
+        return ("npm", ["npm", "ci"])
+    if (wt / "package.json").is_file():
+        # No lockfile but a package.json — fall back to plain install
+        return ("npm", ["npm", "install"])
+    if (wt / "requirements.txt").is_file():
+        return ("pip", ["pip", "install", "-r", "requirements.txt"])
+    if (wt / "pyproject.toml").is_file() and (wt / "poetry.lock").is_file():
+        return ("poetry", ["poetry", "install"])
+    if (wt / "pyproject.toml").is_file() and (wt / "uv.lock").is_file():
+        return ("uv", ["uv", "sync"])
+    if (wt / "Gemfile.lock").is_file():
+        return ("bundler", ["bundle", "install"])
+    # Cargo, Go modules, etc. handle deps in-toolchain — no install step needed.
+    return None
+
+
+def install_deps(wt: Path) -> tuple[bool, str]:
+    """Install dependencies in worktree if a recognized package manager is in
+    use. Returns (success, message). success=True when the install ran cleanly
+    OR when the project doesn't need an install step (Cargo, Go, etc.).
+    """
+    detected = detect_package_manager(wt)
+    if detected is None:
+        return True, "no install step (Cargo / Go / no recognized manifest)"
+    label, cmd = detected
+    rc, _, err = sh(cmd, cwd=wt)
+    if rc == 0:
+        return True, f"{label} install ok ({' '.join(cmd)})"
+    if rc == 127:
+        return False, f"{label} install failed — `{cmd[0]}` not on PATH"
+    return False, f"{label} install failed (rc={rc}): {err[:200]}"
+
+
 def process_branch(branch: str, root: Path, args, manifest: dict) -> tuple[str, str]:
     """Returns (action, message). action ∈ {'spawned', 'reused', 'skipped', 'failed', 'planned'}."""
     repo_name = root.name
@@ -225,6 +275,17 @@ def process_branch(branch: str, root: Path, args, manifest: dict) -> tuple[str, 
     if rc != 0:
         return "failed", f"git push -u {args.remote} {branch} failed: {err}"
 
+    # Optionally install dependencies (--prep-deps) so Phase 3 / Phase 8 don't
+    # discover missing node_modules / .venv mid-flight.
+    deps_msg = ""
+    if args.prep_deps:
+        ok, msg = install_deps(Path(wt))
+        deps_msg = f"; deps: {msg}"
+        if not ok:
+            # Surface but do not fail spawn — the worktree itself is valid;
+            # the user can install deps manually if the auto-install couldn't.
+            return action, f"{action} worktree at {wt}; pushed -u {args.remote} {branch}{deps_msg}"
+
     # Update manifest
     entry = find_or_create_entry(manifest, branch)
     sha = head_sha(wt)
@@ -236,7 +297,7 @@ def process_branch(branch: str, root: Path, args, manifest: dict) -> tuple[str, 
         "status": "SPAWNED",
         "updated_at": utc_now_iso(),
     })
-    return action, f"{action} worktree at {wt}; pushed -u {args.remote} {branch}"
+    return action, f"{action} worktree at {wt}; pushed -u {args.remote} {branch}{deps_msg}"
 
 
 def main() -> int:
@@ -247,6 +308,14 @@ def main() -> int:
     ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
     ap.add_argument("--worktree-prefix", default=None,
                     help="custom worktree path prefix (default: ../<repo>-wt-)")
+    ap.add_argument("--prep-deps", action="store_true",
+                    help="After creating each worktree, detect the package manager "
+                         "(pnpm-lock.yaml, package-lock.json, bun.lockb, yarn.lock, "
+                         "requirements.txt, pyproject.toml + poetry.lock/uv.lock, Gemfile.lock) "
+                         "and run the corresponding install. Cargo and Go are no-ops. "
+                         "Use for any project whose validate command (Phase 3 build, Phase 8 test) "
+                         "needs node_modules / .venv / equivalent. If install fails, the worktree "
+                         "itself is left intact and a warning is surfaced.")
     ap.add_argument("--dry-run", action="store_true", help="print plan without doing anything")
     ap.add_argument("--execute", action="store_true", help="actually create worktrees and push")
     args = ap.parse_args()

--- a/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.md
@@ -1,144 +1,153 @@
 # trigger-codex-rescue.py
 
-Phase 6 entry point. After `open-comprehensive-pr.py` (or the PR-Creator sub-agent) opens a PR, this script triggers Codex rescue against it. Codex rescue is **Codex's own background sub-agent**, not a Claude Agent we dispatch — we hand it the PR link, and Codex's infrastructure spawns the review job.
+Phase 6 entry point. After the PR-Creator sub-agent opens a PR, this wrapper queues a Codex rescue review against it via `node codex-companion.mjs task --background --write --fresh --model gpt-5.5 --effort xhigh --prompt-file <path> --json` — the same code path the `/codex:resc` slash command runs internally. Codex's `task --background` returns `{ jobId, status: "queued", title, logFile }` immediately; the rescue review continues in a detached worker and lands on the PR like any other reviewer's comments.
+
+This is the **programmatic-loop equivalent** of `/codex:resc` for cases where main agent is dispatching rescues across N PRs in parallel and typing N slash commands is awkward. Both paths are first-class.
 
 ## Usage
 
 ```bash
-python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo
-python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo --model gpt-5.5 --effort xhigh
-python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo --dry-run
+# Default: queue rescue, write rescue_review_id + rescue_started_at to manifest, return.
+python3 scripts/trigger-codex-rescue.py \
+    --pr 42 --branch feat/foo \
+    --worktree /Users/.../wt-feat-foo \
+    --prompt-file /tmp/rescue-prompt-pr-42.md
+
+# Pipe the prompt on stdin instead of a file
+cat prompt.md | python3 scripts/trigger-codex-rescue.py \
+    --pr 42 --branch feat/foo --worktree /path/to/wt
+
+# Block until the rescue job terminates (max 30 min)
+python3 scripts/trigger-codex-rescue.py \
+    --pr 42 --branch feat/foo --worktree /path \
+    --prompt-file /tmp/p.md --wait --timeout-ms 1800000
+
+# Dry-run prints the resolved codex-companion.mjs path + the planned invocation
+python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo --worktree /path --dry-run
 ```
 
 ## Behavior
 
-1. Read the manifest entry for `<branch>` to get `worktree_path`.
-2. Inside that worktree, invoke the codex rescue CLI:
+1. Read the rescue prompt (from `--prompt-file` or stdin). Persist to `/tmp/codex-rescue-prompt-pr-<n>.md`.
+2. Discover `codex-companion.mjs` (env-var first, then `~/.claude/plugins/cache/openai-codex/codex/<latest>/`).
+3. From inside `<worktree>`, invoke:
+   ```bash
+   node codex-companion.mjs task \
+        --background --write --fresh \
+        --model <m> --effort <e> \
+        --prompt-file /tmp/codex-rescue-prompt-pr-<n>.md --json
    ```
-   codex review --rescue --background --fresh --model <m> --effort <e> --pr <n>
-   ```
-3. Capture the rescue job id from stdout (regex patterns; fallback to synthetic).
-4. Update the manifest entry with:
-   - `rescue_review_id` — the job id
-   - `rescue_started_at` — UTC ISO timestamp
-   - `rescue_status` — `"running"` (later updated to `"completed"` / `"timeout"` / `"failed"` by `await-pr-reviews.py`)
-   - `rescue_pr_number` — for cross-reference
-   - `rescue_model` — for audit
-   - `rescue_effort` — for audit
-5. Return immediately. **Does not poll.** Phase 6's `await-pr-reviews.py` owns the wait.
+   `task --background` honors the flag (unlike `review`, which always runs synchronously). Returns immediately with the queued-job descriptor.
+4. Parse `{ jobId, status: "queued", title, logFile }` from stdout.
+5. Update the manifest entry's `rescue_review_id`, `rescue_started_at`, `rescue_status: "running"`, plus audit fields (`rescue_pr_number`, `rescue_model`, `rescue_effort`, `rescue_title`, `rescue_log_file`).
+6. If `--wait`: poll `node codex-companion.mjs status <job-id> --wait --timeout-ms <n> --json` until terminal. Update `rescue_status` (`completed | failed | cancelled`), `rescue_finished_at`, `rescue_phase`, `rescue_elapsed`.
+7. Else: return immediately. Phase 6's `await-pr-reviews.py` (the comment-poller Monitor) handles the wait via PR comments.
 
 ## Flags
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--pr <n>` | required | PR number to review. |
+| `--pr <n>` | required | PR number. |
 | `--branch <b>` | required | Branch name (manifest entry key). |
-| `--manifest <path>` | `/tmp/codex-review-manifest.json` | Manifest to update. |
-| `--model <m>` | `gpt-5.5` | Codex model (per the user's spec). |
-| `--effort <e>` | `xhigh` | Codex effort level (per the user's spec). |
+| `--worktree <path>` | required | Worktree directory; codex runs from here. |
+| `--prompt-file <path>` | (stdin) | Comprehensive review prompt for Codex. If absent, reads stdin. |
+| `--manifest <path>` | `<repo-root>/.codex-review-manifest.json` | Manifest to update. Defaults repo-local. |
+| `--model <m>` | `gpt-5.5` | Codex reasoning model. |
+| `--effort <e>` | `xhigh` | Codex effort: `none\|minimal\|low\|medium\|high\|xhigh`. |
+| `--wait` | off | Block on `status --wait` until terminal. |
+| `--timeout-ms <n>` | `1800000` (30 min) | Total wall-clock cap when `--wait` is set. |
 | `--dry-run` | off | Print the plan; no invocation, no manifest write. |
 
 ## Exit codes
 
 | Code | Meaning |
 |---|---|
-| `0` | Rescue triggered; job id parsed; manifest updated. |
-| `1` | Rescue triggered but no job id parseable from output; synthetic id used; manifest still updated. Caller may proceed but should be aware. |
-| `2` | Codex CLI not found OR codex returned a hard error. Manifest marked `rescue_status: "failed"`. |
+| `0` | Rescue queued (and completed if `--wait`); manifest updated. |
+| `1` | `--wait` set but the job timed out before terminal status. |
+| `2` | Queue failed (codex error, unparseable response, manifest error). |
+| `127` | Codex plugin not installed. Surface to user. |
 
-## Adjustment point — codex rescue CLI form
+## Plugin discovery
 
-The script tries (in order) these forms:
+Same logic as `run-codex-review.py`:
 
-```python
-candidates = [
-    ["codex", "review", "--rescue", "--background", "--fresh",
-     "--model", model, "--effort", effort, "--pr", str(pr)],
-    ["codex", "rescue", "--background", "--fresh",
-     "--model", model, "--effort", effort, "--pr", str(pr)],
-    ["codex", "resc", "--background", "--fresh",
-     "--model", model, "--effort", effort, "--pr", str(pr)],
-]
-```
+1. **`${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs`** if the env var is set.
+2. **Latest semver-sorted version** under `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs`.
+3. Else exit 127 with install instructions pointing at https://github.com/openai/codex-plugin-cc.
 
-If your installation uses a different form (e.g. `claude codex resc`, `cdx-rescue`, etc.), edit `invoke_rescue()`'s `candidates` list. The script picks the first form that doesn't return rc=127 (command not found).
-
-## Job-id parsing
-
-The script tries these regex patterns on launch stdout (case-insensitive):
-
-```
-\brescue[- ]?job[- ]?id[:=]\s*([A-Za-z0-9_-]+)
-\b(cdx[- ]?rescue[- ]?[A-Za-z0-9_-]+)
-\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)
-\bbackground job[:=]\s*([A-Za-z0-9_-]+)
-```
-
-If none match, a synthetic id `cdx-rescue-unknown-<unix-ts>` is generated and a warning is printed (exit 1, not 0). The synthetic id is still recorded so subsequent scripts can correlate.
+The discovery function is inlined in the script (one duplication is fine; not a shared module).
 
 ## Why these defaults
 
-- **`--background`** is non-negotiable (per the skill's invariant). Inline mode would block the agent.
-- **`--fresh`** clears prior session bias. The rescue is a last check; we want it cold.
-- **`--model gpt-5.5`** is the strongest reasoning model available; appropriate for a one-shot rescue.
-- **`--effort xhigh`** spends more compute. Acceptable here because rescue is one-shot per PR (not 20 rounds).
+- **`--background`** is non-negotiable — `task --background` returns immediately with a job id; without it main agent would block for the entire rescue duration (1–5 minutes per PR × N PRs serially).
+- **`--write`** lets Codex post the rescue review back to the PR as a comment.
+- **`--fresh`** clears prior session bias. The rescue is a last check; we want Codex evaluating the PR cold.
+- **`--model gpt-5.5`** is the strongest reasoning model available.
+- **`--effort xhigh`** spends more compute. Acceptable because rescue is one-shot per PR (not 20 rounds).
+
+## Polling pattern (`--wait` mode)
+
+```bash
+node codex-companion.mjs status <job-id> --wait --timeout-ms 1800000 --json
+```
+
+Returns `{ workspaceRoot, job: { id, status, phase, title, summary, logFile, startedAt, completedAt, updatedAt, elapsed, duration, progressPreview, kindLabel } }` when the job reaches a terminal status (`completed`, `failed`, `cancelled`) or when the timeout expires (job stays `running`/`queued`).
 
 ## When to run
 
 - **Phase 6**, immediately after the PR-Creator sub-agent reports the PR number/URL.
 - One invocation per PR; do not invoke twice for the same PR.
+- Without `--wait`: returns in <2s; the comment-poller Monitor (`await-pr-reviews.py` or inlined Monitor command) catches the rescue review when it lands on the PR.
+- With `--wait`: blocks for up to `--timeout-ms`. Use only when main agent has nothing else to do.
 
-## Safety
-
-- Read-only on git state (no commits, no pushes).
-- Writes to manifest only — atomic write via `tempfile + os.replace`.
-- Never invokes a Claude Agent — Codex rescue is Codex's own sub-agent, separate process.
-
-## Sample output (success)
+## Sample output (success, no `--wait`)
 
 ```
-triggering codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
-  ✓ rescue triggered: job id = cdx-rescue-7f8a9c12
-  ✓ manifest updated: /tmp/codex-review-manifest.json
+queueing codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
+  ✓ queued: jobId=task-1714138200-abc123 status=queued
+    logFile: /Users/.../codex-companion/state/jobs/task-1714138200-abc123.log
+  ✓ manifest updated: /Users/.../repo/.codex-review-manifest.json
 ```
 
-## Sample output (parse failure but trigger succeeded)
+## Sample output (success, with `--wait`)
 
 ```
-triggering codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
-⚠  no recognizable rescue job id in launch output; using synthetic: cdx-rescue-unknown-1714138200
-  ✓ rescue triggered: job id = cdx-rescue-unknown-1714138200
-  ✓ manifest updated: /tmp/codex-review-manifest.json
+queueing codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
+  ✓ queued: jobId=task-1714138200-abc123 status=queued
+    logFile: /Users/.../codex-companion/state/jobs/task-1714138200-abc123.log
+  ✓ manifest updated: /Users/.../repo/.codex-review-manifest.json
+  waiting up to 1800s for rescue to finish...
+  ✓ rescue completed (jobId=task-1714138200-abc123)
 ```
 
-(exit 1 — caller should treat the rescue as triggered but log the parse issue)
-
-## Sample output (codex not installed)
+## Sample output (plugin missing)
 
 ```
-✗ codex CLI not found: command not found: codex
+codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin
+(https://github.com/openai/codex-plugin-cc) — expected at ...
 ```
 
-(exit 2 — manifest marked `rescue_status: "failed"` with the error)
+(exit 127; manifest `rescue_status: "failed"`, `rescue_error: "codex plugin unavailable"`)
 
 ## Failure modes
 
 | Failure | Wrapper behavior | Caller (Phase 6) action |
 |---|---|---|
-| codex CLI not on PATH | Exit 2; manifest `rescue_status: failed` | Skip rescue stream; await-pr-reviews.py will see no rescue items. |
-| Codex hard error (network, auth) | Exit 2; manifest `rescue_status: failed` with error text | Same as above. |
-| Job id parse failure | Exit 1; synthetic id; manifest `rescue_status: running` | Proceed; await-pr-reviews.py polls based on PR comments, not job id. |
-| Worktree missing | Exit 2; manifest unchanged | Spawn-review-worktrees may have been bypassed; surface for human. |
+| Plugin not installed | Exit 127; `rescue_status: "failed"`, `rescue_error: "codex plugin unavailable"` | Surface to user; install plugin. |
+| `task --background` rejected by Codex (auth, network) | Exit 2; `rescue_status: "failed"`, error in manifest | Skip rescue stream; await-pr-reviews.py sees no rescue items. |
+| Queue response unparseable | Exit 2; `rescue_status: "failed"`, `rescue_error: "unparseable queue response"` | Same. |
+| `--wait` timeout (job still running) | Exit 1; manifest `rescue_status` reflects current state (likely `queued` or `running`) | Caller polls `status` later, or treats rescue as in-flight and proceeds. |
+| Worktree missing | Exit 2 with stderr; no manifest update | Spawn-review-worktrees may have been bypassed; surface for human. |
+| Rescue completes with `failed` or `cancelled` | Exit 2; manifest reflects status | Surface for human. |
 
 ## Read/write surface
 
-- **Reads**: manifest (initial), worktree path (verifies dir exists), codex CLI stdout/stderr.
-- **Writes**: manifest entry for `<branch>` (atomic).
-- **Does NOT**: commit, push, modify the worktree, comment on the PR, or dispatch any Claude Agent.
+- **Reads**: rescue prompt (file or stdin), manifest (initial), worktree directory, codex-companion stdout/stderr.
+- **Writes**: `/tmp/codex-rescue-prompt-pr-<n>.md` (the prompt persistance), manifest entry for `<branch>` (atomic via `tempfile + os.replace`).
+- **Does NOT**: commit, push, modify the worktree, comment on the PR (Codex itself does that via `--write`), or dispatch any Claude Agent.
 
-## Extending
+## See also
 
-- Replace `invoke_rescue()`'s `candidates` with your codex CLI form.
-- Replace `parse_rescue_job_id()`'s patterns with your codex output convention.
-- Add a `--policy <path>` flag if your codex rescue accepts a policy file (e.g. severity tuning).
-- Add a `--prompt <text>` flag to inject extra guidance into the rescue's prompt context (if codex supports it).
+- `scripts/run-codex-review.py` — the Phase 3 sibling that wraps `codex-companion.mjs review` (synchronous; for per-round inner-loop reviews).
+- `scripts/await-pr-reviews.py` — the Phase 6 sibling that polls PR comments and waits for the rescue review (and external bots) to land.
+- `references/post-pr-review-protocol.md` — full Phase 6 / 7 / 8 flow.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.py
@@ -38,6 +38,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
@@ -133,21 +135,41 @@ def load_manifest(path: str) -> dict | None:
         return None
 
 
+@contextlib.contextmanager
+def _manifest_lock(manifest_path: str):
+    """fcntl.LOCK_EX around manifest read-modify-write. Required because
+    Phase 6 queues N parallel rescues that all touch the same manifest;
+    without the lock, simultaneous writers clobber each other and lose
+    updates. Mirrors the recipe in parallel-subagent-protocol.md.
+    """
+    lock_path = manifest_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    with open(lock_path, "w") as lock_fp:
+        fcntl.flock(lock_fp, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fp, fcntl.LOCK_UN)
+
+
 def update_manifest_entry(path: str, branch: str, updates: dict) -> bool:
-    manifest = load_manifest(path)
-    if manifest is None:
-        return False
-    found = False
-    for entry in manifest.get("branches", []):
-        if entry.get("branch") == branch:
-            entry.update(updates)
-            entry["updated_at"] = utc_now_iso()
-            found = True
-            break
-    if not found:
-        return False
-    atomic_write(path, json.dumps(manifest, indent=2))
-    return True
+    """Lock-safe read-modify-write. Returns True iff a matching branch entry
+    was found and updated. Caller must check the return value."""
+    with _manifest_lock(path):
+        manifest = load_manifest(path)
+        if manifest is None:
+            return False
+        found = False
+        for entry in manifest.get("branches", []):
+            if entry.get("branch") == branch:
+                entry.update(updates)
+                entry["updated_at"] = utc_now_iso()
+                found = True
+                break
+        if not found:
+            return False
+        atomic_write(path, json.dumps(manifest, indent=2))
+        return True
 
 
 def repo_local_default(wt: Path, name: str) -> str:
@@ -281,6 +303,14 @@ def main() -> int:
         return 2
     prompt_path = write_prompt_file(prompt, args.pr)
 
+    # Pre-resolve the companion path so rc=127 from invoke_rescue can be
+    # attributed to a missing `node` binary, not a missing plugin.
+    try:
+        _find_codex_companion()
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 127
+
     # Manifest is optional — if absent, we still queue the rescue but skip the update.
     manifest_present = load_manifest(manifest_path) is not None
     if not manifest_present:
@@ -291,11 +321,12 @@ def main() -> int:
     rc, out, err = invoke_rescue(args.pr, args.model, args.effort, prompt_path, wt)
 
     if rc == 127:
-        print(err or "codex plugin unavailable", file=sys.stderr)
+        # Plugin path was already verified above — so 127 here means `node` is missing
+        print(f"✗ `node` not on PATH (codex-companion.mjs requires Node.js): {err[:500]}", file=sys.stderr)
         if manifest_present:
             update_manifest_entry(manifest_path, args.branch, {
                 "rescue_status": "failed",
-                "rescue_error": "codex plugin unavailable",
+                "rescue_error": "node not on PATH",
                 "rescue_started_at": started_at,
             })
         return 127
@@ -336,7 +367,7 @@ def main() -> int:
         print(f"    logFile: {log_file}")
 
     if manifest_present:
-        update_manifest_entry(manifest_path, args.branch, {
+        updated = update_manifest_entry(manifest_path, args.branch, {
             "rescue_review_id": job_id,
             "rescue_started_at": started_at,
             "rescue_status": "running",
@@ -346,7 +377,13 @@ def main() -> int:
             "rescue_title": title,
             "rescue_log_file": log_file,
         })
-        print(f"  ✓ manifest updated: {manifest_path}")
+        if updated:
+            print(f"  ✓ manifest updated: {manifest_path}")
+        else:
+            # Rescue is QUEUED on Codex's side but manifest didn't update.
+            # Common cause: --branch mistyped. Surface so caller can correlate.
+            print(f"⚠  rescue queued (jobId={job_id}) but manifest entry "
+                  f"for branch '{args.branch}' not found at {manifest_path}", file=sys.stderr)
 
     if not args.wait:
         return 0

--- a/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.py
@@ -1,25 +1,38 @@
 #!/usr/bin/env python3
-"""Trigger /codex:resc --background --fresh --model gpt-5.5 --effort xhigh on a PR.
+"""Trigger codex rescue for a PR via the OpenAI Codex Claude Code plugin.
 
-Codex rescue is Codex's own background sub-agent (not a Claude Agent dispatched
-by us). We hand it the PR link; Codex's infrastructure spawns the review job;
-the review lands on the PR like any other reviewer's comments.
-
-This script invokes the codex CLI's rescue form, captures the rescue job id,
-and updates the manifest entry for the branch with rescue_review_id /
-rescue_started_at. Returns immediately — does not poll. Phase 6's
-await-pr-reviews.py owns the wait.
+Wraps `node codex-companion.mjs task --background --write --fresh
+--model gpt-5.5 --effort xhigh --prompt-file <path> --json` — the same
+code path the `/codex:resc` slash command runs internally. The companion's
+`task --background` is the one subcommand that actually honors `--background`:
+it spawns a detached Codex worker and returns
+`{ jobId, status: "queued", title, logFile }` immediately. Phase 6's
+`await-pr-reviews.py` (or this script's `--wait` flag) owns the wait.
 
 Usage:
-    python3 trigger-codex-rescue.py --pr 42 --branch feat/foo
-    python3 trigger-codex-rescue.py --pr 42 --branch feat/foo --dry-run
-    python3 trigger-codex-rescue.py --pr 42 --branch feat/foo \\
-        --model gpt-5.5 --effort xhigh
+    # Default: queue rescue, write rescue_review_id + rescue_started_at to manifest, return.
+    python3 trigger-codex-rescue.py \\
+        --pr 42 --branch feat/foo \\
+        --worktree /path/to/wt \\
+        --prompt-file /tmp/rescue-prompt-pr-42.md
+
+    # If main agent has the prompt in stdin:
+    cat prompt.md | python3 trigger-codex-rescue.py \\
+        --pr 42 --branch feat/foo --worktree /path/to/wt
+
+    # Block until the rescue job completes (default cap 30 min):
+    python3 trigger-codex-rescue.py \\
+        --pr 42 --branch feat/foo --worktree /path/to/wt \\
+        --prompt-file /tmp/p.md --wait --timeout-ms 1800000
+
+    # Optional: write to a non-default manifest:
+    python3 trigger-codex-rescue.py ... --manifest /repo/.codex-review-manifest.json
 
 Exit codes:
-    0  rescue triggered; manifest updated
-    1  triggered but couldn't parse a job id (synthetic id used; manifest still updated)
-    2  codex CLI failed; manifest marked rescue_status=failed
+    0  rescue queued (and completed if --wait); manifest updated
+    1  --wait specified but the job timed out before terminal status
+    2  rescue queue failed (codex CLI error, manifest update failed)
+  127  codex plugin not installed (caller surfaces FAILED)
 """
 
 from __future__ import annotations
@@ -31,14 +44,53 @@ import re
 import subprocess
 import sys
 import tempfile
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-DEFAULT_MANIFEST = "/tmp/codex-review-manifest.json"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_EFFORT = "xhigh"
+DEFAULT_TIMEOUT_MS = 1_800_000  # 30 min — matches Phase 6 total cap
 
+
+# ─── codex-companion.mjs discovery (version-agnostic) ─────────────────────────
+# (Same shape as run-codex-review.py — duplicated by design; one shared helper
+# for two callers was overengineering and would force sys.path hacks.)
+
+def _find_codex_companion() -> Path:
+    """Discover the OpenAI Codex plugin's codex-companion.mjs.
+
+    Resolution order:
+      1. ${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs (set by Claude Code harness).
+      2. Latest semver-sorted version under
+         ~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs.
+
+    Plugin source: https://github.com/openai/codex-plugin-cc/tree/main/plugins/codex
+    """
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidate = Path(plugin_root) / "scripts" / "codex-companion.mjs"
+        if candidate.is_file():
+            return candidate
+
+    cache = Path.home() / ".claude" / "plugins" / "cache" / "openai-codex" / "codex"
+    if cache.is_dir():
+        def _key(p: Path) -> tuple:
+            m = re.match(r"^(\d+)\.(\d+)\.(\d+)", p.name)
+            return (1, int(m[1]), int(m[2]), int(m[3])) if m else (0, p.name)
+        for v in sorted((p for p in cache.iterdir() if p.is_dir()), key=_key, reverse=True):
+            candidate = v / "scripts" / "codex-companion.mjs"
+            if candidate.is_file():
+                return candidate
+
+    raise FileNotFoundError(
+        "codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin "
+        "(https://github.com/openai/codex-plugin-cc) — expected at "
+        "$CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs or at "
+        "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs."
+    )
+
+
+# ─── Generic helpers ──────────────────────────────────────────────────────────
 
 def sh(cmd, cwd=None, timeout=None):
     try:
@@ -98,120 +150,248 @@ def update_manifest_entry(path: str, branch: str, updates: dict) -> bool:
     return True
 
 
-# ─── Codex rescue invocation — adjustment point per environment ──────────────
+def repo_local_default(wt: Path, name: str) -> str:
+    rc, out, _ = sh(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=wt)
+    if rc == 0 and out:
+        return str(Path(out).parent / name)
+    return f"/tmp/{name}"
 
-def invoke_rescue(pr: int, model: str, effort: str, wt: Path) -> tuple[int, str, str]:
-    """Launch codex rescue in --background mode. Return (rc, stdout, stderr).
 
-    Adjust the command form here to match the codex CLI in your environment.
-    Common forms (try in order):
-      - codex review --rescue --background --fresh --model <m> --effort <e> --pr <n>
-      - codex rescue --background --fresh --model <m> --effort <e> --pr <n>
-      - codex resc --background --fresh --model <m> --effort <e> --pr <n>
+# ─── Codex rescue invocation ─────────────────────────────────────────────────
+
+def write_prompt_file(prompt: str, pr: int) -> Path:
+    """Persist the rescue prompt to a stable path so codex-companion can read it.
+    Returns the path. /tmp is fine for the prompt — it's input, not state."""
+    path = Path(f"/tmp/codex-rescue-prompt-pr-{pr}.md")
+    path.write_text(prompt)
+    return path
+
+
+def invoke_rescue(pr: int, model: str, effort: str, prompt_file: Path,
+                  wt: Path, timeout: int = 120) -> tuple[int, str, str]:
+    """Spawn codex-companion task --background. Returns (rc, stdout, stderr).
+
+    The companion's `task` subcommand DOES honor --background — unlike `review`,
+    which runs synchronously regardless. Background returns
+    `{ jobId, status: "queued", title, logFile }` on stdout immediately.
     """
-    candidates = [
-        ["codex", "review", "--rescue", "--background", "--fresh",
-         "--model", model, "--effort", effort, "--pr", str(pr)],
-        ["codex", "rescue", "--background", "--fresh",
-         "--model", model, "--effort", effort, "--pr", str(pr)],
-        ["codex", "resc", "--background", "--fresh",
-         "--model", model, "--effort", effort, "--pr", str(pr)],
+    try:
+        companion = _find_codex_companion()
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+
+    cmd = [
+        "node", str(companion), "task",
+        "--background",
+        "--write",
+        "--fresh",
+        "--model", model,
+        "--effort", effort,
+        "--prompt-file", str(prompt_file),
+        "--json",
     ]
-    for cmd in candidates:
-        rc, out, err = sh(cmd, cwd=wt, timeout=120)
-        if rc != 127:  # found the binary, even if it failed for other reasons
-            return rc, out, err
-    return 127, "", "no codex rescue CLI form succeeded; check codex install / PATH"
+    return sh(cmd, cwd=wt, timeout=timeout)
 
 
-def parse_rescue_job_id(stdout: str) -> str | None:
-    """Extract a rescue job id from launch stdout. Adjust regex per CLI output."""
-    patterns = [
-        r"\brescue[- ]?job[- ]?id[:=]\s*([A-Za-z0-9_-]+)",
-        r"\b(cdx[- ]?rescue[- ]?[A-Za-z0-9_-]+)",
-        r"\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)",
-        r"\bbackground job[:=]\s*([A-Za-z0-9_-]+)",
+def wait_for_rescue(job_id: str, wt: Path, timeout_ms: int) -> tuple[int, dict | None, str]:
+    """Poll codex-companion status <job-id> --wait until terminal.
+
+    Returns (rc, parsed_status_payload, stderr).
+    """
+    try:
+        companion = _find_codex_companion()
+    except FileNotFoundError as e:
+        return 127, None, str(e)
+
+    cmd = [
+        "node", str(companion), "status", job_id,
+        "--wait",
+        "--timeout-ms", str(timeout_ms),
+        "--json",
     ]
-    for pat in patterns:
-        m = re.search(pat, stdout, flags=re.IGNORECASE)
-        if m:
-            return m.group(1)
-    return None
+    rc, out, err = sh(cmd, cwd=wt, timeout=(timeout_ms / 1000) + 60)
+    if rc != 0:
+        return rc, None, err or out
+    try:
+        return rc, json.loads(out), err
+    except (ValueError, TypeError):
+        return rc, None, f"could not parse status JSON: {out[:500]}"
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def read_prompt(args) -> str:
+    if args.prompt_file:
+        return Path(args.prompt_file).read_text()
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise SystemExit("provide --prompt-file <path> or pipe the prompt on stdin")
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--pr", type=int, required=True, help="PR number")
     ap.add_argument("--branch", required=True, help="branch name (manifest entry key)")
-    ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
+    ap.add_argument("--worktree", required=True, help="worktree path; codex runs from here")
+    ap.add_argument("--prompt-file",
+                    help="Path to the comprehensive review prompt for Codex. If absent, reads stdin.")
+    ap.add_argument("--manifest",
+                    help="Manifest path. Default: <repo-root>/.codex-review-manifest.json")
     ap.add_argument("--model", default=DEFAULT_MODEL)
-    ap.add_argument("--effort", default=DEFAULT_EFFORT)
+    ap.add_argument("--effort", default=DEFAULT_EFFORT,
+                    help="Codex reasoning effort: none|minimal|low|medium|high|xhigh")
+    ap.add_argument("--wait", action="store_true",
+                    help="Block until the rescue job terminates (status ∈ completed|failed|cancelled). "
+                         "Default: queue and return immediately.")
+    ap.add_argument("--timeout-ms", type=int, default=DEFAULT_TIMEOUT_MS,
+                    help=f"Total wall-clock cap when --wait is set. Default {DEFAULT_TIMEOUT_MS} ms (30 min).")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
-    manifest = load_manifest(args.manifest)
-    if manifest is None:
-        print(f"manifest absent or unreadable: {args.manifest}", file=sys.stderr)
-        return 2
-
-    entry = next((e for e in manifest.get("branches", []) if e.get("branch") == args.branch), None)
-    if entry is None:
-        print(f"branch {args.branch} not in manifest", file=sys.stderr)
-        return 2
-
-    wt = Path(entry.get("worktree_path", ""))
+    wt = Path(args.worktree)
     if not wt.is_dir():
         print(f"worktree not found: {wt}", file=sys.stderr)
         return 2
 
+    manifest_path = args.manifest or repo_local_default(wt, ".codex-review-manifest.json")
+
     if args.dry_run:
-        print(f"DRY-RUN: would invoke codex rescue for PR #{args.pr} in {wt}")
-        print(f"  branch: {args.branch}")
-        print(f"  model:  {args.model}")
-        print(f"  effort: {args.effort}")
-        print(f"  manifest entry would be updated with rescue_review_id (synthetic if no parse)")
+        try:
+            companion = _find_codex_companion()
+        except FileNotFoundError as e:
+            print(f"DRY-RUN: {e}", file=sys.stderr)
+            return 127
+        print(f"DRY-RUN: would invoke")
+        print(f"  node {companion} task --background --write --fresh "
+              f"--model {args.model} --effort {args.effort} --prompt-file <prompt> --json")
+        print(f"  cwd:        {wt}")
+        print(f"  PR:         #{args.pr}")
+        print(f"  branch:     {args.branch}")
+        print(f"  manifest:   {manifest_path}")
+        print(f"  wait:       {args.wait}")
+        if args.wait:
+            print(f"  timeout-ms: {args.timeout_ms}")
         return 0
 
-    print(f"triggering codex rescue: PR #{args.pr} in {wt} ({args.model}, effort={args.effort})...")
+    # Read the rescue prompt (file or stdin) and persist to /tmp so codex-companion
+    # can --prompt-file it. Multiline content survives this round-trip.
+    prompt = read_prompt(args)
+    if not prompt.strip():
+        print("rescue prompt is empty; aborting", file=sys.stderr)
+        return 2
+    prompt_path = write_prompt_file(prompt, args.pr)
+
+    # Manifest is optional — if absent, we still queue the rescue but skip the update.
+    manifest_present = load_manifest(manifest_path) is not None
+    if not manifest_present:
+        print(f"⚠  manifest not found at {manifest_path}; rescue will queue but no manifest update", file=sys.stderr)
+
     started_at = utc_now_iso()
-    rc, out, err = invoke_rescue(args.pr, args.model, args.effort, wt)
+    print(f"queueing codex rescue: PR #{args.pr} in {wt} ({args.model}, effort={args.effort})...")
+    rc, out, err = invoke_rescue(args.pr, args.model, args.effort, prompt_path, wt)
 
     if rc == 127:
-        print(f"✗ codex CLI not found: {err}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "rescue_status": "failed",
-            "rescue_error": "codex CLI not on PATH",
-            "rescue_started_at": started_at,
-        })
+        print(err or "codex plugin unavailable", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": "codex plugin unavailable",
+                "rescue_started_at": started_at,
+            })
+        return 127
+
+    if rc != 0:
+        print(f"✗ codex task --background failed (rc={rc}): {err[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": (err or out)[:500],
+                "rescue_started_at": started_at,
+            })
         return 2
 
-    if rc not in (0, 1):  # 0 = ok, 1 sometimes used for "submitted with warnings"
-        print(f"✗ codex rescue failed (rc={rc}): {err}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "rescue_status": "failed",
-            "rescue_error": (err or out)[:500],
-            "rescue_started_at": started_at,
-        })
+    # Parse the queued-job descriptor: { jobId, status: "queued", title, logFile, summary? }
+    try:
+        payload = json.loads(out)
+    except (ValueError, TypeError):
+        print(f"✗ could not parse codex queue response: {out[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": "unparseable queue response",
+                "rescue_started_at": started_at,
+            })
         return 2
 
-    job_id = parse_rescue_job_id(out) or parse_rescue_job_id(err)
-    parse_failure = False
+    job_id = payload.get("jobId") or ""
     if not job_id:
-        job_id = f"cdx-rescue-unknown-{int(time.time())}"
-        parse_failure = True
-        print(f"⚠  no recognizable rescue job id in launch output; using synthetic: {job_id}")
+        print(f"✗ no jobId in queue response: {payload}", file=sys.stderr)
+        return 2
 
-    update_manifest_entry(args.manifest, args.branch, {
-        "rescue_review_id": job_id,
-        "rescue_started_at": started_at,
-        "rescue_status": "running",
-        "rescue_pr_number": args.pr,
-        "rescue_model": args.model,
-        "rescue_effort": args.effort,
-    })
-    print(f"  ✓ rescue triggered: job id = {job_id}")
-    print(f"  ✓ manifest updated: {args.manifest}")
-    return 1 if parse_failure else 0
+    queued_status = payload.get("status", "queued")
+    title = payload.get("title", "")
+    log_file = payload.get("logFile", "")
+    print(f"  ✓ queued: jobId={job_id} status={queued_status}")
+    if log_file:
+        print(f"    logFile: {log_file}")
+
+    if manifest_present:
+        update_manifest_entry(manifest_path, args.branch, {
+            "rescue_review_id": job_id,
+            "rescue_started_at": started_at,
+            "rescue_status": "running",
+            "rescue_pr_number": args.pr,
+            "rescue_model": args.model,
+            "rescue_effort": args.effort,
+            "rescue_title": title,
+            "rescue_log_file": log_file,
+        })
+        print(f"  ✓ manifest updated: {manifest_path}")
+
+    if not args.wait:
+        return 0
+
+    # --wait: block on status --wait until terminal
+    print(f"  waiting up to {args.timeout_ms / 1000:.0f}s for rescue to finish...")
+    rc, status_payload, err = wait_for_rescue(job_id, wt, args.timeout_ms)
+    finished_at = utc_now_iso()
+
+    if rc == 127:
+        print(err, file=sys.stderr)
+        return 127
+    if rc != 0 or status_payload is None:
+        print(f"✗ status --wait failed: rc={rc}: {err[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": (err or "wait failed")[:500],
+                "rescue_finished_at": finished_at,
+            })
+        return 2
+
+    job = status_payload.get("job") or {}
+    final_status = job.get("status", "unknown")
+    if final_status == "completed":
+        print(f"  ✓ rescue completed (jobId={job_id})")
+    elif final_status in {"failed", "cancelled"}:
+        print(f"✗ rescue {final_status} (jobId={job_id})", file=sys.stderr)
+    else:
+        # Could be 'queued' or 'running' if status --wait timed out
+        print(f"⚠  rescue not terminal yet: status={final_status} (jobId={job_id})", file=sys.stderr)
+
+    if manifest_present:
+        update_manifest_entry(manifest_path, args.branch, {
+            "rescue_status": final_status,
+            "rescue_finished_at": finished_at,
+            "rescue_phase": job.get("phase", ""),
+            "rescue_elapsed": job.get("elapsed", ""),
+        })
+
+    if final_status == "completed":
+        return 0
+    if final_status in {"queued", "running"}:
+        return 1  # timed out before terminal
+    return 2  # failed or cancelled
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Rewrite `scripts/run-codex-review.py` and `scripts/trigger-codex-rescue.py` to actually invoke the codex plugin's `codex-companion.mjs` correctly (the prior versions were stubs with broken `codex review --background` fallback chains). Discovery is version-agnostic via `${CLAUDE_PLUGIN_ROOT}` then semver-sorted glob over `~/.claude/plugins/cache/openai-codex/codex/<version>/`.
- Harden the ten-phase flow against every friction point caught in production traces: slash-vs-shell invocation matrix, applier-only worker briefs, main-agent-as-coordinator, Phase 8a/8b split with squash-merge `git rebase --onto` mechanics, Phase 9 four-step cleanup with hard exit gate, throttled REST-based PR creation, and `CONVERGED-AT-CAP` terminal state.
- New `references/event-driven-orchestration.md` codifies the Monitor / ScheduleWakeup / `Bash run_in_background` / `Agent run_in_background` patterns the skill needs across phases.

## What this PR changes

### Scripts (rewritten end-to-end)

| Script | Before | After |
|---|---|---|
| `run-codex-review.py` | Stub: tried `codex review --background` (no such CLI flag); commented "adjust to your environment" | Discovers `codex-companion.mjs` automatically; spawns `node codex-companion.mjs review --json` synchronously; parses both native and adversarial JSON envelopes; writes round-log; updates manifest. New `--mode adversarial` flag. Wall-clock cap default 1500s. Manifest defaults repo-local. |
| `trigger-codex-rescue.py` | Stub: tried `codex review --rescue` / `codex rescue` / `codex resc` fallback chain (none exist) | Spawns `node codex-companion.mjs task --background --write --fresh --model gpt-5.5 --effort xhigh --prompt-file <p> --json`. Captures `jobId`, `logFile`. Optional `--wait` polls `status --wait` until terminal. Reads prompt from `--prompt-file` or stdin. |

Both scripts inline the same ~20-line `_find_codex_companion()` discovery function (version-agnostic; one duplication is fine — sibling Python imports need `sys.path` hacks).

### SKILL.md hardening (across multiple production-trace iterations)

- **Slash-command invocation matrix** explicit: `/codex:review` is `disable-model-invocation: true`; sub-agents go through the wrapper. `/codex:resc` has two first-class paths (slash-typed for 1-2 PRs, wrapper for programmatic loops).
- **Worker brief = APPLIER, not EVALUATOR.** Production traces showed `/do-review`-framed worker briefs caused 100% decision-only failure (8/8 first-attempt workers stopped at \"Verdict: apply\" without pushing). Eval moves to main agent; workers receive pre-decided fix specs and apply mechanically.
- **Coordinator-as-subagent dropped.** Long-lived (5+h) coordinator sub-agents drift past harness session limits. Main agent IS the coordinator across all branches; sub-agents are short-lived single-purpose appliers / PR-Creators / evaluators.
- **Phase 8 split into 8a (apply) + 8b (merge).** 8b documents squash-merge mechanics: capture `foundation_pre_merge_tip` BEFORE merging foundation; rebase leaves with `git rebase --onto origin/main <foundation_tip> <leaf>` to skip the now-redundant foundation commits; retarget via `gh pr edit --base main`; sequential merge with CI-wait between (no `--auto` for divergent stacks); `--delete-branch` flag halves Phase 9 cleanup.
- **Phase 9 hard exit gate.** Four-step cleanup: worktrees → local branches → remote branches → temp files. Audit verifies 0 stale anything; all non-BLOCKED branches MUST merge to main before Phase 9 can pass.
- **Phase 5 throttled to ≤4 parallel PR-Creators** using REST `gh api repos/.../pulls` (parallel `gh pr create` exhausts GraphQL budget — verified in production).
- **CONVERGED-AT-CAP terminal state added** (replaces the agent-invented `DONE-PRAGMATIC`).
- **Authorization rule.** When user prompt authorizes full flow, no end-of-phase option menus; one-sentence phase transitions; never \"how would you like to proceed?\" mid-flight.
- **External bot list extended:** `cubic-dev-ai` + `copilot-pull-request-reviewer` joined Copilot, Greptile, Devin in the canonical sources list.

### New reference

- `references/event-driven-orchestration.md` (255 lines): pinned spec for `Monitor` / `ScheduleWakeup` / `Bash run_in_background` / `Agent run_in_background` usage in Phases 3-8. Includes per-PR comment-poller Monitor shape with `PR-N-DONE quiet`/`cap` termination markers, cache-window math for `ScheduleWakeup` delays, and anti-patterns from production traces.

## Test plan

- [x] `python3 scripts/validate-skills.py` → all 42 skills pass.
- [x] `run-codex-review.py --dry-run` resolves `codex-companion.mjs` to the installed version (`1.0.4` today); prints intended invocation; exits 0.
- [x] `run-codex-review.py --mode adversarial --dry-run` switches to `adversarial-review` subcommand correctly.
- [x] `trigger-codex-rescue.py --dry-run` resolves the same path; prints the queued-task invocation.
- [x] No orphan references in `SKILL.md` (every `references/*.md` is linked).
- [x] No stale \"adjust to your environment\" / \"legacy fallback\" framing remaining anywhere in the skill tree.
- [x] No stale `Coordinator sub-agent` references in production-relevant text (only in historical \"why we dropped this\" explanations).
- [ ] Live-fire test: run `/run-codex-review` end-to-end on a small repo with 2-3 branches and verify Phase 0 → Phase 9 completes without agent-side improvisation.

## Reviewer questions

1. **Plugin discovery fallback path** — The wrappers fall back to `~/.claude/plugins/cache/openai-codex/codex/<latest>/scripts/codex-companion.mjs` when `${CLAUDE_PLUGIN_ROOT}` isn't set. Is this path stable across the OpenAI Codex Claude Code plugin's installation modes? (i.e. is it always under `~/.claude/plugins/cache/openai-codex/codex/<version>/`, or do user-customized install dirs exist?)
2. **Adversarial mode default** — Should `--mode adversarial` be the default instead of `review`? Adversarial gives structured findings (severities `critical|high|medium|low`, no regex parsing); native review gives free-form text the wrapper has to regex-parse. Default-review preserves existing skill semantics; default-adversarial is more reliable. Is there a reason to keep native as default?
3. **Phase 8b leaf-rebase strategy** — When foundation squash-merges with 1 logical commit but N original commits in the stack, the wrapper script rebases each leaf with `git rebase --onto origin/main <foundation_tip> <leaf>`. This works when the leaf was branched directly off foundation. Are there scenarios where leaves are branched off OTHER leaves (chained stack)? If so, the `--onto` arg needs to be each leaf's ancestor, not foundation_tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Codex review/rescue wrappers with `codex-companion.mjs`, strengthened the ten‑phase flow, and added reliability fixes plus tooling for dependency prep and Phase 8 apply.

- **New Features**
  - `spawn-review-worktrees.py --prep-deps`: detects the project’s package manager and runs install (pnpm, bun, yarn, npm, Python `requirements.txt`/Poetry/uv, Ruby; Cargo/Go no-ops).
  - `apply-evaluator-decisions.py`: builds the ordered Phase 8a apply queue from evaluator JSON; blocks on ambiguous items; supports `--json`.

- **Bug Fixes**
  - Manifest updates are now `flock`-guarded in `run-codex-review.py` and `trigger-codex-rescue.py` to avoid parallel write clobbering; both scripts validate that a branch entry exists before writing.
  - Severity parsing maps `[P1..P4]` to `critical|high|medium|low` so DONE classification is accurate; only JSON-shaped stdout is normalized to avoid masking Codex errors.
  - Environment checks distinguish missing plugin vs missing `node`; plugin path is pre‑resolved and `last_status` is set accurately.
  - Docs aligned with the flow: repo‑local manifest default, main‑agent‑as‑coordinator, Phase 8b `git rebase --onto` guidance, event-driven poller pagination, and normalized bot names.

<sup>Written for commit c6b3b32277c15b6c7888f02269d0dcea9a8b9a0b. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

