### PR TITLE
feat(skills): add run industry research

### DIFF
--- a/NAMING.md
+++ b/NAMING.md
@@ -48,6 +48,7 @@ When two skills overlap, use distinct verbs:
 
 - `do-review` (do a PR review) vs `ask-review` (ask for a review on your branch)
 - `do-debug` (entry-level systematic debug) vs `do-think` (deep reasoning framework)
+- `run-research` (answer a technical research question) vs `run-industry-research` (build a full market/category research corpus)
 - `optimize-agentic-cli` vs `optimize-agentic-mcp`
 
 ## Canonical Rules
@@ -84,7 +85,7 @@ When renaming a published skill:
 7. Search cross-skill references and update each
 8. Run `python3 scripts/validate-skills.py`
 
-## Current Canonical Skill Names (42)
+## Current Canonical Skill Names (43)
 
 - `apply-clean-architecture`
 - `apply-liquid-glass`
@@ -120,6 +121,7 @@ When renaming a published skill:
 - `run-codex-exec`
 - `run-codex-review`
 - `run-github-scout`
+- `run-industry-research`
 - `run-issue-tree`
 - `run-playwright`
 - `run-repo-cleanup`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-42 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+43 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 
@@ -54,6 +54,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [run-codex-exec](skills/run-codex-exec/) | orchestration | Parallel codex exec agents in git worktrees with auto-commit + live monitor |
 | [run-codex-review](skills/run-codex-review/) | orchestration | Per-branch /codex:review fix loops + /ask-review PR + codex rescue + multi-bot /do-review evaluation |
 | [run-github-scout](skills/run-github-scout/) | productivity | Adaptive GitHub repo discovery and shortlisting for concrete needs |
+| [run-industry-research](skills/run-industry-research/) | productivity | Industry research corpora with evidence packs and comparisons |
 | [run-issue-tree](skills/run-issue-tree/) | productivity | Plan and execute GitHub Issue trees with sub-issues and waves |
 | [run-playwright](skills/run-playwright/) | testing | Browser testing with Playwright CLI |
 | [run-repo-cleanup](skills/run-repo-cleanup/) | productivity | Sweep dirty tree + unpushed commits + N worktrees into focused private-fork PRs with self-review bodies |

--- a/skills/run-industry-research/README.md
+++ b/skills/run-industry-research/README.md
@@ -1,0 +1,19 @@
+# run-industry-research
+
+Researching an industry, market, SaaS, open-source, or product category and need a source-backed corpus with comparisons.
+
+**Category:** productivity
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/run-industry-research
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/run-industry-research/skills/run-industry-research/SKILL.md
+++ b/skills/run-industry-research/skills/run-industry-research/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: run-industry-research
+description: Use skill if you are researching an industry, market, SaaS, open-source, or product category and need a source-backed corpus with comparisons.
+---
+
+# Run Industry Research
+
+Run deep, source-backed industry research into corpora with product or project evidence packs, cross-category comparisons, Reddit/practitioner context, and audit-ready synthesis.
+
+## Trigger Boundary
+
+Use this skill when the user asks for:
+
+- comprehensive industry research, market landscape, category map, or competitive landscape
+- deep product-category audits with many vendors, tools, frameworks, or open-source projects
+- SaaS research, open-source technology ecosystem research, developer-tool landscape research, or provider comparison
+- a reusable research folder with product pages, comparison rollups, pricing/unit economics, source ledgers, Reddit/audience evidence, and master summaries
+
+Do not use this skill for:
+
+- a single technical question or architecture decision; use `run-research`
+- finding GitHub repositories only; use `run-github-scout`
+- codebase-only analysis, code review, or implementation work
+- a quick one-page market summary where a full corpus would be overkill
+
+## Hard Limits
+
+- Persistent research output must stay under **1000 files** unless the user explicitly raises the cap.
+- No placeholder files. Every created file must contain source-backed, independently useful content.
+- Design the output architecture before dispatching agents or writing product files.
+- Use context-specific category names. Do not blindly reuse `01-pricing`, `05-security`, or `07-benchmarks` when the vertical needs different names.
+- Separate confirmed facts, vendor/project claims, practitioner evidence, and inference.
+- Search before synthesis. Never treat snippets as evidence.
+
+## Decision Tree
+
+1. **Clarify outcome if missing**
+   - Ask: "What will you do with this research?"
+   - Also clarify target audience, geography, and whether the result is for buying, strategy, implementation, investment, or content.
+   - Skip questions when the user's intent is already clear.
+2. **Choose corpus scale**
+   - `compact`: 1-10 entities, 15-80 files.
+   - `standard`: 10-40 entities, 80-350 files.
+   - `deep`: 40-100 entities, 250-900 files.
+   - `tiered`: 100+ entities. Keep full evidence packs for top-tier entities only; put long-tail discoveries in `_meta/discovered-*.md`.
+3. **Choose research archetype**
+   - SaaS/vendor/product category.
+   - Open-source technology ecosystem.
+   - Developer infrastructure or cloud platform market.
+   - Data/API/provider market.
+   - Regulated industry or compliance-heavy market.
+   - Consumer app, hardware, or content ecosystem.
+   - Read `references/category-taxonomies.md` and pick or adapt one taxonomy.
+4. **Design file budget and architecture**
+   - Read `references/research-architecture.md`.
+   - Produce a tree plan with file-count budget before creating files.
+   - Include `_meta/`, entity folders, top-level entity profiles, `_cross-product/` or `_cross-ecosystem/`, and a root `README.md`.
+5. **Write mission briefs**
+   - Read `references/mission-briefs.md`.
+   - Assign each agent one product, project, domain, or cross-cutting criterion.
+   - Include exact output ownership, source expectations, fallback chain, and definition of done.
+6. **Research and write**
+   - Use `run-research` methodology: planner, diverse web queries, Reddit/practitioner searches, scrape/read sources, loop on gaps.
+   - Write evidence packs as research lands. Do not wait for all agents before processing completed outputs.
+7. **Synthesize**
+   - Read all local outputs personally.
+   - Create root README, main entity profiles, cross-category rollups, source map, claims ledger, contradictions, and next-test backlog.
+   - Read `references/evidence-and-synthesis.md` before final synthesis.
+8. **Verify**
+   - Count files; fail if over the agreed cap.
+   - Run local markdown link checks.
+   - Check every entity has required minimum evidence or is explicitly listed as long-tail/insufficient-evidence.
+   - Check cross-product rollups cite both local files and original source URLs where possible.
+
+## Output Architecture Contract
+
+Default shape:
+
+```text
+[topic-slug]/
+|-- README.md
+|-- _meta/
+|   |-- research-plan.md
+|   |-- methodology-and-source-policy.md
+|   |-- discovered-entities.md
+|   `-- file-budget.md
+|-- _cross-[scope]/
+|   |-- 00-overview/
+|   |-- [criterion-a]/
+|   |-- [criterion-b]/
+|   `-- 09-sources/
+|-- [entity-slug]/
+|   |-- 00-overview/
+|   |-- [entity-specific-context]/
+|   `-- 09-sources/
+`-- [entity-slug].md
+```
+
+Resolve bracketed names into concrete kebab-case folder names before work starts. Each folder name must reveal the buyer or researcher question it answers.
+
+## Required Evidence Layers
+
+Every full entity evidence pack should usually include:
+
+- overview, taxonomy, positioning, and evidence grade
+- pricing, unit economics, funding, or sustainability when relevant
+- product/platform/project capabilities
+- integrations/ecosystem/developer experience
+- operations, reliability, maintenance, or release posture
+- security, compliance, licensing, governance, or risk
+- audience, Reddit, GitHub issues, reviews, forums, or community voice
+- benchmarks, performance, test plans, or reproducibility
+- buyer fit, adoption fit, alternatives, and no-fit cases
+- source map, claims ledger, contradictions, open gaps, and follow-up tests
+
+Rename these layers for the vertical. For example, open-source research should use `license-governance-security`, not generic `security`; data-provider research should use `coverage-quality-rights`, not generic `platform`.
+
+## Completion Gate
+
+Do not call the corpus complete until all are true:
+
+- File count is under cap and recorded in `_meta/file-budget.md`.
+- Root `README.md` points to the highest-signal entry points.
+- Every main profile links to its evidence pack.
+- Cross-category rollups exist for every important decision criterion.
+- Source map and claims ledger exist at entity and cross-category level, or the absence is explained.
+- Reddit/practitioner evidence is direct when available, labeled adjacent when sparse, and never presented as consensus without attribution.
+- All stale placeholders, broken local links, hidden junk files, and unresolved naming mismatches are fixed or documented.
+
+## Reference Routing
+
+| File | Read when |
+|---|---|
+| `references/research-architecture.md` | Designing the corpus tree, file budget, entity tiers, and validation gates. |
+| `references/category-taxonomies.md` | Choosing context-specific folder/category names for SaaS, open source, developer tools, data providers, regulated industries, or consumer markets. |
+| `references/mission-briefs.md` | Writing high-quality prompts for product, project, cross-product, Reddit, and source-verification agents. |
+| `references/evidence-and-synthesis.md` | Applying source hierarchy, Reddit rules, pricing/unit-economics standards, source maps, claims ledgers, and final synthesis checks. |
+
+## Output Contract
+
+Show these artifacts as they are produced:
+
+1. Scope classification and chosen corpus scale.
+2. File-budget plan with expected entity count and maximum file count.
+3. Output architecture tree with context-specific category names.
+4. Agent mission map, if agents are used.
+5. Research progress notes with source gaps and retry decisions.
+6. Final corpus summary: file count, entry points, critical findings, unresolved gaps, and verification results.
+
+## Guardrails
+
+- Do not make landing-page-style reports. Build the actual research corpus.
+- Do not collapse product facts, pricing, practitioner sentiment, and source verification into one undifferentiated file.
+- Do not create raw dump folders unless the user explicitly asks. Summarize and source-map instead.
+- Do not use the same category names for every vertical when better names are available.
+- Do not outsource final synthesis. The orchestrator reads the files and resolves contradictions personally.
+- Do not exceed 8 researcher agents per wave unless the user explicitly authorizes a larger wave.

--- a/skills/run-industry-research/skills/run-industry-research/references/category-taxonomies.md
+++ b/skills/run-industry-research/skills/run-industry-research/references/category-taxonomies.md
@@ -1,0 +1,234 @@
+# Category Taxonomies
+
+How to choose context-specific folder names and comparison criteria for different industry research verticals.
+
+## Selection Rule
+
+Pick the taxonomy that matches the buyer or researcher decision. Then rename folders so each path says what the file answers in that vertical.
+
+Good:
+
+```text
+_cross-product/01-pricing-unit-economics/
+_cross-ecosystem/05-license-governance-security/
+_cross-provider/03-data-coverage-quality/
+```
+
+Weak:
+
+```text
+_cross-product/01-context/
+_cross-product/05-security/
+_cross-product/07-other/
+```
+
+## SaaS Or Product Category
+
+Use for vendor landscapes, B2B SaaS, infrastructure products, API products, marketplaces, or buying decisions.
+
+Entity contexts:
+
+```text
+00-overview/
+01-pricing-unit-economics/
+02-product-capabilities/
+03-integrations-ecosystem/
+04-operations-reliability-support/
+05-security-compliance-legal/
+06-audience-reviews-reddit/
+07-benchmarks-performance-tests/
+08-buyer-fit-alternatives/
+09-sources-claims-gaps/
+```
+
+Cross contexts:
+
+```text
+00-category-map-and-rankings/
+01-pricing-unit-economics/
+02-capability-matrix/
+03-integrations-ecosystem/
+04-operations-reliability-support/
+05-security-compliance-legal/
+06-audience-market-signal/
+07-benchmarks-performance-tests/
+08-buyer-scenarios-shortlists/
+09-sources-claims-gaps/
+```
+
+Required emphasis:
+
+- native pricing units, overages, gated enterprise terms, unit economics
+- product layer and control surface
+- integrations and switching cost
+- status pages, incident history, SLA, support, changelog
+- security, privacy, compliance, acceptable use, legal risk
+- reviews, Reddit, HN, forums, migration stories, pricing complaints
+- benchmark claims and buyer-run test plan
+
+## Open-Source Technology Ecosystem
+
+Use for frameworks, libraries, developer tools, model runtimes, infrastructure components, or open-source alternatives.
+
+Entity contexts:
+
+```text
+00-overview/
+01-project-health-maintenance/
+02-installation-api-devex/
+03-architecture-extension-model/
+04-ecosystem-integrations/
+05-license-governance-security/
+06-community-github-reddit/
+07-benchmarks-performance-reproducibility/
+08-adoption-fit-alternatives/
+09-sources-claims-gaps/
+```
+
+Cross contexts:
+
+```text
+00-ecosystem-map-and-rankings/
+01-project-health-maintenance/
+02-api-devex-and-documentation/
+03-architecture-extension-model/
+04-ecosystem-integrations/
+05-license-governance-security/
+06-community-maintainer-signal/
+07-benchmarks-performance-reproducibility/
+08-adoption-scenarios-alternatives/
+09-sources-claims-gaps/
+```
+
+Required emphasis:
+
+- release cadence, maintainer bus factor, issue velocity, abandoned forks
+- license compatibility and governance
+- install path, API stability, docs quality, examples, migration friction
+- benchmarks and reproducibility, not only README claims
+- GitHub issues, discussions, Reddit, HN, Stack Overflow, Discord/forum evidence
+
+## Developer Infrastructure Or Cloud Platform
+
+Use for hosting, databases, observability, auth, serverless, orchestration, or cloud runtime categories.
+
+Suggested contexts:
+
+```text
+00-platform-map-and-rankings/
+01-pricing-capacity-unit-economics/
+02-runtime-architecture-control-plane/
+03-deployment-integrations-devex/
+04-reliability-scaling-observability/
+05-security-compliance-data-boundaries/
+06-practitioner-incidents-migrations/
+07-performance-benchmarks-load-tests/
+08-workload-fit-exit-paths/
+09-sources-claims-gaps/
+```
+
+Required emphasis:
+
+- pricing under realistic capacity and traffic
+- data plane vs control plane
+- regions, scaling, quotas, cold starts, failover, backup/restore
+- lock-in and exit path
+- incident history and migration stories
+
+## Data, API, Or Content Provider Market
+
+Use for search APIs, data vendors, scraping APIs, enrichment providers, vector data, or content/license markets.
+
+Suggested contexts:
+
+```text
+00-provider-map-and-rankings/
+01-pricing-usage-unit-economics/
+02-data-coverage-quality-freshness/
+03-api-contracts-integrations/
+04-operations-rate-limits-support/
+05-data-rights-compliance-privacy/
+06-audience-accuracy-complaints/
+07-benchmarks-evaluation-methods/
+08-use-case-fit-vendor-risk/
+09-sources-claims-gaps/
+```
+
+Required emphasis:
+
+- coverage, freshness, accuracy, deduplication, data provenance
+- rate limits, SLAs, quota behavior, retries
+- contractual rights, redistribution, privacy, retention
+- evaluation datasets and test queries
+
+## Regulated Or Compliance-Heavy Industry
+
+Use for healthcare, finance, insurance, legal, education, government, or security markets.
+
+Suggested contexts:
+
+```text
+00-industry-map-and-regulatory-frame/
+01-market-structure-and-economics/
+02-product-capabilities-and-workflows/
+03-integrations-and-data-exchange/
+04-operations-risk-and-service-model/
+05-regulatory-compliance-legal/
+06-stakeholder-voice-and-adoption/
+07-outcomes-evidence-and-benchmarks/
+08-procurement-fit-and-risk/
+09-sources-claims-gaps/
+```
+
+Required emphasis:
+
+- regulations, certifications, audit requirements, legal restrictions
+- stakeholder groups and procurement barriers
+- risk controls, data handling, retention, explainability
+- outcomes evidence and clinical/financial/legal proof where applicable
+
+## Consumer Apps, Hardware, Or Media Ecosystem
+
+Use for consumer products, apps, devices, creator tools, marketplaces, entertainment, or prosumer categories.
+
+Suggested contexts:
+
+```text
+00-market-map-and-positioning/
+01-pricing-packaging-monetization/
+02-product-experience-features/
+03-platform-ecosystem-integrations/
+04-operations-availability-support/
+05-privacy-safety-policy-risk/
+06-audience-reviews-social-signal/
+07-performance-quality-tests/
+08-user-fit-alternatives/
+09-sources-claims-gaps/
+```
+
+Required emphasis:
+
+- onboarding, UX, retention, subscriptions, app-store reviews
+- social signal, influencer bias, support complaints
+- privacy, safety, content moderation, policy issues
+- real user scenarios and alternatives
+
+## Naming Rules
+
+1. Preserve numeric order for scanability.
+2. Prefer 2-4 domain words after the prefix.
+3. Use the buyer's language, not internal architecture.
+4. Include the risk domain in the folder name when it matters: `compliance`, `license`, `data-rights`, `regulatory`, `governance`.
+5. Use `sources-claims-gaps` for final verification folders across all archetypes.
+6. Do not create a category just because a template has it; create it because evidence and decisions need it.
+
+## Category Completeness Check
+
+Ask these questions before dispatch:
+
+- Does every category answer a distinct decision question?
+- Are pricing/economics separated from capability claims?
+- Is practitioner evidence separated from official documentation?
+- Is source verification separate from synthesis?
+- Are category names specific enough that another agent can infer what belongs there?
+- If this were an open-source corpus, would SaaS-only names still make sense? If not, rename them.

--- a/skills/run-industry-research/skills/run-industry-research/references/evidence-and-synthesis.md
+++ b/skills/run-industry-research/skills/run-industry-research/references/evidence-and-synthesis.md
@@ -1,0 +1,134 @@
+# Evidence And Synthesis
+
+How to turn web research, Reddit/practitioner signal, and local evidence packs into an audit-ready industry corpus.
+
+## Source Hierarchy
+
+| Source type | Best for | Caveat |
+|---|---|---|
+| Official docs, API references, pricing pages | Product facts, limits, billing units, setup, supported features. | Marketing/docs can omit failures and gated terms. |
+| Changelogs, release notes, status pages | Freshness, incidents, release cadence, operational history. | Status pages may under-report real user impact. |
+| GitHub repos, issues, discussions | Open-source health, bugs, maintainer response, community friction. | Issues overrepresent problems. |
+| Legal, security, privacy, trust pages | Compliance, retention, acceptable use, license, data handling. | Sales/security claims may require contract review. |
+| Reddit, HN, forums, reviews | Practitioner experience, migrations, pricing pain, reliability complaints. | Bias, astroturfing, sparse samples, and adjacent confusion are common. |
+| Analyst reports, market data, filings | Market size, funding, macro trends, public-company facts. | Often gated, lagging, or too broad for product decisions. |
+
+Use the strongest source for the claim type. For pricing, official pages beat blog summaries. For lived experience, direct practitioner threads beat vendor case studies.
+
+## Claims Ledger
+
+Every important file should feed a claims ledger:
+
+| Claim | Type | Evidence | Confidence | Caveat | Follow-up |
+|---|---|---|---|---|---|
+| Product supports X API. | Confirmed fact | Official docs URL, captured date. | High | Version may change. | Recheck before implementation. |
+| Vendor is best at Y. | Vendor claim | Homepage or blog URL. | Low | No independent benchmark. | Run buyer test. |
+| Users complain about pricing. | Practitioner report | Reddit/HN/review URL with date. | Medium | Sample may be biased. | Search broader category. |
+
+Claim types:
+
+- confirmed fact
+- vendor/project claim
+- practitioner report
+- inference
+- contradicted
+- unverified
+
+## Pricing And Unit Economics
+
+For SaaS, platforms, APIs, data providers, and usage-based products:
+
+1. Preserve native units first.
+2. Identify included quotas, overages, hard caps, free tiers, trials, and enterprise gating.
+3. Normalize only when public variables are sufficient.
+4. Model scenarios, not just plan prices.
+5. Include hidden cost variables: retries, storage, logs, data transfer, add-ons, support, proxy/CAPTCHA, seats, model/API costs, usage spikes, and compliance needs.
+6. If a variable is missing, write `insufficient public data` and name the variable.
+
+## Open-Source Health
+
+For open-source projects:
+
+- stars and downloads are weak signals unless paired with release cadence and issue response
+- inspect license, governance, maintainer count, open issues, stale PRs, security advisories, docs freshness, examples, test suite, CI, and dependency health
+- distinguish project popularity from production readiness
+- capture forks, commercial backing, and cloud-hosted product links separately
+
+## Reddit And Practitioner Evidence
+
+Required fields for direct audience evidence:
+
+- source URL and venue
+- author or username when public
+- date
+- product/entity mentioned
+- direct or adjacent relevance
+- sentiment and topic label
+- short direct quote when useful
+- bias note, such as founder reply, promotional account, angry support case, or competitor comparison
+
+Rules:
+
+- Do not say "Reddit consensus" without a source ledger.
+- If direct evidence is sparse, say so.
+- Use adjacent evidence only when labeled adjacent.
+- Preserve enough direct comments to support synthesis, but avoid long non-Reddit quotations.
+
+## Cross-Category Synthesis
+
+A good cross-category file does more than merge notes. It should answer:
+
+- Which entities are directly comparable, adjacent, or not comparable?
+- Which entity wins for each scenario and why?
+- Which ranking is source-backed, and which is provisional?
+- What pricing, benchmark, compliance, or reliability unknown would change the answer?
+- What should the buyer test next?
+
+Each cross-category `00-overall-comparison.md` should include:
+
+1. Scope and capture date.
+2. Short recommendation.
+3. Matrix or ranking.
+4. Evidence confidence.
+5. Important contradictions.
+6. Scenario-specific guidance.
+7. Tests or data needed to change the recommendation.
+8. Sources.
+
+## Root README
+
+The root README is an entry point, not a full report. It should include:
+
+- scope and capture date
+- start-here table
+- entity index
+- cross-category rollup index
+- evidence-layer explanation
+- caveats and unresolved gaps
+
+Do not put volatile pricing tables in the README unless the user explicitly wants that. Link to the pricing rollup instead.
+
+## Final Verification
+
+Run these checks before declaring completion:
+
+- file count under cap
+- no hidden junk files
+- no broken local markdown links
+- all core entities have a profile and evidence pack
+- all cross-category rollups exist
+- all source maps and claims ledgers exist or gaps are explicit
+- no placeholder text such as TODO, TBD, or "fill later"
+- no stale links to renamed folders
+- root README and main profiles point to current folder names
+
+## Completion Statement
+
+The final handoff should state:
+
+- corpus path
+- total files and entity count
+- top entry points
+- critical findings
+- unresolved gaps
+- verification run and any checks not run

--- a/skills/run-industry-research/skills/run-industry-research/references/mission-briefs.md
+++ b/skills/run-industry-research/skills/run-industry-research/references/mission-briefs.md
@@ -1,0 +1,158 @@
+# Mission Briefs
+
+How to write agent prompts for industry-scale research without losing ownership, source quality, or file budget control.
+
+## Brief Structure
+
+Every mission brief should contain:
+
+1. Context.
+2. Mission objective.
+3. Local context to read.
+4. Output ownership.
+5. Research guidance.
+6. Definition of done.
+7. Handback format.
+
+Include this fallback chain in every brief:
+
+```text
+If MCP tools fail, use WebFetch/WebSearch. If those fail, use curl from the shell. Do not stop because one tool is unavailable.
+```
+
+## Product Or Vendor Evidence Pack Agent
+
+Use when one agent owns one product, vendor, framework, project, or provider.
+
+```text
+## Context
+
+We are building a source-backed industry research corpus for [topic]. The final tree has a hard cap of [N] files, so create only evidence-justified files. Your entity is [entity]. The goal is not a generic overview; it is an audit-ready evidence pack that can feed a top-level profile and cross-category comparison rollups.
+
+## Mission
+
+Create or enhance [entity-slug]/ with independently useful evidence files covering the categories assigned below. Separate confirmed facts, vendor/project claims, practitioner evidence, and inference.
+
+## Local Context To Read
+
+- Root README.
+- `_meta/research-plan.md`.
+- `_meta/methodology-and-source-policy.md`.
+- Existing `[entity-slug].md`, if present.
+- Existing `[entity-slug]/` files, if present.
+- Relevant `_cross-[scope]/` files if they already exist.
+
+## Output Ownership
+
+You own only:
+
+- `[entity-slug]/[context]/01-meaningful-title.md`
+- `[entity-slug]/README.md`
+
+Do not edit other entity folders. Do not rewrite root synthesis unless asked.
+
+## Research Guidance
+
+Use official docs, pricing pages, changelogs, status pages, SDK repos, legal/security pages, review sites, Reddit, HN, GitHub issues, forums, and practitioner blogs. Search for negative signal: complaints, migrations, alternatives, pricing pain, reliability failures, abandoned project, license risk, and "switched from".
+
+## Definition Of Done
+
+- [ ] Every non-trivial claim cites a source URL or local source file.
+- [ ] Pricing/economics use native units first and normalize only when variables permit.
+- [ ] Practitioner evidence includes source, date, author/user, and bias label where possible.
+- [ ] Source map and claims ledger exist or are explicitly marked insufficient evidence.
+- [ ] No placeholder files were created.
+
+## Handback Format
+
+List files created/edited, key findings, unresolved gaps, and source-quality concerns.
+```
+
+## Cross-Category Comparison Agent
+
+Use when one agent compares all core entities by one decision criterion.
+
+```text
+## Context
+
+We are building cross-category rollups from completed entity evidence packs. Your job is not to re-research every entity from scratch; it is to read the local evidence packs, verify important claims against original URLs where needed, and produce comparison files for [criterion].
+
+## Mission
+
+Create `_cross-[scope]/[criterion]/00-overall-comparison.md` plus any justified granular files. The output must help a buyer, strategist, or technical lead decide how entities rank for [criterion].
+
+## Local Context To Read
+
+- Root README.
+- `_meta/research-plan.md`.
+- `_meta/discovered-entities.md`.
+- All core entity profiles.
+- Relevant context folders inside each core entity.
+
+## Output Ownership
+
+You own only:
+
+- `_cross-[scope]/[criterion]/00-overall-comparison.md`
+- `_cross-[scope]/[criterion]/01-*.md`
+
+## Definition Of Done
+
+- [ ] Comparison separates direct, adjacent, and not-comparable entities.
+- [ ] Rankings include confidence levels and conditions that could change them.
+- [ ] Every row cites local evidence and original source URLs where available.
+- [ ] Missing variables are stated instead of guessed.
+- [ ] A "tests that would change the recommendation" section is included.
+```
+
+## Reddit And Audience Agent
+
+Use when practitioner signal is broad enough to deserve a dedicated mission.
+
+```text
+## Context
+
+This mission is about public practitioner experience: Reddit, HN, GitHub issues, forums, review sites, migration posts, and complaints. Official docs are useful only for checking what practitioners are reacting to.
+
+## Mission
+
+Create audience evidence files that preserve direct voices with attribution and separate direct evidence from adjacent evidence.
+
+## Research Guidance
+
+Search product-specific and category-wide terms. At least 25% of searches should target negative signal: "regret", "switched from", "pricing", "down", "support", "broken", "alternatives", "license", "abandoned", "migration".
+
+## Definition Of Done
+
+- [ ] Thread/source inventory includes URL, date, venue, relevance, and direct/adjacent label.
+- [ ] Direct quotes include username/author, date, venue, and permalink where available.
+- [ ] Promotional or founder-biased comments are labeled, not silently removed.
+- [ ] Sparse evidence is stated directly.
+- [ ] No non-Reddit source is over-quoted; summarize when needed.
+```
+
+## Source Verification Agent
+
+Use when the corpus is large enough that source integrity needs a separate pass.
+
+```text
+## Mission
+
+Audit source quality across the corpus. Create source maps, claims ledgers, contradiction files, and follow-up test backlogs.
+
+## Definition Of Done
+
+- [ ] Every high-impact claim is classified as confirmed, vendor claim, practitioner report, inference, contradicted, or unverified.
+- [ ] Time-sensitive facts include capture date.
+- [ ] Broken, gated, JS-only, unavailable, and contradictory sources are labeled.
+- [ ] Follow-up tests are concrete and buyer-actionable.
+```
+
+## Agent Wave Rules
+
+- Dispatch independent missions in parallel.
+- Default maximum is 8 agents per wave.
+- Keep write scopes disjoint.
+- Do not let agents create subagents.
+- Retry a failed mission at most twice, with a narrower prompt each time.
+- The orchestrator must read all outputs personally before final synthesis.

--- a/skills/run-industry-research/skills/run-industry-research/references/research-architecture.md
+++ b/skills/run-industry-research/skills/run-industry-research/references/research-architecture.md
@@ -1,0 +1,155 @@
+# Research Architecture
+
+How to design a large industry research corpus before dispatching researchers or creating files.
+
+## The Core Shape
+
+A strong industry corpus has four layers:
+
+| Layer | Purpose | Typical files |
+|---|---|---|
+| Root entry point | Shows what to read first and what the corpus covers. | `README.md` |
+| Meta | Scope, methodology, file budget, discovery list, templates, briefs. | `_meta/*.md` |
+| Entity evidence packs | Deep product, vendor, framework, project, company, or provider research. | `[entity]/00-*` through `[entity]/09-*` |
+| Cross-category synthesis | Comparisons by buyer criterion, source verification, rankings, contradictions. | `_cross-product/*` or `_cross-ecosystem/*` |
+
+Use top-level `[entity].md` files when the user wants readable main pages. These should summarize and link to the detailed evidence pack, not duplicate every detail.
+
+## File Budget
+
+The default hard cap is 1000 persistent files.
+
+Before writing, estimate:
+
+```text
+total_files =
+  root_and_meta_files
+  + entity_count * average_entity_files
+  + cross_context_count * average_cross_files
+  + top_level_profile_count
+```
+
+Recommended budgets:
+
+| Corpus scale | Entity count | Full entities | Avg files per full entity | Cross files | Target total |
+|---|---:|---:|---:|---:|---:|
+| Compact | 1-10 | all | 8-20 | 10-30 | 15-80 |
+| Standard | 10-40 | 10-25 | 10-25 | 30-80 | 80-350 |
+| Deep | 40-100 | 20-60 | 10-30 | 50-150 | 250-900 |
+| Tiered | 100+ | top 20-50 | 10-25 | 50-150 | under 1000 |
+
+If the estimate exceeds 1000:
+
+1. Tier entities into `core`, `secondary`, and `discovered-only`.
+2. Give full evidence packs only to `core`.
+3. Give compact profiles to `secondary`.
+4. Put discovered-only entities in `_meta/discovered-entities.md`.
+5. Combine narrow context files into one broader file only when it stays independently useful.
+
+## Standard Tree
+
+```text
+[topic-slug]/
+|-- README.md
+|-- _meta/
+|   |-- research-plan.md
+|   |-- methodology-and-source-policy.md
+|   |-- discovered-entities.md
+|   |-- file-budget.md
+|   `-- templates-or-briefs.md
+|-- _cross-[scope]/
+|   |-- 00-overview/
+|   |   |-- 00-overall-comparison.md
+|   |   |-- 01-category-map.md
+|   |   |-- 02-ranking-by-scenario.md
+|   |   `-- 03-evidence-grade-scorecard.md
+|   |-- [criterion-one]/
+|   |   |-- 00-overall-comparison.md
+|   |   `-- 01-specific-question.md
+|   `-- 09-sources/
+|       |-- 00-overall-comparison.md
+|       |-- 01-source-map.md
+|       |-- 02-claims-ledger.md
+|       `-- 03-contradictions-and-gaps.md
+|-- [entity-slug]/
+|   |-- 00-overview/
+|   |-- [context-one]/
+|   |-- [context-two]/
+|   `-- 09-sources/
+`-- [entity-slug].md
+```
+
+## Entity Tiers
+
+| Tier | Criteria | Output |
+|---|---|---|
+| Core | Directly comparable, high buyer relevance, enough sources, likely decision candidate. | Full evidence pack plus main profile. |
+| Secondary | Relevant but adjacent, early, region-specific, or source-limited. | Compact profile or fewer context files. |
+| Discovered-only | Mentioned in searches but not worth full treatment yet. | Row in `_meta/discovered-entities.md`. |
+
+Promote a secondary entity to core when it changes rankings, pricing economics, adoption interpretation, or category boundaries.
+
+## Main Profile Pattern
+
+Each top-level `[entity].md` should be a readable synthesis:
+
+1. Research metadata.
+2. Executive summary.
+3. Evidence pack map.
+4. Positioning and taxonomy.
+5. Deep profile.
+6. Pricing, sustainability, or unit economics where relevant.
+7. Product, platform, project, or capability analysis.
+8. Integrations or ecosystem.
+9. Operations, maintenance, reliability, or support.
+10. Security, compliance, licensing, governance, or legal risk.
+11. Audience and practitioner signal.
+12. Benchmarks, performance, or reproducibility.
+13. Buyer/adoption fit.
+14. Source map.
+15. Open gaps and follow-up tests.
+
+Rename sections where the vertical requires it, but keep the evidence logic.
+
+## Validation Commands
+
+Run equivalent checks before completion:
+
+```bash
+find [topic-slug] -type f | wc -l
+find [topic-slug] -name '.DS_Store' -o -name 'Thumbs.db' -o -name '*.tmp' -o -name '*.bak' -o -name '*~'
+```
+
+Run a local markdown link checker. A minimal Ruby version:
+
+```bash
+ruby - <<'RUBY'
+require 'pathname'
+root = Pathname.new(ARGV.fetch(0))
+missing = []
+Dir[root.join('**/*.md')].sort.each do |file|
+  text = File.read(file)
+  text.scan(/\[[^\]]+\]\(([^)]+)\)/) do |m|
+    target = m[0]
+    next if target =~ /\A(?:https?:|mailto:|#)/
+    path = target.split('#', 2).first
+    next if path.nil? || path.empty?
+    full = Pathname.new(file).dirname.join(path.gsub('%20', ' ')).cleanpath
+    missing << [file, target, full.to_s] unless full.exist?
+  end
+end
+puts "missing_local_links=#{missing.size}"
+missing.each { |file, target, full| puts "#{file} -> #{target} => #{full}" }
+RUBY
+```
+
+## Common Architecture Failures
+
+| Failure | Fix |
+|---|---|
+| Every product has identical empty folders. | Create only evidence-justified files. |
+| Cross-product comparisons repeat product summaries. | Compare by buyer criterion and cite product packs. |
+| Pricing is copied from pages without unit economics. | Preserve native units, normalize where possible, state missing variables. |
+| Reddit evidence is summarized as consensus. | Preserve thread, username, date, quote, and bias label. |
+| Source verification is missing. | Add source maps, claims ledgers, contradictions, and open test backlogs. |
+| Tree exceeds 1000 files. | Tier entities and collapse long-tail into discovery lists. |


### PR DESCRIPTION
# feat(skills): add run-industry-research

## Summary
Adds `run-industry-research`, a productivity skill for building comprehensive industry, market, SaaS, open-source ecosystem, and product-category research corpora. The skill packages the browser-system-style audit workflow into the public skills-pack layout with a focused `SKILL.md`, four routed reference files, an outer install README, root README index entry, and `NAMING.md` registry updates.

## Context / Why now
The existing `run-research` skill is good for technical questions and multi-source research, but it does not define the file-budgeted corpus architecture needed for large market landscapes with product evidence packs, cross-product rollups, source ledgers, Reddit/practitioner signal, and completion gates. This new skill specializes that workflow and keeps persistent output under a default 1000-file cap.

## The 4 Items

1. `skills/run-industry-research/README.md`
   - Adds the per-skill install page using the standard public pack command.
   - Category is `productivity`, matching adjacent research and handoff skills.

2. `skills/run-industry-research/skills/run-industry-research/SKILL.md`
   - Defines trigger boundaries, negative triggers, hard limits, scale choices, corpus architecture, evidence layers, completion gates, reference routing, and output contract.
   - Uses `run-` rather than `build-` because current `NAMING.md` frames `run` as the verb for driving a CLI, tool, or workflow.

3. `skills/run-industry-research/skills/run-industry-research/references/*.md`
   - Adds deep references for corpus architecture, category taxonomies, mission briefs, and evidence/synthesis rules.
   - All four reference files are explicitly routed from `SKILL.md`, so validation sees no orphan references.

4. Root repo index updates
   - Adds the skill row to `README.md`.
   - Updates the README headline count and `NAMING.md` canonical count to 43, matching the current base plus this skill.
   - Adds a `run-research` vs `run-industry-research` disambiguation line.

## Files Touched

| Path | Purpose |
|---|---|
| `README.md` | Skill count and index row |
| `NAMING.md` | Canonical list and disambiguation |
| `skills/run-industry-research/README.md` | Per-skill install and overview |
| `skills/run-industry-research/skills/run-industry-research/SKILL.md` | Main skill instructions |
| `skills/run-industry-research/skills/run-industry-research/references/category-taxonomies.md` | Vertical-specific folder/category names |
| `skills/run-industry-research/skills/run-industry-research/references/evidence-and-synthesis.md` | Source hierarchy, claims ledgers, synthesis checks |
| `skills/run-industry-research/skills/run-industry-research/references/mission-briefs.md` | Agent mission brief templates |
| `skills/run-industry-research/skills/run-industry-research/references/research-architecture.md` | File budget and corpus tree guidance |

## Verification

- `python3 scripts/validate-skills.py` passes: `Validated 43 skills` and `All validations passed`.
- Manual orphan-reference check from the skill content directory produced no output.
- Frontmatter description is 21 words and starts with `Use skill if you are`.
- `grep -R "build-industry-research" -n skills/run-industry-research README.md NAMING.md` returned no stale-name matches.
- Manual trigger review covered 5 should-trigger and 5 should-not-trigger prompts; the boundaries are intentionally adjacent to but narrower than `run-research`.

## Weaknesses and Open Questions

- The skill is intentionally corpus-heavy. The 1000-file default cap prevents runaway output, but reviewers should check whether the cap should be lower for public-pack defaults.
- Naming is the main review point: the local draft was `build-industry-research`, but the public repo's current intent-verb rules make `run-industry-research` the better canonical name.
- The PR does not attempt to reorganize adjacent research skills; it only adds a specialized corpus-building workflow and one explicit disambiguation line.

## Request to Reviewer

Please review trigger overlap with `run-research`, the `run-` naming choice, and whether the reference split is the right balance between concise activation and enough guidance for large industry research corpora.

## Follow-ups

- A future PR could add examples from a completed corpus as optional assets or docs, but this PR keeps the skill lean and reference-routed.
