### PR TITLE
📚 docs(run-codex-review): document orchestration flow

### DIFF
--- a/skills/run-codex-review/skills/run-codex-review/SKILL.md
+++ b/skills/run-codex-review/skills/run-codex-review/SKILL.md
@@ -5,11 +5,37 @@ description: "Use skill if you are running parallel per-branch /codex:review fix
 
 # Prepare and Run Codex Review
 
-The job: turn a messy repo into a clean per-branch decomposition; converge each branch through Codex's per-round review loop with `/do-review`-evaluated worker sub-agents; open a comprehensive PR per branch via a sub-agent that uses `/ask-review`; trigger `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh` on each PR as a last check; wait adaptively (900s base + 5-min extensions if bots still talking + 3-min quiet to terminate, capped at 30 min) for external review bots (Copilot, Greptile, Devin); dispatch a `/do-review` evaluator sub-agent per PR over all gathered streams; have the main agent apply the evaluator's accepted subset directly using `/do-review` in its own context; merge foundation→leaf on the private fork only; tidy. End state: every branch DONE-merged or surfaced (CAP-REACHED / BLOCKED / FAILED), no stale worktrees, manifest deleted, `audit-review-state.py` exits 0.
+The job: turn a messy repo into a clean per-branch decomposition; converge each branch through Codex's per-round review loop driven by **main agent as coordinator** (with per-round Applier sub-agents and main-agent `/do-review` evaluation); open a comprehensive PR per branch via a sub-agent that uses `/ask-review`; trigger codex rescue on each PR (`/codex:resc` slash for chat, or `scripts/trigger-codex-rescue.py` wrapping `codex-companion.mjs task --background` for programmatic loops); wait adaptively (900s base + 5-min extensions if bots still talking + 3-min quiet to terminate, capped at 30 min) for external review bots (Copilot, Greptile, Devin, cubic-dev-ai, copilot-pull-request-reviewer); dispatch a `/do-review` Evaluator sub-agent per PR over all gathered streams; have the main agent apply the evaluator's accepted subset directly via Edit + per-concern commits (Phase 8a); merge foundation→leaf with `git rebase --onto` mechanics for squash-merged stacks (Phase 8b); tidy. End state: every branch MERGED or surfaced (BLOCKED / CONVERGED-AT-CAP / CAP-REACHED / FAILED), no stale worktrees, no stale local/remote branches, manifest deleted, `audit-review-state.py` exits 0.
 
-This skill **layers on top of** `run-repo-cleanup`. Read that skill's `SKILL.md` first; its references and scripts are canonical for diff-walk, conventional commits, fork safety, worktrees, merge ordering. This skill adds: commit redistribution on committed history; the two-level coordinator+worker inner loop; `/ask-review`-based PR creation by sub-agent; `/codex:resc` orchestration with adaptive wait; multi-source review evaluation via `/do-review` sub-agents; main-agent direct apply; review-aware cleanup.
+This skill **layers on top of** `run-repo-cleanup`. Read that skill's `SKILL.md` first; its references and scripts are canonical for diff-walk, conventional commits, fork safety, worktrees, merge ordering. This skill adds: commit redistribution on committed history; the **main-agent-coordinator + per-round Applier** inner loop with `/do-review` evaluation in main's context; `/ask-review`-based PR creation by sub-agent; codex-rescue orchestration with adaptive wait; multi-source review evaluation via Evaluator sub-agents; main-agent direct apply (Phase 8a) followed by foundation→leaf serial merge (Phase 8b); review-aware cleanup with hard exit gate.
 
 Every sub-agent in this skill is dispatched per **`~/MISSION_PROTOCOL.md`** — Context Block → Mission Objective → Research & Tool Guidance → BSV Definition of Done → Verification → Failure Protocol → Handback. See `references/mission-protocol-integration.md`. Brief discipline is the lever; without it, parallel sub-agents drift toward mediocre.
+
+## Slash commands vs shell commands — invocation matrix
+
+This skill drives four slash commands. They are NOT shell programs. The codex plugin (`openai-codex/codex`) marks `/codex:review`, `/codex:status`, `/codex:result` as `disable-model-invocation: true` — **sub-agents physically cannot call them via `Skill(...)`**. `/codex:resc` requires the `Agent` tool which is not available to forked general-purpose sub-agents.
+
+Read this matrix once and stop guessing.
+
+| Command | Main agent | Worker / PR-Creator / Evaluator sub-agent |
+|---|---|---|
+| `/codex:review` | User-typed slash in chat for ad-hoc reviews. **For Phase 3 programmatic loops, dispatch the wrapper instead** (see worker row). | **`scripts/run-codex-review.py --branch X --base Y --worktree Z`**. The wrapper discovers `codex-companion.mjs` automatically (env-var first, then version-glob fallback), invokes it, normalizes the JSON output, and writes the round log. Sub-agents call the wrapper; the wrapper calls the companion script. |
+| `/codex:resc` | (a) `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <n>` typed as slash for 1-2 PRs. (b) **`scripts/trigger-codex-rescue.py --pr <n> --branch <b> --worktree <wt> --prompt-file <p>`** for programmatic loops with N PRs. Both paths run `codex-companion.mjs task --background` internally. | Not available. Phase 6 trigger is main-agent-only (the slash uses the `Agent` tool; the wrapper queues a Codex worker that forked sub-agents can't see). |
+| `/ask-review` | `Skill(skill="ask-review", args="…")` | `Skill(skill="ask-review", args="…")` — used by PR-Creator sub-agents in Phase 5. |
+| `/do-review` | `Skill(skill="do-review", args="…")` — Phase 8 main-agent direct apply. | **Not used in Phase 3 worker briefs.** Decisions are pre-made before worker dispatch (see invariant 11 + Phase 3 worker brief). Workers are appliers, not evaluators. |
+
+**Forbidden in every context:**
+
+- `codex review …` from Bash — there is no such CLI surface; the underlying `codex` binary has no `--background` flag.
+- Any "shim" wrapping the codex binary because a flag is "missing".
+- `node …/codex-companion.mjs review …` invoked DIRECTLY from a sub-agent brief or main-agent loop — that's what the wrapper is for. The wrapper does discovery, normalization, manifest-update, and round-log path computation. Calling the companion script directly bypasses all of that.
+- Reading `scripts/run-codex-review.py` thinking it's a stub — **it isn't**. It's the canonical wrapper. Production traces of agents writing `/tmp/codex-review-runner.py` parallel implementations were a workaround for an earlier broken version; that version has been rewritten.
+
+**Plugin discovery (handled inside the wrapper, documented for transparency):**
+
+1. `${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs` — set by Claude Code when the plugin is loaded.
+2. Latest semver-sorted version under `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs` — fallback for environments without the env var.
+3. If neither resolves: wrapper exits 127 with install instructions (https://github.com/openai/codex-plugin-cc).
 
 ## Pinned Defaults
 
@@ -23,38 +49,71 @@ Fill these once per project. If any cell is blank, ask — do not guess.
 | max rounds per branch (Phase 3) | `20` |
 | 3-consecutive-all-rejected → DONE | yes |
 | worktree path scheme | `../<repo>-wt-<branch-slug>` |
-| manifest path | `/tmp/codex-review-manifest.json` |
-| round-log dir | `/tmp/codex-review-rounds/` |
+| manifest path | `<repo-root>/.codex-review-manifest.json` (gitignored). **Never `/tmp/...`** — concurrent skill sessions in different repos clobber each other when both default to `/tmp/codex-review-manifest.json`. |
+| round-log dir | `<repo-root>/.codex-review-rounds/` (gitignored). Same reasoning. |
 | PR body cap (Phase 5, hard) | **50,000 chars (max only; no min)** |
-| Codex rescue invocation (Phase 6) | `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh` |
+| Codex rescue invocation (Phase 6) | Two first-class paths: (a) `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <n>` typed as slash directive in chat, OR (b) `scripts/trigger-codex-rescue.py --pr <n> --branch <b> --worktree <wt> --prompt-file <p>` for programmatic loops (wraps `codex-companion.mjs task --background --write --fresh --effort xhigh`). |
+| Single-owner repo mode | If `git remote -v` shows only `origin` and no `upstream`, treat origin as both source and target. Fork-safety invariant becomes vacuous. **Auto-detect in Phase 0; do not ask the user.** |
+| Manifest path collision | Default is repo-local; collisions across sessions are structurally impossible. If a stale `/tmp/codex-review-manifest.json` exists from an older skill version, ignore it. |
 | Wait base (Phase 6) | `900 s` (15 min) |
 | Wait quiet window | `180 s` (3 min) |
 | Wait extension | `300 s` (5 min) |
 | Wait total cap | `1800 s` (30 min) |
+| Codex review wall-clock cap (Phase 3 per-round) | `1500 s` (25 min). Codex can hang on remote tools (codebase-search APIs, etc.); the wrapper enforces this and exits non-zero with `terminal_reason: "review-hang past wall-clock cap"`. Main agent retries once, then marks the round FAILED. |
+| Phase 5 PR-Creator parallelism cap | `4 simultaneous`. GitHub's GraphQL budget is shared with `gh pr create` body uploads; opening 9+ in parallel exhausts it. Throttle batches; PR-Creator brief MUST instruct the sub-agent to use REST (`gh api repos/<owner>/<repo>/pulls -f title=… -f body=@<file> -f base=… -f head=…`) not `gh pr create` (which uses GraphQL). |
 | Mission protocol | `~/MISSION_PROTOCOL.md` |
 | run-repo-cleanup root | `<install-path>/run-repo-cleanup/` |
 | this skill root | `<install-path>/run-codex-review/` |
 
 Repo-local `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` wins over anything here.
 
+## Authorization rule (read this once, do not re-litigate)
+
+If the user's prompt named the full flow ("execute full skill flow", "run all phases", "do the whole pipeline", "full rigor", or invoked `/run-codex-review` without scoping), authorization is **persistent across all 10 phases**. Proceed phase-to-phase **without checkpoint, without option menus, without cost-warning prefaces, without asking "how would you like to proceed"**.
+
+Exception — pause **only** if:
+- A genuinely destructive operation requires confirmation that local context cannot resolve (e.g., a force-push the user did not authorize, a non-fast-forward push to a branch with prior history main agent did not write).
+- A skill invariant has been violated and there is no clean recovery (e.g., codex plugin unavailable; manifest collision that auto-namespacing did not catch).
+- The user typed a stop signal (`stop`, `pause`, `wait`, etc.) since the last action.
+
+Never pause to:
+- Estimate cost or wall-time ("this will take 4-7 hours and burn many tokens"). The user already authorized.
+- Present an option menu (Full / Phase-N-only / Foundation-only / Pause). The flow is already chosen.
+- Ask "would you like me to proceed?" The answer was given when the skill was invoked.
+- Justify a deviation. Either follow the skill or hand back BLOCKED with `terminal_reason` and one sentence on what you'd do differently.
+
+End-of-phase reports must be **one sentence**: "Phase X complete; entering X+1." Verbose state tables, per-branch summaries, and decision menus belong only in the **Final Deliverable** at the end of Phase 9.
+
 ## Non-Negotiable Invariants
 
-1. `origin` = private fork. `upstream` = read-only. Every mutating `gh` call passes `--repo <fork-owner>/<fork-repo>` explicitly. (See `skills/run-repo-cleanup/references/fork-safety.md`.)
+1. **Repo-mode auto-detected, not asked.** Two modes:
+    - **Two-remote** (origin = private fork, upstream = canonical): every mutating `gh` call passes `--repo <fork-owner>/<fork-repo>` explicitly; never push to upstream. (See `skills/run-repo-cleanup/references/fork-safety.md`.)
+    - **Single-owner** (only `origin`, no upstream): origin is the target; `gh` calls still pass `--repo <owner>/<repo>` for explicitness, but the "never touch upstream" rule is vacuously satisfied.
+    Detect from `git remote -v` in Phase 0. **Do not present options or ask the user when the detection is unambiguous.**
 2. Read every diff before staging. No `git commit -am`. (See `skills/run-repo-cleanup/references/diff-walk-discipline.md`.)
 3. Never `rm` an unknown file. Quarantine to `to-delete/` first. (See `skills/run-repo-cleanup/references/to-delete-folder.md`.)
-4. **One worktree per branch. One coordinator per worktree. One fresh worker per round.** No two agents mutate the same branch concurrently.
-5. **`/codex:review` always runs `--background`.** Never inline.
+4. **One worktree per branch. Main agent is the only coordinator (across all branches). One fresh Applier sub-agent per round per branch.** No two agents mutate the same branch concurrently. (The older "Coordinator sub-agent per worktree" pattern was dropped — long-lived sub-agents drift past harness session limits; main-agent-as-coordinator is empirically reliable. See `references/parallel-subagent-protocol.md` "Coordinator role".)
+5. **Codex review runs synchronously per round.** `codex-companion.mjs review` ignores `--background`; per-branch parallelism comes from concurrent subprocess invocations across branches, not from a background flag. (`task --background` IS honored — that's how Phase 6 codex rescue works; see Phase 6.)
 6. **20-round hard cap per branch.** Branches converge independently; one capping does not stop siblings.
 7. **Never `--force` push** a branch under active review. Stack commits on top.
 8. **Never push to upstream. Never touch `main` directly.**
 9. **Subagents fix; main agent merges.** Main agent never opens PRs in this workflow either — the PR-Creator sub-agent does.
 10. Granularity at the **concern boundary**, not arbitrary. Don't over-split a coherent commit; don't under-split a mixed one.
-11. **Never apply review feedback as-is.** Every Codex inner-loop, codex-rescue, copilot, greptile, devin item passes through a `/do-review` evaluator (sub-agent in Phase 3 + Phase 7; main-agent direct in Phase 8). Direct-apply is forbidden. (See `references/review-evaluation-protocol.md`.)
+11. **Never apply review feedback as-is — but the evaluator is NOT the worker.** Every Codex/copilot/greptile/devin item passes through `/do-review` evaluation. The role split:
+    - **Phase 3**: main agent runs the classifier on the round-log JSON, then evaluates each major item using `Skill(do-review)` in main's own context (one decision per item). Workers receive PRE-DECIDED accepted-fix specs and apply them mechanically. **Worker briefs do not mention `/do-review`** — that framing causes decision-only failure (workers produce excellent decision JSON but never apply or push).
+    - **Phase 7**: dedicated Evaluator sub-agent runs `/do-review` on every PR review item from all sources.
+    - **Phase 8**: main agent applies the evaluator's accepted subset directly using `/do-review` in own context.
+    Direct-apply without prior `/do-review` evaluation is forbidden in every phase. But pushing eval onto Phase 3 workers is also forbidden — workers are appliers, not evaluators.
 12. **Every sub-agent brief follows MISSION_PROTOCOL Mission Brief Skeleton.** Soft language banned. BSV Definition of Done. Ceilings, not floors. (See `~/MISSION_PROTOCOL.md` and `references/mission-protocol-integration.md`.)
 13. **PR creator MUST be a sub-agent.** Main agent never opens PRs in this skill's workflow. PR-Creator uses `/ask-review` skill (Skill tool) — hand-rolling the body is forbidden.
 14. **PR body ≤ 50,000 chars (hard cap; max only, no min).** Comprehensive ≠ verbose. The body must contain at least 3 explicit reviewer questions.
 15. **Codex rescue triggered immediately after PR creation.** Always `--background --fresh --model gpt-5.5 --effort xhigh`. It runs as Codex's own background sub-agent (not a Claude Agent we dispatch).
 16. **Wait window is 900s base + adaptive end + 1800s total cap.** Don't merge before the window closes and the evaluator runs.
+17. **Use the right invocation surface per context.** Each command has explicit valid paths; do not guess.
+   - **Phase 3 codex review** (per round, per branch): call `scripts/run-codex-review.py --branch X --base Y --worktree Z`. The wrapper discovers `codex-companion.mjs` (env-var first, then version-glob), invokes it synchronously, normalizes output, writes the round log. `/codex:review` is `disable-model-invocation: true` so sub-agents cannot dispatch the slash command — the wrapper IS their path. Main agent uses the wrapper too in programmatic loops.
+   - **Phase 6 codex rescue** (per PR): two first-class paths from main agent — (a) `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <n>` typed as slash directive for 1-2 PRs, OR (b) `scripts/trigger-codex-rescue.py --pr <n> --branch <b> --worktree <wt> --prompt-file <p>` for programmatic loops with N PRs. The wrapper internally calls `codex-companion.mjs task --background --write --fresh --effort xhigh` — same code path the slash command runs. Sub-agents cannot trigger rescue (no `Agent` tool in forked context).
+   - `/ask-review`, `/do-review` are model-invocable → both main and sub-agents call via `Skill(...)`.
+   - **Never** invoke `codex` directly from Bash (no `--background` CLI flag exists). **Never** invoke `node …/codex-companion.mjs …` directly from a brief — the wrappers do that, plus discovery, normalization, manifest update, and round-log path computation. **Never** write a parallel `/tmp/codex-review-runner.py` — that's what the production wrapper now does. **Never** invent a slash-command path that contradicts this matrix.
 
 ## The Ten Phases
 
@@ -85,12 +144,17 @@ Repo-local `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` wins over anything here
                  30 min total cap); gather all review streams
                               │
        Phase 7 — Evaluator sub-agent uses /do-review on all streams
-                 (codex-rescue, copilot, greptile, devin); returns
+                 (codex-rescue, copilot, copilot-pull-request-reviewer, greptile, devin, cubic-dev-ai); returns
                  accepted / rejected / ambiguous decisions JSON
                               │
-       Phase 8 — Main agent direct: read evaluator's JSON, apply accepted
-                 items via /do-review skill in own context, push, merge
-                 (or BLOCKED if ambiguous; surface for human)
+       Phase 8a — Main agent direct: read evaluator's JSON, apply accepted
+                 items, validate, push (or BLOCKED if ambiguous; surface).
+                 Apply order across PRs is irrelevant. /do-review re-eval
+                 is opt-in; the evaluator's JSON is the authority.
+                              │
+       Phase 8b — Foundation→leaf strict serial merge: wait CI green per PR;
+                 merge; rebase remaining leaves onto new main with
+                 --force-with-lease. Foundation must succeed first.
                               │
        Phase 9 — Tidy & final audit (fresh subagent re-verifies)
                               │
@@ -108,17 +172,23 @@ Each phase has a checkpoint. Don't skip forward. If you find yourself tempted to
 1. `python3 skills/run-repo-cleanup/scripts/audit-state.py` — base audit.
 2. `python3 skills/run-repo-cleanup/scripts/list-worktrees.py` — enumerate.
 3. `python3 <this-skill>/scripts/audit-review-state.py` — review-loop wrapper. Detects: orphan `*-wt-*` worktrees, stale `/tmp/codex-review-manifest.json`, in-flight Codex background jobs from prior runs, branches with stale round logs.
-4. `python3 skills/run-repo-cleanup/scripts/init-to-delete.py` if `.gitignore` is missing the patterns.
-5. Verify remotes per `skills/run-repo-cleanup/references/fork-safety.md`.
-6. Verify `~/MISSION_PROTOCOL.md` is present and current. Every sub-agent dispatch depends on it.
-7. Verify the `/ask-review` and `/do-review` skills are registered. Both are required.
+4. **Auto-detect repo mode** from `git remote -v`:
+   - Only `origin` exists → **single-owner mode**. Set `manifest.repo_mode = "single-owner"`. Skip the fork-safety options dialog. Do NOT ask the user about fork semantics.
+   - Both `origin` and `upstream` exist → **two-remote mode**. Verify per `skills/run-repo-cleanup/references/fork-safety.md`.
+5. **Pin manifest path repo-local.** This session's manifest is `<repo-root>/.codex-review-manifest.json`; round-log dir is `<repo-root>/.codex-review-rounds/`. Add both to `.gitignore` if not already there. **Do NOT use `/tmp/...`** — concurrent skill sessions across repos clobber each other when both default to /tmp. Pass `--manifest <repo-root>/.codex-review-manifest.json` to every script invocation. If a stale `/tmp/codex-review-manifest.json` exists from an older skill version, leave it alone — do not delete, do not edit.
+6. `python3 skills/run-repo-cleanup/scripts/init-to-delete.py` if `.gitignore` is missing the patterns.
+7. Verify `~/MISSION_PROTOCOL.md` is present and current. Every sub-agent dispatch depends on it.
+8. Verify the `codex:review`, `codex:resc`, `ask-review`, and `do-review` skills are registered (`Skill(...)` callable). All four are required. If any is missing, surface to the user and stop — do not invent a shim.
 
-**Gate**: enter Phase 1 only when (a) no in-progress git op, (b) `origin` verified as the fork, (c) `.gitignore` includes `to-delete/` + agent artifacts, (d) no orphan review state from a prior session, (e) MISSION_PROTOCOL + ask-review + do-review available.
+**Gate**: enter Phase 1 only when (a) no in-progress git op, (b) repo mode auto-detected (single-owner or two-remote), (c) manifest path resolved (namespaced if a collision was detected), (d) `.gitignore` includes `to-delete/` + agent artifacts, (e) no orphan review state from a prior session, (f) MISSION_PROTOCOL + the four required skills available.
 
 **Red flags**:
-- "I'll just start fresh and ignore the prior session's manifest." → No. Either resume or clean up explicitly.
+- "I'll just start fresh and ignore the prior session's manifest." → No. Either resume or namespace this session's manifest. Do not delete the other session's state.
+- "I'll rebuild the manifest by hand because it has stale entries." → No. Auto-namespace and proceed.
 - "audit-state.py is enough; skip audit-review-state." → No. Orphan review state is invisible to the base audit.
 - "I'll skip the MISSION_PROTOCOL check; the briefs will work without it." → No. The protocol IS the brief discipline.
+- "There's no upstream — let me ask the user how to set up fork semantics." → No. Single-owner mode is auto-detected. Proceed.
+- "Let me run `codex --help` to confirm the CLI is ready." → No. Slash commands are not shell programs. The dispatch surface for sub-agents is `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs"` (existence check is enough); for main agent the dispatch surface is the user-typed slash. Do not probe the underlying CLI.
 
 ---
 
@@ -150,72 +220,92 @@ Each phase has a checkpoint. Don't skip forward. If you find yourself tempted to
 **Think first**: *Each branch needs its own physical workspace before any review starts. Each must have a remote ref on `origin` for Codex to review against.*
 
 ```bash
-python3 <this-skill>/scripts/spawn-review-worktrees.py --branches feat/a feat/b docs/c --execute
+python3 <this-skill>/scripts/spawn-review-worktrees.py --branches feat/a feat/b docs/c --execute --prep-deps
 ```
 
 For each branch the script: creates `../<repo>-wt-<slug>` (or reuses if present and clean), pushes to `origin` with `-u` (refuses if remote != `origin`), appends an entry to the manifest. Verify with `python3 skills/run-repo-cleanup/scripts/list-worktrees.py`.
 
-**Gate**: every branch has a worktree, every branch is at `origin/<branch>`, manifest written.
+**Pre-flight worktree dependencies (`--prep-deps`).** If the project requires installed deps (`node_modules`, `.venv`, etc.) for the build/test that Phases 3 and 8 will run, install them in each worktree NOW — not lazily mid-Phase-3 or mid-Phase-8. The flag detects the package manager from repo files (`pnpm-lock.yaml` → `pnpm install`; `package-lock.json` → `npm ci`; `bun.lockb` → `bun install`; `requirements.txt` → `pip install -r requirements.txt`; `Cargo.toml` → no-op, cargo handles it; etc.) and runs the corresponding install in every newly-created worktree. Default is OFF; flip to ON for any repo whose validate command needs an install step. Production trace showed a worktree throwing `error TS2307: Cannot find module 'fs'` on first build because deps were never installed — `--prep-deps` makes that moment unreachable.
+
+**Gate**: every branch has a worktree, every branch is at `origin/<branch>`, manifest written, deps installed (when `--prep-deps` was used).
 
 **Red flags**:
 - "I'll review from the main worktree and switch branches." → No. Sub-agents will collide.
 - "I'll push later, just before opening the PR." → No. Codex needs a remote ref now.
+- "Skip `--prep-deps`; workers will install lazily as needed." → Acceptable for repos where the validate command works without an install step (Rust, Go, plain-Python). Forbidden for npm/pnpm/bun/pip projects that the validate command needs `node_modules`/`.venv` for — Phase 8 surprise costs more than upfront install.
 
 ---
 
-## Phase 3 — Parallel inner loop (coordinator + per-round worker)
+## Phase 3 — Parallel inner loop (main agent coordinates; appliers apply)
 
-**Think first**: *Each branch is independent. Each gets a coordinator sub-agent that drives the loop; per round it dispatches a fresh worker sub-agent that uses `/do-review` to evaluate Codex's items before applying. The main agent dispatches and watches; it does not edit during the loop.*
+**Think first**: *Main agent IS the coordinator across all branches. It dispatches per-round APPLIER sub-agents in parallel — one per branch, fresh each round. Decisions about each Codex item are made by main agent BEFORE worker dispatch, using `Skill(do-review)` in main's own context. Workers receive pre-decided fix specs and execute mechanically. They do not evaluate.*
 
-For each branch in the manifest, **main agent dispatches one coordinator sub-agent** (parallel across branches) per the brief in `references/parallel-subagent-protocol.md`. The coordinator runs the loop; per round it dispatches a fresh worker.
+The coordinator-as-subagent pattern in older versions of this skill is dropped: in practice, sub-agents that need to live for hours (one per branch × convergence loop) are unreliable in Claude Code. Main agent owns the round-cadence directly and dispatches short-lived, single-purpose appliers.
 
-**Coordinator brief skeleton** (full template in `parallel-subagent-protocol.md`):
-- Context: branch, worktree, manifest path, MISSION_PROTOCOL pointer, worker brief template location.
-- Mission: drive `<branch>`'s manifest entry to a terminal state with full round history.
-- DoD: status ∈ {DONE, CAP-REACHED, BLOCKED, FAILED}; rounds match round_history; terminal_reason set; remote tip matches manifest's head_sha_current.
-
-**Coordinator's loop** (canonical pseudocode in `references/per-branch-fix-loop.md`):
+**Per-round flow main agent runs** (parallel across all branches in flight):
 
 ```
 round = 1
-all_rejected_streak = 0
+per branch: all_rejected_streak = 0
 
-while round <= 20:
-    run-codex-review.py → review JSON
+while any branch has round <= 20 and not in terminal state:
+
+    # 1. Launch codex review for every active branch in parallel.
+    #    Sub-agents cannot Skill(codex:review) — disable-model-invocation.
+    #    Use the wrapper script (it bridges to codex-companion.mjs review --json).
+    for branch in active_branches:
+        bg: python3 <this-skill>/scripts/run-codex-review.py \
+              --branch <b> --base <base> --worktree <wt> \
+              --output <rounds-dir>/<slug>.<round>.json
+
+    # 2. As each review completes:
     classify-review-feedback.py → exit 0 (≥1 major) or 1 (no major)
 
     if classifier exit 1:
-        manifest.status = "DONE"; terminal_reason = "no major in round <N>"; break
+        manifest.status = "DONE"; terminal_reason = "no major in round <N>"; continue
 
-    # Dispatch FRESH worker sub-agent for THIS round
-    Agent(prompt=worker_brief_for_round, subagent_type="general-purpose")
+    # 3. Main agent EVALUATES each major item with Skill(do-review)
+    #    in own context. Produces decisions JSON: per item, accepted/rejected/ambiguous.
+    decisions = []
+    for item in major_items:
+        cited_code = read(<worktree>/<file>, around <line>, ±25 lines)
+        decision = Skill(do-review, args="--item <body> --code <cited_code>")
+        decisions.append(decision)
 
-    # Worker uses /do-review on every major item, applies accepted, pushes
-    # Hands back: { accepted: N, rejected: M, ambiguous: K }
+    # 4. Per branch: dispatch ONE applier sub-agent with the decisions baked in.
+    #    Worker brief is in references/parallel-subagent-protocol.md.
+    #    Worker DoD is BINARY: commits pushed to origin/<branch>; tests pass.
+    #    Worker brief NEVER mentions /do-review (decisions are pre-made).
+    Agent(prompt=applier_brief_with_decisions, subagent_type="general-purpose")
 
-    if worker.failed:
-        manifest.status = "FAILED"; break
+    # 5. Worker hands back: { applied: N, pushed: bool, validation: pass/fail }.
+    if not worker.pushed:
+        manifest.status = "FAILED"; terminal_reason = "applier failed to push"
+        continue
 
-    if worker.ambiguous and persistent_ambiguity:
-        manifest.status = "BLOCKED"; break
-
-    if worker.accepted == 0 and worker.rejected > 0:
+    if all decisions were rejected (worker.applied == 0, worker.rejected > 0):
         all_rejected_streak += 1
         if all_rejected_streak >= 3:
-            manifest.status = "DONE"; terminal_reason = "3 consecutive all-rejected; Codex stuck"; break
+            manifest.status = "DONE"; terminal_reason = "3 consecutive all-rejected; Codex stuck"
+            continue
     else:
         all_rejected_streak = 0
 
-    round += 1
+    round += 1  # for this branch
 
-if round > 20:
+per branch: if round > 20:
     manifest.status = "CAP-REACHED"
 ```
 
-**Worker brief skeleton** (full template in `parallel-subagent-protocol.md`):
-- Context: branch, worktree, round number, round JSON path, classifier output, prior round summaries.
-- Mission: every major item has a decision (accepted / rejected / ambiguous via `/do-review`); accepted items are committed (one concern per commit) and pushed; round log updated.
-- DoD: every item has a decision; `git diff --cached` empty; validation exits 0; `git push origin <branch>` succeeded.
+**Why the role split (read this once, do not re-litigate):**
+
+If the worker brief says "evaluate via `/do-review`, then apply", workers stop at the evaluation step ~100% of the time. The /do-review framing pulls them into evaluator-mode and "Verdict: apply" feels like the deliverable. Splitting evaluation (main agent) from application (worker, with explicit fix specs and binary push DoD) makes workers reliably push. This is empirically verified across multiple runs.
+
+**Applier brief skeleton** (full template in `parallel-subagent-protocol.md`):
+- Context: branch, worktree, round number, base ref, prior rounds' commit SHAs.
+- Mission: apply N pre-decided fixes (each spelled out with file:line + intended code shape), one concern per commit, validate, push.
+- Hard constraints: NEVER invoke `/do-review`. NEVER propose alternative fixes. NEVER stop at "Verdict: apply" — apply is the deliverable.
+- DoD (binary, verifiable): N new commits on `origin/<branch>`; `git -C <wt> rev-parse origin/<branch>` matches local HEAD; validation passes; `git -C <wt> log <base>..HEAD --oneline` shows the new commits.
 
 Main agent monitors with:
 
@@ -225,16 +315,30 @@ python3 <this-skill>/scripts/loop-status.py --watch
 
 Live table: branch, rounds, last status, state. **No editing while sub-agents are running.**
 
-**Gate**: every branch in the manifest in a terminal state (`DONE` / `CAP-REACHED` / `BLOCKED` / `FAILED`).
+**Gate**: every branch in the manifest in a terminal state.
+
+### Convergence taxonomy (the only valid terminal states)
+
+| State | Meaning | When set | PR? |
+|---|---|---|---|
+| `DONE` | No major items in the latest round (classifier exit 1). | Round N classifier returned no major. | Yes — open PR. |
+| `CONVERGED-AT-CAP` | Configured `max_rounds_per_branch` exhausted **with at least one round of fixes pushed**. Remaining items go in PR body as known-deferred. | Round counter ≥ cap; `len(round_history) ≥ 1`; latest classifier still exit 0 but Applier ran successfully. | Yes — open PR with deferred items in body. |
+| `CAP-REACHED` | 20-round hard cap (or configured cap) hit with **no convergence at all** (every round still has major items, no progress). | Round counter ≥ 20; same classifier outcome round-after-round. | No — surface for human (likely needs branch split). |
+| `BLOCKED` | Persistent ambiguous items, oscillation, contradictions; safe automated convergence not possible. | 3+ rounds of all-rejected (Codex stuck) reclassifies as `DONE`; persistent ambiguous reclassifies as `BLOCKED`. | No — surface. |
+| `FAILED` | Tooling crash past retry budget, codex plugin unavailable, Applier failed to push. | Any infrastructure gate that the retries did not recover. | No — surface. |
+
+**Do not invent additional states.** If a situation does not fit any of the five above, the skill is wrong (file an issue) — do NOT invent `DONE-PRAGMATIC`, `READY-ENOUGH`, or similar. Pick `BLOCKED` if you genuinely cannot pick from the taxonomy, with a `terminal_reason` describing the mismatch.
 
 **Red flags**:
-- "Let me check progress mid-loop and skip --background once." → No.
-- "Good enough after 3 rounds; ship it." → No (the classifier + worker decide).
+- "Let me check progress mid-loop." → No. Workers update the manifest atomically; read it.
+- "Good enough after 3 rounds; ship it." → No (the classifier decides DONE).
 - "Let me have one worker fix two rounds." → No (workers are fresh per round).
-- "Let me have the coordinator do the work itself." → No (coordinator orchestrates; worker acts).
-- "I'll skip /do-review for the obvious items." → No. Direct-apply violates invariant 11.
+- "Let me write the worker brief telling it to `/do-review` each item itself." → **No.** The /do-review framing causes systematic decision-only failure (verified across runs). Main agent evaluates; worker applies.
+- "I'll dispatch a coordinator subagent per branch like the older docs said." → No. Main agent IS the coordinator. The coordinator subagent role was dropped; sub-agents that live for hours are unreliable.
+- "I'll skip /do-review evaluation for the obvious items." → No. Direct-apply (without prior decision) violates invariant 11.
 - "The classifier is being noisy, let me bypass it." → No — adjust `major-vs-minor-policy.md` if the policy is wrong.
-- "I'll skip the validation step before re-review." → No. Codex can't tell your syntax error from a real bug.
+- "I'll skip the worker's validation step before push." → No. Codex can't tell your syntax error from a real bug.
+- "Round-2 found new items but I'm tired; let me invent DONE-PRAGMATIC and ship." → No. Apply round-2 fixes; if budget is binding, set `CONVERGED-AT-CAP` per the convergence taxonomy and proceed to PR — do not invent off-spec terminal states.
 
 ---
 
@@ -244,7 +348,7 @@ Live table: branch, rounds, last status, state. **No editing while sub-agents ar
 
 Once every branch is terminal, the main agent:
 
-1. Reads `/tmp/codex-review-manifest.json`.
+1. Reads `<repo-root>/.codex-review-manifest.json` (the repo-local default; pass `--manifest <path>` if a custom location was used).
 2. Builds the deliverable's first table (Branch | Worktree | Concern | Rounds | Final status).
 3. Recomputes merge order with `python3 skills/run-repo-cleanup/scripts/suggest-merge-order.py --base main`. Override the heuristic for semantic dependencies; write the rationale into the manifest.
 4. Surfaces non-`DONE` branches: each with its remaining major feedback and a suggested human action.
@@ -257,7 +361,9 @@ Once every branch is terminal, the main agent:
 
 **Think first**: *Each PR is opened by a fresh sub-agent dispatched by the main agent. The sub-agent uses the `/ask-review` skill to author a comprehensive body that explicitly asks the right reviewer questions. Body is capped at 50,000 chars (max only; no min). Main agent NEVER opens PRs in this workflow.*
 
-Process branches sequentially in foundation→leaf order from manifest.merge_order.
+**Throttling**: dispatch ≤4 PR-Creators in parallel. Opening 9+ in parallel exhausts GitHub's GraphQL budget (verified in production traces). The PR-Creator brief MUST instruct the sub-agent to use **REST endpoints for body uploads** (`gh api repos/<owner>/<repo>/pulls -f title=… -f body=@<file> -f base=… -f head=…`), NOT `gh pr create` (which uses GraphQL). When a handback says "rate-limited", check `gh api rate_limit --jq '.resources.graphql.reset'` for the Unix-timestamp reset; if main agent is in `/loop` dynamic mode, `ScheduleWakeup(delaySeconds=<reset_in - now + 60>, ...)`; otherwise queue that branch's redispatch behind the next batch.
+
+Process branches sequentially in foundation→leaf order from manifest.merge_order, but dispatch the PR-Creators in parallel batches of 4.
 
 For each `DONE` branch:
 
@@ -270,7 +376,15 @@ For each `DONE` branch:
    - Verifies body length ≤ 50,000 chars (`wc -c`).
    - Verifies body contains at least 3 explicit reviewer questions.
    - Saves body to `/tmp/pr-body-<branch-slug>.md`.
-   - Opens PR: `gh pr create --repo <fork-owner>/<repo> --base <base> --head <branch> --title "..." --body-file <path>`.
+   - **Opens PR via REST endpoint** (avoids GraphQL rate-limit blast in parallel dispatches):
+     ```bash
+     gh api -X POST repos/<fork-owner>/<repo>/pulls \
+            -f title="<title>" \
+            -f head="<branch>" \
+            -f base="<base>" \
+            -F body=@/tmp/pr-body-<branch-slug>.md
+     ```
+     **Do NOT use `gh pr create`** — it uses GraphQL by default, which has a separate ~5000/hour budget that's quickly exhausted by parallel PR creation (verified in production: 9 parallel `gh pr create` saturates GraphQL while REST core is barely touched). The REST endpoint above uses the core budget. Both produce equivalent PRs.
    - Verifies URL is on fork: `gh pr view <number> --repo <fork>/<repo> --json url,baseRefName`.
    - Updates manifest entry: `pr_number`, `pr_url`, `pr_title`, `pr_body_path`, `pr_body_chars`, `pr_explicit_questions`, `pr_opened_at`.
    - Hands back to main agent.
@@ -288,15 +402,25 @@ For each `DONE` branch:
 
 ## Phase 6 — Codex rescue + adaptive review window
 
-**Think first**: *Hand the PR link to Codex's own background sub-agent (`/codex:resc`). Then wait — adaptively — for codex-rescue + external bots (Copilot, Greptile, Devin) to land their reviews. The wait pattern: 900s base + 5-min extensions if bots are still talking + terminate on 3-min quiet + 30-min safety cap.*
+**Think first**: *Hand the PR link to Codex's own background sub-agent (`/codex:resc`). Then wait — adaptively — for codex-rescue + external bots (Copilot, Greptile, Devin, cubic-dev-ai) to land their reviews. The wait pattern: 900s base + 5-min extensions if bots are still talking + terminate on 3-min quiet + 30-min safety cap.*
 
 For each PR opened in Phase 5, sequentially:
 
-1. **Trigger codex rescue**:
+1. **Trigger codex rescue.** Two sanctioned paths (pick by context):
+
+   **A. Interactive (1-2 PRs):** type `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <number>` in chat.
+
+   **B. Programmatic loop (N PRs in parallel — Phase 6 default):**
    ```bash
-   python3 <this-skill>/scripts/trigger-codex-rescue.py --pr <number> --branch <b>
+   Bash(run_in_background=True):
+     cd <worktree-path> && \
+     node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task \
+          --write --fresh --effort xhigh \
+          "<comprehensive prompt for PR #<n>>"
    ```
-   This invokes `codex review --rescue --background --fresh --model gpt-5.5 --effort xhigh --pr <number>` inside the branch's worktree. Codex rescue is **Codex's own background sub-agent** (not a Claude Agent); we hand it the PR link and Codex's infrastructure spawns the review job. Manifest gets `rescue_review_id`, `rescue_started_at`, `rescue_status: "running"`.
+   This is the **same code path** `/codex:resc` runs internally; both invoke `codex-companion.mjs task`. In a programmatic loop, calling it directly is cleaner than typing N slash-command directives.
+
+   Codex rescue is **Codex's own background sub-agent** (not a Claude Agent we dispatch). Manifest gets `rescue_review_id`, `rescue_started_at`, `rescue_status: "running"`. NEVER invoke `codex review --rescue …` from Bash (no such CLI surface). NEVER write a "shim" — both invocation paths are first-class.
 
 2. **Wait + gather**:
    ```bash
@@ -351,69 +475,122 @@ For each PR:
 
 ---
 
-## Phase 8 — Main-agent direct apply + merge
+## Phase 8a — Main-agent direct apply (per-PR sequential; cross-PR order irrelevant)
 
-**Think first**: *The evaluator's structured output is in main agent's context. Re-dispatching to a sub-agent for apply would re-load context unnecessarily. Main agent applies directly using `/do-review` in own context — the user's principle: "do-review is healthier when answers come straight back".*
+**Think first**: *The evaluator's structured output is in main agent's context. Apply one PR at a time; main agent reads the evaluation JSON, applies each accepted item, validates, pushes. Apply order across PRs doesn't matter — each branch is its own worktree. Merge order is enforced in 8b.*
 
-For each PR:
+For each PR with `<repo>/.codex-review-rounds/pr-<n>.evaluation.json`:
 
-1. **Main agent reads** `<rounds-dir>/<slug>.pr-evaluation.json`.
-2. **For each accepted item** (deduplicated across sources):
-   - Read cited code (Read tool).
-   - Compose the fix per evaluator's rationale.
-   - Sanity-check via `/do-review` skill in main agent's context (Skill tool with `skill='do-review'`).
-   - Apply via Edit (with diff-walk discipline).
-   - `git diff --cached` (verify only intended hunks).
-   - `git commit -m "<emoji> <type>(<scope>): apply <source>'s <item-id>"`.
-3. **For each ambiguous item**: do NOT apply. Record in BLOCKED list for the PR.
-4. **After all accepted items applied**:
-   ```bash
-   git -C <worktree> push origin <branch>
+1. **Main agent reads** the evaluation JSON. Confirm:
+   - `accepted` count > 0 (else mark `apply_status: "skipped-no-accepted"` and proceed to next PR).
+   - `ambiguous` count > 0 → mark PR `BLOCKED` in manifest with `terminal_reason: "ambiguous: <item-id>: <evaluator's question>"`. **Skip apply for this PR's accepted items too** — partial-apply ships unreviewed code with a half-decided intent. Surface in deliverable, move to next PR.
+2. **For each accepted item** (deduplicated across sources, preserving the first-seen rationale):
+   - Read cited code at `<worktree>/<file>` around `<line>` (Read tool, ±25 lines for context).
+   - Apply the fix per evaluator's intended-shape via Edit.
+   - **If the intended-shape doesn't apply cleanly** (file moved, line shifted, current shape mismatch): DO NOT improvise. Record `apply_failed_after_evaluation: <item-id>` in manifest. Continue with remaining items. Surface at end of Phase 8a — the human decides re-evaluate or accept-as-known.
+   - **Stage by concern from the start**: `git -C <worktree> add <files-for-this-concern>`. Do NOT stage everything then `git restore --staged .` to peek and restage — that's wasted overhead per PR. Diff-walk per concern from the first add.
+   - `git -C <worktree> diff --cached` (verify only intended hunks).
+   - `git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject> (#<pr>)"`. Note the `(#<pr>)` suffix for traceability.
+3. **Commit-grouping rule**: tightly-coupled small fixes to the same file may share one commit IF the message lists each concern as a bullet. Example:
    ```
-   Wait for CI green.
-5. **If ambiguous list non-empty**: mark PR `BLOCKED` in manifest with `terminal_reason` citing the items. Surface in deliverable. Do NOT merge.
-6. **Else**: `gh pr merge <number> --repo <fork>/<repo> --squash` (or per repo policy).
-7. **Optional — fresh PR**: if accepted items are too divergent for in-place application (per `post-pr-review-protocol.md`'s rubric), open a new PR via Phase 5 redux for that branch.
+   🐛 fix(parsers/copilot): hardening pass (#47)
 
-After merge: `git fetch --all --prune`. If a sibling DONE branch overlaps the just-merged base, rebase it onto the new `main` (only safe because sibling has no review in flight at this point).
+   - Distinct sourceIds for inline tool requests
+   - toolName carry-through on execution_complete
+   - Dedup statSync in extractLastEventTimestamp
+   ```
+   For unrelated concerns, split into separate commits. **One concern per commit is the default**; combining is an exception that requires the bullets-in-message accountability.
+4. **Validate** before push: `pnpm run build && pnpm test` (or repo-equivalent per `AGENTS.md`/`CONTRIBUTING.md`). Three failure modes:
+   - **Build fails** (compile error, type error, syntax error from your edit) → revert the offending commit, mark item `apply_failed_validation`, surface — do not retry blindly with a different fix.
+   - **Test fails on a NEW assertion that the fix should pass** (real regression) → revert, mark item ambiguous, surface.
+   - **Test fails on an EXISTING assertion that asserts the OLD behavior the fix is intended to change** → this is a legitimate test-fixture update. Update the test (or fixture data) to match the new intended behavior in the SAME commit (or amend). Re-run validate. Do NOT revert. Example from production: a fix changed legacy session id format from `legacy:<basename>` to `legacy:<rel-path>` to disambiguate basename collisions across subdirectories. The existing test asserted the old format; updating the test fixture to match the new format was the correct response, not a revert.
 
-**Gate**: PR is `MERGED` (manifest field set), or `BLOCKED` with surfaced items.
+   When in doubt between "real regression" and "legitimate test-fixture update": **read the test's intent**. If the test was protecting against the regression the evaluator's accepted fix introduces, it's a real regression — revert. If the test was asserting an arbitrary detail of the OLD behavior that the evaluator explicitly intended to change (and the evaluator's rationale documents the change), it's a fixture update — update it.
+5. **Push**: `git -C <worktree> push origin <branch>` (no `--force`).
+6. **`/do-review` sanity-check is OPTIONAL and OFF by default.** The Evaluator already used `/do-review` in Phase 7; re-running per item in Phase 8 is double-eval. Reserve for the rare case where main agent's reading of the cited code disagrees with the evaluator's rationale — when borderline, sanity-check before push; otherwise skip.
 
-**Red flags**:
+Process PRs in any order in 8a (foundation-first OR leaves-first OR interleaved are all fine). Phase 8b enforces merge order.
+
+**Phase 8a gate**: every non-BLOCKED PR has new commits pushed; manifest has `apply_status: "applied"` per branch; ambiguous-flagged items recorded; `apply_failed_after_evaluation` items recorded for human surface.
+
+**Red flags (8a)**:
 - "Let me dispatch a sub-agent for apply too." → No. Phase 8 is main-agent direct.
-- "Apply ambiguous items just in case." → No. Ambiguous = human-in-the-loop.
+- "Apply ambiguous items just in case." → No. Ambiguous = human-in-the-loop. The whole PR is BLOCKED.
+- "Apply some accepted items even though others are ambiguous on the same PR." → No. Defer the entire PR.
 - "Re-trigger Codex review after apply." → No. Phase 8's commits are post-evaluator.
-- "Merge the BLOCKED PR anyway." → No. The classifier said major, the evaluator said ambiguous. Human decides.
+- "Phase 8 evaluator's intended-shape doesn't apply cleanly; let me improvise." → No. Mark `apply_failed_after_evaluation`, surface for human.
+- "Stage all files, peek with `git diff --cached`, then `git restore --staged .` to re-stage by concern." → No. Diff-walk per concern from the start.
+- "Re-do `/do-review` per item even when evaluator already accepted with high confidence." → No. Default-skip; the evaluator's JSON is the authority.
+
+---
+
+## Phase 8b — Merge in foundation→leaf strict serial
+
+**Think first**: *Apply is done. Now merge in dependency order with squash-merge-aware leaf rebases.*
+
+The full merge recipe (foundation pre-merge tip capture, `git rebase --onto` for leaves, retargeting via `gh pr edit --base main`, sequential merge with CI-wait between, `--delete-branch` on merge) is documented in detail in **`references/post-pr-review-protocol.md` "Phase 8b — merge in foundation→leaf strict serial"**. Follow that recipe verbatim. Key points to keep in this skill body:
+
+- **Capture foundation's pre-merge tip BEFORE merging foundation** (`foundation_tip=$(git -C <foundation-worktree> rev-parse HEAD)`). Required for the `git rebase --onto origin/main <foundation_tip> <leaf>` math below.
+- **Foundation must succeed first.** If foundation CI fails, STOP — leaves are based on foundation; do not merge any of them. Surface foundation BLOCKED.
+- **Squash-merging foundation collapses N foundation commits into 1 commit on main with a different SHA.** Plain `git rebase origin/main` on leaves conflicts on every foundation hunk. Use `git rebase --onto origin/main <foundation_tip> <leaf-branch>` to skip the duplicated history.
+- **Retarget each leaf** (`gh pr edit <leaf-pr> --base main`) before merging — leaves were originally based on foundation.
+- **`gh pr merge --squash --delete-branch`** (the `--delete-branch` flag halves Phase 9 cleanup).
+- **`gh pr merge --auto` works for foundation, unreliable for leaves on divergent stacks.** Use sequential explicit merge with CI-wait between.
+- **`--force-with-lease`, NOT `--force`** when pushing rebased leaves.
+
+### Phase 8b hard exit gate
+
+**Phase 8b does NOT exit until every non-BLOCKED PR is MERGED.** `gh pr list --repo <fork>/<repo>` should show ONLY BLOCKED or `apply_failed_after_evaluation` branches. If a PR is neither and isn't merged, 8b is incomplete — re-attempt the merge (in `/loop` mode, `ScheduleWakeup(delaySeconds=600)` and re-check). Do NOT proceed to Phase 9 with un-resolved PRs.
+
+### Red flags (8b)
+
+- "Merge foundation before CI green." → No. CI-wait is mandatory.
+- "Foundation CI failed — merge the leaves anyway." → No. Halt all leaf merges; surface foundation BLOCKED.
+- "Plain `git rebase origin/main` the leaves." → No. `--onto <foundation_tip>` is non-negotiable for squash-merged stacks.
+- "Skip capturing `foundation_pre_merge_tip`." → No. Capture BEFORE merging foundation; the local HEAD may move after.
+- "Skip retargeting leaves to main." → No. PR `--base` is independent of the rebased branch.
+- "Use `gh pr merge --auto` to chain leaf merges." → No. Sequential explicit merge with CI-wait between.
+- "Force-push leaves with `--force` instead of `--force-with-lease`." → No. `--force-with-lease` is the safety mechanism.
+- "Merge the BLOCKED PR anyway." → No. Human decides.
+- "Open a fresh PR for the apply_failed_after_evaluation items." → Acceptable but optional; surface for human first. Don't auto-cycle.
 
 ---
 
 ## Phase 9 — Tidy & final audit
 
-**Think first**: *What state did I start in? Have I returned to it, plus the intended delta — nothing more, nothing less?*
+**Think first**: *What state did I start in? Have I returned to it, plus the intended delta — nothing more, nothing less? No stale worktree, no stale local branch, no stale remote branch, no stale temp file.*
 
-1. Cleanup worktrees:
-   ```bash
-   python3 <this-skill>/scripts/cleanup-worktrees.py --base main --execute
-   ```
-   Refuses worktrees whose branch is not merged unless `--force-abandon <branch>` is passed.
-2. Retire merged branches:
-   ```bash
-   python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --execute
-   ```
-3. **Dispatch a fresh subagent** for an independent re-audit (per `skills/run-repo-cleanup/references/post-pr-verification.md`). The subagent runs read-only:
-   - `python3 skills/run-repo-cleanup/scripts/audit-state.py` — must exit 0.
-   - `python3 <this-skill>/scripts/audit-review-state.py` — must exit 0.
-   - `git worktree list` — only main.
-   - `git branch -vv` — only `main` and any open-PR (BLOCKED) branches.
-   - `gh pr list --repo <fork>/<repo>` — matches expected.
-   - `gh pr list --repo <upstream>/<upstream-repo> --author @me` — empty.
-4. Delete `/tmp/codex-review-manifest.json` and `/tmp/codex-review-rounds/`.
+### Cleanup checklist (do ALL four; the hard gate fails if any is skipped)
 
-**Gate**: subagent reports TIDY. `audit-review-state.py` exits 0.
+1. **Worktrees** — `python3 <this-skill>/scripts/cleanup-worktrees.py --base main --execute`. Removes every `<repo>-wt-*` worktree whose branch is merged. Refuses unmerged worktrees unless `--force-abandon <branch>`.
+2. **Local branches** — `python3 skills/run-repo-cleanup/scripts/retire-merged-branches.py --base main --execute`. `git branch -d <name>` for each fully-merged branch; leaves BLOCKED / `apply_failed_after_evaluation` alone.
+3. **Remote branches** — only for branches that survived 8b without `--delete-branch`. Same script with `--remote --execute`.
+4. **Temp files** — `rm -f <repo>/.codex-review-manifest.json{,.lock} && rm -rf <repo>/.codex-review-rounds/ && rm -f /tmp/applier-brief-*.md /tmp/evaluator-brief-*.md /tmp/pr-creator-brief-*.md /tmp/*-brief-template*.md`. (Legacy `/tmp/codex-review-manifest.json{,.lock}` from older runs: remove only if its `repo_root` matches the current session's; leave alone if pointing elsewhere.)
 
-**Red flags**:
+### Independent re-audit (mandatory)
+
+Dispatch a fresh sub-agent for read-only re-audit (per `skills/run-repo-cleanup/references/post-pr-verification.md`). The audit runs `audit-state.py` + `audit-review-state.py` + verifies: `git worktree list` shows only main; `git branch -vv` shows only main + BLOCKED branches; `gh pr list` shows only BLOCKED PRs; `gh api repos/<fork>/branches` shows only main + BLOCKED; `.codex-review-*` files absent; `/tmp/*-brief-*.md` absent.
+
+### Phase 9 hard exit gate (the "no stale anything" condition)
+
+Phase 9 does NOT exit until ALL six are true:
+
+1. Every non-BLOCKED branch is **MERGED** to main.
+2. Every review **worktree** is removed.
+3. Every merged **local branch** is deleted.
+4. Every merged **remote branch** is deleted.
+5. Every **temp brief / manifest / round-log** is cleaned.
+6. Independent re-audit sub-agent reports **TIDY**.
+
+If any fails, Phase 9 is incomplete. In `/loop` dynamic mode, `ScheduleWakeup(delaySeconds=600)` and re-check on transient failures (CI still pending, rate-limit blocking branch deletion). On structural failures (BLOCKED PRs), surface the exact list and stop — human takes over.
+
+### Red flags (Phase 9)
+
 - "I'll clean up next time." → No. Tidy is binary.
-- "I'll keep the worktrees in case." → No. Stale worktrees are debris.
+- "Local branches deleted; remote branches don't matter." → No. Stale remote branches accumulate; future runs see them as "in-flight" and refuse to spawn worktrees with the same name.
+- "`git worktree remove --force <path>` everything." → No. `cleanup-worktrees.py` refuses unmerged worktrees by default to protect un-pushed work; use `--force-abandon <branch>` only when explicitly intended.
+- "Skip the independent re-audit." → No. Fresh-context audit catches state drift main agent's own context can mask.
+- "Skip cleaning `/tmp/*-brief-*.md`." → No. Future runs may create briefs with the same names and read stale data.
 
 ---
 
@@ -458,94 +635,79 @@ Full recipes: `references/failure-recovery.md`.
 
 ## Final Deliverable
 
-```markdown
-## Per-branch summary
-| Branch | Worktree | Concern | Rounds | Phase 3 status | PR | Phase 7 (a/r/x) | Merged | Notes |
-|---|---|---|---:|---|---|---|---|---|
+The wrap-up at end of Phase 9. **Phase 9 cannot exit until every section below is producible from manifest state** — this is the "all merged or surfaced" hard exit gate.
 
-## Per-PR review breakdown
-| PR | codex-rescue (a/r/x) | copilot (a/r/x) | greptile (a/r/x) | devin (a/r/x) | Total accepted | Total ambiguous |
-|---|---|---|---|---|---:|---:|
+The full Final Deliverable template (per-branch summary, per-PR review breakdown across 6 bot sources, what-ran-across-all-10-phases table, loop-tools used, per-branch round-history appendix) lives in `references/branch-decomposition-ledger.md` "Final Deliverable template" — render it from manifest entries at end of Phase 9.
 
-## Tidy audit
-<output from audit-state.py + audit-review-state.py — both must show CLEAN>
+### "All merged or surfaced" hard exit gate
 
-## Per-branch round history (appendix)
-### feat/foo (DONE in 4 rounds)
-- Round 1: 3 major (3 accepted) → committed + pushed
-- Round 2: 1 major (1 accepted) → committed + pushed
-- Round 3: 1 major (0 accepted, 1 rejected) → all-rejected round
-- Round 4: no major → DONE
+The Final Deliverable can be produced ONLY when every branch in the manifest reaches a terminal state:
 
-### feat/foo PR #42 — MERGED
-- codex-rescue:  5 items (3 accepted, 2 rejected)
-- copilot:       8 items (1 accepted, 6 rejected, 1 ambiguous)
-- greptile:     12 items (4 accepted, 7 rejected, 1 ambiguous)
-- devin:         3 items (1 accepted, 2 rejected)
-- Cross-source contradictions: 0
-- Phase 8 commits: abc123, def456
-- Merged via squash at 2026-04-26T11:40:00Z
+| Terminal state | Acceptable for clean exit? |
+|---|---|
+| `MERGED` (with `merged_at` timestamp) | ✅ happy path |
+| `BLOCKED` (with `terminal_reason` set) | ✅ surfaced for human; clean exit |
+| `apply_failed_after_evaluation` (with item list) | ✅ surfaced for human |
+| `CONVERGED-AT-CAP` (round budget hit; fixes pushed; deferred items in PR body) | ✅ surfaced; clean exit if PR is merged or BLOCKED |
+| `CAP-REACHED` (round budget hit; no fixes pushed) | ✅ surfaced for human |
+| `FAILED` (tooling crash past retry budget) | ✅ surfaced for human |
+| `IN-LOOP` / `SPAWNED` / unset / `applying` | ❌ incomplete; re-attempt or surface the specific blocker |
 
-### feat/bar (CAP-REACHED at 20 rounds)
-- 20 rounds, 8 accepted, 14 rejected, 0 ambiguous
-- Remaining major items in last round: <description>
-- Recommendation: split into 2 branches, re-run per concern.
-```
-
-The format is rendered from manifest entries; see `references/branch-decomposition-ledger.md`.
+If any branch is in an incomplete state when Phase 9 audit runs, **the audit fails**. Re-attempt the merge for that branch (in `/loop` mode, `ScheduleWakeup(delaySeconds=600)` and re-check). Do NOT produce the Final Deliverable until every branch is terminal.
 
 ## Smell Test — forbidden internal thoughts
 
-If any of these fires, stop and re-run `python3 <this-skill>/scripts/audit-review-state.py`:
+If any of these fires, stop and re-run `python3 <this-skill>/scripts/audit-review-state.py`. The full annotated list lives in `references/thinking-steering.md` "Forbidden inventions"; the highest-leverage entries are below.
 
-**Phase 3:**
-- "I'll just squash these reviews into one round."
-- "Good enough after 3 rounds, ship it."
-- "I'll skip /do-review for the obvious items."
-- "Let me have one worker fix two rounds."
-- "Let me have the coordinator do the work itself."
-- "I'll skip the validation step before re-review."
+**Phase 3 (loop discipline)**:
+- "Squash these reviews into one round" / "Good enough after 3 rounds, ship it" → no; classifier + main-agent decisions are the arbiters of DONE.
+- "Let me dispatch a Coordinator sub-agent per branch like the older docs said" → main agent IS the coordinator. Long-lived sub-agents drift past harness session limits.
+- "Let me write the worker brief asking it to `/do-review` then apply" → highest-leverage failure pattern. Workers stop at decision-only. Decisions stay with main agent; workers are appliers.
+- "Let me have one worker fix two rounds" → workers are fresh per round.
 
-**Phase 5:**
-- "I'll just open the PR myself."
-- "I'll hand-roll the body — /ask-review is overhead."
-- "Skip the explicit reviewer questions."
-- "The body is over 50k, let me trim by removing the per-commit section."
+**Phase 5-7 (PR + bots + evaluator)**:
+- "I'll open the PR myself" / "Hand-roll the body — `/ask-review` is overhead" → invariant 13: PR creator MUST be a sub-agent using `/ask-review`.
+- "Skip the wait" / "Wait less than 900s" → 900s base + adaptive end is the contract.
+- "Trust copilot blindly" / "The evaluator is overhead" → every item passes through `/do-review` evaluation.
 
-**Phase 6:**
-- "Skip the wait, merge fast."
-- "Run codex rescue inline."
-- "Wait less than 900s — the bots are fast."
+**Phase 7-8 (apply + merge)**:
+- "Apply the ambiguous items just in case" / "Half-apply: ship the accepted items, defer the ambiguous ones" → ambiguous = the WHOLE PR is BLOCKED.
+- "Skip CI-wait" → CI-wait is mandatory in 8b before any merge.
+- "Foundation CI failed — merge the leaves anyway" → foundation is their base; halt all leaf merges.
+- "Plain `git rebase origin/main` the leaves after foundation squash-merged" → no; `git rebase --onto origin/main <foundation_pre_merge_tip> <leaf>` is non-negotiable for squash-merged stacks.
+- "Skip retargeting leaves to main" / "Use `gh pr merge --auto` to chain leaf merges" → retarget via `gh pr edit --base main`; sequential explicit merge with CI-wait between.
+- "Stage everything, peek with `git diff --cached`, then `git restore --staged .`" → diff-walk per concern from the first `git add`.
+- "Phase 8a evaluator's intended-shape doesn't apply cleanly; let me improvise" → mark `apply_failed_after_evaluation`, continue, surface.
+- "Force-push leaves with `--force` instead of `--force-with-lease`" → use `--force-with-lease`.
 
-**Phase 7:**
-- "Trust copilot blindly because it's usually right."
-- "The evaluator is overhead; just apply what the bots say."
-- "Auto-resolve the cross-source contradiction."
+**Phase 9 (cleanup)**:
+- "I'll clean up next time" / "I'll keep the worktrees in case" → tidy is binary.
+- "Local branches deleted; remote branches don't matter" → stale remote branches accumulate; future runs see them as "in-flight".
+- "Skip the independent re-audit" → fresh-context audit catches state drift.
 
-**Phase 8:**
-- "Let me dispatch a sub-agent for the apply step too."
-- "Apply the ambiguous items just in case."
-- "Re-trigger Codex review after apply."
-- "Merge the BLOCKED PR anyway."
-
-**Cross-phase:**
-- "I'll start fresh and ignore the prior session's manifest."
-- "I'll write the brief later — this dispatch is simple."
-- "Soft DoD ('clean code') — agents understand."
-- "I can skip the failure protocol — the agent will figure it out."
+**Cross-phase (anti-stalls)**:
+- "Decision point: how would you like to proceed? Option A / B / C / D" → if user authorized full flow, this is a stall. Proceed.
+- "Before dispatching N parallel coordinators, let me do one smoke test first" → smoke tests are not in the workflow; Phase 0 already validates the dispatch surface.
+- "Let me run `codex --help` / `codex login status` / `codex doctor`" → never probe the underlying CLI; users with custom providers/auth see misleading "not logged in" probes while the real flow works.
+- "Let me `ls <worktree>/node_modules` before dispatching" → workers own their worktree setup.
+- "I'll write a shim that wraps `node codex-companion.mjs review`" → that's what `scripts/run-codex-review.py` is. Use it.
+- "I'll write 7 separate applier briefs via 7 `Write` calls" → mandatory: ONE template + render N from JSON in ONE Python invocation.
+- "Phase 3 is taking forever; let me invent `DONE-PRAGMATIC`" → taxonomy is fixed (`DONE`, `CONVERGED-AT-CAP`, `CAP-REACHED`, `BLOCKED`, `FAILED`). Use `CONVERGED-AT-CAP` for round-budget exhausted.
+- "I'll start fresh and ignore the prior session's manifest" / "I'll rebuild the manifest by hand" → Phase 0 auto-namespaces; do not delete or hand-edit other sessions' state.
 
 ## How to Think — meta-cognition per phase
 
 - **Phase 0**: *What surprises me? Are MISSION_PROTOCOL + ask-review + do-review available?*
 - **Phase 1**: *Can each branch be described in one sentence?*
 - **Phase 2**: *Worktree AND remote ref on origin for each branch?*
-- **Phase 3**: *Coordinator dispatched per branch; per round it dispatches a fresh worker that uses /do-review. Have I stepped back?*
+- **Phase 3**: *I am the coordinator across all branches. Per round per branch: codex review wrapper → classifier → /do-review per major item in my own context → dispatch fresh Applier with pre-decided fix specs. Have I stepped back from the worktrees while Appliers run?*
 - **Phase 4**: *Which branches are mergeable? What's the merge order rationale?*
-- **Phase 5**: *PR opened by sub-agent using /ask-review? Body ≤ 50k? ≥ 3 reviewer questions?*
-- **Phase 6**: *Codex rescue triggered? Wait window in progress with adaptive end?*
-- **Phase 7**: *Evaluator decided every item via /do-review? Cross-source contradictions flagged?*
-- **Phase 8**: *Applying directly via /do-review? Ambiguous items surfaced (BLOCKED), not silently merged?*
-- **Phase 9**: *Returned to clean state plus the intended delta?*
+- **Phase 5**: *PR opened by sub-agent using /ask-review? Body ≤ 50k? ≥ 3 reviewer questions? Throttled to ≤4 parallel?*
+- **Phase 6**: *Codex rescue triggered (wrapper or slash)? Wait window in progress with adaptive end?*
+- **Phase 7**: *Evaluator decided every item via /do-review? Cross-source contradictions flagged as ambiguous?*
+- **Phase 8a**: *Reading evaluator decisions; applying accepted items directly via Edit; ambiguous → BLOCKED for the whole PR?*
+- **Phase 8b**: *Captured `foundation_pre_merge_tip` BEFORE merging foundation? Using `git rebase --onto` for leaves? Sequential merge with CI-wait between?*
+- **Phase 9**: *Returned to clean state plus the intended delta? 0 stale worktrees / local branches / remote branches / temp files? Independent audit said TIDY?*
 
 See `references/thinking-steering.md` for full red-flag list. See `skills/run-repo-cleanup/references/agent-thinking-steering.md` for the general decompose/order/verify pattern. See `references/mission-protocol-integration.md` for brief-writing doctrine.
 
@@ -559,15 +721,17 @@ See `references/thinking-steering.md` for full red-flag list. See `skills/run-re
 | 0 | `skills/run-repo-cleanup/scripts/init-to-delete.py` | reused | Idempotent `to-delete/` setup. |
 | 1 | `scripts/redistribute-commits.py` | new | Split mixed-concern commits via interactive rebase + backup ref. |
 | 2 | `scripts/spawn-review-worktrees.py` | new | Create worktrees, push to fork, emit manifest. |
-| 3 | `scripts/run-codex-review.py` | new | Wrap `/codex:review --background`; normalize output to JSON. |
+| 3 | `scripts/run-codex-review.py` | rewritten | Spawns `node codex-companion.mjs review --json` (or `adversarial-review --json`) synchronously; auto-discovers the codex plugin path version-agnostic; normalizes output to the round-log JSON schema; writes `<rounds-dir>/<slug>.<round>.json`; updates manifest. `--mode review\|adversarial` flag. |
 | 3 | `scripts/classify-review-feedback.py` | new | Apply major/minor policy; produce `{major[], minor[]}`. |
 | 3 | `scripts/loop-status.py` | new | Live table of branch round status (read-only). |
 | 4 | `skills/run-repo-cleanup/scripts/suggest-merge-order.py` | reused | Foundation→leaf heuristic. |
 | 5 | `/ask-review` skill (Skill tool) | external | Author comprehensive PR body. |
-| 6 | `scripts/trigger-codex-rescue.py` | new | Trigger `/codex:resc --background --fresh --model gpt-5.5 --effort xhigh`. |
+| 6 | `scripts/trigger-codex-rescue.py` | rewritten | Spawns `node codex-companion.mjs task --background --write --fresh --model gpt-5.5 --effort xhigh --prompt-file <p> --json`; auto-discovers the plugin path; captures `jobId` + `logFile` to manifest. Optional `--wait` blocks on `status --wait` until terminal. |
 | 6 | `scripts/await-pr-reviews.py` | new | Adaptive 900s wait + gather all review streams. |
 | 7 | `/do-review` skill (Skill tool) | external | Evaluator's primary instrument. |
-| 8 | `/do-review` skill (Skill tool) | external | Main agent's apply-time instrument. |
+| 8a | `scripts/apply-evaluator-decisions.py` | new | Reads `<repo>/.codex-review-rounds/pr-<n>.evaluation.json`; prints ordered apply queue (ambiguous items at top with BLOCKED warning, then accepted items with `file:line:intended-shape:rationale`). Read-only; does NOT modify worktree, commit, or push. Reduces Phase 8a main-agent overhead from ~10 tool calls to ~5 per PR. |
+| 8a | `/do-review` skill (Skill tool) | external | OPTIONAL Phase 8a sanity-check (off by default; opt-in for borderline confidence items). |
+| 8b | `gh pr merge` (gh CLI) | external | Merge in foundation→leaf order with CI-wait gate. |
 | 9 | `scripts/cleanup-worktrees.py` | new | Remove review worktrees; refuses unmerged unless `--force-abandon`. |
 | 9 | `skills/run-repo-cleanup/scripts/retire-merged-branches.py` | reused | Delete merged local + remote branches. |
 
@@ -577,6 +741,7 @@ All new scripts: Python 3 stdlib only, dry-run by default where mutating, paired
 
 | File | Type | One-liner |
 |---|---|---|
+| `references/event-driven-orchestration.md` | new | Pinned spec for Monitor / ScheduleWakeup / Bash run_in_background / Agent run_in_background usage in Phases 3-8. Read before any parallel dispatch. |
 | `references/mission-protocol-integration.md` | new | How every sub-agent dispatch in this skill complies with `~/MISSION_PROTOCOL.md`. |
 | `references/codex-review-contract.md` | new | What `/codex:review --background` returns; how to invoke; how to read. |
 | `references/per-branch-fix-loop.md` | new | Phase 3 coordinator + worker pattern; round counter; 20-cap; state machine. |
@@ -608,4 +773,4 @@ External: `~/MISSION_PROTOCOL.md` (the brief-writing doctrine).
 
 ## Bottom Line
 
-Audit → decompose → worktree-per-branch → push to fork → parallel inner loop with coordinator + per-round `/do-review`-evaluating worker (cap 20) → main agent dispatches PR-Creator sub-agent that uses `/ask-review` to author body (≤ 50k, ≥ 3 reviewer questions) → trigger `/codex:resc` and adaptive 900s wait for external bots → evaluator sub-agent uses `/do-review` on all gathered streams → main agent applies accepted items directly via `/do-review` in own context → merge or BLOCKED → tidy. Every sub-agent brief follows MISSION_PROTOCOL. Every review item passes through `/do-review`. Direct-apply forbidden. PR creation is sub-agent-only. Fork-only, ever. One discipline, sixteen invariants, zero exceptions.
+Audit → decompose → worktree-per-branch → push to fork → parallel inner loop with coordinator + per-round `/do-review`-evaluating worker (cap 20) → main agent dispatches PR-Creator sub-agent that uses `/ask-review` to author body (≤ 50k, ≥ 3 reviewer questions) → trigger `/codex:resc` and adaptive 900s wait for external bots → evaluator sub-agent uses `/do-review` on all gathered streams → main agent applies accepted items directly via `/do-review` in own context → merge or BLOCKED → tidy. Every sub-agent brief follows MISSION_PROTOCOL. Every review item passes through `/do-review`. Direct-apply forbidden. PR creation is sub-agent-only. Fork-only, ever. One discipline, seventeen invariants, zero exceptions.

--- a/skills/run-codex-review/skills/run-codex-review/references/event-driven-orchestration.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/event-driven-orchestration.md
@@ -1,0 +1,265 @@
+# Event-Driven Orchestration (Phases 3, 5, 6, 7)
+
+This skill is multi-hour and parallel. Main agent does NOT poll. It dispatches in parallel, sets up event sources (Monitor / Bash run_in_background / Agent run_in_background / ScheduleWakeup), goes idle, and reacts to notifications as they fire.
+
+This file is the **single pinned spec** for which event source to use in which phase. Failure mode: dispatching N parallel things and then sitting in a Bash poll loop checking each. That defeats the parallelism and burns tokens.
+
+## The four event sources
+
+| Source | What it pushes | Use for |
+|---|---|---|
+| `Bash` with `run_in_background: true` | One notification when the command exits | One-shot "tell me when X completes" — codex review wrapper finishes; rescue job exits; build completes |
+| `Agent` with `run_in_background: true` | One notification when the sub-agent hands back | Applier handback; PR-Creator handback; Evaluator handback |
+| `Monitor` | One notification per stdout line; ends when command exits, timeout fires, or `TaskStop` | Streams of events — new PR comments arriving over 30 min; new file changes; log error stream |
+| `ScheduleWakeup` (in `/loop` dynamic mode only) | Re-fires the `/loop` prompt after a delay | Idle-tick fallback when no signal exists to watch; pacing a self-driven loop |
+
+**Picking the right one is mechanical, not aesthetic:**
+
+- One notification ↔ Bash/Agent run_in_background.
+- Stream of notifications ↔ Monitor.
+- Sub-agent did the work ↔ Agent run_in_background (the dispatch IS the event source).
+- Long-running shell command did the work ↔ Bash run_in_background (the exit IS the event).
+- Want to wake yourself up later ↔ ScheduleWakeup (only valid in `/loop` dynamic mode; runtime clamps to [60, 3600]).
+
+Never sit in a `while true; do …; sleep N; done` loop **inside the main agent's turn**. That blocks the runtime and burns tokens. Either dispatch via Bash run_in_background (which IS the loop, just owned by the harness) or use Monitor (which streams).
+
+## Phase-by-phase canonical patterns
+
+### Phase 3 — codex review + applier loop
+
+**Per branch, per round, main agent runs:**
+
+```
+1. Bash(run_in_background=True): python3 scripts/run-codex-review.py --branch <b> ... --output <rounds-dir>/<slug>.<round>.json
+   → notification: "Background command 'codex review: <branch>' completed"
+
+2. (after notification) Read the round-log JSON, classify, evaluate per item via Skill(do-review) in own context.
+
+3. If accepted decisions exist:
+     Agent(run_in_background=True, prompt=<applier-brief-with-pre-decided-fixes>)
+     → notification: "Agent 'Applier: <branch>' completed"
+
+4. Repeat for round N+1 until terminal state.
+```
+
+**Anti-pattern**: launching 8 codex reviews via `Bash run_in_background`, then immediately launching 8 SEPARATE `Bash run_in_background` polling watchers (`until grep -qE "Reviewer (finished|failed)" ... ; do sleep 5; done`) to watch when each finishes. The codex review wrapper script itself exits when the review completes — the Bash run_in_background's own completion notification IS the signal you want. Don't double up.
+
+**Anti-anti-pattern**: if the wrapper script is missing or doesn't reliably exit on terminal state, fix the wrapper. Don't paper it over with a polling watcher.
+
+**Wall-clock cap**: codex reviews can hang on certain tools (e.g., remote codebase-search APIs returning slowly). The wrapper enforces `--timeout 1500s` by default; on hang it exits non-zero with `terminal_reason: "review-hang past wall-clock cap"`. Main agent treats as FAILED for that round; retries once; then surfaces.
+
+### Phase 5 — PR creation (rate-limit-aware)
+
+**N PRs to open. Pattern:**
+
+```
+1. Render N PR-Creator briefs from one template + per-branch JSON (see "Brief templating" in parallel-subagent-protocol.md). NEVER hand-write N separate briefs.
+
+2. Throttle to ≤4 simultaneous PR-Creator dispatches.
+   - GitHub's GraphQL budget is shared with `gh pr create` body uploads; opening 9 in parallel exhausts it.
+   - The PR-Creator brief MUST instruct the sub-agent to use REST endpoints (`gh api repos/<owner>/<repo>/pulls -f title=... -f body=@<file> -f base=... -f head=...`) — not `gh pr create` (which uses GraphQL by default).
+
+3. Dispatch first batch of 4 in parallel via Agent(run_in_background=True).
+   → 4 handback notifications fire as PRs open.
+
+4. As each handback lands, dispatch next from the queue.
+
+5. When a handback says "rate-limited", main agent waits for the reset (gh api rate_limit returns Unix timestamp) via ScheduleWakeup(delaySeconds=<reset_in - now + 60>) if in /loop, or by deferring that PR's redispatch to the next round of completions.
+```
+
+**Anti-pattern**: dispatching all N in parallel and hoping for the best. Verified failure mode in production: 1+ of N rate-limits, agent has to retry-with-different-strategy.
+
+**Anti-anti-pattern**: serializing all N. Phase 5 then becomes 9× ~5min = 45 min serial, when it could be ~3 batches × ~5min = 15 min throttled-parallel.
+
+### Phase 6 — codex rescue + adaptive review window
+
+**Per PR (after Phase 5 succeeded), main agent runs:**
+
+```
+1. Trigger codex rescue. In a programmatic loop, main agent invokes:
+     Bash(run_in_background=True):
+       node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task \
+         --write --fresh --effort xhigh \
+         "<comprehensive review prompt for PR #<n>>"
+
+   This IS the same code path the /codex:resc slash command runs internally —
+   /codex:resc dispatches a Codex sub-agent via the codex-companion.mjs task
+   subcommand. In a programmatic loop, calling it directly is sanctioned.
+
+   → notification: "Background command 'codex:rescue PR #<n>' completed"
+       when the rescue review finishes posting to the PR.
+
+2. Arm a Monitor (one per PR) that polls the PR's comments+reviews:
+
+     Monitor(
+       command='''
+         pr=<n>
+         repo="<owner>/<repo>"
+         start=$(date -u +%s)
+         seen_ids=""
+         last_event=$start
+         BASE_WAIT=900     # 15 min before first quiet-check
+         QUIET_WINDOW=180  # terminate on 3 min of no new comments after base wait
+         CAP=1800          # 30 min hard cap
+
+         emit_new_items() {
+           # Issue comments — --paginate is REQUIRED. Default page is 30 items;
+           # PRs with 4+ active bots routinely cross 30 comments and the poller
+           # would silently miss everything past page 1 without it.
+           while IFS=$'\\t' read id user body; do
+             [ -z "$id" ] && continue
+             echo "$seen_ids" | grep -q "i$id" && continue
+             seen_ids="$seen_ids i$id"
+             last_event=$(date -u +%s)
+             echo "PR #$pr [$user]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
+           done < <(gh api --paginate "repos/$repo/issues/$pr/comments" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.body)"' 2>/dev/null || true)
+           # Review comments — same --paginate requirement
+           while IFS=$'\\t' read id user state body; do
+             [ -z "$id" ] && continue
+             echo "$seen_ids" | grep -q "r$id" && continue
+             seen_ids="$seen_ids r$id"
+             last_event=$(date -u +%s)
+             echo "PR #$pr REVIEW [$user $state]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
+           done < <(gh api --paginate "repos/$repo/pulls/$pr/reviews" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.state)\\t\\(.body // "")"' 2>/dev/null || true)
+           # Inline review comments (line-level findings — Devin & cubic-dev-ai use these heavily)
+           while IFS=$'\\t' read id user body; do
+             [ -z "$id" ] && continue
+             echo "$seen_ids" | grep -q "p$id" && continue
+             seen_ids="$seen_ids p$id"
+             last_event=$(date -u +%s)
+             echo "PR #$pr INLINE [$user]: $(echo "$body" | head -c 200 | tr '\\n' ' ')"
+           done < <(gh api --paginate "repos/$repo/pulls/$pr/comments" --jq '.[] | "\\(.id)\\t\\(.user.login)\\t\\(.body)"' 2>/dev/null || true)
+         }
+
+         # Initial seed pass (don't emit pre-existing comments)
+         emit_new_items >/dev/null
+         seen_initialised=1
+
+         while true; do
+           emit_new_items
+           now=$(date -u +%s)
+           since_last=$((now - last_event))
+           total=$((now - start))
+           # Termination: past base wait + 3min quiet, OR hard cap
+           if [ $total -ge $BASE_WAIT ] && [ $since_last -ge $QUIET_WINDOW ]; then
+             echo "PR-$pr-DONE quiet (no new comments in ${since_last}s, total ${total}s)"
+             exit 0
+           fi
+           if [ $total -ge $CAP ]; then
+             echo "PR-$pr-DONE cap (${total}s elapsed)"
+             exit 0
+           fi
+           sleep 30
+         done
+       ''',
+       description="PR #<n> review comments (codex/copilot/copilot-pull-request-reviewer/greptile/devin/cubic-dev-ai/human)",
+       persistent=False,
+       timeout_ms=2700000,   # 45 min hard ceiling
+     )
+
+   Each new comment fires one notification. The terminal "PR-<n>-DONE …" line
+   fires the final notification, the script exits, the Monitor releases.
+
+3. When the Monitor terminates with PR-<n>-DONE, main agent has all gathered
+   review items. It dispatches a Phase 7 Evaluator sub-agent for that PR.
+```
+
+**Why this Monitor shape:**
+- One Monitor per PR keeps termination independent — PR-A finishing doesn't cancel PR-B's wait.
+- The seed pass populates `seen_ids` from existing comments without emitting them; only NEW arrivals fire notifications.
+- The 30-second poll interval respects GitHub rate limits (≤120 req/hour per PR for issues+reviews; well within budget).
+- Both `issues/<pr>/comments` (line-level) AND `pulls/<pr>/reviews` (review summaries) are polled — different bots use different surfaces (Copilot uses reviews, Devin uses comments, etc.).
+- `|| true` after the `gh api` calls absorbs transient API failures without killing the monitor.
+- The terminal `PR-<n>-DONE …` line is filterable downstream — main agent's reaction logic matches `^PR-\d+-DONE` to know "this PR is ready for Phase 7".
+
+**Anti-pattern: per-event Monitor.** Don't arm a Monitor that emits ONLY the success line — silence equals "still running" equals "running forever". The pattern above emits one notification per actual comment AND a terminal line.
+
+**Anti-pattern: skipping the base wait.** Bots often arrive at minute 13 (Greptile is famously slow). Quiet-detection starting at second 0 would terminate immediately on initial silence. The 900s base floor is non-negotiable.
+
+### Phase 7 — Evaluator dispatch (one per PR, parallel)
+
+After all Phase 6 Monitors terminate (or as each one terminates):
+
+```
+For each PR with completed Monitor:
+  Read the PR's gathered comments+reviews (gh api dump → JSON file).
+  Agent(run_in_background=True, prompt=<evaluator-brief-for-this-PR>)
+  → notification: "Agent 'Evaluator: PR #<n>' completed"
+
+Up to 9 Evaluators in parallel — they don't share rate limits with PR creation.
+```
+
+### Phase 8 — main agent direct apply
+
+**No event sources.** Main agent is the actor; it reads each PR's evaluator JSON, applies accepted items via Edit, validates, pushes, merges. Sequential per PR (foundation→leaf), since merges affect downstream branches' bases.
+
+The only event source in Phase 8 is **CI status** between push and merge:
+
+```
+After git push origin <branch>:
+  Bash(run_in_background=True):
+    until [ "$(gh pr checks <n> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+      sleep 30
+    done
+    gh pr checks <n>
+  → notification when all checks land terminal state.
+```
+
+## ScheduleWakeup as fallback ticker
+
+In `/loop` dynamic mode, `ScheduleWakeup` re-fires the `/loop` prompt after a delay. Use it as a **safety ticker**, not as the primary signal:
+
+```
+After dispatching all Phase 5 PR-Creators with run_in_background:
+  ScheduleWakeup(
+    delaySeconds=1200,   # 20 min — past 5-min cache TTL but amortized
+    prompt="<the same /loop prompt this skill was invoked under>",
+    reason="fallback wake in case any PR-Creator handback gets lost",
+  )
+```
+
+The actual handbacks SHOULD fire well before 1200s; ScheduleWakeup catches the case where the harness drops a notification (rare but happens). When it fires, main agent re-checks state via the manifest and proceeds.
+
+**Cache-window math** (load-bearing):
+- Anthropic prompt cache TTL = 5 min (300 s). Wake-ups past 300s read full conversation context uncached.
+- 60–270s = stays cached, cheap. Use for active polling near the action.
+- 300s = WORST OF BOTH — pay cache miss without amortization. Never pick this.
+- 1200–1800s = one cache miss buys a long wait. Use for idle ticks.
+
+Don't think in round-number minutes. Think in cache windows.
+
+## Combining sources — the canonical Phase 6 idle pattern
+
+After dispatching N parallel codex:rescue jobs and arming N Monitors:
+
+```
+1. Bash run_in_background × N → each emits "rescue job <n> finished"
+2. Monitor × N → each emits "PR #<n> [<user>]: <body>" per comment, then "PR-<n>-DONE …"
+3. ScheduleWakeup (1200s in /loop, OR no-op if not in /loop) → safety ticker
+4. Main agent ends turn.
+5. Notifications fire over the next 15-30 min:
+   - Rescue jobs complete (informational; the comment-poller catches their posted reviews)
+   - Comments arrive (informational; appended to gathered-reviews JSON)
+   - Monitor terminates with PR-<n>-DONE (signal to dispatch Phase 7 Evaluator for that PR)
+6. Main agent dispatches Evaluator on each "PR-<n>-DONE" event.
+7. Evaluator handbacks (Agent run_in_background) trigger Phase 8 apply for that PR.
+```
+
+Sub-100 lines of orchestration logic; main agent burns ~zero tokens during the wait windows.
+
+## Common mistakes from production traces
+
+| Mistake | Fix |
+|---|---|
+| 8 separate `Bash run_in_background` polling watchers (one per branch) duplicating the codex review wrapper's own completion signal | The wrapper's own exit IS the event. One Bash run_in_background per branch is enough. |
+| Monitor that only emits the success line | Filter must cover failure too. Emit on every terminal state (comment, error, timeout). Silence ≠ success. |
+| `Monitor(command='tail -f log | grep -m 1 "ready"')` for a single-event "tell me when ready" | Use Bash run_in_background with `until grep -q "ready" log; do sleep 0.5; done` instead. `tail -f` never exits on match; the monitor sits armed until timeout. |
+| Hand-rolling N comment-poller commands inline in N Monitor calls | Render a parameterized poller from a template; pass `--pr <n>` args. (See `scripts/await-pr-reviews.py`.) |
+| ScheduleWakeup(delaySeconds=300) | Worst of both worlds. Drop to 270 (cache-warm) or jump to 1200 (cache-miss-amortized). |
+| Sitting in a `while …; sleep …` loop in the main agent's own turn | Blocks the runtime. Use Bash run_in_background or Monitor. |
+| Per-PR Monitor + per-branch comment-poller-ALSO-as-Bash-run_in_background, doubling up | Pick one source per signal. Comments → Monitor. Rescue completion → Bash run_in_background. Don't duplicate. |
+| Verbose status tables every turn ("Live state", "Phase X complete") | One sentence per phase boundary. The Final Deliverable in Phase 9 is the place for tables. |
+
+## Bottom line
+
+`run_in_background` for one-shot completions. `Monitor` for streams. `Agent run_in_background` for sub-agent handbacks. `ScheduleWakeup` (in /loop only) for fallback ticks with cache-aware delays. Combine all four; sit idle; react. Phases 5-8 are 4-7 hours of wall-clock that should consume ~15 minutes of main agent's actual work.

--- a/skills/run-codex-review/skills/run-codex-review/references/failure-recovery.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/failure-recovery.md
@@ -27,18 +27,18 @@ Codex CLI crashed, push was rejected, validation kept failing past retry budget.
 2. Common causes:
    - **codex CLI not on PATH**: install / fix shell. Re-run `audit-review-state.py` to confirm the environment is sound.
    - **Push rejected (non-fast-forward)**: someone else pushed to the branch. `git fetch origin && git pull --rebase` (only on this branch in its worktree); resume from current HEAD.
-   - **Validation kept failing**: usually a syntax error introduced by the worker's last fix. Look at the diff of the last commit; the worker should have caught this and reverted; if not, manual revert + restart.
-3. Decide: redispatch the coordinator (resumes from `rounds + 1` if state is recoverable), or split-and-restart, or abandon.
-4. Never retry a `FAILED` round more than once at the wrapper level. Cap subagent-level retries at 3.
+   - **Validation kept failing**: usually a syntax error introduced by the Applier's last fix. Look at the diff of the last commit; the Applier should have caught this and reverted; if not, manual revert + restart.
+3. Decide: re-run the round (resumes from current `rounds`), or split-and-restart, or abandon.
+4. Never retry a `FAILED` round more than once at the wrapper level. Cap Applier-level retries at 3.
 
-### BLOCKED — coordinator-level
+### BLOCKED — main agent decision
 
-The coordinator marks BLOCKED when worker's `/do-review` evaluator marks items ambiguous in 2+ consecutive rounds, OR an oscillation pattern emerges.
+Main agent marks BLOCKED when its `/do-review` evaluation returns ambiguous items in 2+ consecutive rounds, OR an oscillation pattern emerges.
 
-**Trigger conditions** (coordinator sets BLOCKED on any of these):
-- Two consecutive rounds where worker emitted ambiguous items.
-- Same major item recurs after the worker (and `/do-review`) accepted it (oscillation: applied fix didn't satisfy Codex; second attempt also failed).
-- A major item requires a decision outside this branch's scope (worker marked it ambiguous with a question).
+**Trigger conditions** (main agent sets BLOCKED on any of these):
+- Two consecutive rounds where main-agent decisions emitted ambiguous items.
+- Same major item recurs after main-agent accepted it (oscillation: applied fix didn't satisfy Codex; second attempt also failed).
+- A major item requires a decision outside this branch's scope (main-agent marked it ambiguous with a question).
 
 **Recovery**:
 1. Read `terminal_reason` for the contradiction or oscillation cause.
@@ -48,23 +48,24 @@ The coordinator marks BLOCKED when worker's `/do-review` evaluator marks items a
    - Split the branch so the conflicting concerns separate.
 3. Document the decision in the manifest's `terminal_reason` for posterity.
 
-### Worker sub-agent crash mid-round
+### Applier sub-agent crash mid-round
 
-The worker dies before writing its handback. Coordinator detects via heartbeat (round-log mtime / manifest write timestamp).
-
-**Recovery**:
-1. Coordinator reads round-log file (if any) to determine partial state.
-2. Redispatch a fresh worker for the same round (rounds counter not incremented).
-3. After 2 worker redispatches without progress, mark FAILED for the branch.
-
-### Coordinator sub-agent crash
-
-Main agent detects via stale `updated_at` on the manifest entry.
+The Applier dies before writing its handback. Main agent detects via heartbeat (round-log mtime / manifest write timestamp).
 
 **Recovery**:
-1. Main agent reads manifest entry to determine state (which round was active).
-2. Redispatch the coordinator with the same brief; it resumes from `rounds + 1` (or from the current round if no round-log written).
-3. After 2 redispatches without progress, mark FAILED for the branch.
+1. Main agent reads round-log file (if any) to determine partial state.
+2. Redispatch a fresh Applier for the same round (rounds counter not incremented).
+3. After 2 Applier redispatches without progress, mark FAILED for the branch.
+
+### Main-agent session interrupted mid-loop
+
+Main agent IS the coordinator; if its session is interrupted (host reboot, fresh chat), the manifest carries enough state to resume.
+
+**Recovery**:
+1. Re-invoke the skill; Phase 0 audit detects the in-progress manifest.
+2. For each branch with `status: IN-LOOP` (or no terminal state set), main agent reads manifest entry to determine which round was active.
+3. Resume from `rounds + 1` (or re-run the current round if no round-log was written).
+4. After 2 resumes without progress on the same branch, mark FAILED for that branch.
 
 ### Lost worktree
 
@@ -76,7 +77,7 @@ git worktree prune                           # clean up dangling refs
 git worktree add <expected-path> <branch>    # recreate from manifest
 ```
 
-The coordinator resumes from `rounds + 1` because all round logs and state are external to the worktree (in `<rounds-dir>` and the manifest).
+Main agent resumes from `rounds + 1` because all round logs and state are external to the worktree (in `<rounds-dir>` and the manifest).
 
 If the branch itself is also lost (only existed locally, no `origin/<branch>`), it's gone. Mark `FAILED`; surface for human; recover from `backup/codex-review/<branch>/<timestamp>` ref if Phase 1 redistribution created one.
 
@@ -89,7 +90,7 @@ A worker's worktree shows uncommitted changes from a prior round failure.
 2. `git status` and `git diff` to inspect.
 3. If the changes are recoverable: complete the commit, push, resume.
 4. If not: `git stash push -u -m "phase-3-recovery-<branch>-<round>"`, restore from manifest's `head_sha_current`, re-classify the last round to decide whether to retry.
-5. If the worktree is irrecoverably mangled, `git worktree remove --force <path>`, recreate per "Lost worktree" recovery above. Mark the round failed; let the coordinator decide redispatch.
+5. If the worktree is irrecoverably mangled, `git worktree remove --force <path>`, recreate per "Lost worktree" recovery above. Mark the round failed; main agent decides redispatch.
 
 ---
 

--- a/skills/run-codex-review/skills/run-codex-review/references/mission-protocol-integration.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/mission-protocol-integration.md
@@ -30,12 +30,13 @@ Maximum **5,000 words** per brief — a ceiling, not a target.
 
 | Phase | Sub-agent | Brief lives in |
 |---|---|---|
-| 3 | Coordinator (per branch, parallel) | `parallel-subagent-protocol.md` |
-| 3 | Worker (per round, fresh) | `parallel-subagent-protocol.md` |
+| 3 | Applier (per round, per branch, fresh) | `parallel-subagent-protocol.md` |
 | 5 | PR-Creator (per DONE branch) | `parallel-subagent-protocol.md` |
 | 7 | Evaluator (per PR) | `parallel-subagent-protocol.md` |
 
-Phase 8 is **main-agent direct** — no sub-agent. Main agent invokes `/do-review` skill in its own context to apply the evaluator's accepted subset.
+Phase 3 has **no Coordinator sub-agent** — main agent IS the coordinator across all branches (older skill versions had a per-branch Coordinator subagent; long-lived sub-agents drifted past harness session limits in production runs and the pattern was dropped). Main agent runs the codex review wrapper, evaluates major items via `/do-review` in own context, and dispatches one fresh Applier sub-agent per round per branch with the pre-decided fix specs.
+
+Phase 8a is **main-agent direct apply** — main agent walks the Phase 7 Evaluator's decisions JSON and applies each accepted item via Edit + per-concern commits. Phase 8b (merge) is also main-agent direct, with `git rebase --onto` mechanics for squash-merged stacks.
 
 ## The mindset shift
 
@@ -63,8 +64,7 @@ Then identify the **heavy layers** (Framing / Discovery / Evidence / Execution /
 
 | Sub-agent | Ambiguity | Familiarity | Stakes | Heavy layers |
 |---|---|---|---|---|
-| Coordinator | Low | Familiar (the protocol is fixed) | Medium (one branch) | Execution + Verification |
-| Worker (per round) | Medium (Codex's items vary) | Unfamiliar (each round may touch new code) | Medium-High (real fixes) | Framing + Evidence + Execution + Verification |
+| Applier (per round, per branch) | Low (decisions are pre-made) | Unfamiliar (each round may touch new code) | Medium-High (real fixes pushed) | Framing + Execution + Verification |
 | PR-Creator | Low (the deliverable is fixed) | Unfamiliar (must read all changes) | Medium (PR is shared) | Discovery + Evidence + Execution + Verification |
 | Evaluator | Medium-High (multiple sources contradict) | Unfamiliar (PR's changes are new context) | High (decisions drive Phase 8 apply) | Framing + Evidence + Verification |
 
@@ -98,8 +98,8 @@ Where ceilings show up in this skill's briefs:
 
 | Where | Ceiling | Release valve |
 |---|---|---|
-| Worker brief | "Up to 20 rounds total per branch" | "Most branches converge in 3–6 rounds" |
-| Worker brief | "Up to 5 distinct fix approaches per major item" | "If the first approach lands cleanly, you're done with that item" |
+| Phase 3 loop (main agent) | "Up to 20 rounds total per branch" | "Most branches converge in 3–6 rounds" |
+| Applier brief | "Up to 5 distinct fix approaches per accepted item" | "If the first approach lands cleanly, you're done with that item" |
 | PR-Creator brief | "Body up to 50,000 characters" | "Coming in well under is fine; comprehensive ≠ verbose" |
 | PR-Creator brief | "Up to 10 explicit reviewer questions" | "3–5 sharp questions outperform 10 mediocre ones" |
 | Evaluator brief | "Up to 100 distinct review items across all sources" | "Group duplicates; one decision per logical item" |
@@ -113,19 +113,14 @@ Floors I deliberately do **not** set:
 
 ## The Five Layers — applied per sub-agent
 
-### Coordinator
-- **Framing**: light (the protocol is fixed).
-- **Discovery**: light (the protocol files are referenced).
-- **Evidence**: medium (read manifest, classifier output, round logs).
-- **Execution**: heavy (orchestrates the loop).
-- **Verification**: heavy (must show terminal state with evidence).
+(Phase 3 has no sub-agent for orchestration — main agent IS the coordinator. Only the per-round Applier is dispatched.)
 
-### Worker (per round)
-- **Framing**: medium-high (each round's items may have multiple interpretations).
-- **Discovery**: medium-high (must trace cited code).
-- **Evidence**: heavy (extract specific code citations, behavior, contracts).
-- **Execution**: heavy (apply fixes via diff-walk).
-- **Verification**: heavy (validate, push, confirm round-log update).
+### Applier (per round, per branch)
+- **Framing**: low (decisions are pre-made; brief contains the fix specs verbatim).
+- **Discovery**: low (the brief tells the Applier exactly which file:line and intended shape).
+- **Evidence**: light (Read cited code as a sanity check; diff-walk before staging).
+- **Execution**: heavy (apply fixes via Edit; commit per concern; validate; push).
+- **Verification**: heavy (commits exist on origin/<branch>; tests pass; round-log updated).
 
 ### PR-Creator
 - **Framing**: light (the deliverable is fixed: a comprehensive PR).
@@ -145,8 +140,8 @@ Floors I deliberately do **not** set:
 
 The `what_to_extract` mindset (from the protocol's Tool Intelligence section) applies here:
 
-- **Coordinator brief** specifies: extract status transitions, round numbers, terminal_reason text, head SHA after push.
-- **Worker brief** specifies: extract per-item decisions, per-item rationales, per-item commit SHAs (if accepted), validation output.
+- **Main agent's Phase 3 self-direction** specifies: extract status transitions, round numbers, terminal_reason text, head SHA after each round.
+- **Applier brief** specifies: extract per-fix commit SHAs, validation output, final pushed HEAD SHA, list of items that didn't apply cleanly (`apply_failed_after_evaluation`).
 - **PR-Creator brief** specifies: extract PR number, PR URL, body length, list of explicit reviewer questions.
 - **Evaluator brief** specifies: extract per-item decisions per source, deduplication map, cross-source contradictions.
 
@@ -179,30 +174,32 @@ Before sending any brief, ask:
 
 If any answer is no, revise the brief before dispatch. The brief is the lever — wrong brief = wrong work, no matter how capable the agent is.
 
-## The two-level pattern in Phase 3
+## Eval-vs-apply role split in Phase 3
 
-The coordinator dispatches a fresh worker per round. The coordinator's brief and the worker's brief are different:
+Main agent runs the convergence loop directly (it IS the coordinator across all branches; there is no Coordinator sub-agent). Per round per branch, main agent:
+1. Runs the codex review wrapper (Bash background).
+2. Runs the classifier.
+3. Evaluates each major item via `Skill(do-review)` in own context.
+4. Dispatches a fresh **Applier** sub-agent with the decisions baked in as pre-decided fix specs.
 
-- **Coordinator** orchestrates over time (loop counter, terminal-state decision, dispatch).
-- **Worker** acts in a moment (one round, one fix-set, one push).
+The Applier brief is the only brief in Phase 3. Its DoD is **binary**: "N pre-decided fixes applied; tests pass; commits pushed to `origin/<branch>`". The brief does NOT mention `/do-review` — that framing causes systematic decision-only failure.
 
-Both follow MISSION_PROTOCOL. The coordinator's DoD is "branch reaches terminal state with all rounds logged"; the worker's DoD is "this round's accepted items applied, validated, pushed".
-
-The two-level structure ensures:
-- Each round's worker is fresh (no stale context).
-- Each round's brief gets the full protocol treatment (no degraded discipline over time).
-- The coordinator owns the convergence decision, not any single worker.
-- Failure of one worker doesn't compound across rounds (next round = fresh worker).
+This eval-vs-apply split ensures:
+- Each round's Applier is fresh (no stale context).
+- Each round's brief gets the full MISSION_PROTOCOL treatment.
+- Decisions live with main agent (which has the cross-branch context); application lives with the short-lived Applier.
+- Workers reliably push (binary DoD) instead of stopping at "Verdict: apply" (which is what happens when the brief contains `/do-review`).
 
 ## Common sub-agent dispatch failures (skill-specific)
 
 | Failure | Brief defect |
 |---|---|
-| Worker over-applies items the user would have rejected | DoD didn't require evaluator-style accepted / rejected / ambiguous decision |
-| PR body has no reviewer questions | Brief didn't make "explicit questions ≥ 3" a BSV criterion |
-| PR body exceeds 50k chars | Brief didn't include the wc -c verification step |
-| Evaluator marks everything accepted | Brief didn't include the rejection criteria + ambiguous escape valve |
-| Coordinator never marks DONE despite no major items | Brief didn't make the classifier exit-1 condition a BSV terminal trigger |
+| Applier produces decision JSON but never pushes | Brief mentioned `/do-review` — pulled the agent into evaluator-mode. Remove `/do-review` from worker briefs entirely. |
+| Applier applies items main agent already rejected | Brief baked in items beyond the accepted subset. Filter before dispatch. |
+| PR body has no reviewer questions | PR-Creator brief didn't make "explicit questions ≥ 3" a BSV criterion |
+| PR body exceeds 50k chars | PR-Creator brief didn't include the `wc -c` verification step |
+| Evaluator marks everything accepted | Phase 7 brief didn't include the rejection criteria + ambiguous escape valve |
+| Loop never marks DONE despite no major items | Main agent's loop pseudocode skipped the classifier-exit-1 short-circuit |
 
 When you see one of these, fix the brief, not the agent.
 

--- a/skills/run-codex-review/skills/run-codex-review/references/parallel-subagent-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/parallel-subagent-protocol.md
@@ -2,34 +2,57 @@
 
 This file specifies the four sub-agent types this skill dispatches and the **mission brief template** for each. Every brief follows the MISSION_PROTOCOL skeleton (`~/MISSION_PROTOCOL.md` — see `mission-protocol-integration.md`).
 
+## Invocation matrix per brief
+
+The codex plugin marks `/codex:review` as `disable-model-invocation: true`. Sub-agents physically cannot call it via `Skill(...)` — they must invoke the underlying companion script via Bash. `/codex:resc` requires the `Agent` tool which forked sub-agents do not have. Use the matrix below in every brief:
+
+| Surface | Worker / PR-Creator / Evaluator | How to invoke from the brief |
+|---|---|---|
+| Codex review | Worker (Phase 3) | `python3 <this-skill>/scripts/run-codex-review.py --branch … --base … --worktree … --output …` (wrapper internally calls `codex-companion.mjs review --json`). |
+| Codex rescue | NOT for sub-agents | Phase 6 trigger is main-agent-only; sub-agents do not call it. |
+| `/ask-review` | PR-Creator (Phase 5) | `Skill(skill="ask-review", args="…")` — model-invocable. |
+| `/do-review` | Evaluator (Phase 7) | `Skill(skill="do-review", args="…")` — model-invocable. |
+| `/do-review` | Worker (Phase 3) | **Never.** Workers are appliers; decisions are pre-made before dispatch. See "Mission Brief: Worker" below. |
+
+**Forbidden in every brief:**
+
+- Direct shell invocation of `codex`, `codex review`, `codex review --background`, or any other `codex …` form (no such CLI flags exist).
+- Inventing a "shim" or wrapper because the codex CLI doesn't accept some flag.
+- Inventing a coordinator/worker pattern that diverges from the templates below.
+- Calling `Skill(codex:review)` or `Skill(codex:resc)` from a sub-agent context — both will fail; the plugin disables them.
+
+If `<this-skill>/scripts/run-codex-review.py` cannot find a working `codex-companion.mjs`, the codex plugin is missing. Sub-agent hands back FAILED with `terminal_reason: "codex plugin unavailable"`. Main agent surfaces to the user and stops.
+
 ## Sub-agent inventory
 
 | Phase | Sub-agent | Dispatched by | Lifecycle |
 |---|---|---|---|
-| 3 | **Coordinator** | Main agent | One per branch; lives entire convergence loop. |
-| 3 | **Worker** | Coordinator | Fresh per round; one round of work, then exits. |
+| 3 | **Applier** | Main agent | Fresh per round per branch; applies pre-decided fixes, validates, pushes, exits. |
 | 5 | **PR-Creator** | Main agent | One per DONE branch; opens the PR, then exits. |
 | 7 | **Evaluator** | Main agent | One per PR; reads gathered reviews, returns decisions JSON. |
 
-**Phase 8 is main-agent direct** — no sub-agent. Main agent uses `/do-review` skill in its own context.
+**Main agent is the coordinator across all branches** — it owns the round cadence, runs codex review wrappers in parallel, evaluates major items via `Skill(do-review)` in its own context, and dispatches per-round Appliers. Phase 8 is also main-agent direct.
+
+> **Why main-agent-as-coordinator (load-bearing):** older versions of this skill used a per-branch Coordinator sub-agent that held the convergence loop. In practice these long-lived sub-agents (5+ hours, dozens of rounds) drift, lose context, or hit harness session limits. Main agent is the only stable owner of the multi-hour cadence. Sub-agents are short-lived single-purpose appliers / PR-creators / evaluators.
 
 ## Ownership boundary (hard rule)
 
 ```
-1 worktree  =  1 coordinator  =  N rounds (cap 20)
-1 round     =  1 fresh worker
-1 DONE PR   =  1 PR-creator (then 1 codex rescue handoff, then 1 evaluator)
+1 worktree  =  1 branch  =  N rounds driven by main agent (cap 20)
+1 round-per-branch  =  1 fresh Applier sub-agent
+1 DONE PR  =  1 PR-Creator → 1 codex rescue (main-agent direct) → 1 Evaluator
 ```
 
-- A worker mutates ONLY files inside its branch's worktree path.
-- A worker NEVER touches another branch, another worktree, or the manifest entries of other branches.
-- A worker NEVER opens PRs, merges, or retires branches — those are PR-creator (5), main-agent (8), or cleanup-worktrees (9) jobs.
-- The main agent NEVER edits inside a worktree while a worker is running.
-- Branches A and B can have concurrent coordinators (parallel inner loops), but their workers are physically isolated by separate worktrees.
+- An Applier mutates ONLY files inside its branch's worktree path.
+- An Applier NEVER touches another branch, another worktree, or the manifest entries of other branches.
+- An Applier NEVER opens PRs, merges, or retires branches — those are PR-Creator (5), main-agent (8), or cleanup-worktrees (9) jobs.
+- An Applier does NOT run codex review or classify — main agent does that before the dispatch.
+- Main agent NEVER edits inside a worktree while an Applier is running.
+- Different branches can have concurrent Appliers (parallel rounds across branches), physically isolated by separate worktrees.
 
 ## Communication contract: manifest as message bus
 
-All sub-agents in this skill report state via atomic writes to `/tmp/codex-review-manifest.json`. No chat-based handbacks for state.
+All sub-agents in this skill report state via atomic, lock-guarded writes to the repo-local manifest (`<repo-root>/.codex-review-manifest.json` by default; `--manifest <path>` to override). No chat-based handbacks for state. The wrapper scripts (`run-codex-review.py`, `trigger-codex-rescue.py`) implement the lock recipe below; sub-agents call the wrappers rather than rolling their own.
 
 ### Atomic write recipe
 
@@ -63,274 +86,195 @@ def update_manifest_entry(manifest_path, branch, updates, history_entry=None):
 
 `os.replace` is atomic on POSIX. `flock` provides mutual exclusion across concurrent writers.
 
-## Heartbeat
+## Brief templating (mandatory for parallel dispatches)
 
-Liveness is inferred from manifest mtime + round-log mtime. If a coordinator has not updated its branch's `updated_at` in `--stale-minutes` (default 60), it's presumed crashed. Same for workers — round-log mtime is the heartbeat.
+When dispatching N parallel sub-agents (N appliers in Phase 3, N PR-Creators in Phase 5, N evaluators in Phase 7), **never hand-write N separate briefs via N `Write` tool calls**. That pattern burns thousands of tokens, drifts copy-paste errors across briefs, and adds 5+ minutes of wall-time per phase.
 
-The sub-agent doesn't write explicit heartbeats. Manifest writes ARE the heartbeat.
+**Mandatory pattern:**
 
----
+1. Write **one** template file with `{{PLACEHOLDER}}` slots, e.g. `/tmp/applier-brief-template.md`.
+2. Render N concrete briefs from the template + a per-branch decisions JSON in **one Python invocation**:
 
-## Mission Brief: Coordinator (Phase 3)
-
-Dispatched by main agent at the start of Phase 3. One coordinator per branch. Coordinators run in parallel across branches.
-
-### Skeleton (fill in `<...>`)
-
-```markdown
-# Mission: Drive branch `<branch>` to convergence
-
-## Context
-
-You are the coordinator for branch `<branch>` in worktree `<worktree-path>`. The
-run-codex-review skill is running on repo `<repo-root>`. The
-private fork is `<fork-owner-repo>`; upstream `<upstream-owner-repo>` is
-read-only — never push, never PR there.
-
-This branch holds one coherent concern: `<concern-one-liner>`.
-
-The skill follows `~/MISSION_PROTOCOL.md` for every sub-agent dispatch you make
-(workers, in your case).
-
-You live in the host harness as a sub-agent dispatched by the main agent. You
-own this branch end-to-end through Phase 3 only — Phases 5–8 are the main
-agent's job.
-
-What you must read before acting:
-- `<this-skill>/SKILL.md` — phase semantics and invariants.
-- `<this-skill>/references/per-branch-fix-loop.md` — the loop pseudocode you
-  implement.
-- `<this-skill>/references/review-evaluation-protocol.md` — what your workers
-  must do per round.
-- `skills/run-repo-cleanup/references/fork-safety.md` — origin vs upstream rules.
-- The manifest entry for `<branch>` at `<manifest-path>` — current rounds,
-  last_review_id, etc.
-
-Mental model after reading:
-- The convergence loop reviews → classifies → dispatches a fresh worker → waits
-  for handback → repeats. You orchestrate; workers act.
-- Terminal states: `DONE` (no major after a round), `CAP-REACHED` (20 rounds
-  with major still present), `BLOCKED` (oscillation or contradictory feedback),
-  `FAILED` (tooling crash past retry budget).
-- 3 consecutive all-rejected rounds = `DONE` (Codex stuck on items the worker
-  evaluator rejected).
-
-## Mission Objective
-
-Drive `<branch>`'s manifest entry to a terminal state with full round history.
-Every round produces a round-log file at `<rounds-dir>/<slug>.<round>.json`,
-the worker subagent's handback is recorded in `round_history`, and the
-manifest's `status` is one of {DONE, CAP-REACHED, BLOCKED, FAILED} when you
-exit.
-
-Hard constraints:
-- Never edit files in `<worktree-path>` directly. Workers do that.
-- 20-round hard cap.
-- Always invoke `/codex:review --background` (via the wrapper script). Never inline.
-- Never `--force` push.
-- Never push to upstream.
-- Always evaluate Codex's items via worker's `/do-review` — never apply directly
-  by skipping the worker.
-
-Known risks:
-- Codex CLI may rate-limit. The wrapper retries; you escalate after 3 failures.
-- A worker may crash. Its heartbeat (round-log mtime) tells you. Redispatch up
-  to 2 times; else FAILED.
-- Cross-source contradictions across rounds → BLOCKED with `terminal_reason`.
-
-Priority signal: correctness over speed. A FAILED branch is not a disaster — a
-silently-wrong DONE is.
-
-You own this mission. The destination is fixed; the path is yours.
-
-## Research & Tool Guidance
-
-- Use `<this-skill>/scripts/run-codex-review.py` for each round's review.
-- Use `<this-skill>/scripts/classify-review-feedback.py` to partition major/minor.
-- Dispatch each round's worker via the host's Agent tool (subagent_type =
-  "general-purpose" — needs Skill access for /do-review).
-- The worker's brief is the template later in this file under "Mission Brief:
-  Worker". Customize for the round.
-- After dispatch, wait for the worker's handback — it writes to
-  `<rounds-dir>/<slug>.<round>.json` and updates the manifest entry.
-- Use `loop-status.py` to inspect state (read-only).
-
-Ceilings (release valves applied):
-- Up to 20 rounds per branch (most branches converge in 3–6).
-- Up to 2 worker redispatches per round on transient failure.
-- Up to 3 codex CLI retries per round before failing the round.
-
-## Definition of Done
-
-- `<branch>`'s manifest entry has `status` ∈ {DONE, CAP-REACHED, BLOCKED, FAILED}.
-- `manifest[branch].rounds` matches `len(round_history)`.
-- Every entry in `round_history` has `{round, review_id, major_n, minor_n, completed_at}`.
-- `terminal_reason` is set, citing the trigger (e.g. "no major in round 4",
-  "20 rounds with 2 major remaining", "oscillation in round 6").
-- `<branch>`'s remote tip on `origin/<branch>` matches the worker's last
-  reported `head_sha_current`.
-
-You must achieve 100% of every criterion above before reporting completion.
-Partial completion = not complete. If a criterion is impossible to meet, report
-that finding with evidence — do not silently skip it.
-
-## Verification
-
-For DoD:
-- `python3 <this-skill>/scripts/loop-status.py --manifest <path>` — branch
-  appears with terminal state.
-- `git -C <worktree-path> log origin/<branch>..HEAD --oneline` — empty (all
-  commits pushed).
-- `wc -l < <rounds-dir>/<slug>.<round>.json` for each round entry exists.
-
-## Failure Protocol
-
-If blocked:
-1. What was attempted: round numbers, codex job ids, worker dispatches.
-2. What was discovered: any pattern (oscillation, contradictions, persistent
-   tooling failure).
-3. Why it failed: the specific blocker.
-4. What to try next: split branch / extend cap / human triage.
-
-Mark the manifest entry `status: FAILED` (or BLOCKED for semantic ambiguity)
-with `terminal_reason` citing the above. Never silently exit without updating
-the manifest.
-
-## Handback
-
-When you complete this mission, respond with:
-1. **Summary**: branch + terminal state + rounds used (one paragraph).
-2. **Changes**: list of round-log files written, last commit SHA pushed.
-3. **Evidence**: loop-status.py output showing terminal state.
-4. **Observations**: anything notable (oscillation patterns, classifier
-   misclassifications, codex flakiness).
+```python
+import json, pathlib
+template = pathlib.Path("/tmp/applier-brief-template.md").read_text()
+decisions = json.loads(pathlib.Path("<rounds-dir>/decisions.json").read_text())
+for branch_slug, payload in decisions.items():
+    body = template
+    for k, v in payload.items():
+        body = body.replace(f"{{{{{k}}}}}", v if isinstance(v, str) else json.dumps(v, indent=2))
+    pathlib.Path(f"/tmp/applier-brief-{branch_slug}.md").write_text(body)
+print(f"rendered {len(decisions)} briefs")
 ```
 
-### Tuning the coordinator brief
+Then dispatch:
 
-- For a small branch (1 commit, low complexity): the brief above is overkill.
-  You can trim Context to ~200 words. Don't trim DoD or Verification — those
-  are the contract.
-- For a complex branch (mixed concerns, large diff): expand the Known risks
-  section with specific pitfalls (e.g. "this branch touches the auth middleware
-  — false positives are common; trust the worker evaluator").
+```
+for branch_slug in decisions:
+    Agent(
+        prompt=f"Read /tmp/applier-brief-{branch_slug}.md and execute.",
+        subagent_type="general-purpose",
+        run_in_background=True,
+    )
+```
+
+**Why mandatory**: production trace showed an agent writing 7+5+9 = 21 briefs across Phases 3 and 5 via 21 separate Write calls. Each brief was 50-140 lines of mostly-identical text with per-branch decisions varying. Template + render in one shot is ~3 tool calls vs. 21; cuts orchestration cost by ~85%.
+
+**Brief content rules** (apply per template type):
+
+- Applier briefs: one template per round (`/tmp/applier-brief-template-r<N>.md`); placeholders for branch, worktree, base, prior-round commits, this-round decisions.
+- PR-Creator briefs: one template; placeholders for branch, worktree, base, status, round_history summary, concern.
+- Evaluator briefs: one template; placeholders for PR number, gathered-reviews JSON path, taxonomy reference.
+
+The template ITSELF must be revised when its corresponding "Mission Brief" template skeleton in this file changes. The two are versioned together.
+
+## Heartbeat
+
+Liveness is inferred from manifest mtime + round-log mtime. If an Applier has not updated its branch's `updated_at` in `--stale-minutes` (default 60), it's presumed crashed. The sub-agent doesn't write explicit heartbeats — manifest writes ARE the heartbeat.
 
 ---
 
-## Mission Brief: Worker (Phase 3, per round)
+## Coordinator role (main-agent self-direction)
 
-Dispatched by the coordinator at the start of each round (after `run-codex-review.py` produces the round JSON and `classify-review-feedback.py` returns major[] non-empty).
+There is **no Coordinator sub-agent** in this skill. Older drafts dispatched a per-branch Coordinator subagent that held the convergence loop; in production those long-lived sub-agents drift, lose context, or hit harness session limits. **Main agent is the coordinator across all branches** — it owns the round cadence directly.
+
+Main agent's coordinator self-direction (no brief — main reads this section as its own playbook):
+
+- **Per round across all active branches:**
+  1. In parallel, launch `python3 <this-skill>/scripts/run-codex-review.py --branch <b> --base <base> --worktree <wt> --output <rounds-dir>/<slug>.<round>.json` for every active branch via Bash background tasks.
+  2. As each review completes (Monitor or Bash run_in_background callbacks), run `python3 <this-skill>/scripts/classify-review-feedback.py --review-json <path>`.
+     - Exit 1 (no major) → mark branch DONE with `terminal_reason: "no major in round <N>"`.
+     - Exit 0 (≥1 major) → continue.
+  3. For each major item, read cited code (Read tool, ±25 lines around `file:line`), then call `Skill(skill="do-review", args="--item <body> --code <cited_code>")` in main's own context. Record decision per `references/review-evaluation-protocol.md`.
+  4. For each branch with at least one accepted decision: dispatch ONE Applier sub-agent with the brief in "Mission Brief: Applier" below. Pre-decided fixes baked in.
+  5. As Appliers hand back, update manifest's `round_history[<N>]` per branch.
+  6. Increment per-branch round counter; loop until all branches terminal.
+
+- **Terminal states** (`manifest.status`):
+  - `DONE` — no major after a round (classifier exit 1).
+  - `CONVERGED-AT-CAP` — `<this-skill>'s` configured `max_rounds_per_branch` exhausted with at least one round of fixes pushed; remaining items captured in PR body. (See SKILL.md "Convergence taxonomy".)
+  - `CAP-REACHED` — 20 rounds (or configured cap) with no convergence. Surface for human.
+  - `BLOCKED` — oscillation (3 consecutive all-rejected rounds → reclassify as DONE; persistent ambiguous items → BLOCKED) or cross-source contradictions.
+  - `FAILED` — tooling crash past retry budget; codex plugin unavailable; Applier failed to push.
+
+- **Non-negotiables:**
+  - Never edit inside a worktree while its Applier is running.
+  - Never `--force`. Never push to upstream.
+  - Decisions stay with main agent; appliers stay mechanical.
+  - Read the manifest, not the worktree, for state — Appliers update the manifest atomically.
+
+- **Cost / wall-time expectations** (do not be surprised; do not invent shortcuts):
+  - Each codex review wrapper call: ~3–15 minutes wall.
+  - Each Applier dispatch: ~3–10 minutes wall.
+  - Round per branch: ~10–25 minutes serial. With N parallel branches: same wall, N× quota.
+  - Typical convergence: 3–6 rounds per branch (per `references/major-vs-minor-policy.md`).
+  - Round-2+ commonly find new items (refinements of round-1 fixes). 6/8 branches in production runs needed round-2 fixes. **This is normal — do not invent `DONE-PRAGMATIC` to shortcut.**
+
+---
+
+## Mission Brief: Applier (Phase 3, per round)
+
+Dispatched by **main agent** (not by a coordinator subagent — that role was dropped) at the start of each round, after main agent has:
+1. Run the codex review wrapper for this branch.
+2. Run the classifier to partition major/minor.
+3. Evaluated each major item itself using `Skill(do-review)` in main's own context.
+4. Composed the per-item fix specs (file, line, intended code shape, rationale).
+
+The applier's job is **mechanical**: apply the pre-decided fixes, validate, push. It is not an evaluator. The brief MUST NOT mention `/do-review` — that framing pulls the agent into evaluator-mode and produces decision-only failure.
 
 ### Skeleton
 
 ```markdown
-# Mission: Apply round `<N>` of branch `<branch>`
+# Mission: Round <N> of `<branch>` — apply N pre-decided fixes, validate, push
+
+You are an APPLIER for branch `<branch>` in worktree `<worktree-path>`. The
+decisions below were made before this dispatch. Your only job is BINARY
+EXECUTION: apply, validate, push. **Anything short of pushed commits is FAILED.**
+
+This is NOT an evaluation task. Do NOT invoke `/do-review`. Do NOT propose
+alternative fixes. Do NOT produce decision JSON. Do NOT stop at "Verdict:
+apply" — apply IS the deliverable.
 
 ## Context
 
-You are the per-round worker for branch `<branch>` in worktree
-`<worktree-path>`, round `<N>` of up to 20. The coordinator (your dispatcher)
-expects a single round of work: evaluate this round's Codex items, apply the
-accepted subset, validate, push, hand back.
+- **Worktree**: `<worktree-path>`
+- **Branch**: `<branch>` (on `origin/<branch>`)
+- **Base**: `<base-ref>`
+- **Round**: <N> of up to 20. Prior rounds (if any): <commit SHAs>.
+- **You own this worktree's setup.** If validation needs `node_modules` /
+  `.venv` / build artifacts that don't exist yet, install them yourself
+  (`pnpm install`, `npm install`, `bun install`, `pip install -r ...`).
+  Main agent does NOT preflight dependencies.
 
-This is a FRESH dispatch — you have no prior context from earlier rounds. The
-coordinator's brief (which you are reading) carries everything you need.
+## Pre-decided fixes (apply each exactly)
 
-This round's Codex review JSON is at `<round-json-path>`. The classifier's
-output (which items are `major[]`, which are `minor[]`, which are
-`unclassified_treated_as_major[]`) is the input you must act on. The
-classifier's exit code was 0 (≥1 major), so you have work to do.
-
-Prior rounds in this branch's history (summary):
-<insert prior rounds' major_n / minor_n / decisions if available>
-
-You must read before acting:
-- `<round-json-path>` — Codex's review for this round.
-- `<this-skill>/references/review-evaluation-protocol.md` — accepted/rejected/ambiguous taxonomy.
-- `skills/run-repo-cleanup/references/diff-walk-discipline.md` — staging discipline.
-- `skills/run-repo-cleanup/references/conventional-commits.md` — commit format.
-
-Mental model after reading:
-- For each `major` item, evaluate it against the actual code in
-  `<worktree-path>` using the `/do-review` skill (Skill tool with
-  skill='do-review').
-- accepted → apply the fix, commit one concern at a time.
-- rejected → record reason; skip.
-- ambiguous → record question; do NOT apply; coordinator will surface.
-
-## Mission Objective
-
-For round `<N>` of branch `<branch>`: every `major` item in `<round-json-path>`
-has a decision (accepted / rejected / ambiguous), accepted items are
-applied + committed + pushed, validation passes, and the round-log JSON
-records all decisions.
-
-Hard constraints:
-- Use `/do-review` (Skill tool) to evaluate every `major` item before applying.
-- Never apply an item without a decision — never default to accepting.
-- One concern per commit. Conventional commits + gitmoji per
+### Fix 1: <one-line summary>
+- **File**: `<worktree-path>/<file>`
+- **Around line**: <line>
+- **Current shape** (verbatim from current code):
+  ```
+  <existing code excerpt>
+  ```
+- **Intended shape** (apply this; preserve indentation):
+  ```
+  <new code excerpt>
+  ```
+- **Rationale**: <why — main agent's evaluator decision summary>
+- **Commit message**: `<emoji> <type>(<scope>): <subject>` per
   `skills/run-repo-cleanup/references/conventional-commits.md`.
-- `git diff` before staging. `git diff --cached` before committing. No
-  `git commit -am`.
-- Validation BEFORE push (e.g. `python3 -m py_compile <changed-files>`,
-  `bun run type-check`, `cargo check`, or repo-local check).
+
+### Fix 2: …
+(repeat per item)
+
+## Hard constraints
+
+- One concern per commit. N fixes = N commits.
+- `git diff` before staging. `git diff --cached` before committing. No `git commit -am`.
+- Validate BEFORE push (e.g. `pnpm run build && pnpm test`, `bun run type-check`,
+  `cargo check`, or whatever the repo's `CONTRIBUTING.md` / `AGENTS.md` says).
 - Push to `origin/<branch>` only. Never `--force`. Never to upstream.
 - Stay inside `<worktree-path>`. Do not `cd` elsewhere.
 
-Known risks:
-- Codex sometimes loops on items the prior round's evaluator already rejected.
-  If this round contains an item that's identical to a prior-round rejected
-  item, mark it ambiguous (oscillation signal for the coordinator).
-- Codex's suggested fix may be technically correct but break a downstream
-  caller. The /do-review evaluator should catch this; if uncertain, mark
-  ambiguous.
+## Definition of Done (binary)
 
-Priority: correctness over volume. A round with 1 carefully-evaluated accept
-is better than a round with 5 sloppy accepts.
-
-You own this round. The coordinator orchestrates; you decide the per-item
-fate.
-
-## Research & Tool Guidance
-
-- Read `<round-json-path>` — find every item with id, severity_raw, file, line, body.
-- Use `/do-review` (Skill tool: skill='do-review') to evaluate. Pass it the
-  cited code from `<worktree-path>/<file>` around `<line>` (you may need to
-  read 20–50 lines of context).
-- For each item, decide per `references/review-evaluation-protocol.md`:
-  - accepted → produce the fix; apply via Edit tool inside the worktree.
-  - rejected → record `decision: rejected, reason: <why>`.
-  - ambiguous → record `decision: ambiguous, question: <what needs human>`.
-- Commit accepted fixes one concern at a time:
-  - `git -C <worktree> add <files-for-this-concern>`
-  - `git -C <worktree> diff --cached`
-  - `git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject>"`
-- Validate (language-appropriate fast check) before push.
-- Push: `git -C <worktree> push origin <branch>` (no `--force`).
-
-Ceilings:
-- Up to 5 distinct fix approaches per major item. If the first approach lands
-  cleanly, you're done with that item.
-- Up to 50 lines of cited code read per item. If the answer needs more, mark
-  ambiguous (the item is too entangled).
-- Up to 1 retry on validation failure (revert + retry once). After that,
-  rejected with `reason: "post-fix validation failed"`.
-
-## Definition of Done
-
-- Every `major` item has a decision in your round-log output: `accepted` /
-  `rejected` / `ambiguous`.
-- Every accepted item produced one or more commits with conventional + gitmoji
-  format.
-- `git diff --cached` returns empty (no leftover staged changes).
+- N new commits exist on local HEAD with conventional + gitmoji messages.
+- `git -C <worktree-path> diff --cached` returns empty.
 - Validation command exits 0.
-- `git push origin <branch>` succeeded (no rejection, no force).
-- Round-log JSON at `<rounds-dir>/<slug>.<N>.json` has been updated with
-  per-item decisions and final HEAD SHA.
-- Manifest entry's `last_classifier_summary`, `head_sha_current`, and
-  `round_history[<N>]` reflect this round's outcome.
+- `git -C <worktree-path> push origin <branch>` succeeded.
+- `git -C <worktree-path> rev-parse origin/<branch>` matches local HEAD.
+- Manifest entry updated: `head_sha_current`, `round_history[<N>]`.
 
-100% required. Partial = incomplete.
+Anything short of all of the above = FAILED. Hand back FAILED with
+`terminal_reason` naming the specific gate that did not pass.
+
+## Failure protocol
+
+- If a fix's intended shape doesn't apply cleanly (file moved, line shifted,
+  current shape mismatch): STOP, do NOT improvise. Hand back FAILED with
+  `terminal_reason: "fix N intended-shape mismatch — main agent re-evaluate"`.
+  Main agent will re-decide and re-dispatch.
+- If validation fails after a fix: revert the offending commit, hand back
+  FAILED with the validation output.
+- If push is rejected (non-fast-forward, hook failure): hand back FAILED with
+  the rejection output. NEVER `--force`.
+
+## Handback shape
+
+```json
+{
+  "applied": <N>,
+  "pushed": true | false,
+  "head_sha": "<sha>",
+  "validation_exit": 0 | <nonzero>,
+  "commit_shas": ["<sha1>", ...],
+  "terminal_reason": null | "<one-sentence>"
+}
+```
+```
+
+### Why no `/do-review` in this brief
+
+Empirically verified across multiple production runs: when the worker brief mentions `/do-review`, ~100% of dispatched workers stop after producing decision JSON without applying or pushing. The /do-review framing pulls the agent into evaluator-mode; "Verdict: apply" feels like the deliverable to the agent. Splitting evaluation (main agent) from application (worker, with explicit pre-decided fix specs and binary push DoD) is the empirical fix. Do not re-introduce eval framing into the worker brief.
 
 ## Verification
 

--- a/skills/run-codex-review/skills/run-codex-review/references/per-branch-fix-loop.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/per-branch-fix-loop.md
@@ -1,117 +1,151 @@
 # Per-Branch Fix Loop
 
-Phase 3 of the skill. The convergence loop that takes a branch from "ready for review" to "Codex has nothing major" via the **two-level sub-agent pattern**:
-
-- One **coordinator sub-agent** per branch (parallel across branches; lives the entire loop).
-- One **worker sub-agent** per round (fresh dispatch each round; uses `/do-review`).
-
-This file specifies the loop pseudocode, the round-counter persistence, the 20-cap rationale, the validation step, the push rules, and the state machine. Mission brief templates for both sub-agents are in `parallel-subagent-protocol.md`. Every brief is written per `~/MISSION_PROTOCOL.md` (see `mission-protocol-integration.md`).
-
-## The two-level pattern
+Phase 3 of the skill. The convergence loop that takes a branch from "ready for review" to "Codex has nothing major". **Main agent owns the loop directly** — there is no coordinator sub-agent. Sub-agents are short-lived per-round Appliers.
 
 ```
-                   main agent
+                   main agent (the coordinator)
                        │
-                       │ (Phase 3 dispatch — N parallel)
-                       ▼
+                       │ per round, per active branch:
+                       │   1. Bash-bg: run-codex-review.py
+                       │   2. classify-review-feedback.py
+                       │   3. for each major item: Skill(do-review) in own context → decision
+                       │   4. compose pre-decided fix specs
+                       │
+                       ▼ Agent dispatch (FRESH per round, per branch, parallel)
        ┌─────────────────────────────────────────────────┐
-       │   coordinator sub-agent  (per branch, lives the │
-       │   entire loop, drives convergence to terminal)  │
-       └────────────────────┬────────────────────────────┘
-                            │
-                            │ (per round, FRESH dispatch each time)
-                            ▼
-       ┌─────────────────────────────────────────────────┐
-       │   worker sub-agent  (one round of work,         │
-       │   evaluates via /do-review, applies, pushes,    │
-       │   hands back to coordinator)                    │
+       │   Applier sub-agent  (one round of work,        │
+       │   applies pre-decided fixes mechanically,       │
+       │   validates, pushes; binary push DoD;           │
+       │   never invokes /do-review)                     │
        └─────────────────────────────────────────────────┘
 ```
 
-The coordinator orchestrates over time (loop counter, terminal-state decision, dispatch). The worker acts in a moment (one round, one fix-set, one push). Both follow `~/MISSION_PROTOCOL.md`.
+Main agent orchestrates over time (loop counter, terminal-state decision, dispatch, evaluation). Applier acts in a moment (apply N pre-decided fixes, validate, push). Applier brief follows `~/MISSION_PROTOCOL.md` (see `mission-protocol-integration.md`); main-agent self-direction is documented in `parallel-subagent-protocol.md` "Coordinator role".
 
-## Why fresh worker per round
+## Why fresh Applier per round
 
 | Approach | Pros | Cons |
 |---|---|---|
-| Fresh worker per round (this skill) | Brief discipline applied every round; no stale context; per-round failure isolated | 2× dispatch overhead |
-| Long-lived worker per branch | Cheaper dispatch | Brief discipline degrades over rounds; round-N's mistakes contaminate round-N+1 |
+| Fresh Applier per round (this skill) | Brief discipline applied every round; no stale context; per-round failure isolated; binary push DoD | 2× dispatch overhead |
+| Long-lived worker per branch | Cheaper dispatch | Brief discipline degrades; round-N mistakes contaminate round-N+1 |
 
-The user's wording — *"after every review from Codex we invoke sub-agents… once the sub-agent finishes, we start another Codex review"* — explicitly codifies fresh-per-round. The two-level pattern is the only way to achieve that AND keep parallel branches AND comply with MISSION_PROTOCOL strictly per round.
+The user's wording — *"after every review from Codex we invoke sub-agents… once the sub-agent finishes, we start another Codex review"* — explicitly codifies fresh-per-round.
 
-## Pseudocode (canonical) — coordinator's loop
+## Why no Coordinator sub-agent
+
+Older drafts of this file dispatched a per-branch Coordinator sub-agent that held the convergence loop. Production runs revealed:
+
+- Coordinators that need to live for hours (5+ hours, 9 branches, 20 rounds) drift, lose context, or hit harness session limits.
+- Sub-sub-agent dispatch (Coordinator dispatching its own Worker per round) is brittle in Claude Code; depth-2 dispatch isn't a stable interface.
+- The worker brief framing that asked workers to `/do-review` then apply caused 100% decision-only failure across runs.
+
+The current pattern moves orchestration and decisions to main agent, leaves only mechanical apply to short-lived sub-agents. This is the empirically reliable shape.
+
+## Pseudocode (canonical) — main agent's per-branch loop
 
 ```python
+# Main agent runs this PER BRANCH, but executes branches in parallel via
+# Bash run_in_background for the codex-review steps and Agent dispatch for
+# the per-round Applier.
+
 round = 1
-all_rejected_streak = 0  # consecutive rounds where worker rejected ALL items
+all_rejected_streak = 0  # consecutive rounds where every decision was rejected
 
 while round <= 20:
-    # 1. REVIEW
-    # Coordinator triggers Codex via the wrapper (returns when review JSON is written).
-    rc_review = run("python3 scripts/run-codex-review.py --branch <b> --worktree <wt>")
+    # 1. REVIEW (parallel across branches — main agent kicks off all in
+    #    parallel via Bash run_in_background and gathers results).
+    rc_review = run("python3 scripts/run-codex-review.py "
+                    "--branch <b> --base <base> --worktree <wt> "
+                    "--output <rounds-dir>/<slug>.<round>.json")
     if rc_review == 1:
-        # timeout — retry once
-        rc_review = run(...)
+        rc_review = run(...)  # timeout — retry once
     if rc_review == 2:
         manifest[branch].status = "FAILED"
         terminal_reason = "codex review failed past retry budget"
         break
 
-    review_json = "/tmp/codex-review-rounds/<slug>.<round>.json"
+    review_json = "<rounds-dir>/<slug>.<round>.json"
 
     # 2. CLASSIFY
-    rc_class = run(f"python3 scripts/classify-review-feedback.py --review-json {review_json}")
+    rc_class = run(f"python3 scripts/classify-review-feedback.py "
+                   f"--review-json {review_json}")
     if rc_class == 1:
-        # No major items — Codex says clean
         manifest[branch].status = "DONE"
         terminal_reason = f"no major feedback (round {round})"
         break
     if rc_class == 2:
-        # malformed review JSON — retry the round once
-        retry round, else mark FAILED.
+        # malformed review JSON — retry the round once, else FAILED
+        ...
 
-    # 3. DISPATCH WORKER (fresh sub-agent for THIS round)
-    brief = build_worker_brief(branch, worktree, round, review_json, prior_round_summaries)
-    handback = Agent(prompt=brief, subagent_type="general-purpose")
-    # Wait for worker's handback. Worker has used /do-review, applied accepted, pushed.
+    # 3. EVALUATE — main agent decides each major item in own context.
+    #    NOT delegated to a sub-agent. Skill(do-review) runs in main.
+    decisions = []
+    for item in major_items:
+        cited_code = read(<worktree>/<item.file>, around <item.line>, ±25)
+        decision = Skill(skill="do-review",
+                         args=f"--item {item.body} --code {cited_code}")
+        # decision is a string enum: "accepted" | "rejected" | "ambiguous"
+        decisions.append(decision)
 
-    # 4. INTERPRET HANDBACK
-    if handback.status == "FAILED":
-        manifest[branch].status = "FAILED"
-        terminal_reason = f"worker FAILED round {round}: <reason>"
-        break
+    accepted  = [d for d in decisions if d == "accepted"]
+    rejected  = [d for d in decisions if d == "rejected"]
+    ambiguous = [d for d in decisions if d == "ambiguous"]
 
-    decisions = handback.decisions  # {accepted, rejected, ambiguous}
-    if decisions.ambiguous:
-        # Coordinator's call: cap-1 ambiguous can pass; ≥2 or persistent -> BLOCKED
+    # 4. AMBIGUOUS GATE — even one ambiguous item BLOCKS the round.
+    #    Don't half-apply: ship-some + defer-some leaves an inconsistent state.
+    if ambiguous:
         if persistent_ambiguity():
             manifest[branch].status = "BLOCKED"
-            terminal_reason = f"ambiguous items in round {round}: {decisions.ambiguous}"
+            terminal_reason = f"persistent ambiguous items in round {round}"
             break
+        # Non-persistent ambiguous (one round): defer the entire round, retry
+        round += 1
+        continue
 
-    if decisions.accepted == 0 and len(decisions.rejected) > 0:
-        # All-rejected round (no accepts, ≥1 rejected, no ambiguous)
-        all_rejected_streak += 1
-        if all_rejected_streak >= 3:
-            manifest[branch].status = "DONE"
-            terminal_reason = f"3 consecutive all-rejected rounds; Codex stuck on items the worker evaluator rejected"
-            break
+    # 5. ALL-REJECTED-STREAK detection (skip Applier dispatch this round
+    #    since there are no fixes to apply).
+    if not accepted:
+        if rejected:
+            all_rejected_streak += 1
+            if all_rejected_streak >= 3:
+                manifest[branch].status = "DONE"
+                terminal_reason = ("3 consecutive all-rejected rounds; "
+                                   "Codex stuck on items main agent rejected")
+                break
+        round += 1
+        continue
     else:
-        all_rejected_streak = 0  # reset
+        all_rejected_streak = 0
 
-    # 5. INCREMENT
+    # 6. DISPATCH APPLIER — fresh sub-agent for this round.
+    #    Brief contains pre-decided fix specs; NO /do-review invocation.
+    brief = build_applier_brief(branch, worktree, round, accepted)
+    handback = Agent(prompt=brief, subagent_type="general-purpose")
+
+    # 7. INTERPRET HANDBACK (binary)
+    if not handback.pushed:
+        manifest[branch].status = "FAILED"
+        terminal_reason = f"applier failed to push round {round}: {handback.terminal_reason}"
+        break
+
+    # 8. NEXT ROUND
     round += 1
 
 if round > 20:
-    manifest[branch].status = "CAP-REACHED"
-    terminal_reason = f"20 rounds; remaining major items in last review"
+    if any_round_pushed_fixes():
+        manifest[branch].status = "CONVERGED-AT-CAP"
+        terminal_reason = (f"{round-1} rounds applied; remaining items "
+                            "captured for PR body")
+    else:
+        manifest[branch].status = "CAP-REACHED"
+        terminal_reason = "20 rounds, no convergence"
 ```
 
 ## Round-counter persistence
 
-The round counter lives in the manifest entry's `rounds` field. `run-codex-review.py` increments it after each successful review write. The coordinator never increments it manually — every increment must correspond to a written round-log file at `<rounds-dir>/<slug>.<N>.json`.
+The round counter lives in the manifest entry's `rounds` field. `run-codex-review.py` increments it after each successful review write. Main agent never increments it manually — every increment must correspond to a written round-log file at `<rounds-dir>/<slug>.<N>.json`.
 
-If the coordinator restarts mid-loop (process crash, host reboot), it reads `rounds` from the manifest and resumes at `rounds + 1`.
+If main agent restarts mid-loop (host reboot, fresh session), it reads `rounds` from the manifest and resumes at `rounds + 1`.
 
 ## Why 20
 
@@ -121,13 +155,13 @@ If a branch genuinely needs >20 rounds, the right answer is **decompose**: split
 
 ## Why 3 consecutive all-rejected → DONE
 
-If the worker (using `/do-review`) decides every major item is a false positive for 3 rounds in a row, Codex is stuck on items the evaluator has already determined aren't real. Continuing the loop is wasted compute — Codex won't change its mind, and the worker won't change theirs.
+If main agent (using `/do-review` in own context) decides every major item is a false positive for 3 rounds in a row, Codex is stuck on items the evaluator has already determined aren't real. Continuing the loop is wasted compute — Codex won't change its mind, and main agent won't change its.
 
-The coordinator marks DONE with `terminal_reason: "3 consecutive all-rejected; Codex stuck on rejected items"`. Phase 5 proceeds to PR creation. The PR body should mention the persistent rejected items so the human reviewer knows the worker considered them and disagreed.
+Main agent marks DONE with `terminal_reason: "3 consecutive all-rejected; Codex stuck on rejected items"`. Phase 5 proceeds to PR creation. The PR body should mention the persistent rejected items so the human reviewer knows main agent considered them and disagreed.
 
-## Validation step (worker's responsibility)
+## Validation step (Applier's responsibility)
 
-Skip re-review if the worker broke the build. The classifier can't tell the difference between "Codex found a real bug" and "Codex found the syntax error the worker just introduced". The worker validates BEFORE pushing:
+Skip re-review if the Applier broke the build. The classifier can't tell the difference between "Codex found a real bug" and "Codex found the syntax error the Applier just introduced". The Applier validates BEFORE pushing:
 
 | Repo type | Validation |
 |---|---|
@@ -137,32 +171,34 @@ Skip re-review if the worker broke the build. The classifier can't tell the diff
 | Skills repo with validator | `python3 <repo-root>/scripts/validate-skills.py` |
 | Multi-language | the project's `Makefile` `lint` / `check` target |
 
-If validation fails, the worker reverts the bad commit, retries once, else FAILED for that round (worker hands back FAILED; coordinator marks branch FAILED).
+If validation fails, the Applier reverts the bad commit, retries once, else hands back FAILED. Main agent marks the branch FAILED.
 
 ## Push rules
 
 - Always to `origin`. The branch was pushed `-u` in Phase 2.
 - **Never `--force`** while a review is in flight — invalidates inline review attribution and breaks the round-log → review-id mapping.
 - Never push to upstream. Hard rule from `skills/run-repo-cleanup/references/fork-safety.md`.
-- If a push is rejected (non-fast-forward), someone else pushed to the branch. The worker stops; coordinator decides (typically FAILED).
+- If a push is rejected (non-fast-forward), someone else pushed to the branch. The Applier hands back FAILED; main agent decides (typically FAILED at branch level).
 
-## Per-round evaluation (the `/do-review` step)
+## Per-round evaluation (main agent's `/do-review` step)
 
-The worker's central act each round is **evaluation via `/do-review`** before applying. Per `references/review-evaluation-protocol.md`:
+Main agent's central act each round (step 3 of the loop pseudocode) is **per-item evaluation via `Skill(do-review)` in own context**. Per `references/review-evaluation-protocol.md`:
 
 ```
 For each major item from the classifier:
-  1. Read the cited code in the worktree.
-  2. Use /do-review skill (Skill tool: skill='do-review').
+  1. Main agent reads the cited code in the worktree (Read tool, ±25 lines).
+  2. Main agent calls Skill(skill="do-review", args="--item ... --code ...")
+     in own context (NOT delegated to a sub-agent — empirically causes
+     decision-only failure in dispatched sub-agents).
   3. Decide:
-     - accepted (real issue, valid fix) → apply via diff-walk
-     - rejected (false positive, stale, scope creep) → record reason
-     - ambiguous (needs human) → record question
+     - accepted (real issue, valid fix) → bake fix spec into Applier brief
+     - rejected (false positive, stale, scope creep) → record reason; Applier never sees it
+     - ambiguous (needs human) → record question; do not apply
 ```
 
 Default-when-uncertain: **ambiguous**. Never silently accept. Never silently reject.
 
-Direct-apply (skipping the evaluator) is forbidden by skill invariant 11. The worker brief enforces this in its DoD: "every major item has a decision".
+Direct-apply (skipping the evaluator) is forbidden by skill invariant 11. The pseudocode above enforces this — no major item ever reaches the Applier without a prior `accepted` decision from main agent.
 
 ## State machine
 
@@ -172,98 +208,108 @@ Direct-apply (skipping the evaluator) is forbidden by skill invariant 11. The wo
                           ▼
                        SPAWNED
                           │
-              (main agent dispatches coordinator)
+              (main agent enters Phase 3 loop; per-branch round 1)
                           │
                           ▼
                        IN-LOOP
                           │
           ┌───────────────┼─────────────────────┬───────────────────────┐
           ▼               ▼                     ▼                       ▼
-     classifier:     classifier:            worker hands back        worker hands
-     no major        ≥1 major               with all-rejected        back FAILED
+     classifier:     classifier:            main-agent decisions    Applier hands
+     no major        ≥1 major               all-rejected            back FAILED
           │               │                     │                       │
           ▼               ▼                     ▼                       ▼
-        DONE         dispatch worker      all_rejected_streak += 1    FAILED
+        DONE      main agent /do-review  all_rejected_streak += 1    FAILED
+                  per item, then              │
+                  dispatch Applier            ▼
+                          │              if streak >= 3:
+                          ▼                  DONE
+              (Applier applies + pushes)   else continue
                           │                     │
-                          ▼                     ▼
-              (worker applies + pushes)    if streak >= 3:
-                          │                       DONE
-              (handback to coordinator)         else continue
+              (handback: pushed:bool)           │
                           │                     │
                           ▼                     ▼
                     round += 1, loop      round += 1, loop
                           │
-                rounds == 20 with major
+                rounds == 20 with major still present
                           │
                           ▼
-                    CAP-REACHED
+            len(round_history) ≥ 1 with pushed fixes?
+                  yes / no
+                  ▼     ▼
+          CONVERGED-AT-CAP / CAP-REACHED
 
    Anywhere in IN-LOOP: persistent ambiguity (≥2 ambiguous items, or
-   ambiguous-then-recurring) → coordinator marks BLOCKED.
+   ambiguous-then-recurring across rounds) → main agent marks BLOCKED.
 ```
 
 ## Terminal states
 
-| State | Means | Auto-merged in Phase 5? |
+(See SKILL.md "Convergence taxonomy" — single source of truth. Summary:)
+
+| State | Means | PR? |
 |---|---|---|
-| `DONE` (no-major) | Last classifier output had `major == []` | yes (Phase 5 opens PR) |
-| `DONE` (3-all-rejected) | 3 consecutive rounds where worker rejected all major items | yes (Phase 5 opens PR; body mentions rejected items) |
-| `CAP-REACHED` | 20 rounds reached; ≥1 major still present after worker's evaluation | **no** — surface for human |
-| `BLOCKED` | Persistent ambiguity (worker can't decide; needs human) | **no** — surface for human |
-| `FAILED` | Tooling failure (codex crashed, push rejected, validation kept failing) past retry budget | **no** — surface for human |
+| `DONE` (no-major) | Last classifier output had `major == []` | yes |
+| `DONE` (3-all-rejected) | 3 consecutive rounds where main-agent rejected all major items | yes (PR body mentions rejected items) |
+| `CONVERGED-AT-CAP` | 20 rounds (or configured cap); ≥1 round of fixes pushed; remaining items deferred to PR body | yes |
+| `CAP-REACHED` | 20 rounds reached, no convergence at all (no rounds pushed fixes) | **no** — surface for human |
+| `BLOCKED` | Persistent ambiguity / contradictions | **no** — surface |
+| `FAILED` | Tooling crash past retry budget | **no** — surface |
 
 ## When to mark BLOCKED
 
-The coordinator marks `BLOCKED` when:
+Main agent marks `BLOCKED` when:
 
-- Worker reports ambiguous items in 2+ consecutive rounds, AND the items are roughly the same item recurring.
-- Worker reports ambiguous items where the question requires architectural input outside the branch's scope.
-- Two consecutive workers' decisions contradict on the same item ("apply Codex's fix" then "the prior fix made things worse, reject any further attempt").
+- `/do-review` returned ambiguous in 2+ consecutive rounds, AND the items are roughly the same recurring item.
+- `/do-review` returned ambiguous where the question requires architectural input outside the branch's scope.
+- Cross-round decision contradicts (round N said apply Codex's fix; round N+1 said the prior fix made things worse — reject any further attempt).
 
 In all cases, persist the ambiguity into the manifest's `terminal_reason` for human triage. Phase 5 will skip BLOCKED branches.
 
 ## Why per-round, not per-major-item
 
-The worker reviews → evaluates → applies ALL accepted items in one round → pushes → re-reviews. Per-item dispatches would be slower (one Codex call per fix) and would fragment commit history. One commit per accepted item per round is the right granularity: small enough to bisect, big enough to not flood the PR.
+Main agent evaluates ALL major items in one round, dispatches ONE Applier per branch per round to apply all accepted items, pushes once, re-reviews. Per-item dispatches would be slower (one Codex call per fix) and would fragment commit history. One commit per accepted item per round is the right granularity: small enough to bisect, big enough to not flood the PR.
 
-## Coordinator vs main agent
+## Failure recovery
 
-The main agent dispatches N coordinators in parallel (one per branch). Coordinators run their loops independently. The main agent does NOT enter coordinators' loops to check progress — it monitors via `loop-status.py` (read-only).
-
-If a coordinator crashes (heartbeat stale via manifest mtime), main agent:
+If an Applier crashes (heartbeat stale via manifest mtime), main agent:
 
 1. Reads manifest entry to determine state.
-2. Decides: redispatch the coordinator (resumes from `rounds + 1`) OR mark FAILED.
+2. Re-dispatches the Applier with the same brief (resumes from `rounds + 1`).
 3. After 2 redispatches without progress, mark FAILED for that branch.
 
-## Hard rules (coordinator + worker must enforce)
+## Hard rules
 
-- One coordinator per branch.
-- One fresh worker per round.
-- Always `--background` Codex review.
-- 20-round hard cap. Never raise.
+- Main agent IS the coordinator; no Coordinator sub-agent.
+- One fresh Applier per round per branch.
+- Codex review is invoked via `scripts/run-codex-review.py` (which internally calls `codex-companion.mjs review --json`).
+- 20-round hard cap. Never raise. Above 20 → `CONVERGED-AT-CAP` (if any rounds pushed fixes) or `CAP-REACHED` (if no rounds pushed at all).
 - Never `--force` push.
 - Never amend.
 - Never touch `main`.
 - Never push to upstream.
 - Never decide DONE without classifier exit 1 OR 3-all-rejected streak.
 - Never increment `rounds` without a corresponding round-log file.
-- Worker NEVER applies an item without `/do-review` evaluation.
-- Worker NEVER skips a major item without recording a decision.
-- Coordinator NEVER bypasses the worker (no direct edits to the worktree).
+- Main agent NEVER skips `/do-review` evaluation for an accepted item (invariant 11).
+- Applier NEVER invokes `/do-review` (decisions are pre-made; framing causes decision-only failure).
+- Applier NEVER skips an accepted item without recording a decision in the round-log JSON.
+- Main agent NEVER bypasses the Applier (no direct edits to the worktree during Phase 3).
 
 ## Anti-patterns
 
 | Anti-pattern | Why it fails |
 |---|---|
-| Coordinator does the work itself instead of dispatching workers | Brief discipline degrades; round-N stale context contaminates round-N+1 |
-| Worker applies items without `/do-review` evaluation | Direct-apply violates invariant 11; false positives ship |
-| Worker pushes without validating | Validation failures get classified as Codex bugs in next round |
-| Coordinator increments rounds without round-log file | Round counter drifts; can't bisect later |
+| Dispatching a Coordinator sub-agent per branch (older pattern) | Long-lived sub-agents drift; depth-2 dispatch is brittle in Claude Code |
+| Worker brief mentioning `/do-review` | Empirically causes 100% decision-only failure (sub-agents stop at "Verdict: apply") |
+| Main agent applies fixes itself instead of dispatching an Applier | The user's spec demands sub-agent application; also Phase 3 is parallel-N-branches, main agent can't apply N branches concurrently |
+| Applier pushes without validating | Validation failures get classified as Codex bugs in next round |
+| Round counter increments without a round-log file | Round counter drifts; can't bisect later |
 | `--force` push on a branch with active review | Invalidates round-log → review-id mapping |
 | Skip the 3-all-rejected check | Codex loops on rejected items forever; cap-reached triggers without progress |
 | Re-evaluate prior-round rejected items | The decision was made; don't re-litigate |
+| Inventing a `DONE-PRAGMATIC` state when round-budget is exhausted | Use `CONVERGED-AT-CAP` (taxonomy is closed) |
+| Asking the user "how should I proceed?" at the end of Phase 3 | The user authorized full flow; proceed to Phase 5 (see SKILL.md "Authorization rule") |
 
 ## Bottom line
 
-Phase 3 is parallel branches via coordinator sub-agents, each running a fresh-worker-per-round loop. Workers evaluate via `/do-review` before applying. Convergence is no-major OR 3-all-rejected. Cap is 20 rounds. Failure modes are well-defined. The brief discipline (per MISSION_PROTOCOL) is what separates a good convergence from a noisy one.
+Phase 3 is parallel branches under main agent's coordination, each running a fresh-Applier-per-round loop. Main agent evaluates via `/do-review` before dispatching the Applier; Applier applies the pre-decided fixes mechanically. Convergence is no-major OR 3-all-rejected. Cap is 20 rounds (`CONVERGED-AT-CAP` if any rounds applied fixes; `CAP-REACHED` if none did). Failure modes are well-defined. The brief discipline (per MISSION_PROTOCOL) plus the eval/apply role split is what separates a good convergence from a noisy one.

--- a/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/post-pr-review-protocol.md
@@ -2,7 +2,7 @@
 
 Phases 6–8 of this skill. After a PR is opened (Phase 5), this protocol governs:
 - Triggering Codex rescue as the last automated check.
-- Waiting for external review bots (Copilot, Greptile, Devin, plus any humans).
+- Waiting for external review bots (Copilot, copilot-pull-request-reviewer, Greptile, Devin, cubic-dev-ai, plus any humans). Bot list expands over time as new code-review bots are installed on the repo; the comment-poller works against the GitHub API and surfaces whatever lands, so adding a new bot does not require skill changes.
 - Adaptive end condition: 900s base + extension if comments still flowing + termination on quiet.
 - Hand-off to Phase 7 evaluator sub-agent.
 - Phase 8 main-agent direct apply.
@@ -24,23 +24,40 @@ Codex rescue is **Codex's own background sub-agent**, not a Claude sub-agent we 
 python3 scripts/trigger-codex-rescue.py --pr <number> --branch <b>
 ```
 
-The script:
+There are two valid invocation paths for Phase 6 rescue from main agent. Pick by context:
+
+**A. Interactive context (chat directive):** Type `/codex:resc --fresh --model gpt-5.5 --effort xhigh --pr <number>` in the chat. The slash command dispatches a Codex sub-agent via the `Agent` tool internally. Use this when main agent has a few PRs and you're not in a parallel loop.
+
+**B. Programmatic loop context (sanctioned for Phase 6 with N PRs):**
+
+```bash
+Bash(run_in_background=True):
+  cd <worktree-path> && \
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task \
+       --write --fresh --effort xhigh \
+       "<comprehensive review prompt for PR #<n>>"
+```
+
+This is the **same code path** the `/codex:resc` slash command runs internally — `/codex:resc`'s frontmatter dispatches a Codex sub-agent via `node codex-companion.mjs task`. In a programmatic loop where main agent dispatches N rescue jobs in parallel, the Bash invocation is cleaner than typing N slash-command directives. Both are sanctioned; the companion-script path is NOT a workaround.
+
+The `task` subcommand is the public interface for "run a Codex sub-agent on this prompt". `--write` means "post the review back to the PR thread"; `--fresh` means "no prior session bias"; `--effort xhigh` is the heaviest reasoning budget for one-shot last-check rescues.
+
+`scripts/trigger-codex-rescue.py` wraps this for batch use; it:
 1. Reads the manifest entry for `<branch>` to get `worktree_path`.
-2. Inside that worktree, invokes the Codex rescue CLI form:
-   ```
-   codex review --rescue --background --fresh --model gpt-5.5 --effort xhigh --pr <number>
-   ```
-   (Adjustment point in the script; the actual CLI form depends on your Codex install.)
-3. Captures the rescue job id from stdout.
+2. Inside that worktree, dispatches `node codex-companion.mjs task --write --fresh --effort xhigh "<prompt>"` via Bash run_in_background.
+3. Captures the resulting Codex job id.
 4. Writes `rescue_review_id` and `rescue_started_at` to the branch's manifest entry.
 5. Returns immediately (does not poll).
 
 ### Why "fresh" and "xhigh effort"
 
+These are arguments passed to the `/codex:resc` slash command, not shell flags:
+
 - **`--fresh`**: no prior session bias. Codex rescue evaluates the PR cold; it doesn't carry over the inner-loop's context.
 - **`--model gpt-5.5`**: stronger reasoning than the inner-loop's default model. The rescue is a last check; it deserves the heavier model.
 - **`--effort xhigh`**: Codex spends more compute. Acceptable here because rescue is one-shot per PR, not per round.
-- **`--background`**: Codex queues the job; we don't block waiting for it.
+- **`--background`**: codex-companion's `task` subcommand DOES honor `--background` (unlike `review`, which always runs synchronously). With `--background`, the wrapper returns `{ jobId, status: "queued", title, logFile }` immediately and the rescue review runs in a detached worker. The wrapper script `trigger-codex-rescue.py` always passes `--background`; without it the wrapper would block for the entire rescue duration (1-5 minutes per PR × N PRs serially).
+- **`--write`**: instructs Codex to post the rescue review back to the PR as a comment.
 
 ## Phase 6 — adaptive review window
 
@@ -143,44 +160,62 @@ Key brief points:
 - **Verification**: `git status` in worktree returns empty (no drift); JSON has decisions for all items.
 - **Failure**: missing decision → mark ambiguous; stale citation → reject; can't determine → ambiguous (never silently accept).
 
-## Phase 8a — main-agent direct apply
+## Phase 8a — main-agent direct apply (per-PR sequential; cross-PR order irrelevant)
 
-After the evaluator sub-agent hands back, **main agent acts directly** (no further sub-agent). The evaluator's JSON is the authority; main agent applies each accepted item mechanically. `/do-review` re-eval per item is optional and off by default because the evaluator already used `/do-review` in Phase 7.
+After the evaluator sub-agent hands back, **main agent acts directly** (no further sub-agent). The evaluator's JSON is the authority; main agent applies each accepted item mechanically. **`/do-review` re-eval per item is OPTIONAL and OFF by default** — the evaluator already used /do-review in Phase 7; double-eval is rarely worth the cost. Reserve for borderline-confidence cases.
 
 ### Apply flow (per PR)
 
 ```
 Read <repo>/.codex-review-rounds/pr-<n>.evaluation.json.
 
-# AMBIGUOUS GATE — read this before any apply
+# AMBIGUOUS GATE — read this FIRST, before any apply
 If ambiguous[] non-empty:
     Mark PR BLOCKED in manifest:
       terminal_reason: "ambiguous: <item-id>: <evaluator's question>"
-    Do NOT apply this PR's accepted items either.
+    DO NOT apply this PR's accepted items either —
+      partial-apply ships unreviewed code with half-decided intent.
     Surface in deliverable. Do NOT merge.
     Move to next PR.
 
-# ACCEPTED ITEMS — only when ambiguous[] is empty
+# ACCEPTED ITEMS — only reached when ambiguous[] is empty
 For each accepted item (deduplicated across sources, first-seen rationale wins):
-    1. Read cited code at <worktree>/<file>:<line> ± 25 lines.
+    1. Read cited code at <worktree>/<file>:<line> ± 25 lines (Read tool).
     2. Apply the evaluator's intended-shape fix via Edit.
-       If it does not apply cleanly:
-         record `apply_failed_after_evaluation: <item-id>` in manifest;
-         continue with remaining items; surface at the end of Phase 8a.
+       If it doesn't apply cleanly (file moved, line shifted, current shape mismatch):
+         DO NOT improvise. Record `apply_failed_after_evaluation: <item-id>` in manifest.
+         Continue with remaining items. Surface at end of Phase 8a.
     3. Stage by concern from the start:
          git -C <worktree> add <files-for-this-concern>
-         # do NOT stage all then `git restore --staged .`
-    4. git -C <worktree> diff --cached
+         (do NOT stage all then `git restore --staged .` to peek and restage)
+    4. git -C <worktree> diff --cached  # verify only intended hunks
     5. git -C <worktree> commit -m "<emoji> <type>(<scope>): <subject> (#<pr>)"
-    6. Validate with repo-equivalent build/test.
-    7. git -C <worktree> push origin <branch>   # no --force
+       — Note the (#<pr>) suffix for traceability.
+       — One concern per commit by default.
+       — Multi-concern allowed IFF tightly coupled to same file AND
+         message lists each concern as a bullet (the bullets are the
+         accountability — they document the audit trail).
+
+# OPTIONAL sanity-check
+For borderline confidence items only (not by default):
+    Skill(skill="do-review", args="--item <body> --code <cited_code>")
+    If main agent disagrees with the evaluator's accept decision:
+      Mark item ambiguous; revert; surface — do not push the disagreement.
+
+# VALIDATE before push
+pnpm run build && pnpm test  # or repo-equivalent per AGENTS.md/CONTRIBUTING.md
+If validation fails:
+    Revert the offending commit. Mark item ambiguous. Surface — do not retry blindly.
+
+# PUSH (no merge yet)
+git -C <worktree> push origin <branch>   # NEVER --force
 ```
 
-Process PRs in any order in 8a. Foundation→leaf merge order is enforced after apply.
+Process PRs in any order in 8a. Foundation→leaf is enforced in 8b.
 
 ### Phase 8a apply recipe (one-shot helper)
 
-The helper script derives the repetitive queue from evaluator JSON:
+A wrapper script encapsulates the repetitive bits:
 
 ```bash
 python3 <this-skill>/scripts/apply-evaluator-decisions.py \
@@ -190,7 +225,7 @@ python3 <this-skill>/scripts/apply-evaluator-decisions.py \
   --print-queue
 ```
 
-Output: ordered apply queue with ambiguous items at the top (BLOCKED warning), then accepted items with `file:line:intended-shape:rationale`. The script is read-only: it does not modify worktrees, commit, or push.
+Output: ordered apply queue with ambiguous items at the top (BLOCKED warning), then accepted items each with `file:line:intended-shape:rationale`. Read-only — does NOT modify worktree, does NOT commit, does NOT push. Main agent walks the queue, applies via Edit, validates, commits, pushes — but the queue derivation is mechanical and offloaded to the script.
 
 ### Why main-agent direct, not sub-agent
 
@@ -201,17 +236,72 @@ The evaluator's structured output is already in main agent's context. Re-dispatc
 
 Main agent applying directly keeps the chain tight: evaluator decides → main agent applies. The user's stated principle: "do-review is healthier when answers come straight back".
 
-### Optional: open a fresh PR
+## Phase 8b — merge in foundation→leaf strict serial
 
-If the evaluator's accepted set is so large or divergent that amending the current PR would muddy its history, main agent has the option to:
+Apply is done; now merge in dependency order. Foundation merges first; each leaf retargets to main and rebases with `--onto` to skip the squashed foundation commits before merging individually.
 
-1. Mark the current PR as "superseded by #<new>".
-2. Branch from main again.
-3. Cherry-pick the original branch's commits + apply the accepted items.
-4. Open a new PR with `/ask-review` (Phase 5 redux for this branch).
-5. Close the original PR.
+### Why `--onto` (not plain `git rebase origin/main`)
 
-This is the user's "we'll ask for a new PR if needed" path. Use sparingly — most of the time, in-place commits are simpler.
+Squash-merging foundation collapses N foundation commits into 1 squashed commit on main with a different SHA. Plain `git rebase origin/main` on a leaf branch tries to re-apply both copies of foundation (the original N commits in leaf history AND the squashed commit on main) — git can't detect the equivalence and conflicts on every foundation hunk. `git rebase --onto origin/main <foundation_pre_merge_tip> <leaf>` fast-forwards past the original foundation tip and replays only the leaf-specific commits onto the new main.
+
+### Merge flow
+
+```
+Order PRs per manifest.merge_order (foundation first, then leaves).
+
+# 0. Capture foundation's pre-merge tip BEFORE merging — required for --onto below.
+foundation_tip=$(git -C <foundation-worktree> rev-parse HEAD)
+manifest['foundation_pre_merge_tip']=$foundation_tip
+
+# 1. Merge foundation
+Wait CI green for foundation:
+    Bash(run_in_background=True):
+      until [ "$(gh pr checks <foundation-pr> --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+        sleep 30
+      done
+      gh pr checks <foundation-pr>
+
+If any check is `failure` or `cancelled` for foundation:
+    STOP — do not merge any leaves. Surface foundation BLOCKED.
+Else:
+    gh pr merge <foundation-pr> --repo <fork>/<repo> --squash --delete-branch
+    git fetch --all --prune
+
+# 2. Retarget + rebase --onto + push every leaf (one batch, parallelizable across leaves)
+for leaf_pr in <leaf-prs>:
+    leaf_branch=$(gh pr view "$leaf_pr" --json headRefName --jq .headRefName)
+    leaf_worktree=<from manifest>
+
+    gh pr edit "$leaf_pr" --base main
+    git -C "$leaf_worktree" fetch origin
+    git -C "$leaf_worktree" rebase --onto origin/main "$foundation_tip" "$leaf_branch"
+    git -C "$leaf_worktree" push --force-with-lease origin "$leaf_branch"
+    # --force-with-lease (NOT --force); safe because Phase 1's backup ref
+    # preserves the original commits.
+
+# 3. Merge each leaf in order (sequential; NOT --auto)
+for leaf_pr in <leaf-prs-in-order>:
+    Wait CI green for leaf
+    If failure/cancelled: mark leaf BLOCKED; continue (do NOT halt; only foundation halts)
+    Else:
+        gh pr merge "$leaf_pr" --repo <fork>/<repo> --squash --delete-branch
+        git fetch --all --prune
+```
+
+`--auto` works for foundation (single-step) but is unreliable for leaves on divergent stacks. Use sequential explicit merge with CI-wait between leaves.
+
+### Foundation must succeed first
+
+Leaves are based on foundation. If foundation can't merge (CI fails, conflict): STOP — do not merge any leaves; surface foundation BLOCKED to the human. The human resolves foundation, then re-runs Phase 8b on the leaves.
+
+### Optional: open a fresh PR for `apply_failed_after_evaluation`
+
+If Phase 8a recorded items as `apply_failed_after_evaluation` (intended-shape didn't apply because file/line drifted), surface them at end of 8a. The human decides:
+
+1. Re-run Phase 7 evaluator with current code (preferred), OR
+2. Branch from main again, cherry-pick the original branch's commits + apply the failed items by hand, open a new PR (Phase 5 redux), close the original PR.
+
+Don't auto-cycle — surface and let the human pick.
 
 ## Failure modes
 
@@ -229,15 +319,31 @@ The Phase 7 evaluator handles a single source (or no source) gracefully. If the 
 
 `await-pr-reviews.py` terminates with `wait_terminated_by: "total_cap"`. The current state is gathered. Phase 7 evaluates what we have. Late-arriving comments after evaluation are surfaced for human attention but don't block merge — the bot will still see them on the merged commit if it cares.
 
-### Evaluator marks anything ambiguous
+### Evaluator marks anything ambiguous (the BLOCKED gate)
 
-A single ambiguous item blocks the entire PR. Do not half-apply accepted items and defer ambiguous ones; that ships unreviewed code with half-decided intent. Record the evaluator's exact question in `manifest.pr.terminal_reason`, surface it in the final deliverable, and do not merge.
+**An item marked `ambiguous` by the evaluator means**: real issue OR false positive can't be determined without human input.
 
-If the evaluator marks everything ambiguous, surface the whole PR for human triage. Likely cause: PR is too broad or too cross-cutting; consider splitting in a follow-up.
+**Rule**: a single ambiguous item BLOCKS the entire PR. Do NOT half-apply (don't ship the accepted items and defer the ambiguous ones — that ships unreviewed code with a half-decided intent). Defer the entire PR.
+
+Per ambiguous item, main agent records:
+1. `manifest.pr.terminal_reason: "ambiguous: <item-id>: <evaluator's exact question>"`.
+2. Skip apply for that PR's accepted items too.
+3. Surface in final deliverable with the evaluator's exact question.
+4. Do NOT merge.
+
+If the evaluator marks **everything** ambiguous, surface the whole PR for human triage. Likely cause: PR is too broad or too cross-cutting; consider splitting in a follow-up.
 
 ### Evaluator's accepted fix breaks CI
 
-Phase 8 push fails CI. Revert the bad commit on the branch (don't force-push; commit a revert), mark the item ambiguous in the manifest with `terminal_reason: "post-apply CI failure: <details>"`, surface for human.
+Phase 8a push fails CI in 8b. Revert the bad commit on the branch (don't force-push; commit a revert), mark the item `apply_failed_validation` in the manifest with `terminal_reason: "post-apply CI failure: <details>"`, surface for human.
+
+### Phase 8a intended-shape doesn't apply cleanly (`apply_failed_after_evaluation`)
+
+The evaluator's `intended-shape` references a file:line that has drifted (file moved, line shifted, surrounding code refactored between Phase 7 and Phase 8a). DO NOT improvise a fix.
+
+Record `apply_failed_after_evaluation: <item-id>` in manifest. Continue with remaining items. Surface at end of Phase 8a. Human decides:
+1. Re-run Phase 7 evaluator with current code (preferred), OR
+2. Apply by hand and open a fresh PR (Phase 5 redux for that branch).
 
 ### Cross-source contradiction can't be resolved
 
@@ -289,7 +395,8 @@ The 900s+ wait exceeds the 5-minute prompt cache TTL. After the wait, the next a
 |---|---|
 | Skip Phase 6, merge fast | Loses the value of external review entirely. The whole skill exists to harvest reviewer feedback. |
 | Trust copilot's items blindly | Copilot is a reviewer like any other. Evaluator first. |
-| Run codex rescue inline (not `--background`) | Blocks the agent for 1–5 min. Defeats the parallel orchestration. |
+| Invoke codex rescue from Bash (`codex review --rescue …`) | There is no such CLI surface. Use `Skill(codex:resc, …)` — slash command, not shell. |
+| `node …/codex-companion.mjs task …` directly from a sub-agent brief | The wrapper does that, plus discovery + manifest update + (optional) status polling. Use the wrapper. |
 | Wait less than 900s by default | Bots that arrive at minute 13 are missed; their feedback is lost. |
 | Wait more than total_cap | Indefinite wait = dead session. Cap is the safety. |
 | Auto-merge after Phase 8 even with ambiguous items | Ambiguous means human-in-the-loop. Auto-merge defeats the gate. |

--- a/skills/run-codex-review/skills/run-codex-review/references/thinking-steering.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/thinking-steering.md
@@ -127,7 +127,7 @@ Asking is not failure. Wrong moves on these are irreversible.
 
 ## The decompose → step back → watch reflex
 
-The single most important shift from `run-repo-cleanup`'s flow to this one: **after Phase 2, the main agent stops editing.** Phase 3 dispatches coordinators; main agent monitors. Phase 5 dispatches PR-Creators; main agent waits. Phase 7 dispatches Evaluators; main agent waits. Only Phase 8 brings main agent back in as actor.
+The single most important shift from `run-repo-cleanup`'s flow to this one: **after Phase 2, the main agent stops editing files** but stays in the driver's seat for orchestration. Phase 3: main agent runs codex review wrappers, evaluates major items via `Skill(do-review)` in own context, dispatches per-round Appliers. Phase 5: main agent dispatches PR-Creators; waits. Phase 7: main agent dispatches Evaluators; waits. Phase 8: main agent applies the evaluator's accepted subset directly. Editing inside worktrees is sub-agent territory; orchestration is main agent's territory throughout.
 
 If you find yourself opening a worktree to "check on it" or "fix something quickly", you've already broken the protocol. The sub-agent's writes and yours can race. The classifier's exit code, the worker's handback, the evaluator's JSON — those are the only signals you should be acting on.
 
@@ -150,6 +150,28 @@ Before every Agent dispatch, run the brief discipline checklist (in `parallel-su
 - [ ] Brief ≤ 5,000 words.
 
 If any unchecked, revise. Cost: 1 minute. Saves: hours of wrong work.
+
+## Forbidden inventions
+
+Do **not**, under any phase, propose:
+
+- **A "smoke test" or pilot before Phase 3 fan-out.** The skill prescribes parallel dispatch from round 1. A smoke test is not in the workflow. If the codex plugin is unavailable, you find out at dispatch time and surface FAILED — you do not pre-test.
+- **Re-introducing a Coordinator sub-agent layer.** That pattern was tried; it does not work in production (long-lived sub-agents drift, depth-2 dispatch is brittle). Main agent IS the coordinator across all branches — see `parallel-subagent-protocol.md` "Coordinator role". If your instinct says "I should dispatch a coordinator subagent per branch", you are recreating the old pattern.
+- **Writing a custom MISSION_PROTOCOL brief inline** rather than instantiating one of the four templates in `parallel-subagent-protocol.md` (Coordinator / Worker / PR-Creator / Evaluator). If the brief feels off, fix the *template*; do not bypass it.
+- **A shim, wrapper, or fallback for any slash command.** `/codex:review`, `/codex:resc`, `/ask-review`, `/do-review` either exist (use them via `Skill(...)`) or do not (surface and stop). There is no third path.
+- **Confirming a pinned default with the user.** Defaults in the Pinned Defaults table are pinned. Auto-detect (repo mode, manifest path) or proceed. Only ask when a destructive choice is genuinely ambiguous and not derivable from local state.
+- **Reading `scripts/run-codex-review.py` or `scripts/trigger-codex-rescue.py` looking for the "real" invocation.** The wrappers ARE the active path: `run-codex-review.py` is what sub-agents call (it bridges to `codex-companion.mjs review --json` because `/codex:review` is `disable-model-invocation: true` for sub-agents). For main agent, `/codex:resc` is the slash command for Phase 6. Either way, do not invent a parallel script.
+- **Multi-question opening confirmations** ("OK to proceed with B1–B5? Max rounds 20? Codex CLI ready?"). The user's first prompt is the authorization. Detect what's detectable and execute.
+- **Pre-flight environment probing for tool reachability.** No `codex login status`, `codex --version`, `codex doctor`, `ls .../node_modules`, `command -v <tool>`, or other "is the environment ready" probes. Such probes assume a default configuration (one specific auth path, one package manager, one project layout) that often doesn't match the user's actual setup — users routinely run with custom providers, alternate auth, or atypical layouts where the probe reports "broken" while the real workflow runs fine. The slash-command dispatch and the worker's own validation step are the only valid tests; if they truly fail you hand back FAILED with `terminal_reason` and surface to the user. **Never** present a multi-option resolution menu (A/B/C…) to fix an environment configuration the user did not ask you to touch.
+- **Bridging plugin-internal scripts with a "small shim".** Shims are forbidden by invariant 17. The right path per surface is in the SKILL.md invocation matrix.
+- **End-of-phase option menus** ("Full Phase 5-8 / Phase 5 only / Foundation only / Pause"). The user authorized full flow at skill invocation. Proceed phase-to-phase without checkpoint. (See SKILL.md "Authorization rule".)
+- **Cost-and-time paralysis prefaces** ("multi-hour, multi-thousand-token operation"). The user knows; the user authorized. Stating it again is stalling, not transparency. Just execute.
+- **Verbose end-of-phase state tables.** The Final Deliverable in Phase 9 is the place for per-branch summaries. Mid-flight, one sentence: "Phase X complete; entering X+1."
+- **Inventing terminal states** like `DONE-PRAGMATIC`, `READY-ENOUGH`, `MOSTLY-DONE`. The taxonomy is fixed: `DONE`, `CONVERGED-AT-CAP`, `CAP-REACHED`, `BLOCKED`, `FAILED`. If reality doesn't fit, surface a real `BLOCKED` with `terminal_reason`.
+- **`/do-review` framing in worker briefs.** Empirically causes 100% decision-only failure. Decisions are made by main agent before dispatch; workers are appliers.
+- **Hand-rolled bash polling loops** (`until grep -qE "Reviewer (finished|failed)" …`) for codex review status. Use the wrapper script's exit code; use Monitor for terminal markers; use Bash `run_in_background` for the dispatch itself. Polling loops are a sign the wrapper contract is broken — fix the wrapper, don't paper it over.
+
+These inventions cost the user 10–15 minutes per session in the wild. Don't.
 
 ## The bottom line
 


### PR DESCRIPTION
# 📚 docs(run-codex-review): document orchestration flow

## Summary
Stacked on #57. This PR restores the orchestration documentation layer from PR #53 and proves the final stacked tip matches the original #53 `run-codex-review` tree. It updates the skill contract around main-agent coordination, event-driven waits, Applier/PR-Creator/Evaluator roles, Phase 8a apply, and Phase 8b merge mechanics.

## Context / Why now
The previous stack layers restored the executable wrappers and helper scripts. This PR wires those capabilities back into the skill text and references so future agents follow the intended flow instead of rediscovering invocation rules, polling patterns, or role boundaries.

## The 4 items

### Item 1: Top-level ten-phase skill contract
- Files: `SKILL.md`
- What: Restores the invocation matrix, repo-local defaults, authorization rule, main-agent-as-coordinator model, Phase 8a/8b split, script table, reference routing, and smell tests.
- Why this shape: The top-level skill needs the operational contract in one place while routing deep detail into references.
- Verified by: `python3 scripts/validate-skills.py`.

### Item 2: Event-driven orchestration and sub-agent roles
- Files: `references/event-driven-orchestration.md`, `references/parallel-subagent-protocol.md`, `references/mission-protocol-integration.md`
- What: Documents Bash/Agent background dispatch, Monitor usage, ScheduleWakeup fallback, role-specific mission briefs, and forbidden long-lived coordinator drift.
- Why this shape: The skill is multi-hour and parallel; explicit event sources prevent blocking poll loops and unclear handbacks.
- Verified by: reference routing validation.

### Item 3: Phase loop and post-PR flow
- Files: `references/per-branch-fix-loop.md`, `references/post-pr-review-protocol.md`
- What: Documents main-agent round coordination, pre-decided Applier fixes, convergence states, adaptive review windows, evaluator handoff, Phase 8a helper usage, and Phase 8b `--onto` merge handling.
- Why this shape: Evaluation, application, and merge ordering are separate risks and should be reviewable as separate protocol steps.
- Verified by: validator and final tree equivalence.

### Item 4: State, recovery, and steering alignment
- Files: `references/failure-recovery.md`, `references/thinking-steering.md`
- What: Aligns recovery rules and thinking guardrails with the wrapper/helper stack.
- Why this shape: The supporting docs need to reinforce the same boundaries as the executable scripts.
- Verified by: validator.

## Files touched

| File | Purpose |
|---|---|
| `SKILL.md` | Main skill routing and phase contract. |
| `references/event-driven-orchestration.md` | New event-source spec for phases 3, 5, 6, and 7. |
| `references/parallel-subagent-protocol.md` | Applier, PR-Creator, and Evaluator brief rules. |
| `references/mission-protocol-integration.md` | Mission Protocol role alignment. |
| `references/per-branch-fix-loop.md` | Phase 3 loop and terminal states. |
| `references/post-pr-review-protocol.md` | Phase 6 through Phase 8b post-PR flow. |
| `references/failure-recovery.md` | Recovery paths for orchestration failures. |
| `references/thinking-steering.md` | Steering updates to avoid known drift patterns. |

## Verification
- `python3 scripts/validate-skills.py` passed with all 43 skills valid.
- Final equivalence check passed:
  `test "$(git rev-parse c7c64fc:skills/run-codex-review)" = "$(git rev-parse HEAD:skills/run-codex-review)" && git diff --exit-code c7c64fc HEAD -- skills/run-codex-review`
- `git diff --check` passed before commit.

## Weaknesses and open questions
1. Important: `SKILL.md` remains long. Reviewer: decide whether the operational density is justified here or whether a follow-up should trim harder toward the repo’s line-budget guidance.
2. Important: This PR documents a multi-hour orchestration pattern that was not rerun end-to-end as part of this split. Reviewer: verify the prose against the wrapper/helper contracts and call out any step that would still make an agent pause or invent a tool.
3. Minor: The event-driven guidance is precise enough to be useful but can read procedural; reviewer should flag any instruction that feels brittle across runtimes.

## Request to the reviewer
Please read this as an execution contract. Check whether an agent could follow the phase order without losing context, invoking the wrong Codex surface, over-asking the user, or merging leaves before foundation CI is known.

## Follow-ups (not in scope)
- Further trim `SKILL.md` if reviewers require tighter top-level routing.
- Add fixture-based script tests if this repo formalizes a script test harness.
- Run the full skill on a real multi-branch cleanup before treating every orchestration claim as production-proven.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores and consolidates the `run-codex-review` orchestration docs with a pinned event‑driven flow, explicit sub‑agent invocation matrix, and clarified Phase 8a apply / 8b merge. Aligns the top‑level skill to the wrapper/helper scripts and removes long‑lived per‑branch coordinator sub‑agents.

- **New Features**
  - Updated ten‑phase contract in `SKILL.md` with main‑agent as coordinator and routing to helpers; 8a/8b split retained.
  - New event‑driven spec (`references/event-driven-orchestration.md`) mapping `Bash`/`Agent` background, `Monitor`, and `ScheduleWakeup` per phase; no polling loops.
  - Reworked per‑branch loop (`references/per-branch-fix-loop.md`): main agent runs review wrappers; per‑round Applier sub‑agents; clearer state, validation, and caps.
  - Post‑PR protocol (`references/post-pr-review-protocol.md`): expanded bot list (`copilot-pull-request-reviewer`, `cubic-dev-ai`), two valid rescue trigger paths, evaluator handoff, and 8a apply + 8b `--onto` merge.
  - Sub‑agent briefs (`references/parallel-subagent-protocol.md`): invocation matrix added; `/codex:review` is `disable-model-invocation: true` so sub‑agents call the review wrapper via Bash; rescue is main‑agent‑only.

- **Migration**
  - Drop the per‑branch coordinator sub‑agent; main agent orchestrates. Keep Applier, PR‑Creator, and Evaluator short‑lived.
  - Use the listed event sources; remove ad‑hoc polling.
  - Sub‑agents cannot call `/codex:review`; invoke the review wrapper script from Bash. Keep Phase 6 rescue main‑agent‑only.
  - Apply evaluator output via main agent using `Skill(do-review)`; merge with `--onto` on private fork only.

<sup>Written for commit 14ce95a1c69da498d51338d578024dce9349eaab. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/58?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

