### PR TITLE
✨ feat(run-codex-review): add phase helper scripts

### DIFF
--- a/skills/run-codex-review/skills/run-codex-review/references/branch-decomposition-ledger.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/branch-decomposition-ledger.md
@@ -4,7 +4,7 @@ The manifest is the durable cross-process state for the entire skill. Every sub-
 
 ## File location
 
-Default: `/tmp/codex-review-manifest.json`. Override with `--manifest <path>` on every script. If the manifest needs to survive reboots, set the path to something under the repo (e.g. `<repo-root>/.codex-review/manifest.json`) and add it to `.gitignore`.
+Default: `<repo-root>/.codex-review-manifest.json` (the wrappers compute this from the worktree's git common-dir and add `.codex-review-manifest.json` next to it). Override with `--manifest <path>` on every script. The repo-local default keeps concurrent skill sessions across different repos from clobbering each other (older skill versions defaulted to `/tmp/codex-review-manifest.json` and concurrent sessions caused lost-update bugs in production). Add `.codex-review-manifest.json{,.lock}` and `.codex-review-rounds/` to `.gitignore`.
 
 ## Schema (top-level)
 
@@ -129,9 +129,10 @@ Notes on fields:
 |---|---|---|
 | `SPAWNED` | `spawn-review-worktrees.py` | Worktree created, branch pushed to origin, no coordinator dispatched yet. |
 | `IN-LOOP` | Main agent on Phase 3 dispatch | Coordinator owns this branch; rounds in progress. |
-| `DONE` | Coordinator | Last classifier output had `major == []`, OR 3 consecutive all-rejected rounds. Ready for Phase 5. |
-| `CAP-REACHED` | Coordinator | 20 rounds reached with major items still present. Surface for human; **no Phase 5**. |
-| `BLOCKED` | Coordinator OR evaluator (Phase 7) | Persistent ambiguity (worker-level or evaluator-level). Surface for human; **no merge**. |
+| `DONE` | Main agent (Phase 3 loop) | Last classifier output had `major == []`, OR 3 consecutive all-rejected rounds. Ready for Phase 5. |
+| `CONVERGED-AT-CAP` | Main agent (Phase 3 loop) | Configured `max_rounds_per_branch` exhausted with at least one round of fixes pushed; remaining items captured for the PR body. Ready for Phase 5; PR body documents the deferred items. |
+| `CAP-REACHED` | Main agent (Phase 3 loop) | 20 rounds reached with major items still present AND no successful round of pushed fixes (every round had failures). Surface for human; **no Phase 5**. |
+| `BLOCKED` | Main agent (Phase 3) OR evaluator (Phase 7) | Persistent ambiguity, oscillation, or contradictions. Surface for human; **no merge**. |
 | `FAILED` | Coordinator OR main agent OR any script | Tooling failure (codex, push, validation, evaluator) past retry budget. |
 | `PR-OPEN` | PR-Creator (Phase 5) | PR has been opened on the fork; pending Phase 6 wait + Phase 7 evaluation. |
 | `PR-EVALUATED` | Evaluator (Phase 7) | Evaluator's decisions JSON written; pending Phase 8 apply. |
@@ -144,11 +145,11 @@ Transitions:
                  (created)
                     │
                     ▼
-                SPAWNED  ──(main agent dispatches coordinator)──▶  IN-LOOP
-                                                                    │
-            ┌──────────────────────────────────────────────┬────────┼──────────────────┐
-            ▼                                              ▼        ▼                  ▼
-          DONE                                        CAP-REACHED  BLOCKED          FAILED
+                SPAWNED  ──(main agent enters Phase 3 loop, round 1)──▶  IN-LOOP
+                                                                          │
+            ┌────────────────────────────┬──────────────────────┬────────┼─────────┬──────────┐
+            ▼                            ▼                      ▼        ▼         ▼          ▼
+          DONE              CONVERGED-AT-CAP              CAP-REACHED  BLOCKED  FAILED
             │                                                 │      │                │
             │ (Phase 5: PR-Creator dispatched)                └──────┴────────────────┘
             ▼                                                       (no further phases;
@@ -264,3 +265,75 @@ After Phase 9 cleanup, a complete branch entry might look like:
 ```
 
 Every phase's contribution is visible. The trace is complete: one round of work → one round of review → one round of decision → final merged state.
+
+## Final Deliverable template
+
+Render at end of Phase 9 from manifest state. Each section maps to specific manifest fields — the template below shows where each value comes from. Phase 9 cannot exit until every section is producible.
+
+```markdown
+## 🎉 Full skill flow complete — N PRs merged to main (or M surfaced as BLOCKED)
+
+### Final state on <fork-owner>/<repo>
+<output of: git log --oneline origin/main~N..origin/main>
+
+E.g.:
+a12dd4e fix(antigravity): protobuf sessions + RPC + cache (#51)
+cf8d3cd feat(parsers/gemini): JSONL + rewind reconciliation (#52)
+…
+3f15720 feat(handoff): structured timeline + verbosity controls (#53)
+
+### Per-branch summary
+| Branch | Concern | Rounds | Phase 3 status | PR | Phase 7 (a/r/x) | Phase 8a apply | Merged at | Notes |
+|---|---|---:|---|---|---|---|---|---|
+
+### Per-PR review breakdown
+| PR | codex-rescue (a/r/x) | Copilot (a/r/x) | copilot-pull-request-reviewer (a/r/x) | greptile (a/r/x) | devin-ai-integration (a/r/x) | cubic-dev-ai (a/r/x) | Total accepted | Total ambiguous |
+|---|---|---|---|---|---|---|---:|---:|
+
+### What ran across all 10 phases
+| Phase | What happened |
+|---|---|
+| 0 | Pre-flight audit — all scripts present, MISSION_PROTOCOL loaded, /ask-review + /do-review available; manifest path repo-local. |
+| 1 | Decomposed N-file dirty tree into M per-concern branches. |
+| 2 | M worktrees spawned with `--prep-deps`, M branches pushed, manifest emitted. |
+| 3 | K rounds × M codex reviews; main agent evaluated, dispatched M Appliers per round; J fixes applied across rounds. |
+| 4 | Merge order computed: foundation, then leaves. |
+| 5 | M PR-Creators (throttled ≤4) opened PRs via REST `gh api repos/.../pulls`. |
+| 6 | M codex-rescue jobs + M Monitors armed; external bots landed reviews; adaptive 900s base + 3-min quiet windows closed cleanly per PR. |
+| 7 | M Evaluator sub-agents used /do-review over gathered streams; produced decisions JSON (≈X items: A accepted, R rejected, U ambiguous). |
+| 8a | Main agent direct-applied accepted decisions across M worktrees; validated build+tests; pushed N commits. |
+| 8b | Captured `foundation_pre_merge_tip`; squash-merged foundation with `--delete-branch`; rebased leaves with `git rebase --onto`; retargeted leaves to main; merged sequentially with CI-wait. |
+| 9 | M worktrees removed, M local branches deleted, M remote branches deleted (mostly via `--delete-branch` in 8b), manifest + round-logs + briefs cleaned; final audit: TIDY. |
+
+### Loop tools that kept this autonomous
+- **Monitor** (M instances): per-PR comment poller; emitted one event per new bot/human comment; terminated on `[PR-N-DONE quiet]` or `[PR-N-DONE cap]`.
+- **ScheduleWakeup** (X fires): cache-aware 1200-1800s fallback tickers covering the 900s adaptive-wait floor.
+- **Agent run_in_background=true** (~K dispatches): Appliers, PR-Creators, Evaluators — each fired a handback notification on completion.
+- **Bash run_in_background=true** (~K launches): per-branch codex review jobs, codex-rescue invocations, CI-wait pollers.
+
+### Lessons captured during execution
+(Only include genuinely novel learnings — not boilerplate. Examples: rate-limit pivot to REST, squash-merge `--onto` mechanic, brief-templating discipline, `/do-review` decision-only failure mode.)
+
+### Tidy audit
+<output from `audit-state.py` + `audit-review-state.py` — both must show CLEAN>
+- `git worktree list` → only main
+- `git branch -vv` → only main + any BLOCKED branches
+- `gh pr list` → only BLOCKED PRs (or empty)
+
+### Per-branch round history (appendix)
+
+#### feat/foo (DONE in 4 rounds, merged as #42)
+- Round 1: 3 major (3 accepted) → committed + pushed
+- Round 2: 1 major (1 accepted) → committed + pushed
+- Round 3: 1 major (0 accepted, 1 rejected) → all-rejected round
+- Round 4: no major → DONE
+- Phase 8a fixes: abc123, def456 (merged as squash 2026-04-26T11:40:00Z)
+
+#### feat/bar (CONVERGED-AT-CAP at 20 rounds, merged as #43 with deferred items in PR body)
+- 20 rounds, 8 accepted, 14 rejected, 0 ambiguous
+- Remaining major items in last round: <listed in PR body>
+
+#### feat/baz (BLOCKED — surfaced for human; NOT merged)
+- terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
+- Suggested human action: <e.g. split into 2 branches, re-run per concern>
+```

--- a/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
@@ -143,38 +143,54 @@ Key brief points:
 - **Verification**: `git status` in worktree returns empty (no drift); JSON has decisions for all items.
 - **Failure**: missing decision → mark ambiguous; stale citation → reject; can't determine → ambiguous (never silently accept).
 
-## Phase 8 — main-agent direct apply
+## Phase 8a — main-agent direct apply
 
-After the evaluator sub-agent hands back, **main agent acts directly** (no further sub-agent). Use `/do-review` skill in main agent's context for sanity-checking each apply.
+After the evaluator sub-agent hands back, **main agent acts directly** (no further sub-agent). The evaluator's JSON is the authority; main agent applies each accepted item mechanically. `/do-review` re-eval per item is optional and off by default because the evaluator already used `/do-review` in Phase 7.
 
-### Apply flow
+### Apply flow (per PR)
 
 ```
-Read evaluator's output JSON.
-For each accepted item (deduplicated across sources):
-    1. Read cited code (Read tool) at <worktree>/<file>:<line> ± context.
-    2. Compose the fix per evaluator's rationale + Codex/source's suggested fix.
-    3. Sanity-check via /do-review skill (in main agent's context):
-       - Does the fix align with the evaluator's rationale?
-       - Does the fix introduce regressions?
-    4. Apply via Edit (with diff-walk discipline).
-    5. git add <files>.
-    6. git diff --cached (verify only intended hunks).
-    7. git commit -m "<emoji> <type>(<scope>): apply <source>'s <item-id>"
-       — or one commit per logical concern (better; matches inner-loop discipline).
+Read <repo>/.codex-review-rounds/pr-<n>.evaluation.json.
 
+# AMBIGUOUS GATE — read this before any apply
 If ambiguous[] non-empty:
-    Mark PR BLOCKED in manifest with terminal_reason citing the items.
-    Surface in deliverable.
-    Do NOT merge.
-    Optional: open a fresh PR with the patches applied (if changes are too divergent for an in-place amendment).
+    Mark PR BLOCKED in manifest:
+      terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
+    Do NOT apply this PR's accepted items either.
+    Surface in deliverable. Do NOT merge.
+    Move to next PR.
 
-Else:
-    git push origin <branch>
-    Wait for CI green.
-    gh pr merge <number> --repo <fork>/<repo> --squash | --merge | --rebase
-       (per repo policy)
+# ACCEPTED ITEMS — only when ambiguous[] is empty
+For each accepted item (deduplicated across sources, first-seen rationale wins):
+    1. Read cited code at <worktree>/<file>:<line> ± 25 lines.
+    2. Apply the evaluator's intended-shape fix via Edit.
+       If it does not apply cleanly:
+         record `apply_failed_after_evaluation: <item-id>` in manifest;
+         continue with remaining items; surface at the end of Phase 8a.
+    3. Stage by concern from the start:
+         git -C <worktree> add <files-for-this-concern>
+         # do NOT stage all then `git restore --staged .`
+    4. git -C <worktree> diff --cached
+    5. git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject> (#<pr>)"
+    6. Validate with repo-equivalent build/test.
+    7. git -C <worktree> push origin <branch>   # no --force
 ```
+
+Process PRs in any order in 8a. Foundation→leaf merge order is enforced after apply.
+
+### Phase 8a apply recipe (one-shot helper)
+
+The helper script derives the repetitive queue from evaluator JSON:
+
+```bash
+python3 <this-skill>/scripts/apply-evaluator-decisions.py \
+  --pr <n> \
+  --worktree <worktree> \
+  --eval <repo>/.codex-review-rounds/pr-<n>.evaluation.json \
+  --print-queue
+```
+
+Output: ordered apply queue with ambiguous items at the top (BLOCKED warning), then accepted items with `file:line:intended-shape:rationale`. The script is read-only: it does not modify worktrees, commit, or push.
 
 ### Why main-agent direct, not sub-agent
 
@@ -213,9 +229,11 @@ The Phase 7 evaluator handles a single source (or no source) gracefully. If the 
 
 `await-pr-reviews.py` terminates with `wait_terminated_by: "total_cap"`. The current state is gathered. Phase 7 evaluates what we have. Late-arriving comments after evaluation are surfaced for human attention but don't block merge — the bot will still see them on the merged commit if it cares.
 
-### Evaluator marks everything ambiguous
+### Evaluator marks anything ambiguous
 
-Surface for human triage. Do not merge. Likely cause: PR is too broad or too cross-cutting; consider splitting in a follow-up.
+A single ambiguous item blocks the entire PR. Do not half-apply accepted items and defer ambiguous ones; that ships unreviewed code with half-decided intent. Record the evaluator's exact question in `manifest.pr.terminal_reason`, surface it in the final deliverable, and do not merge.
+
+If the evaluator marks everything ambiguous, surface the whole PR for human triage. Likely cause: PR is too broad or too cross-cutting; consider splitting in a follow-up.
 
 ### Evaluator's accepted fix breaks CI
 

--- a/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.md
@@ -1,0 +1,126 @@
+# apply-evaluator-decisions.py
+
+Print the ordered apply queue for one PR's Phase 8a main-agent direct apply. Read-only against the worktree. Reduces Phase 8a main-agent overhead from ~10 tool calls to ~5 per PR by offloading the queue derivation: dedup across sources, ambiguous-first BLOCKED gate, accepted items rendered with `file:line` + intended-shape + rationale + commit-message scaffold.
+
+## Usage
+
+```bash
+# Default: human-readable apply queue
+python3 scripts/apply-evaluator-decisions.py \
+    --pr 53 \
+    --worktree /Users/.../wt-feat-foo \
+    --eval /repo/.codex-review-rounds/pr-53.evaluation.json
+
+# Machine-readable (for downstream tooling)
+python3 scripts/apply-evaluator-decisions.py \
+    --pr 53 --worktree /path --eval /path/to.json --json
+```
+
+## Behavior
+
+1. Read `<eval-path>`, validate it's an object, check that `--pr` matches `payload.pr`.
+2. Group items by `decision` (`accepted | rejected | ambiguous`).
+3. Dedup accepted items by `(file, line_start, title-prefix-60)` — first source wins. Production traces show 4+ bots flagging the same issue with slightly different wording; main agent applies once.
+4. If ANY item is ambiguous: print BLOCKED gate first (the whole PR is blocked; main agent must not apply accepted items either). Exit 1.
+5. Else if no accepted items: print no-op message. Exit 3.
+6. Else: print apply queue with each item's `file:line`, current shape, intended shape, rationale, and commit-message scaffold (`(#<pr>)` suffix). Exit 0.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--pr <n>` | required | PR number; cross-checked against `payload.pr` to catch mistyped invocations. |
+| `--worktree <path>` | required | Worktree path. Informational — the script doesn't read worktree contents. |
+| `--eval <path>` | required | Path to `pr-<n>.evaluation.json` (the Phase 7 Evaluator's output). |
+| `--print-queue` | default | Human-readable queue. |
+| `--json` | off | Machine-readable JSON output (mutually exclusive with `--print-queue`). |
+
+## Exit codes
+
+| Code | Meaning | Caller (main-agent) action |
+|---|---|---|
+| `0` | Queue printed; PR has accepted items, zero ambiguous | Walk the queue, apply each, validate, push. |
+| `1` | PR is BLOCKED — at least one ambiguous item | Mark PR BLOCKED in manifest; surface; do NOT apply, do NOT merge. |
+| `2` | Evaluation file missing or malformed, OR --pr mismatches payload.pr | Investigate; do NOT apply blindly. |
+| `3` | No accepted items AND no ambiguous items | Phase 8a is a no-op for this PR; advance to Phase 8b. |
+
+## Expected `pr-<n>.evaluation.json` schema (Phase 7 Evaluator output)
+
+```json
+{
+  "pr": 53,
+  "branch": "feat/foo",
+  "totals": {"accepted": 5, "rejected": 4, "ambiguous": 1},
+  "items": [
+    {
+      "id": "<source>-<n>",
+      "decision": "accepted|rejected|ambiguous",
+      "source": "codex-rescue|copilot|cubic-dev-ai|devin|greptile|<human>",
+      "file": "src/foo.ts",
+      "line_start": 42,
+      "line_end": 42,
+      "title": "Off-by-one in slice",
+      "intended_shape": "slice(0)",
+      "current_shape": "slice(0, -1)",
+      "rationale": "clearly drops last element"
+    }
+  ]
+}
+```
+
+## Sample output (queue)
+
+```
+PR #53 — branch: feat/foo
+  totals: accepted=2 (deduped from 5 raw), rejected=4, ambiguous=0
+
+========================================================================
+APPLY QUEUE (in dedup-source order — apply each via Edit, commit per concern)
+========================================================================
+  [1/2] Off-by-one in slice
+    source:    codex-rescue
+    file:line: src/foo.ts:42
+    rationale: clearly drops last element
+    current shape:
+      slice(0, -1)
+    intended shape:
+      slice(0)
+    commit:    <emoji> <type>(<scope>): Off-by-one in slice (#53)
+  ...
+```
+
+## Sample output (BLOCKED)
+
+```
+========================================================================
+⚠  PR IS BLOCKED — DO NOT APPLY ACCEPTED ITEMS EITHER
+========================================================================
+Per Phase 8a invariant: a single ambiguous item BLOCKS the entire PR.
+Half-apply ships unreviewed code with a half-decided intent.
+
+  [AMBIGUOUS #1] <title>
+    source:    <source>
+    file:line: src/bar.ts:99
+    question:  <evaluator's question>
+
+Action: mark PR BLOCKED in manifest with terminal_reason citing the items above.
+Action: surface in deliverable. Action: do NOT merge.
+```
+
+## Read/write surface
+
+- **Reads**: `--eval` JSON file.
+- **Writes**: nothing. (Stdout only.)
+- **Does NOT**: modify the worktree, commit, push, comment on the PR, or call codex.
+
+## When to run
+
+- **Phase 8a, per PR**, after the Phase 7 Evaluator's handback. One invocation per PR.
+- Main agent walks the printed queue with Edit + git commands per item; this script does NOT do the walk.
+
+## See also
+
+- `scripts/run-codex-review.py` — Phase 3 wrapper (codex-companion review).
+- `scripts/trigger-codex-rescue.py` — Phase 6 wrapper (codex-companion task --background).
+- `references/post-pr-review-protocol.md` — full Phase 6 / 7 / 8 flow including the apply recipe.
+- `references/review-evaluation-protocol.md` — the rubric the Evaluator follows; defines the JSON shape this script consumes.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/apply-evaluator-decisions.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Print the ordered apply queue for a Phase 8a (main-agent direct apply).
+
+Reads the Phase 7 Evaluator's decisions JSON for one PR and prints:
+  - Ambiguous items first with a BLOCKED warning (Phase 8a must NOT apply
+    when any item is ambiguous; the whole PR is BLOCKED).
+  - Accepted items in source-deduped order with `file:line` + intended-shape
+    + rationale, ready for main agent to walk and apply via Edit.
+  - Rejected items as a footer (informational; main agent skips them).
+
+This script is **read-only**: it does NOT modify the worktree, does NOT commit,
+does NOT push. It exists so main agent can offload the queue derivation rather
+than re-deriving it inline per PR (which production traces showed costs ~5
+extra tool calls per PR × 9 PRs × multiple sessions).
+
+The expected `pr-<n>.evaluation.json` shape (produced by Phase 7 Evaluator):
+
+    {
+      "pr": 53,
+      "branch": "feat/foo",
+      "totals": {"accepted": 5, "rejected": 4, "ambiguous": 1},
+      "items": [
+        {
+          "id": "<source>-<n>",
+          "decision": "accepted|rejected|ambiguous",
+          "source": "codex-rescue|copilot|copilot-pull-request-reviewer|cubic-dev-ai|devin|greptile|<human>",
+          "file": "src/foo.ts",
+          "line_start": 42,
+          "line_end": 42,
+          "title": "...",
+          "intended_shape": "<the fix the evaluator approved>",
+          "rationale": "<why the evaluator accepted/rejected/marked ambiguous>",
+          "current_shape": "<excerpt of code as the evaluator saw it>"
+        }
+      ]
+    }
+
+Usage:
+    python3 apply-evaluator-decisions.py \\
+        --pr 53 \\
+        --worktree /path/to/wt \\
+        --eval /repo/.codex-review-rounds/pr-53.evaluation.json \\
+        --print-queue
+
+    # JSON output for downstream tools (one-line-per-item):
+    python3 apply-evaluator-decisions.py --pr 53 --worktree /path --eval /path --json
+
+Exit codes:
+    0  Queue printed; PR has accepted items to apply (and zero ambiguous).
+    1  PR is BLOCKED — at least one ambiguous item; main agent must NOT apply.
+    2  Evaluation file missing or malformed.
+    3  No accepted items AND no ambiguous items (PR done already).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def load_evaluation(path: Path) -> dict:
+    if not path.is_file():
+        raise FileNotFoundError(f"evaluation file not found: {path}")
+    try:
+        with path.open() as f:
+            payload = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"evaluation file is not valid JSON: {e}")
+    if not isinstance(payload, dict):
+        raise ValueError(f"evaluation file root must be an object, got {type(payload).__name__}")
+    return payload
+
+
+def dedupe_items(items: list[dict]) -> list[dict]:
+    """Deduplicate accepted items across review sources by (file, line, title-prefix).
+    Preserves the FIRST seen rationale (earliest source wins). Production traces
+    showed multiple bots flagging the same issue with slightly different wording;
+    main agent applies once.
+    """
+    seen: dict[tuple, dict] = {}
+    for item in items:
+        if item.get("decision") != "accepted":
+            continue
+        key = (
+            (item.get("file") or "").strip().lower(),
+            int(item.get("line_start") or item.get("line") or 0),
+            ((item.get("title") or "").strip().lower())[:60],
+        )
+        if key not in seen:
+            seen[key] = item
+    return list(seen.values())
+
+
+def render_human(payload: dict) -> tuple[str, int]:
+    """Render the apply queue for human / main-agent reading. Returns
+    (text, exit_code). exit_code semantics match the module docstring.
+    """
+    pr = payload.get("pr", "?")
+    branch = payload.get("branch", "?")
+    items = payload.get("items") or []
+
+    by_decision: dict[str, list[dict]] = defaultdict(list)
+    for item in items:
+        d = item.get("decision", "unknown")
+        by_decision[d].append(item)
+
+    ambiguous = by_decision.get("ambiguous", [])
+    accepted = dedupe_items(items)
+    rejected = by_decision.get("rejected", [])
+
+    out: list[str] = []
+    out.append(f"PR #{pr} — branch: {branch}")
+    out.append(f"  totals: accepted={len(accepted)} (deduped from {len(by_decision.get('accepted', []))} raw), "
+               f"rejected={len(rejected)}, ambiguous={len(ambiguous)}")
+    out.append("")
+
+    # Ambiguous goes FIRST so main agent sees the BLOCKED gate before the queue.
+    if ambiguous:
+        out.append("=" * 72)
+        out.append("⚠  PR IS BLOCKED — DO NOT APPLY ACCEPTED ITEMS EITHER")
+        out.append("=" * 72)
+        out.append("Per Phase 8a invariant: a single ambiguous item BLOCKS the entire PR.")
+        out.append("Half-apply ships unreviewed code with a half-decided intent.")
+        out.append("")
+        for i, item in enumerate(ambiguous, start=1):
+            out.append(f"  [AMBIGUOUS #{i}] {item.get('title', '<no title>')}")
+            out.append(f"    source:    {item.get('source', '?')}")
+            out.append(f"    file:line: {item.get('file', '?')}:"
+                       f"{item.get('line_start', item.get('line', '?'))}")
+            rationale = item.get("rationale", "").strip()
+            if rationale:
+                out.append(f"    question:  {rationale}")
+            out.append("")
+        out.append("Action: mark PR BLOCKED in manifest with terminal_reason citing the items above.")
+        out.append("Action: surface in deliverable. Action: do NOT merge.")
+        return "\n".join(out), 1  # exit 1 = BLOCKED
+
+    if not accepted:
+        out.append("No accepted items. PR is either DONE-after-eval (rejected-only)")
+        out.append("or there were no items to begin with. Phase 8a is a no-op for this PR.")
+        return "\n".join(out), 3
+
+    out.append("=" * 72)
+    out.append("APPLY QUEUE (in dedup-source order — apply each via Edit, commit per concern)")
+    out.append("=" * 72)
+    for i, item in enumerate(accepted, start=1):
+        out.append(f"  [{i}/{len(accepted)}] {item.get('title', '<no title>')}")
+        out.append(f"    source:    {item.get('source', '?')}")
+        out.append(f"    file:line: {item.get('file', '?')}:"
+                   f"{item.get('line_start', item.get('line', '?'))}"
+                   + (f"-{item['line_end']}" if item.get('line_end')
+                      and item.get('line_end') != item.get('line_start') else ""))
+        rationale = item.get("rationale", "").strip()
+        if rationale:
+            out.append(f"    rationale: {rationale}")
+        current = (item.get("current_shape") or "").rstrip()
+        intended = (item.get("intended_shape") or "").rstrip()
+        if current:
+            out.append(f"    current shape:")
+            for line in current.splitlines()[:8]:
+                out.append(f"      {line}")
+            if len(current.splitlines()) > 8:
+                out.append(f"      ... ({len(current.splitlines()) - 8} more lines)")
+        if intended:
+            out.append(f"    intended shape:")
+            for line in intended.splitlines()[:8]:
+                out.append(f"      {line}")
+            if len(intended.splitlines()) > 8:
+                out.append(f"      ... ({len(intended.splitlines()) - 8} more lines)")
+        commit_msg = (
+            f"<emoji> <type>(<scope>): {item.get('title', 'apply evaluator decision')[:60]} "
+            f"(#{pr})"
+        )
+        out.append(f"    commit:    {commit_msg}")
+        out.append("")
+
+    out.append("Reminders for main agent:")
+    out.append("  - Stage by concern from the start (do NOT `git add .` then `git restore --staged .`).")
+    out.append("  - Validate before push: `pnpm run build && pnpm test` (or repo-equivalent).")
+    out.append("  - If intended_shape doesn't apply cleanly: do NOT improvise — record")
+    out.append("    `apply_failed_after_evaluation: <id>` in manifest, continue, surface at end.")
+    out.append("  - One concern per commit by default; multi-concern only with bullets-in-message.")
+
+    if rejected:
+        out.append("")
+        out.append("-" * 72)
+        out.append(f"REJECTED ({len(rejected)}, informational — DO NOT apply):")
+        for item in rejected[:8]:
+            out.append(f"  - [{item.get('source', '?')}] {item.get('title', '<no title>')[:80]}")
+        if len(rejected) > 8:
+            out.append(f"  ... ({len(rejected) - 8} more rejected)")
+
+    return "\n".join(out), 0
+
+
+def render_json(payload: dict) -> tuple[str, int]:
+    """JSON-shaped output for downstream tooling. Returns (json_text, exit_code)."""
+    items = payload.get("items") or []
+    by_decision: dict[str, list[dict]] = defaultdict(list)
+    for item in items:
+        by_decision[item.get("decision", "unknown")].append(item)
+
+    ambiguous = by_decision.get("ambiguous", [])
+    accepted = dedupe_items(items)
+    rejected = by_decision.get("rejected", [])
+
+    if ambiguous:
+        exit_code = 1
+        status = "BLOCKED"
+    elif not accepted:
+        exit_code = 3
+        status = "NO-OP"
+    else:
+        exit_code = 0
+        status = "READY"
+
+    output = {
+        "pr": payload.get("pr"),
+        "branch": payload.get("branch"),
+        "status": status,
+        "totals": {
+            "accepted_raw": len(by_decision.get("accepted", [])),
+            "accepted_deduped": len(accepted),
+            "rejected": len(rejected),
+            "ambiguous": len(ambiguous),
+        },
+        "ambiguous": ambiguous,  # full items so caller can format BLOCKED messages
+        "queue": accepted,        # the order to walk
+        "rejected_titles": [
+            f"[{i.get('source', '?')}] {i.get('title', '')[:120]}" for i in rejected
+        ],
+    }
+    return json.dumps(output, indent=2), exit_code
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pr", type=int, required=True, help="PR number (informational)")
+    ap.add_argument("--worktree", required=True,
+                    help="Worktree path (informational; not actually read by this script)")
+    ap.add_argument("--eval", "--evaluation", dest="eval_path", required=True,
+                    help="Path to pr-<n>.evaluation.json from Phase 7")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--print-queue", action="store_true", default=True,
+                      help="(default) Human-readable apply queue")
+    mode.add_argument("--json", action="store_true",
+                      help="Machine-readable JSON output for downstream tooling")
+    args = ap.parse_args()
+
+    eval_path = Path(args.eval_path)
+    try:
+        payload = load_evaluation(eval_path)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    # Make sure the PR number in the file matches the CLI arg (catches mistyped --pr)
+    file_pr = payload.get("pr")
+    if file_pr is not None and int(file_pr) != args.pr:
+        print(f"ERROR: --pr={args.pr} but evaluation file is for PR #{file_pr} ({eval_path})",
+              file=sys.stderr)
+        return 2
+
+    if args.json:
+        text, exit_code = render_json(payload)
+    else:
+        text, exit_code = render_human(payload)
+
+    print(text)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/run-codex-review/skills/run-codex-review/scripts/audit-review-state.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/audit-review-state.py
@@ -3,15 +3,19 @@
 
 Detects:
   - Orphan worktrees matching <repo>-wt-* that aren't in the manifest.
-  - Stale or missing /tmp/codex-review-manifest.json.
+  - Stale or missing manifest at the repo-local default path.
   - Round logs whose mtime is older than --stale-minutes.
   - In-flight Codex jobs from prior runs (best-effort via manifest entries).
 
+Manifest defaults to the repo-local path `<repo-root>/.codex-review-manifest.json`
+(matches the wrappers). Override with `--manifest <path>` if you've placed the
+manifest elsewhere.
+
 Usage:
-    python3 audit-review-state.py
+    python3 audit-review-state.py                                 # repo-local defaults
     python3 audit-review-state.py --json
-    python3 audit-review-state.py --manifest /tmp/codex-review-manifest.json
-    python3 audit-review-state.py --rounds-dir /tmp/codex-review-rounds/
+    python3 audit-review-state.py --manifest /custom/path.json
+    python3 audit-review-state.py --rounds-dir /custom/rounds-dir/
     python3 audit-review-state.py --stale-minutes 60
 
 Exit codes:
@@ -31,8 +35,11 @@ import sys
 import time
 from pathlib import Path
 
-DEFAULT_MANIFEST = "/tmp/codex-review-manifest.json"
-DEFAULT_ROUNDS_DIR = "/tmp/codex-review-rounds/"
+# Defaults are computed lazily from the repo root when args are parsed —
+# see _resolve_default_paths() below. The /tmp legacy paths are checked
+# only as a fallback for older skill versions' state files.
+LEGACY_TMP_MANIFEST = "/tmp/codex-review-manifest.json"
+LEGACY_TMP_ROUNDS_DIR = "/tmp/codex-review-rounds/"
 DEFAULT_STALE_MINUTES = 60
 TERMINAL_STATES = {"DONE", "CAP-REACHED", "BLOCKED", "FAILED"}
 
@@ -252,8 +259,10 @@ def render(report: dict, audit_output: str, audit_rc: int) -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
-    ap.add_argument("--rounds-dir", default=DEFAULT_ROUNDS_DIR)
+    ap.add_argument("--manifest", default=None,
+                    help="Path to manifest. Default: <repo-root>/.codex-review-manifest.json (repo-local).")
+    ap.add_argument("--rounds-dir", default=None,
+                    help="Path to round-logs dir. Default: <repo-root>/.codex-review-rounds/")
     ap.add_argument("--stale-minutes", type=int, default=DEFAULT_STALE_MINUTES)
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
@@ -262,6 +271,21 @@ def main() -> int:
     if root is None:
         print("not inside a git repository", file=sys.stderr)
         return 2
+
+    # Repo-local defaults (matches the wrappers); fall back to legacy /tmp paths
+    # only if a stale manifest exists there.
+    if args.manifest is None:
+        repo_local = str(root / ".codex-review-manifest.json")
+        if Path(repo_local).is_file() or not Path(LEGACY_TMP_MANIFEST).is_file():
+            args.manifest = repo_local
+        else:
+            args.manifest = LEGACY_TMP_MANIFEST  # legacy, surface as actionable
+    if args.rounds_dir is None:
+        repo_local_rounds = str(root / ".codex-review-rounds")
+        if Path(repo_local_rounds).is_dir() or not Path(LEGACY_TMP_ROUNDS_DIR).is_dir():
+            args.rounds_dir = repo_local_rounds
+        else:
+            args.rounds_dir = LEGACY_TMP_ROUNDS_DIR
 
     audit_path = find_run_repo_cleanup_audit()
     audit_output, audit_rc = "", 0

--- a/skills/run-codex-review/skills/run-codex-review/scripts/loop-status.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/loop-status.md
@@ -41,8 +41,8 @@ Columns:
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--manifest <path>` | `/tmp/codex-review-manifest.json` | Source-of-truth manifest. |
-| `--rounds-dir <path>` | `/tmp/codex-review-rounds/` | Per-branch round-log directory. |
+| `--manifest <path>` | `<repo-root>/.codex-review-manifest.json` (repo-local default) | Source-of-truth manifest. |
+| `--rounds-dir <path>` | `<repo-root>/.codex-review-rounds/` | Per-branch round-log directory. |
 | `--stale-minutes <n>` | `60` | Heartbeat threshold for `STALE` flagging. |
 | `--watch` | off | Redraw on a timer. |
 | `--refresh <n>` | `10` | Seconds between redraws (only with `--watch`). |

--- a/skills/run-codex-review/skills/run-codex-review/scripts/spawn-review-worktrees.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/spawn-review-worktrees.py
@@ -178,6 +178,56 @@ def find_or_create_entry(manifest: dict, branch: str) -> dict:
     return entry
 
 
+# ─── Dependency installation per worktree ─────────────────────────────────────
+
+def detect_package_manager(wt: Path) -> tuple[str, list[str]] | None:
+    """Detect which package manager the project uses based on lockfile / config.
+    Returns (label, install command) or None when no install step is needed.
+
+    Detection order matters when multiple lockfiles coexist (e.g. pnpm + npm) —
+    prefer the more specific one. Cargo/Go are no-ops because their toolchains
+    handle vendoring transparently.
+    """
+    if (wt / "pnpm-lock.yaml").is_file():
+        return ("pnpm", ["pnpm", "install", "--frozen-lockfile"])
+    if (wt / "bun.lockb").is_file() or (wt / "bun.lock").is_file():
+        return ("bun", ["bun", "install", "--frozen-lockfile"])
+    if (wt / "yarn.lock").is_file():
+        return ("yarn", ["yarn", "install", "--frozen-lockfile"])
+    if (wt / "package-lock.json").is_file():
+        return ("npm", ["npm", "ci"])
+    if (wt / "package.json").is_file():
+        # No lockfile but a package.json — fall back to plain install
+        return ("npm", ["npm", "install"])
+    if (wt / "requirements.txt").is_file():
+        return ("pip", ["pip", "install", "-r", "requirements.txt"])
+    if (wt / "pyproject.toml").is_file() and (wt / "poetry.lock").is_file():
+        return ("poetry", ["poetry", "install"])
+    if (wt / "pyproject.toml").is_file() and (wt / "uv.lock").is_file():
+        return ("uv", ["uv", "sync"])
+    if (wt / "Gemfile.lock").is_file():
+        return ("bundler", ["bundle", "install"])
+    # Cargo, Go modules, etc. handle deps in-toolchain — no install step needed.
+    return None
+
+
+def install_deps(wt: Path) -> tuple[bool, str]:
+    """Install dependencies in worktree if a recognized package manager is in
+    use. Returns (success, message). success=True when the install ran cleanly
+    OR when the project doesn't need an install step (Cargo, Go, etc.).
+    """
+    detected = detect_package_manager(wt)
+    if detected is None:
+        return True, "no install step (Cargo / Go / no recognized manifest)"
+    label, cmd = detected
+    rc, _, err = sh(cmd, cwd=wt)
+    if rc == 0:
+        return True, f"{label} install ok ({' '.join(cmd)})"
+    if rc == 127:
+        return False, f"{label} install failed — `{cmd[0]}` not on PATH"
+    return False, f"{label} install failed (rc={rc}): {err[:200]}"
+
+
 def process_branch(branch: str, root: Path, args, manifest: dict) -> tuple[str, str]:
     """Returns (action, message). action ∈ {'spawned', 'reused', 'skipped', 'failed', 'planned'}."""
     repo_name = root.name
@@ -225,6 +275,17 @@ def process_branch(branch: str, root: Path, args, manifest: dict) -> tuple[str, 
     if rc != 0:
         return "failed", f"git push -u {args.remote} {branch} failed: {err}"
 
+    # Optionally install dependencies (--prep-deps) so Phase 3 / Phase 8 don't
+    # discover missing node_modules / .venv mid-flight.
+    deps_msg = ""
+    if args.prep_deps:
+        ok, msg = install_deps(Path(wt))
+        deps_msg = f"; deps: {msg}"
+        if not ok:
+            # Surface but do not fail spawn — the worktree itself is valid;
+            # the user can install deps manually if the auto-install couldn't.
+            return action, f"{action} worktree at {wt}; pushed -u {args.remote} {branch}{deps_msg}"
+
     # Update manifest
     entry = find_or_create_entry(manifest, branch)
     sha = head_sha(wt)
@@ -236,7 +297,7 @@ def process_branch(branch: str, root: Path, args, manifest: dict) -> tuple[str, 
         "status": "SPAWNED",
         "updated_at": utc_now_iso(),
     })
-    return action, f"{action} worktree at {wt}; pushed -u {args.remote} {branch}"
+    return action, f"{action} worktree at {wt}; pushed -u {args.remote} {branch}{deps_msg}"
 
 
 def main() -> int:
@@ -247,6 +308,14 @@ def main() -> int:
     ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
     ap.add_argument("--worktree-prefix", default=None,
                     help="custom worktree path prefix (default: ../<repo>-wt-)")
+    ap.add_argument("--prep-deps", action="store_true",
+                    help="After creating each worktree, detect the package manager "
+                         "(pnpm-lock.yaml, package-lock.json, bun.lockb, yarn.lock, "
+                         "requirements.txt, pyproject.toml + poetry.lock/uv.lock, Gemfile.lock) "
+                         "and run the corresponding install. Cargo and Go are no-ops. "
+                         "Use for any project whose validate command (Phase 3 build, Phase 8 test) "
+                         "needs node_modules / .venv / equivalent. If install fails, the worktree "
+                         "itself is left intact and a warning is surfaced.")
     ap.add_argument("--dry-run", action="store_true", help="print plan without doing anything")
     ap.add_argument("--execute", action="store_true", help="actually create worktrees and push")
     args = ap.parse_args()


### PR DESCRIPTION
# ✨ feat(run-codex-review): add phase helper scripts

## Summary
Stacked on #56. This PR restores the helper-script layer from PR #53 as a focused executable/tooling change. It adds the Phase 8a apply-queue helper, `--prep-deps` worktree preparation, and repo-local review-state defaults without pulling in the remaining orchestration prose.

## Context / Why now
The wrapper PR gives the skill stable review/rescue state. This PR adds the small utilities that consume or prepare that state during later phases, keeping script behavior reviewable before the final documentation PR wires everything into the full flow.

## The 3 items

### Item 1: Phase 8a evaluator queue helper
- Files: `scripts/apply-evaluator-decisions.py`, `scripts/apply-evaluator-decisions.md`, `references/post-pr-review-protocol.md`
- What: Reads `pr-<n>.evaluation.json`, blocks the whole PR on ambiguous items, dedupes accepted items, and prints a read-only apply queue.
- Why this shape: Queue derivation is mechanical and repeated per PR. The main agent should apply fixes, not re-derive evaluator ordering and ambiguity rules every time.
- Verified by: `--help` plus sample READY, BLOCKED, and no-op evaluation JSON fixtures.

### Item 2: Worktree dependency prep
- Files: `scripts/spawn-review-worktrees.py`
- What: Adds `--prep-deps` package-manager detection so worktrees can install dependencies before Phase 3/8 validation.
- Why this shape: Missing dependencies surfaced late in prior traces. Installing at worktree creation avoids mid-apply surprises.
- Verified by: `--help` and dry-run branch-missing behavior without mutating worktrees.

### Item 3: Review state defaults and ledger alignment
- Files: `scripts/audit-review-state.py`, `scripts/loop-status.md`, `references/branch-decomposition-ledger.md`
- What: Aligns helper/state docs around repo-local manifests and round logs while still surfacing legacy `/tmp` state when present.
- Why this shape: Repo-local state avoids cross-repo collisions; legacy detection keeps prior sessions visible instead of silently hiding them.
- Verified by: validator and `audit-review-state.py --help`; JSON audit was exercised and correctly surfaced existing legacy `/tmp` review state as actionable.

## Files touched

| File | Purpose |
|---|---|
| `scripts/apply-evaluator-decisions.py` | New read-only Phase 8a queue helper. |
| `scripts/apply-evaluator-decisions.md` | Helper usage, output, and exit-code contract. |
| `scripts/spawn-review-worktrees.py` | Adds `--prep-deps` dependency preparation. |
| `scripts/audit-review-state.py` | Updates review-state discovery and legacy-state surfacing. |
| `scripts/loop-status.md` | Aligns status docs with manifest path behavior. |
| `references/branch-decomposition-ledger.md` | Documents helper-relevant state fields. |
| `references/post-pr-review-protocol.md` | Adds the Phase 8a apply-helper and ambiguity gate details. |

## Verification
- `python3 scripts/validate-skills.py` passed with all 43 skills valid.
- `python3 -m py_compile` passed for `apply-evaluator-decisions.py`, `spawn-review-worktrees.py`, and `audit-review-state.py`; generated `__pycache__/` was removed before validation.
- `python3 .../apply-evaluator-decisions.py --help` printed the expected CLI.
- Sample evaluator JSON produced expected exits: accepted queue `0`, ambiguous BLOCKED `1`, no-op `3`.
- `python3 .../spawn-review-worktrees.py --help` printed `--prep-deps`.
- `python3 .../audit-review-state.py --help` printed repo-local defaults.

## Weaknesses and open questions
1. Important: `--prep-deps` uses lockfile/config detection and may be ambiguous in repos with multiple package managers. Reviewer: confirm the detection order is appropriate.
2. Important: `apply-evaluator-decisions.py` dedupes accepted items. Reviewer: verify the dedupe key is conservative enough for repeated findings on the same line.
3. Minor: `audit-review-state.py` surfaced existing legacy `/tmp` state in this local environment. That is intentional compatibility behavior, but it means audit output can remain actionable even when the current repo-local path is clean.

## Request to the reviewer
Please focus on CLI contracts and mutability boundaries: which helpers are read-only, which can create worktrees/install dependencies, and whether exit codes are clear enough for agents to compose safely.

## Follow-ups (not in scope)
- The final docs PR wires these helpers into the complete ten-phase orchestration contract.
- Fixture-based tests can be added later if the repo grows a formal script test harness.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Phase 8a helper to derive the evaluator apply queue (with an ambiguous gate that blocks the entire PR), adds `--prep-deps` to worktree creation, and switches review-state defaults to repo-local paths for safer concurrent runs.

- **New Features**
  - `scripts/apply-evaluator-decisions.py`: prints an ordered Phase 8a apply queue from `pr-<n>.evaluation.json`; dedupes accepted items; if any item is ambiguous, prints a BLOCKED gate and exits without applying; supports `--json`, PR cross-check, and commit-message scaffolds.
  - `scripts/spawn-review-worktrees.py --prep-deps`: detects and installs deps via `pnpm`/`bun`/`yarn`/`npm`/`pip`/`poetry`/`uv`/`bundler` (Cargo/Go are no-ops). Failures surface as warnings; worktree spawn still succeeds.
  - `scripts/audit-review-state.py`: defaults to `<repo-root>/.codex-review-manifest.json` and `<repo-root>/.codex-review-rounds/`, falling back to legacy `/tmp` only when present.
  - Docs: Phase 8a apply recipe and helper usage; repo-local defaults in `loop-status.md`; ledger updates (repo-local manifest path, `CONVERGED-AT-CAP`, clarified `CAP-REACHED`/`BLOCKED` ownership); final deliverable template.

- **Migration**
  - Use repo-local defaults; add `.codex-review-manifest.json{,.lock}` and `.codex-review-rounds/` to `.gitignore`. Legacy `/tmp` state is still detected but should be migrated.
  - Optional: pass `--prep-deps` when spawning worktrees to avoid mid-loop missing-deps.
  - For Phase 8a, call `scripts/apply-evaluator-decisions.py`; if any item is ambiguous, mark the PR BLOCKED and do not apply accepted items.

<sup>Written for commit 80467095cea10525f1c795cee3137e016459b9c1. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

