### PR TITLE
🐛 fix(run-codex-review): restore wrapper content lost in PR #56 squash

### DIFF
--- a/skills/run-codex-review/skills/run-codex-review/references/codex-review-contract.md
+++ b/skills/run-codex-review/skills/run-codex-review/references/codex-review-contract.md
@@ -1,43 +1,68 @@
 # Codex Review Contract
 
-`/codex:review --background` is the per-branch reviewer in this skill. This file is the **single pinned spec** for how the skill calls it, parses it, and decides "no major feedback".
+`/codex:review` is the per-branch reviewer in this skill. It is a Claude Code slash command from the OpenAI Codex plugin (`openai-codex/codex`, source: https://github.com/openai/codex-plugin-cc). This file is the **single pinned spec** for how the skill invokes it, parses it, and decides "no major feedback".
 
-## Invocation forms
+## How callers invoke a codex review
 
-Two forms exist; both must run **inside the branch's worktree** so Codex sees the right HEAD:
+**Always through the wrapper, never directly.**
 
-1. **Slash command** (interactive Claude Code session):
-   ```
-   /codex:review --background
-   ```
-
-2. **Underlying CLI** (programmatic; what scripts call):
-   ```bash
-   codex review --background [--branch <b>] [--base main]
-   ```
-
-`scripts/run-codex-review.py` calls the CLI form. If the CLI signature in your environment differs, adjust `run-codex-review.py`'s `invoke_codex()` function — keep the rest of this contract identical.
-
-## Background-job lifecycle
-
-```
-launch  →  capture job id  →  poll  →  complete  →  fetch artifact  →  normalize JSON
+```bash
+python3 <this-skill>/scripts/run-codex-review.py \
+  --branch <branch> \
+  --base <base> \
+  --worktree <worktree-path>
 ```
 
-1. Launch returns a job id on stdout (e.g. `cdx-job-abc123`). Capture it; persist in manifest as `last_review_id`.
-2. Poll the job's status endpoint at `--poll-interval` (default 30s). Codex reports `running` / `completed` / `failed`.
-3. On `completed`, fetch the artifact (file path / API call / `gh` PR comment — depends on your Codex install).
-4. Normalize the artifact to the JSON schema below. Persist to `<rounds-dir>/<branch-slug>.<round>.json`.
+The wrapper does:
+1. Discover `codex-companion.mjs` automatically — env-var first (`${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs`), version-glob fallback (`~/.claude/plugins/cache/openai-codex/codex/<latest>/scripts/codex-companion.mjs`).
+2. Spawn `node codex-companion.mjs review --base <ref> --scope branch --json` synchronously inside the worktree.
+3. Parse the JSON envelope.
+4. Normalize to the round-log schema below.
+5. Write `<rounds-dir>/<slug>.<round>.json`.
+6. Update the manifest entry's `last_review_id`, `last_review_at`, `last_status`, `rounds`, `head_sha_current`, and append a `round_history` entry.
 
-If the job is still `running` after `--timeout` (default 1800s = 30 min), the wrapper marks the round `timeout` and returns exit 1; the subagent decides whether to retry the round (caps at 3 attempts).
+Sub-agents call the wrapper. Main agent (in programmatic loops) calls the wrapper. The wrapper is the contract; the underlying `codex-companion.mjs` invocation is the wrapper's implementation detail.
 
-## Normalized JSON schema
+### Why the wrapper matters
 
-Every round emits one file. Schema:
+`/codex:review` is `disable-model-invocation: true` in the plugin manifest — sub-agents physically cannot dispatch the slash command via `Skill(...)`. The slash itself runs `node codex-companion.mjs review` internally. Instead of every brief reinventing the discovery + invocation + parse + normalize chain (production traces showed agents writing 245-line `/tmp/codex-review-runner.py` shims session-after-session), `scripts/run-codex-review.py` does it once, version-agnostically, with a stable CLI surface.
+
+### Adversarial mode (structured findings, opt-in)
+
+`/codex:review` emits free-form text in `codex.stdout`; the wrapper regex-parses it. For projects that want pre-parsed findings with explicit severities (`critical | high | medium | low`), the wrapper supports `--mode adversarial`, which invokes `node codex-companion.mjs adversarial-review --json` instead. The `result.findings[]` array maps directly to round-log `items[]` — no regex needed.
+
+Default is `--mode review` (matches existing skill semantics). Switch to `--mode adversarial` when the regex parser misses items because Codex emitted unusual formatting.
+
+### Forbidden invocation paths
+
+| Forbidden | Why |
+|---|---|
+| `codex review …` from Bash | No such CLI surface — the underlying `codex` binary has no `--background` review flag. |
+| `Skill(skill="codex:review", ...)` from a sub-agent | `disable-model-invocation: true` in the plugin manifest. Will fail. |
+| `node …/codex-companion.mjs review …` directly from a sub-agent brief | The wrapper does that, plus discovery + normalization + manifest update + round-log path computation. Calling the companion script directly bypasses all of that. |
+| Inventing a "shim" because `codex --help` doesn't list `--background` | The flag belongs to the slash command, not the CLI. The wrapper handles it. |
+| Re-running `/codex:review` as user-typed text from a sub-agent | Sub-agents cannot type slash commands. They use the wrapper. |
+| Writing a parallel `/tmp/codex-review-runner.py` | That's what the production wrapper now does. Don't duplicate it. |
+
+### Plugin missing → surface, do not fabricate
+
+If the wrapper's discovery returns 127 (`codex-companion.mjs` not found at `${CLAUDE_PLUGIN_ROOT}/scripts/` or `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/`), the codex plugin is missing. The wrapper exits 127 with install instructions. Sub-agent hands back FAILED with `terminal_reason: "codex plugin unavailable"`. Main agent surfaces to the user and stops the skill. **Never** substitute a free-form `codex` Bash call or any other plugin's reviewer.
+
+## Synchronous execution (not background)
+
+Despite the legacy "—background" framing in earlier versions of this skill, the codex-companion `review` and `adversarial-review` subcommands ALWAYS run synchronously — `--background` is parsed but ignored. The wrapper invokes them with a wall-clock cap (default 1500s = 25 min) and returns when codex returns. Per-branch parallelism comes from concurrent subprocess invocations across branches, not from a background flag.
+
+If a single review hangs past the wall-clock cap (Codex can stall on remote tools like codebase-search APIs), the wrapper exits 1 with `terminal_reason: "review-hang past wall-clock cap"`. Caller retries once, then marks the round FAILED.
+
+(Note: `task --background` is different — it DOES honor the flag and runs out-of-band. That's how Phase 6 codex rescue works. See `scripts/trigger-codex-rescue.py` and `references/post-pr-review-protocol.md`.)
+
+## Normalized JSON schema (round-log)
+
+Every round emits one file at `<rounds-dir>/<slug>.<round>.json`:
 
 ```json
 {
-  "review_id": "cdx-job-abc123",
+  "review_id": "<codex thread id>",
   "branch": "feat/foo",
   "head_sha": "deadbeef1234...",
   "started_at": "2026-04-26T10:00:00Z",
@@ -46,7 +71,7 @@ Every round emits one file. Schema:
   "items": [
     {
       "id": "cdx-1",
-      "severity_raw": "high",
+      "severity_raw": "P1",
       "file": "src/foo.ts",
       "line": 42,
       "body": "Off-by-one in the slice — drops the last element."
@@ -55,16 +80,65 @@ Every round emits one file. Schema:
 }
 ```
 
-`severity_raw` is whatever Codex emits (`high|medium|low`, `error|warning|info`, etc.). The classifier (`classify-review-feedback.py`) maps it onto major/minor per `major-vs-minor-policy.md`. Don't pre-classify here — keep the wrapper's normalization mechanical.
+`severity_raw` is whatever Codex emits — the regex parser accepts `P1` / `P2` / `P3` / `P4` / `critical` / `high` / `medium` / `low` (case-insensitive). The adversarial-review path emits `critical | high | medium | low` directly. The classifier (`classify-review-feedback.py`) maps these onto major/minor per `major-vs-minor-policy.md`. **Don't pre-classify here** — keep the wrapper's normalization mechanical.
 
-If Codex's artifact is unstructured (free-text), `items` is `[]` and the classifier falls back to regex over `raw_text`. Mark `severity_raw: "unstructured"` in this case.
+If Codex's `codex.stdout` doesn't match the expected `[severity] Title — file:line` pattern (free-form prose with no item headers, or fully unrecognized format), `items` is `[]` and the classifier falls back to regex over `raw_text`.
+
+## codex-companion JSON envelopes (wrapper input)
+
+What `codex-companion.mjs review --json` emits to stdout:
+
+```json
+{
+  "review": "Review",
+  "target": { "mode": "branch", "label": "...", "baseRef": "main" },
+  "threadId": "...",
+  "sourceThreadId": "...",
+  "codex": {
+    "status": 0,
+    "stderr": "",
+    "stdout": "<free-form review text — `[Px] title — file:line` items>",
+    "reasoning": "<optional>"
+  }
+}
+```
+
+What `codex-companion.mjs adversarial-review --json` emits:
+
+```json
+{
+  "review": "Adversarial Review",
+  "result": {
+    "verdict": "approve|needs-attention",
+    "summary": "...",
+    "findings": [
+      {
+        "severity": "critical|high|medium|low",
+        "title": "...",
+        "body": "...",
+        "file": "src/foo.ts",
+        "line_start": 42,
+        "line_end": 42,
+        "confidence": 0.9,
+        "recommendation": "..."
+      }
+    ],
+    "next_steps": ["..."]
+  },
+  "rawOutput": "...",
+  "parseError": null,
+  "reasoningSummary": null
+}
+```
+
+The wrapper handles both shapes; callers don't need to care which mode produced the round-log.
 
 ## Detecting "no major feedback"
 
 The subagent decides DONE-vs-continue from the classifier's output, not from the raw artifact:
 
 ```bash
-python3 scripts/classify-review-feedback.py --review-json <round-json>
+python3 <this-skill>/scripts/classify-review-feedback.py --review-json <round-json>
 ```
 
 Exit code:
@@ -74,38 +148,32 @@ Exit code:
 
 Never decide DONE by eyeballing the raw text. The classifier is the single arbiter so the loop terminates the same way every time.
 
-## Always `--background`
-
-`--background` is non-negotiable. Inline mode blocks the subagent:
-
-| Mode | Effect |
-|---|---|
-| `--background` | Codex runs out-of-band. Subagent polls; can do other work in between. Per-branch parallelism works. |
-| inline | Subagent blocks until Codex returns. Other branches stall waiting. Defeats the whole skill. |
-
-If the user/environment disables `--background` mode, this skill cannot run as designed — fall back to `run-repo-cleanup` for serial cleanup.
-
 ## Failure modes and what the wrapper does
 
 | Failure | Wrapper behavior | Caller (subagent) action |
 |---|---|---|
-| codex CLI not installed | Exit 2 with stderr "codex not on PATH" | Cannot proceed; mark branch FAILED. |
-| Network failure mid-launch | Exit 2 with raw error in stderr | Retry round (max 3); else FAILED. |
-| Job stuck `running` past timeout | Exit 1; manifest marked `timeout` | Retry round (max 3); else FAILED. |
-| Job `completed` but artifact missing | Exit 2 with stderr explaining where it looked | Cannot recover; mark FAILED. |
-| Artifact present but malformed | Normalization writes `items: []`, `severity_raw: "unstructured"`; exit 0 | Classifier falls back to regex; loop continues normally. |
-| Branch HEAD changed mid-review (someone else pushed) | Wrapper warns; review may be stale | Discard the round, retry from current HEAD. |
+| Codex plugin not installed | Exit 127 with install instructions; manifest `last_status: "plugin-missing"` | Hand back FAILED with `terminal_reason: "codex plugin unavailable"`; main surfaces to user. |
+| Worktree not on the right branch | Exit 2; no manifest update | `git -C <wt> checkout <branch>`; retry. |
+| `codex-companion.mjs` exits non-zero with no stdout | Exit 2; manifest `last_status: "failed"` | Retry the round once. |
+| `codex-companion.mjs` exits non-zero but stdout has parseable JSON | Wrapper logs warning, normalizes anyway, exit 0 | Round log written; loop continues. |
+| Wall-clock timeout (Codex hung on a tool) | Exit 1; manifest `last_status: "timeout"`, `terminal_reason: "review-hang past wall-clock cap"` | Retry once; else mark FAILED. |
+| Output doesn't match expected JSON envelope | Exit 0 with `items: []`, raw text in `raw_text` | Classifier falls back to regex over `raw_text`. |
+| Branch HEAD changed mid-review (someone else pushed) | Not detected by wrapper; review may be stale | Discard the round, retry from current HEAD. |
 
 ## Read-only invariants
 
-`run-codex-review.py` itself is **mostly** read-only with respect to the repo — its only writes are the round-log file under `<rounds-dir>` and the manifest update. It does **not** push, commit, or modify the worktree. Pushing is the subagent's job after applying fixes.
+`run-codex-review.py` is read-only on the repo's content (no git mutations: no push, no commit, no checkout). Its only writes are:
+- `<rounds-dir>/<slug>.<round>.json` — the round log.
+- `<repo-root>/.codex-review-manifest.json` (or `--manifest <path>`) — the manifest entry update.
+
+Pushing fix commits is the Applier sub-agent's job in Phase 3, not the wrapper's.
 
 ## Adjusting the contract
 
-If your Codex installation deviates from the schema above:
+If a future Codex plugin version changes the JSON shape:
 
-1. Edit `scripts/run-codex-review.py`'s `normalize_review()` function to match Codex's actual output.
+1. Update `normalize_review()` in `scripts/run-codex-review.py` to match the new shape.
 2. Update this doc's Schema section in lock-step.
 3. Run `scripts/classify-review-feedback.py` against a sample normalized JSON to confirm the classifier still partitions correctly.
 
-Don't let the contract drift silently. The schema in this file is what the rest of the skill assumes.
+The wrapper's external CLI surface (`--branch`, `--base`, `--worktree`, `--mode`, `--output`, `--manifest`, `--rounds-dir`, `--timeout`, `--dry-run`) is stable across plugin upgrades — callers don't change.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.md
@@ -1,27 +1,40 @@
 # run-codex-review.py
 
-Wrapper around `/codex:review --background` for one branch in one worktree. Launches the background review, polls to completion, fetches the artifact, normalizes to the JSON schema in `references/codex-review-contract.md`, writes the round log, and updates the manifest.
+Wrapper around `node codex-companion.mjs review --json` (or `adversarial-review --json`) for one branch in one worktree. Runs the review synchronously, normalizes output to the JSON schema in `references/codex-review-contract.md`, writes the round log, and updates the manifest.
 
 **This is the single entry point for "do one round of review on this branch".** Subagents call it once per round.
+
+The wrapper invokes the OpenAI Codex Claude Code plugin's companion script — it discovers `codex-companion.mjs` automatically (version-agnostic), so no per-environment adjustment is required.
 
 ## Usage
 
 ```bash
+# Default: native review (free-form text parsed via regex)
 python3 scripts/run-codex-review.py --branch feat/foo --worktree /Users/.../wt-feat-foo
+
+# Pick base branch
 python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --base canary
-python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --timeout 600
+
+# Wall-clock cap (Codex review can hang on remote tools)
+python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --timeout 1500
+
+# Adversarial mode — structured findings with severities critical|high|medium|low
+python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --mode adversarial
+
+# Dry-run prints the resolved codex-companion.mjs path + the planned invocation
 python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --dry-run
 ```
 
 ## Behavior
 
 1. Pre-flight: verify `--worktree` exists and is on `--branch`.
-2. `cd` into the worktree.
-3. Invoke the codex CLI form (see "Adjustment point" below).
-4. Parse the launch output for the background job id.
-5. Poll the job status every `--poll-interval` seconds until completion or `--timeout`.
-6. On completion: fetch the artifact, normalize to the schema, write `<rounds-dir>/<slug>.<round>.json`.
-7. Update the manifest entry's `last_review_id`, `last_review_at`, `last_status`, `rounds`, `head_sha_current`, and append a `round_history` entry.
+2. Discover `codex-companion.mjs` (env-var first, then `~/.claude/plugins/cache/openai-codex/codex/<latest>/`).
+3. Invoke `node codex-companion.mjs <review|adversarial-review> --base <ref> --scope branch --json` synchronously inside the worktree.
+4. Parse the JSON envelope:
+   - **`review` mode**: extract `codex.stdout` (free-form text) and regex-parse `[severity] Title — file:line` items.
+   - **`adversarial` mode**: read `result.findings[]` directly (structured; no regex).
+5. Write `<rounds-dir>/<slug>.<round>.json` with the round-log schema.
+6. Update the manifest entry's `last_review_id`, `last_review_at`, `last_status`, `rounds`, `head_sha_current`, and append a `round_history` entry.
 
 ## Flags
 
@@ -29,37 +42,31 @@ python3 scripts/run-codex-review.py --branch feat/foo --worktree /path --dry-run
 |---|---|---|
 | `--branch <b>` | required | Branch under review. Must match the worktree's HEAD. |
 | `--worktree <path>` | required | Worktree directory; codex runs from here. |
-| `--base <ref>` | `main` | Base passed to the codex CLI (if it accepts one). |
-| `--manifest <path>` | `/tmp/codex-review-manifest.json` | Manifest to update. |
-| `--rounds-dir <path>` | `/tmp/codex-review-rounds/` | Round-log directory. |
-| `--timeout <n>` | `1800` (30 min) | Seconds to wait for the background job to complete. |
-| `--poll-interval <n>` | `30` | Seconds between status polls. |
-| `--dry-run` | off | Print the plan; don't invoke codex. |
+| `--base <ref>` | `main` | Base ref for the diff. |
+| `--mode review\|adversarial` | `review` | `review` = native (free-form text parsed); `adversarial` = adversarial-review (structured `findings[]`). |
+| `--manifest <path>` | `<repo-root>/.codex-review-manifest.json` | Manifest to update. Defaults to repo-local (no `/tmp` cross-repo collisions). |
+| `--rounds-dir <path>` | `<repo-root>/.codex-review-rounds/` | Round-log directory. Same defaulting logic. |
+| `--output <path>` | (computed) | Override the round-log output path. If unset, computed from `<rounds-dir>` + branch slug + round number. |
+| `--timeout <n>` | `1500` (25 min) | Wall-clock cap. On hang, exit 1 with `last_status: "timeout"` and `terminal_reason: "review-hang past wall-clock cap"`. |
+| `--dry-run` | off | Resolve `codex-companion.mjs` path, validate worktree state, print the intended invocation. Don't run codex. |
 
 ## Exit codes
 
 | Code | Meaning | Caller (subagent) action |
 |---|---|---|
 | `0` | Review available; round log written | Run `classify-review-feedback.py` next. |
-| `1` | Timeout (manifest marked `timeout`) | Retry the round (max 3); else mark FAILED. |
-| `2` | Codex/CLI failed (manifest marked `failed`) | Retry the round (max 3); else mark FAILED. |
+| `1` | Timeout (wall-clock cap; manifest marked `timeout`) | Retry the round once; else mark FAILED. |
+| `2` | Codex CLI failed (manifest marked `failed`) | Retry the round once; else mark FAILED. |
+| `127` | Codex plugin not installed | Surface to user; install via Claude Code plugin manager. |
 
-## Adjustment point — codex CLI form
+## Plugin discovery
 
-The exact CLI form depends on your Codex installation. Edit `invoke_codex()` in the script to match.
+The wrapper discovers `codex-companion.mjs` automatically:
 
-Default attempts (in order):
+1. **`${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs`** — set by Claude Code when the plugin is loaded in a live session.
+2. **Latest version under `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs`** — fallback for when the env var isn't set. Versions are sorted semver-ascending; the latest installed wins. Non-semver directory names sort first (so `1.0.4` beats `dev`).
 
-```python
-candidates = [
-    ["codex", "review", "--background", "--branch", branch, "--base", base],
-    ["codex", "review", "--background"],
-]
-```
-
-If your install uses a different form (e.g. `claude codex review`, `cdx review`, `gh codex`), update the list. The script picks the first form that doesn't return `127` (command not found).
-
-Same for the **status** poll (`codex review --status <id>`) and **fetch** (`codex review --fetch <id>`) — adjust if your install uses different subcommands.
+If neither path resolves, the wrapper exits with code 127 and a message pointing at https://github.com/openai/codex-plugin-cc.
 
 ## Schema of the round-log JSON
 
@@ -67,95 +74,115 @@ Per `references/codex-review-contract.md`:
 
 ```json
 {
-  "review_id": "cdx-job-abc123",
+  "review_id": "<codex thread id>",
   "branch": "feat/foo",
   "head_sha": "deadbeef1234...",
   "started_at": "2026-04-26T10:00:00Z",
   "finished_at": "2026-04-26T10:04:32Z",
   "raw_text": "<full Codex output verbatim>",
   "items": [
-    { "id": "...", "severity_raw": "...", "file": "...", "line": 42, "body": "..." }
+    { "id": "cdx-0", "severity_raw": "P1", "file": "src/foo.ts", "line": 42, "body": "..." }
   ]
 }
 ```
 
-`items` is populated when the artifact is structured JSON. When unstructured (free text), `items` is `[]` and the classifier scans `raw_text` instead.
+In `review` mode, `items[]` is populated by regex-parsing `codex.stdout`. Token recognized in the severity slot: `P1` / `P2` / `P3` / `P4` / `critical` / `high` / `medium` / `low` (case-insensitive).
 
-## Job-id parsing
+In `adversarial` mode, `items[]` is populated by mapping `result.findings[]`:
+- `severity_raw` ← `severity` (`critical | high | medium | low`)
+- `file` ← `file`
+- `line` ← `line_start`
+- `body` ← `title + body + recommendation` joined with blank lines
 
-The script tries these patterns on launch stdout (case-insensitive):
+## codex-companion.mjs JSON shapes
 
-```
-\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)
-\b(cdx[- ]?job[- ]?[A-Za-z0-9_-]+)
-\bbackground job[:=]\s*([A-Za-z0-9_-]+)
-```
-
-If none match, a synthetic id `cdx-job-unknown-<unix-ts>` is generated and a warning is printed. The synthetic id is still recorded in the manifest so the round-log filename is unique.
-
-## Polling loop
-
-```
-status = "running"
-while elapsed < timeout:
-    rc, out, _ = sh(["codex", "review", "--status", job_id])
-    if "completed" in out: status = "completed"; fetch; break
-    if "failed" in out:    status = "failed"; break
-    sleep(poll_interval)
+`review --json`:
+```json
+{
+  "review": "Review",
+  "target": { "mode": "branch", "label": "...", "baseRef": "main" },
+  "threadId": "...",
+  "codex": { "status": 0, "stdout": "<free-form text>", "stderr": "...", "reasoning": null }
+}
 ```
 
-If polling exceeds `--timeout`, the script returns exit 1 with `last_status: "timeout"` in the manifest. The subagent decides whether to retry (max 3 retries per round).
+`adversarial-review --json`:
+```json
+{
+  "review": "Adversarial Review",
+  "result": {
+    "verdict": "approve|needs-attention",
+    "summary": "...",
+    "findings": [
+      { "severity": "critical|high|medium|low", "title": "...", "body": "...",
+        "file": "src/foo.ts", "line_start": 42, "line_end": 42,
+        "confidence": 0.0, "recommendation": "..." }
+    ],
+    "next_steps": [...]
+  },
+  "rawOutput": "...",
+  "parseError": null
+}
+```
 
 ## Concurrency safety
 
-`run-codex-review.py` is invoked **once per round per branch** by exactly **one subagent**. No file-locking is needed for the round-log write (each round-log filename is unique by `slug.round.json`). Manifest updates use `tempfile + os.replace` for atomicity, but the protocol assumes one subagent per branch — concurrent invocations on the same branch are an error.
+`run-codex-review.py` is invoked **once per round per branch** by exactly **one subagent**. No file-locking on the round-log write (each round-log filename is unique by `slug.round.json`). Manifest updates use `tempfile + os.replace` for atomicity, but the protocol assumes one subagent per branch — concurrent invocations on the same branch are an error.
 
-## Sample output (success)
+Multiple branches can be reviewed in parallel: each branch's invocation is independent. Parallelism comes from concurrent subprocesses, not from a `--background` flag (the companion's `review` and `adversarial-review` subcommands ignore `--background` — they always run synchronously).
+
+## Sample output (success, native review)
 
 ```
-launching /codex:review --background in /Users/.../myrepo-wt-feat-foo ...
-  job id: cdx-job-7f8a9c; polling every 30s up to 1800s...
-  ✓ round log written: /tmp/codex-review-rounds/feat-foo.03.json
+running codex-companion review (sync) in /Users/.../wt-feat-foo ... timeout=1500s
+  ✓ round log written: /Users/.../repo/.codex-review-rounds/feat-foo.03.json (items=4)
   ✓ manifest updated: rounds=3
 ```
 
 ## Sample output (timeout)
 
 ```
-launching /codex:review --background in /Users/.../myrepo-wt-feat-foo ...
-  job id: cdx-job-7f8a9c; polling every 30s up to 1800s...
-✗ job cdx-job-7f8a9c timed out after 1800s
+running codex-companion review (sync) in /Users/.../wt-feat-foo ... timeout=1500s
+✗ codex review timed out after 1500s
 ```
 
-(exit 1; manifest `last_status: "timeout"`)
+(exit 1; manifest `last_status: "timeout"`, `terminal_reason: "review-hang past wall-clock cap"`)
+
+## Sample output (plugin missing)
+
+```
+codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin
+(https://github.com/openai/codex-plugin-cc) — expected at $CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs
+or at ~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs.
+```
+
+(exit 127; manifest `last_status: "plugin-missing"`)
 
 ## Failure modes
 
 | Failure | Wrapper behavior | Recovery |
 |---|---|---|
-| `codex` CLI not on PATH | Exit 2; `last_status: "failed"` | Install codex; resume. |
+| Plugin not installed | Exit 127; `last_status: "plugin-missing"` | Install plugin; resume. |
 | Worktree not on the right branch | Exit 2 with stderr; no manifest update | `git -C <wt> checkout <branch>`; retry. |
-| Network failure mid-launch | Exit 2; `last_status: "failed"` | Subagent retries (max 3). |
-| Job stuck `running` past timeout | Exit 1; `last_status: "timeout"` | Subagent retries OR raises timeout. |
-| Job `completed` but no artifact | Exit 2; `last_status: "failed"` | Investigate codex install; surface to human. |
-| Artifact malformed JSON | Exit 0; `items: []`, `raw_text` populated | Classifier falls back to regex; loop continues. |
-| Branch HEAD changed mid-review | Wrapper warns via raw_text comparison; review may be stale | Subagent discards round, retries from current HEAD. |
+| codex-companion ran but exited non-zero with no stdout | Exit 2; `last_status: "failed"` | Subagent retries once. |
+| codex-companion ran with non-zero exit but stdout has parseable JSON | Wrapper logs warning, normalizes anyway | Round log written; loop continues. |
+| Wall-clock timeout | Exit 1; `last_status: "timeout"` | Subagent retries once OR mark FAILED. |
+| Output doesn't match expected JSON envelope | Exit 0 with `items: []`, raw text in `raw_text` | Classifier falls back to regex over `raw_text`. |
+| Branch HEAD changed mid-review | Not detected by wrapper; review may be stale | Subagent discards round, retries from current HEAD. |
 
 ## When to run
 
 - Per round, by exactly one subagent per branch.
-- Never invoke twice in parallel on the same branch.
-- Never invoke from outside the branch's worktree.
+- Never invoke twice in parallel on the same branch (use a different worktree if you need parallel branches).
 
 ## Read/write surface
 
-- **Reads**: `<worktree>/...`, manifest, codex CLI status/fetch endpoints.
+- **Reads**: `<worktree>/...`, manifest, the codex-companion script.
 - **Writes**: `<rounds-dir>/<slug>.<round>.json` (new each round), manifest entry for this branch.
 - **Does NOT**: push, commit, modify the worktree, open PRs, edit other branches' entries.
 
-## Extending
+## See also
 
-- Replace `invoke_codex()`'s body with your codex CLI form. Keep the return contract `(rc, stdout, stderr)`.
-- Replace `parse_job_id()`'s patterns with your codex's launch-output convention.
-- Replace `poll_job()`'s status/fetch with your codex's polling contract.
-- Add a per-call `--policy <path>` flag if you want to override the classifier policy from this script (currently the classifier is invoked separately).
+- `scripts/trigger-codex-rescue.py` — the Phase 6 sibling that wraps `codex-companion.mjs task --background` for the rescue review on an open PR.
+- `references/codex-review-contract.md` — the round-log schema this wrapper produces.
+- `references/event-driven-orchestration.md` — how main agent dispatches this wrapper in parallel across N branches via `Bash run_in_background`.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/run-codex-review.py
@@ -1,43 +1,88 @@
 #!/usr/bin/env python3
-"""Wrap /codex:review --background for one branch; normalize output to JSON.
+"""Wrap the OpenAI Codex Claude Code plugin's review for one branch; normalize
+output to the round-log JSON schema in references/codex-review-contract.md.
 
-Invokes the Codex CLI inside the branch's worktree, polls the background job
-to completion, fetches the review artifact, normalizes to the JSON schema in
-references/codex-review-contract.md, and writes the round log + manifest update.
-
-The exact codex CLI form is environment-dependent; see invoke_codex() for the
-adjustment point.
+Invokes `node codex-companion.mjs review --json` (or `adversarial-review --json`)
+inside the branch's worktree. The companion script ignores `--background` for
+review subcommands — it always runs synchronously. Each parallel coordinator
+runs its own subprocess; parallelism comes from concurrent invocations, not
+from background flags.
 
 Usage:
     python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt
     python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt --dry-run
     python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt \\
-        --timeout 1800 --poll-interval 30
+        --base main --timeout 1500 --mode review
+
+    # Adversarial mode (structured findings — no regex, severities are
+    # critical|high|medium|low):
+    python3 run-codex-review.py --branch feat/foo --worktree /path/to/wt --mode adversarial
 
 Exit codes:
     0  review available; round log written
     1  timeout (manifest marked 'timeout'; caller decides retry)
     2  codex/CLI failed (manifest marked 'failed'; caller decides FAILED)
+  127  codex plugin not installed (caller surfaces FAILED)
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
 import subprocess
 import sys
 import tempfile
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-DEFAULT_MANIFEST = "/tmp/codex-review-manifest.json"
-DEFAULT_ROUNDS_DIR = "/tmp/codex-review-rounds/"
-DEFAULT_TIMEOUT = 1800
-DEFAULT_POLL_INTERVAL = 30
+DEFAULT_TIMEOUT = 1500  # 25 min wall-clock cap; Codex review can hang on remote tools
+DEFAULT_MODE = "review"  # native (free-form parsed). "adversarial" → structured findings.
 
+
+# ─── codex-companion.mjs discovery (version-agnostic) ─────────────────────────
+
+def _find_codex_companion() -> Path:
+    """Discover the OpenAI Codex plugin's codex-companion.mjs.
+
+    Resolution order:
+      1. ${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs (env var set by Claude
+         Code harness when the plugin is loaded).
+      2. Latest installed version under
+         ~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs
+         (semver-sorted; latest wins; falls back to lex-sort for non-semver dirs).
+
+    Raises FileNotFoundError if neither resolves. Plugin source:
+      https://github.com/openai/codex-plugin-cc/tree/main/plugins/codex
+    """
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidate = Path(plugin_root) / "scripts" / "codex-companion.mjs"
+        if candidate.is_file():
+            return candidate
+
+    cache = Path.home() / ".claude" / "plugins" / "cache" / "openai-codex" / "codex"
+    if cache.is_dir():
+        def _key(p: Path) -> tuple:
+            m = re.match(r"^(\d+)\.(\d+)\.(\d+)", p.name)
+            return (1, int(m[1]), int(m[2]), int(m[3])) if m else (0, p.name)
+        for v in sorted((p for p in cache.iterdir() if p.is_dir()), key=_key, reverse=True):
+            candidate = v / "scripts" / "codex-companion.mjs"
+            if candidate.is_file():
+                return candidate
+
+    raise FileNotFoundError(
+        "codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin "
+        "(https://github.com/openai/codex-plugin-cc) — expected at "
+        "$CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs or at "
+        "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs."
+    )
+
+
+# ─── Generic helpers ──────────────────────────────────────────────────────────
 
 def sh(cmd, cwd=None, env=None, timeout=None):
     try:
@@ -79,6 +124,17 @@ def atomic_write(path: str, content: str):
         raise
 
 
+def repo_local_default(wt: Path, name: str) -> str:
+    """Repo-local default for state files; main agent's session may pass --manifest
+    explicitly. This default prevents cross-repo /tmp collisions."""
+    # Find repo root from the worktree path (handle the worktree's own .git file)
+    rc, out, _ = sh(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=wt)
+    if rc == 0 and out:
+        # git-common-dir points at the main checkout's .git directory; its parent is repo root
+        return str(Path(out).parent / name)
+    return f"/tmp/{name}"  # last-resort fallback
+
+
 def load_manifest(path: str) -> dict | None:
     if not os.path.isfile(path):
         return None
@@ -89,18 +145,48 @@ def load_manifest(path: str) -> dict | None:
         return None
 
 
-def update_manifest_entry(path: str, branch: str, updates: dict, history_entry: dict | None = None):
-    manifest = load_manifest(path)
-    if manifest is None:
-        return
-    for entry in manifest.get("branches", []):
-        if entry.get("branch") == branch:
-            entry.update(updates)
-            entry["updated_at"] = utc_now_iso()
-            if history_entry is not None:
-                entry.setdefault("round_history", []).append(history_entry)
-            break
-    atomic_write(path, json.dumps(manifest, indent=2))
+@contextlib.contextmanager
+def _manifest_lock(manifest_path: str):
+    """Hold an fcntl.LOCK_EX on `<manifest>.lock` for the duration of a
+    read-modify-write. Required because parallel branches/PRs write to the
+    same manifest concurrently — without the lock, simultaneous writers
+    clobber each other and lose updates.
+
+    The lock file is created next to the manifest (not inside it) and is
+    safe to leave around between runs.
+    """
+    lock_path = manifest_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    with open(lock_path, "w") as lock_fp:
+        fcntl.flock(lock_fp, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fp, fcntl.LOCK_UN)
+
+
+def update_manifest_entry(path: str, branch: str, updates: dict, history_entry: dict | None = None) -> bool:
+    """Atomic read-modify-write under flock. Returns True iff the manifest
+    existed AND a branch entry matching `branch` was found and updated.
+    Callers should check the return value before reporting success.
+    """
+    with _manifest_lock(path):
+        manifest = load_manifest(path)
+        if manifest is None:
+            return False
+        found = False
+        for entry in manifest.get("branches", []):
+            if entry.get("branch") == branch:
+                entry.update(updates)
+                entry["updated_at"] = utc_now_iso()
+                if history_entry is not None:
+                    entry.setdefault("round_history", []).append(history_entry)
+                found = True
+                break
+        if not found:
+            return False
+        atomic_write(path, json.dumps(manifest, indent=2))
+        return True
 
 
 def get_round_for_branch(path: str, branch: str) -> int:
@@ -113,82 +199,165 @@ def get_round_for_branch(path: str, branch: str) -> int:
     return 0
 
 
-# ─── Codex invocation — adjustment point per environment ──────────────────────
+# ─── Codex invocation ─────────────────────────────────────────────────────────
 
-def invoke_codex(branch: str, base: str, wt: Path) -> tuple[int, str, str]:
-    """Launch /codex:review --background. Return (rc, stdout, stderr).
+def invoke_codex(branch: str, base: str, wt: Path, mode: str, timeout: int) -> tuple[int, str, str]:
+    """Spawn codex-companion.mjs <mode> --base <ref> --json synchronously.
 
-    Adjust the command form here to match the codex CLI in your environment.
-    Common forms (try in order):
-      - codex review --background --branch <b> --base <base>
-      - codex review --background
-      - claude codex review --background
+    The companion script's review and adversarial-review subcommands always run
+    foreground regardless of any --background flag. Returns (rc, stdout, stderr).
     """
-    candidates = [
-        ["codex", "review", "--background", "--branch", branch, "--base", base],
-        ["codex", "review", "--background"],
-    ]
-    for cmd in candidates:
-        rc, out, err = sh(cmd, cwd=wt, timeout=120)
-        if rc != 127:  # found and ran (even if it failed for other reasons)
-            return rc, out, err
-    return 127, "", "no codex CLI form succeeded; check codex install / PATH"
-
-
-def parse_job_id(stdout: str) -> str | None:
-    """Extract a background job id from launch stdout.
-
-    Adjust this regex to match what your codex CLI prints.
-    """
-    patterns = [
-        r"\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)",
-        r"\b(cdx[- ]?job[- ]?[A-Za-z0-9_-]+)",
-        r"\bbackground job[:=]\s*([A-Za-z0-9_-]+)",
-    ]
-    for pat in patterns:
-        m = re.search(pat, stdout, flags=re.IGNORECASE)
-        if m:
-            return m.group(1)
-    return None
-
-
-def poll_job(job_id: str, wt: Path, poll_interval: int, timeout: int) -> tuple[str, str]:
-    """Poll the codex job until completion. Returns (status, raw_artifact)."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        rc, out, err = sh(["codex", "review", "--status", job_id], cwd=wt, timeout=60)
-        if rc == 127:
-            return "failed", f"codex --status not available: {err}"
-        text = out.lower()
-        if "completed" in text or "done" in text or "finished" in text:
-            # fetch artifact
-            rc2, art, err2 = sh(["codex", "review", "--fetch", job_id], cwd=wt, timeout=120)
-            if rc2 == 0:
-                return "completed", art
-            return "failed", f"fetch failed: {err2}"
-        if "failed" in text or "cancelled" in text or "errored" in text:
-            return "failed", out
-        time.sleep(poll_interval)
-    return "timeout", ""
-
-
-def normalize_review(raw: str, review_id: str, branch: str, head: str,
-                     started_at: str, finished_at: str) -> dict:
-    """Best-effort normalization of the artifact to the schema in
-    references/codex-review-contract.md. If the artifact is structured JSON,
-    parse it. Otherwise treat as unstructured text and let the classifier
-    fall back to regex over raw_text.
-    """
-    items = []
-    parsed = None
     try:
-        parsed = json.loads(raw)
+        companion = _find_codex_companion()
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+
+    subcmd = "review" if mode == "review" else "adversarial-review"
+    cmd = [
+        "node", str(companion), subcmd,
+        "--base", base,
+        "--scope", "branch",
+        "--json",
+    ]
+    return sh(cmd, cwd=wt, timeout=timeout)
+
+
+# ─── Output normalization ─────────────────────────────────────────────────────
+
+# Severity tokens we recognize in free-form review output. Codex's native review
+# emits items as `[Px] Title — file:line` or `[severity] Title — file:line`.
+_SEV_TOKEN = r"P\d+|critical|high|medium|low"
+
+_FREEFORM_PATTERN = re.compile(
+    rf"^\s*\[(?P<sev>{_SEV_TOKEN})\]\s*"
+    r"(?P<title>.+?)\s*[—–-]+\s*"
+    r"(?P<file>[^\s:]+):(?P<line_start>\d+)(?:-(?P<line_end>\d+))?\s*$"
+    rf"(?P<body>(?:\n(?!\s*\[(?:{_SEV_TOKEN})\]).*)*)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Map Codex's P1/P2/P3/P4 priority tokens to the severity labels the
+# classifier recognizes (`SEVERITY_MAJOR = {"critical","high","error","blocker","must-fix"}`
+# in classify-review-feedback.py). Without this mapping, P1 items lowercase
+# to "p1" — a token the classifier doesn't recognize as major — and a
+# branch with only P1 findings can be classified DONE. Verified against
+# classify-review-feedback.py:79.
+_PRIORITY_TO_SEVERITY = {
+    "p1": "critical",
+    "p2": "high",
+    "p3": "medium",
+    "p4": "low",
+}
+
+
+def _normalize_severity(token: str) -> str:
+    """Lowercase the matched severity token; map P1-P4 priorities to
+    critical/high/medium/low so the classifier recognizes them.
+    """
+    lower = token.lower()
+    return _PRIORITY_TO_SEVERITY.get(lower, lower)
+
+
+def parse_freeform_items(text: str) -> list[dict]:
+    """Regex-parse Codex's free-form review text into items[].
+
+    Matches header lines like:
+        [P1] Title here — src/foo.ts:42
+        <body line 1>
+        <body line 2>
+
+        [P2] Next item — src/bar.ts:13-15
+        ...
+
+    Severity tokens: P1 / P2 / P3 / P4 (mapped to critical/high/medium/low) or
+    critical / high / medium / low (preserved as-is).
+    """
+    items: list[dict] = []
+    for i, m in enumerate(_FREEFORM_PATTERN.finditer(text)):
+        items.append({
+            "id": f"cdx-{i}",
+            "severity_raw": _normalize_severity(m["sev"]),
+            "file": m["file"],
+            "line": int(m["line_start"]),
+            "body": (m["body"] or "").strip() or m["title"].strip(),
+        })
+    return items
+
+
+def normalize_review(raw_json: str, branch: str, head: str,
+                     started_at: str, finished_at: str) -> dict:
+    """Convert codex-companion's --json output to the round-log schema.
+
+    Two input shapes:
+
+    1. review (native):
+        {
+          "review": "Review",
+          "target": {...}, "threadId": "...",
+          "codex": { "status": 0, "stdout": "<free-form text>", "stderr": "...", "reasoning": null }
+        }
+
+    2. adversarial-review (structured):
+        {
+          "review": "Adversarial Review",
+          "result": {
+            "verdict": "approve|needs-attention",
+            "summary": "...",
+            "findings": [{ "severity": "critical|high|medium|low",
+                           "title": "...", "body": "...",
+                           "file": "...", "line_start": N, "line_end": N,
+                           "confidence": 0.0..1.0,
+                           "recommendation": "..." }],
+            "next_steps": [...]
+          },
+          "rawOutput": "...", "parseError": null, ...
+        }
+
+    Output (round-log per references/codex-review-contract.md):
+        {
+          "review_id", "branch", "head_sha",
+          "started_at", "finished_at",
+          "raw_text", "items": [{ "id", "severity_raw", "file", "line", "body" }]
+        }
+    """
+    try:
+        payload = json.loads(raw_json)
     except (ValueError, TypeError):
-        parsed = None
-    if isinstance(parsed, dict) and isinstance(parsed.get("items"), list):
-        items = parsed["items"]
-    elif isinstance(parsed, list):
-        items = parsed
+        # Companion didn't emit valid JSON — degenerate path; pass raw text through
+        # so the classifier's regex fallback can still try.
+        return {
+            "review_id": "",
+            "branch": branch,
+            "head_sha": head,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "raw_text": raw_json,
+            "items": [],
+        }
+
+    review_id = str(payload.get("threadId") or "")
+
+    if payload.get("review") == "Adversarial Review":
+        result = payload.get("result") or {}
+        findings = result.get("findings") or []
+        items = []
+        for i, f in enumerate(findings):
+            title = (f.get("title") or "").strip()
+            body = (f.get("body") or "").strip()
+            recommendation = (f.get("recommendation") or "").strip()
+            combined = "\n\n".join(p for p in (title, body, recommendation) if p)
+            items.append({
+                "id": f"adv-{i}",
+                "severity_raw": str(f.get("severity") or "unknown").lower(),
+                "file": f.get("file") or "",
+                "line": int(f.get("line_start") or 0),
+                "body": combined or title,
+            })
+        raw_text = payload.get("rawOutput") or json.dumps(result, indent=2)
+    else:
+        # Native review — free-form text in codex.stdout.
+        raw_text = (payload.get("codex") or {}).get("stdout") or ""
+        items = parse_freeform_items(raw_text)
 
     return {
         "review_id": review_id,
@@ -196,28 +365,44 @@ def normalize_review(raw: str, review_id: str, branch: str, head: str,
         "head_sha": head,
         "started_at": started_at,
         "finished_at": finished_at,
-        "raw_text": raw,
+        "raw_text": raw_text,
         "items": items,
     }
 
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--branch", required=True)
     ap.add_argument("--worktree", required=True)
     ap.add_argument("--base", default="main")
-    ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
-    ap.add_argument("--rounds-dir", default=DEFAULT_ROUNDS_DIR)
+    ap.add_argument("--manifest",
+                    help="Path to the manifest JSON. Default: <repo-root>/.codex-review-manifest.json")
+    ap.add_argument("--rounds-dir",
+                    help="Directory for round-log JSON files. Default: <repo-root>/.codex-review-rounds/")
+    ap.add_argument("--output",
+                    help="Override round-log output path. If set, overrides --rounds-dir + --branch + round-N path computation.")
     ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT,
-                    help="seconds to wait for the background job to complete")
-    ap.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL)
-    ap.add_argument("--dry-run", action="store_true")
+                    help=f"Wall-clock cap in seconds. Default {DEFAULT_TIMEOUT}s. "
+                         "Codex review can hang on remote tools (codebase-search APIs etc.); "
+                         "on hang, exit non-zero with terminal_reason 'review-hang past wall-clock cap'.")
+    ap.add_argument("--mode", choices=["review", "adversarial"], default=DEFAULT_MODE,
+                    help="codex-companion subcommand. 'review' = native (free-form text parsed via regex; "
+                         "default). 'adversarial' = adversarial-review (structured findings; severities are "
+                         "critical|high|medium|low).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Resolve the codex-companion path, validate worktree state, print intended invocation. Don't run codex.")
     args = ap.parse_args()
 
     wt = Path(args.worktree)
     if not wt.is_dir():
         print(f"worktree not found: {wt}", file=sys.stderr)
         return 2
+
+    # Default manifest + rounds-dir to repo-local paths (avoids /tmp cross-repo collisions)
+    manifest_path = args.manifest or repo_local_default(wt, ".codex-review-manifest.json")
+    rounds_dir = args.rounds_dir or repo_local_default(wt, ".codex-review-rounds")
 
     # Pre-flight: branch is checked out in the worktree
     rc, branch_at_wt, _ = sh(["git", "symbolic-ref", "--short", "HEAD"], cwd=wt)
@@ -229,69 +414,116 @@ def main() -> int:
     started_at = utc_now_iso()
 
     if args.dry_run:
-        print(f"DRY-RUN: would invoke codex review --background in {wt}")
+        try:
+            companion = _find_codex_companion()
+        except FileNotFoundError as e:
+            print(f"DRY-RUN: {e}", file=sys.stderr)
+            return 127
+        subcmd = "review" if args.mode == "review" else "adversarial-review"
+        print(f"DRY-RUN: would invoke")
+        print(f"  node {companion} {subcmd} --base {args.base} --scope branch --json")
+        print(f"  cwd:         {wt}")
         print(f"  branch:      {args.branch}")
-        print(f"  base:        {args.base}")
         print(f"  head:        {head}")
-        print(f"  manifest:    {args.manifest}")
-        print(f"  rounds-dir:  {args.rounds_dir}")
-        print(f"  timeout:     {args.timeout}s, poll {args.poll_interval}s")
+        print(f"  manifest:    {manifest_path}")
+        print(f"  rounds-dir:  {rounds_dir}")
+        print(f"  timeout:     {args.timeout}s")
+        print(f"  mode:        {args.mode}")
         return 0
 
-    print(f"launching /codex:review --background in {wt} ...")
-    rc, out, err = invoke_codex(args.branch, args.base, wt)
-    if rc not in (0, 1):  # 0=ok, 1 sometimes used for "submitted with warnings"
-        print(f"✗ codex launch failed (rc={rc}): {err}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {"last_status": "failed"})
-        return 2
+    # Pre-resolve the companion path so we can distinguish "plugin missing"
+    # (codex-companion.mjs not on disk) from "node missing" (sh returns 127
+    # because `node` itself isn't on PATH).
+    try:
+        companion_path = _find_codex_companion()
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {"last_status": "plugin-missing"})
+        return 127
 
-    job_id = parse_job_id(out) or parse_job_id(err)
-    if not job_id:
-        # Heuristic: if codex returned 0 but no recognizable id, use a synthetic one
-        job_id = f"cdx-job-unknown-{int(time.time())}"
-        print(f"⚠  no recognizable job id in launch output; using synthetic: {job_id}")
-
-    print(f"  job id: {job_id}; polling every {args.poll_interval}s up to {args.timeout}s...")
-    status, raw = poll_job(job_id, wt, args.poll_interval, args.timeout)
+    print(f"running codex-companion {args.mode} (sync) in {wt} ... timeout={args.timeout}s")
+    rc, stdout, stderr = invoke_codex(args.branch, args.base, wt, args.mode, args.timeout)
     finished_at = utc_now_iso()
 
-    if status == "timeout":
-        print(f"✗ job {job_id} timed out after {args.timeout}s", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "last_review_id": job_id,
+    if rc == 127:
+        # node binary not on PATH (plugin path was already verified above)
+        print(f"✗ `node` not on PATH (codex-companion.mjs requires Node.js): {stderr[:500]}", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {
+            "last_status": "node-missing",
+            "last_error": "node not on PATH",
+            "last_review_at": finished_at,
+        })
+        return 127
+
+    if rc == 124:
+        print(f"✗ codex review timed out after {args.timeout}s", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {
             "last_review_at": finished_at,
             "last_status": "timeout",
+            "terminal_reason": "review-hang past wall-clock cap",
         })
         return 1
-    if status == "failed":
-        print(f"✗ job {job_id} failed: {raw[:200]}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "last_review_id": job_id,
+
+    # Decide whether stdout is parseable. Don't normalize if it doesn't look
+    # like the JSON envelope — that previously masked codex errors by writing
+    # an empty round-log marked "reviewed".
+    stdout_looks_jsonish = stdout.strip().startswith("{")
+
+    if rc != 0:
+        if not stdout_looks_jsonish:
+            print(f"✗ codex review failed (rc={rc}): {stderr[:500]}", file=sys.stderr)
+            update_manifest_entry(manifest_path, args.branch, {
+                "last_review_at": finished_at,
+                "last_status": "failed",
+            })
+            return 2
+        # Some Codex paths exit non-zero even on usable JSON output; try to parse
+        print(f"⚠  codex review exited rc={rc}; stdout looks JSON-ish, attempting to parse", file=sys.stderr)
+
+    if not stdout_looks_jsonish:
+        # rc was 0 but stdout isn't a JSON envelope — degenerate path; surface
+        # the failure rather than write a stub round-log.
+        print(f"✗ codex review returned rc=0 but stdout is not a JSON envelope (first 200 chars: {stdout[:200]!r})", file=sys.stderr)
+        update_manifest_entry(manifest_path, args.branch, {
             "last_review_at": finished_at,
             "last_status": "failed",
+            "last_error": "stdout-not-json",
         })
         return 2
 
-    # status == "completed"
-    review = normalize_review(raw, job_id, args.branch, head, started_at, finished_at)
-    round_n = get_round_for_branch(args.manifest, args.branch) + 1
-    log_path = os.path.join(args.rounds_dir, f"{slug(args.branch)}.{round_n:02d}.json")
+    review = normalize_review(stdout, args.branch, head, started_at, finished_at)
+    round_n = get_round_for_branch(manifest_path, args.branch) + 1
+
+    if args.output:
+        log_path = args.output
+    else:
+        log_path = os.path.join(rounds_dir, f"{slug(args.branch)}.{round_n:02d}.json")
+
     atomic_write(log_path, json.dumps(review, indent=2))
-    print(f"  ✓ round log written: {log_path}")
+    print(f"  ✓ round log written: {log_path} (items={len(review['items'])})")
 
     history_entry = {
         "round": round_n,
-        "review_id": job_id,
+        "review_id": review["review_id"],
         "completed_at": finished_at,
+        "items_found": len(review["items"]),
     }
-    update_manifest_entry(args.manifest, args.branch, {
-        "last_review_id": job_id,
+    manifest_updated = update_manifest_entry(manifest_path, args.branch, {
+        "last_review_id": review["review_id"],
         "last_review_at": finished_at,
         "last_status": "reviewed",
         "rounds": round_n,
         "head_sha_current": head,
     }, history_entry=history_entry)
-    print(f"  ✓ manifest updated: rounds={round_n}")
+    if manifest_updated:
+        print(f"  ✓ manifest updated: rounds={round_n}")
+    else:
+        # Round-log is on disk; manifest didn't update. Common cause: --branch
+        # mistyped, or manifest doesn't have a branches[] entry for this branch.
+        # Don't claim success — surface so caller doesn't double-write rounds.
+        print(f"⚠  round-log written but manifest entry for branch '{args.branch}' "
+              f"not found at {manifest_path} (round counter not incremented)", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.md
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.md
@@ -1,144 +1,153 @@
 # trigger-codex-rescue.py
 
-Phase 6 entry point. After `open-comprehensive-pr.py` (or the PR-Creator sub-agent) opens a PR, this script triggers Codex rescue against it. Codex rescue is **Codex's own background sub-agent**, not a Claude Agent we dispatch — we hand it the PR link, and Codex's infrastructure spawns the review job.
+Phase 6 entry point. After the PR-Creator sub-agent opens a PR, this wrapper queues a Codex rescue review against it via `node codex-companion.mjs task --background --write --fresh --model gpt-5.5 --effort xhigh --prompt-file <path> --json` — the same code path the `/codex:resc` slash command runs internally. Codex's `task --background` returns `{ jobId, status: "queued", title, logFile }` immediately; the rescue review continues in a detached worker and lands on the PR like any other reviewer's comments.
+
+This is the **programmatic-loop equivalent** of `/codex:resc` for cases where main agent is dispatching rescues across N PRs in parallel and typing N slash commands is awkward. Both paths are first-class.
 
 ## Usage
 
 ```bash
-python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo
-python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo --model gpt-5.5 --effort xhigh
-python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo --dry-run
+# Default: queue rescue, write rescue_review_id + rescue_started_at to manifest, return.
+python3 scripts/trigger-codex-rescue.py \
+    --pr 42 --branch feat/foo \
+    --worktree /Users/.../wt-feat-foo \
+    --prompt-file /tmp/rescue-prompt-pr-42.md
+
+# Pipe the prompt on stdin instead of a file
+cat prompt.md | python3 scripts/trigger-codex-rescue.py \
+    --pr 42 --branch feat/foo --worktree /path/to/wt
+
+# Block until the rescue job terminates (max 30 min)
+python3 scripts/trigger-codex-rescue.py \
+    --pr 42 --branch feat/foo --worktree /path \
+    --prompt-file /tmp/p.md --wait --timeout-ms 1800000
+
+# Dry-run prints the resolved codex-companion.mjs path + the planned invocation
+python3 scripts/trigger-codex-rescue.py --pr 42 --branch feat/foo --worktree /path --dry-run
 ```
 
 ## Behavior
 
-1. Read the manifest entry for `<branch>` to get `worktree_path`.
-2. Inside that worktree, invoke the codex rescue CLI:
+1. Read the rescue prompt (from `--prompt-file` or stdin). Persist to `/tmp/codex-rescue-prompt-pr-<n>.md`.
+2. Discover `codex-companion.mjs` (env-var first, then `~/.claude/plugins/cache/openai-codex/codex/<latest>/`).
+3. From inside `<worktree>`, invoke:
+   ```bash
+   node codex-companion.mjs task \
+        --background --write --fresh \
+        --model <m> --effort <e> \
+        --prompt-file /tmp/codex-rescue-prompt-pr-<n>.md --json
    ```
-   codex review --rescue --background --fresh --model <m> --effort <e> --pr <n>
-   ```
-3. Capture the rescue job id from stdout (regex patterns; fallback to synthetic).
-4. Update the manifest entry with:
-   - `rescue_review_id` — the job id
-   - `rescue_started_at` — UTC ISO timestamp
-   - `rescue_status` — `"running"` (later updated to `"completed"` / `"timeout"` / `"failed"` by `await-pr-reviews.py`)
-   - `rescue_pr_number` — for cross-reference
-   - `rescue_model` — for audit
-   - `rescue_effort` — for audit
-5. Return immediately. **Does not poll.** Phase 6's `await-pr-reviews.py` owns the wait.
+   `task --background` honors the flag (unlike `review`, which always runs synchronously). Returns immediately with the queued-job descriptor.
+4. Parse `{ jobId, status: "queued", title, logFile }` from stdout.
+5. Update the manifest entry's `rescue_review_id`, `rescue_started_at`, `rescue_status: "running"`, plus audit fields (`rescue_pr_number`, `rescue_model`, `rescue_effort`, `rescue_title`, `rescue_log_file`).
+6. If `--wait`: poll `node codex-companion.mjs status <job-id> --wait --timeout-ms <n> --json` until terminal. Update `rescue_status` (`completed | failed | cancelled`), `rescue_finished_at`, `rescue_phase`, `rescue_elapsed`.
+7. Else: return immediately. Phase 6's `await-pr-reviews.py` (the comment-poller Monitor) handles the wait via PR comments.
 
 ## Flags
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--pr <n>` | required | PR number to review. |
+| `--pr <n>` | required | PR number. |
 | `--branch <b>` | required | Branch name (manifest entry key). |
-| `--manifest <path>` | `/tmp/codex-review-manifest.json` | Manifest to update. |
-| `--model <m>` | `gpt-5.5` | Codex model (per the user's spec). |
-| `--effort <e>` | `xhigh` | Codex effort level (per the user's spec). |
+| `--worktree <path>` | required | Worktree directory; codex runs from here. |
+| `--prompt-file <path>` | (stdin) | Comprehensive review prompt for Codex. If absent, reads stdin. |
+| `--manifest <path>` | `<repo-root>/.codex-review-manifest.json` | Manifest to update. Defaults repo-local. |
+| `--model <m>` | `gpt-5.5` | Codex reasoning model. |
+| `--effort <e>` | `xhigh` | Codex effort: `none\|minimal\|low\|medium\|high\|xhigh`. |
+| `--wait` | off | Block on `status --wait` until terminal. |
+| `--timeout-ms <n>` | `1800000` (30 min) | Total wall-clock cap when `--wait` is set. |
 | `--dry-run` | off | Print the plan; no invocation, no manifest write. |
 
 ## Exit codes
 
 | Code | Meaning |
 |---|---|
-| `0` | Rescue triggered; job id parsed; manifest updated. |
-| `1` | Rescue triggered but no job id parseable from output; synthetic id used; manifest still updated. Caller may proceed but should be aware. |
-| `2` | Codex CLI not found OR codex returned a hard error. Manifest marked `rescue_status: "failed"`. |
+| `0` | Rescue queued (and completed if `--wait`); manifest updated. |
+| `1` | `--wait` set but the job timed out before terminal status. |
+| `2` | Queue failed (codex error, unparseable response, manifest error). |
+| `127` | Codex plugin not installed. Surface to user. |
 
-## Adjustment point — codex rescue CLI form
+## Plugin discovery
 
-The script tries (in order) these forms:
+Same logic as `run-codex-review.py`:
 
-```python
-candidates = [
-    ["codex", "review", "--rescue", "--background", "--fresh",
-     "--model", model, "--effort", effort, "--pr", str(pr)],
-    ["codex", "rescue", "--background", "--fresh",
-     "--model", model, "--effort", effort, "--pr", str(pr)],
-    ["codex", "resc", "--background", "--fresh",
-     "--model", model, "--effort", effort, "--pr", str(pr)],
-]
-```
+1. **`${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs`** if the env var is set.
+2. **Latest semver-sorted version** under `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs`.
+3. Else exit 127 with install instructions pointing at https://github.com/openai/codex-plugin-cc.
 
-If your installation uses a different form (e.g. `claude codex resc`, `cdx-rescue`, etc.), edit `invoke_rescue()`'s `candidates` list. The script picks the first form that doesn't return rc=127 (command not found).
-
-## Job-id parsing
-
-The script tries these regex patterns on launch stdout (case-insensitive):
-
-```
-\brescue[- ]?job[- ]?id[:=]\s*([A-Za-z0-9_-]+)
-\b(cdx[- ]?rescue[- ]?[A-Za-z0-9_-]+)
-\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)
-\bbackground job[:=]\s*([A-Za-z0-9_-]+)
-```
-
-If none match, a synthetic id `cdx-rescue-unknown-<unix-ts>` is generated and a warning is printed (exit 1, not 0). The synthetic id is still recorded so subsequent scripts can correlate.
+The discovery function is inlined in the script (one duplication is fine; not a shared module).
 
 ## Why these defaults
 
-- **`--background`** is non-negotiable (per the skill's invariant). Inline mode would block the agent.
-- **`--fresh`** clears prior session bias. The rescue is a last check; we want it cold.
-- **`--model gpt-5.5`** is the strongest reasoning model available; appropriate for a one-shot rescue.
-- **`--effort xhigh`** spends more compute. Acceptable here because rescue is one-shot per PR (not 20 rounds).
+- **`--background`** is non-negotiable — `task --background` returns immediately with a job id; without it main agent would block for the entire rescue duration (1–5 minutes per PR × N PRs serially).
+- **`--write`** lets Codex post the rescue review back to the PR as a comment.
+- **`--fresh`** clears prior session bias. The rescue is a last check; we want Codex evaluating the PR cold.
+- **`--model gpt-5.5`** is the strongest reasoning model available.
+- **`--effort xhigh`** spends more compute. Acceptable because rescue is one-shot per PR (not 20 rounds).
+
+## Polling pattern (`--wait` mode)
+
+```bash
+node codex-companion.mjs status <job-id> --wait --timeout-ms 1800000 --json
+```
+
+Returns `{ workspaceRoot, job: { id, status, phase, title, summary, logFile, startedAt, completedAt, updatedAt, elapsed, duration, progressPreview, kindLabel } }` when the job reaches a terminal status (`completed`, `failed`, `cancelled`) or when the timeout expires (job stays `running`/`queued`).
 
 ## When to run
 
 - **Phase 6**, immediately after the PR-Creator sub-agent reports the PR number/URL.
 - One invocation per PR; do not invoke twice for the same PR.
+- Without `--wait`: returns in <2s; the comment-poller Monitor (`await-pr-reviews.py` or inlined Monitor command) catches the rescue review when it lands on the PR.
+- With `--wait`: blocks for up to `--timeout-ms`. Use only when main agent has nothing else to do.
 
-## Safety
-
-- Read-only on git state (no commits, no pushes).
-- Writes to manifest only — atomic write via `tempfile + os.replace`.
-- Never invokes a Claude Agent — Codex rescue is Codex's own sub-agent, separate process.
-
-## Sample output (success)
+## Sample output (success, no `--wait`)
 
 ```
-triggering codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
-  ✓ rescue triggered: job id = cdx-rescue-7f8a9c12
-  ✓ manifest updated: /tmp/codex-review-manifest.json
+queueing codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
+  ✓ queued: jobId=task-1714138200-abc123 status=queued
+    logFile: /Users/.../codex-companion/state/jobs/task-1714138200-abc123.log
+  ✓ manifest updated: /Users/.../repo/.codex-review-manifest.json
 ```
 
-## Sample output (parse failure but trigger succeeded)
+## Sample output (success, with `--wait`)
 
 ```
-triggering codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
-⚠  no recognizable rescue job id in launch output; using synthetic: cdx-rescue-unknown-1714138200
-  ✓ rescue triggered: job id = cdx-rescue-unknown-1714138200
-  ✓ manifest updated: /tmp/codex-review-manifest.json
+queueing codex rescue: PR #42 in /Users/.../wt-feat-foo (gpt-5.5, effort=xhigh)...
+  ✓ queued: jobId=task-1714138200-abc123 status=queued
+    logFile: /Users/.../codex-companion/state/jobs/task-1714138200-abc123.log
+  ✓ manifest updated: /Users/.../repo/.codex-review-manifest.json
+  waiting up to 1800s for rescue to finish...
+  ✓ rescue completed (jobId=task-1714138200-abc123)
 ```
 
-(exit 1 — caller should treat the rescue as triggered but log the parse issue)
-
-## Sample output (codex not installed)
+## Sample output (plugin missing)
 
 ```
-✗ codex CLI not found: command not found: codex
+codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin
+(https://github.com/openai/codex-plugin-cc) — expected at ...
 ```
 
-(exit 2 — manifest marked `rescue_status: "failed"` with the error)
+(exit 127; manifest `rescue_status: "failed"`, `rescue_error: "codex plugin unavailable"`)
 
 ## Failure modes
 
 | Failure | Wrapper behavior | Caller (Phase 6) action |
 |---|---|---|
-| codex CLI not on PATH | Exit 2; manifest `rescue_status: failed` | Skip rescue stream; await-pr-reviews.py will see no rescue items. |
-| Codex hard error (network, auth) | Exit 2; manifest `rescue_status: failed` with error text | Same as above. |
-| Job id parse failure | Exit 1; synthetic id; manifest `rescue_status: running` | Proceed; await-pr-reviews.py polls based on PR comments, not job id. |
-| Worktree missing | Exit 2; manifest unchanged | Spawn-review-worktrees may have been bypassed; surface for human. |
+| Plugin not installed | Exit 127; `rescue_status: "failed"`, `rescue_error: "codex plugin unavailable"` | Surface to user; install plugin. |
+| `task --background` rejected by Codex (auth, network) | Exit 2; `rescue_status: "failed"`, error in manifest | Skip rescue stream; await-pr-reviews.py sees no rescue items. |
+| Queue response unparseable | Exit 2; `rescue_status: "failed"`, `rescue_error: "unparseable queue response"` | Same. |
+| `--wait` timeout (job still running) | Exit 1; manifest `rescue_status` reflects current state (likely `queued` or `running`) | Caller polls `status` later, or treats rescue as in-flight and proceeds. |
+| Worktree missing | Exit 2 with stderr; no manifest update | Spawn-review-worktrees may have been bypassed; surface for human. |
+| Rescue completes with `failed` or `cancelled` | Exit 2; manifest reflects status | Surface for human. |
 
 ## Read/write surface
 
-- **Reads**: manifest (initial), worktree path (verifies dir exists), codex CLI stdout/stderr.
-- **Writes**: manifest entry for `<branch>` (atomic).
-- **Does NOT**: commit, push, modify the worktree, comment on the PR, or dispatch any Claude Agent.
+- **Reads**: rescue prompt (file or stdin), manifest (initial), worktree directory, codex-companion stdout/stderr.
+- **Writes**: `/tmp/codex-rescue-prompt-pr-<n>.md` (the prompt persistance), manifest entry for `<branch>` (atomic via `tempfile + os.replace`).
+- **Does NOT**: commit, push, modify the worktree, comment on the PR (Codex itself does that via `--write`), or dispatch any Claude Agent.
 
-## Extending
+## See also
 
-- Replace `invoke_rescue()`'s `candidates` with your codex CLI form.
-- Replace `parse_rescue_job_id()`'s patterns with your codex output convention.
-- Add a `--policy <path>` flag if your codex rescue accepts a policy file (e.g. severity tuning).
-- Add a `--prompt <text>` flag to inject extra guidance into the rescue's prompt context (if codex supports it).
+- `scripts/run-codex-review.py` — the Phase 3 sibling that wraps `codex-companion.mjs review` (synchronous; for per-round inner-loop reviews).
+- `scripts/await-pr-reviews.py` — the Phase 6 sibling that polls PR comments and waits for the rescue review (and external bots) to land.
+- `references/post-pr-review-protocol.md` — full Phase 6 / 7 / 8 flow.

--- a/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.py
+++ b/skills/run-codex-review/skills/run-codex-review/scripts/trigger-codex-rescue.py
@@ -1,44 +1,98 @@
 #!/usr/bin/env python3
-"""Trigger /codex:resc --background --fresh --model gpt-5.5 --effort xhigh on a PR.
+"""Trigger codex rescue for a PR via the OpenAI Codex Claude Code plugin.
 
-Codex rescue is Codex's own background sub-agent (not a Claude Agent dispatched
-by us). We hand it the PR link; Codex's infrastructure spawns the review job;
-the review lands on the PR like any other reviewer's comments.
-
-This script invokes the codex CLI's rescue form, captures the rescue job id,
-and updates the manifest entry for the branch with rescue_review_id /
-rescue_started_at. Returns immediately — does not poll. Phase 6's
-await-pr-reviews.py owns the wait.
+Wraps `node codex-companion.mjs task --background --write --fresh
+--model gpt-5.5 --effort xhigh --prompt-file <path> --json` — the same
+code path the `/codex:resc` slash command runs internally. The companion's
+`task --background` is the one subcommand that actually honors `--background`:
+it spawns a detached Codex worker and returns
+`{ jobId, status: "queued", title, logFile }` immediately. Phase 6's
+`await-pr-reviews.py` (or this script's `--wait` flag) owns the wait.
 
 Usage:
-    python3 trigger-codex-rescue.py --pr 42 --branch feat/foo
-    python3 trigger-codex-rescue.py --pr 42 --branch feat/foo --dry-run
-    python3 trigger-codex-rescue.py --pr 42 --branch feat/foo \\
-        --model gpt-5.5 --effort xhigh
+    # Default: queue rescue, write rescue_review_id + rescue_started_at to manifest, return.
+    python3 trigger-codex-rescue.py \\
+        --pr 42 --branch feat/foo \\
+        --worktree /path/to/wt \\
+        --prompt-file /tmp/rescue-prompt-pr-42.md
+
+    # If main agent has the prompt in stdin:
+    cat prompt.md | python3 trigger-codex-rescue.py \\
+        --pr 42 --branch feat/foo --worktree /path/to/wt
+
+    # Block until the rescue job completes (default cap 30 min):
+    python3 trigger-codex-rescue.py \\
+        --pr 42 --branch feat/foo --worktree /path/to/wt \\
+        --prompt-file /tmp/p.md --wait --timeout-ms 1800000
+
+    # Optional: write to a non-default manifest:
+    python3 trigger-codex-rescue.py ... --manifest /repo/.codex-review-manifest.json
 
 Exit codes:
-    0  rescue triggered; manifest updated
-    1  triggered but couldn't parse a job id (synthetic id used; manifest still updated)
-    2  codex CLI failed; manifest marked rescue_status=failed
+    0  rescue queued (and completed if --wait); manifest updated
+    1  --wait specified but the job timed out before terminal status
+    2  rescue queue failed (codex CLI error, manifest update failed)
+  127  codex plugin not installed (caller surfaces FAILED)
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
 import subprocess
 import sys
 import tempfile
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-DEFAULT_MANIFEST = "/tmp/codex-review-manifest.json"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_EFFORT = "xhigh"
+DEFAULT_TIMEOUT_MS = 1_800_000  # 30 min — matches Phase 6 total cap
 
+
+# ─── codex-companion.mjs discovery (version-agnostic) ─────────────────────────
+# (Same shape as run-codex-review.py — duplicated by design; one shared helper
+# for two callers was overengineering and would force sys.path hacks.)
+
+def _find_codex_companion() -> Path:
+    """Discover the OpenAI Codex plugin's codex-companion.mjs.
+
+    Resolution order:
+      1. ${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs (set by Claude Code harness).
+      2. Latest semver-sorted version under
+         ~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs.
+
+    Plugin source: https://github.com/openai/codex-plugin-cc/tree/main/plugins/codex
+    """
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidate = Path(plugin_root) / "scripts" / "codex-companion.mjs"
+        if candidate.is_file():
+            return candidate
+
+    cache = Path.home() / ".claude" / "plugins" / "cache" / "openai-codex" / "codex"
+    if cache.is_dir():
+        def _key(p: Path) -> tuple:
+            m = re.match(r"^(\d+)\.(\d+)\.(\d+)", p.name)
+            return (1, int(m[1]), int(m[2]), int(m[3])) if m else (0, p.name)
+        for v in sorted((p for p in cache.iterdir() if p.is_dir()), key=_key, reverse=True):
+            candidate = v / "scripts" / "codex-companion.mjs"
+            if candidate.is_file():
+                return candidate
+
+    raise FileNotFoundError(
+        "codex-companion.mjs not found. Install the OpenAI Codex Claude Code plugin "
+        "(https://github.com/openai/codex-plugin-cc) — expected at "
+        "$CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs or at "
+        "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs."
+    )
+
+
+# ─── Generic helpers ──────────────────────────────────────────────────────────
 
 def sh(cmd, cwd=None, timeout=None):
     try:
@@ -81,137 +135,300 @@ def load_manifest(path: str) -> dict | None:
         return None
 
 
-def update_manifest_entry(path: str, branch: str, updates: dict) -> bool:
-    manifest = load_manifest(path)
-    if manifest is None:
-        return False
-    found = False
-    for entry in manifest.get("branches", []):
-        if entry.get("branch") == branch:
-            entry.update(updates)
-            entry["updated_at"] = utc_now_iso()
-            found = True
-            break
-    if not found:
-        return False
-    atomic_write(path, json.dumps(manifest, indent=2))
-    return True
-
-
-# ─── Codex rescue invocation — adjustment point per environment ──────────────
-
-def invoke_rescue(pr: int, model: str, effort: str, wt: Path) -> tuple[int, str, str]:
-    """Launch codex rescue in --background mode. Return (rc, stdout, stderr).
-
-    Adjust the command form here to match the codex CLI in your environment.
-    Common forms (try in order):
-      - codex review --rescue --background --fresh --model <m> --effort <e> --pr <n>
-      - codex rescue --background --fresh --model <m> --effort <e> --pr <n>
-      - codex resc --background --fresh --model <m> --effort <e> --pr <n>
+@contextlib.contextmanager
+def _manifest_lock(manifest_path: str):
+    """fcntl.LOCK_EX around manifest read-modify-write. Required because
+    Phase 6 queues N parallel rescues that all touch the same manifest;
+    without the lock, simultaneous writers clobber each other and lose
+    updates. Mirrors the recipe in parallel-subagent-protocol.md.
     """
-    candidates = [
-        ["codex", "review", "--rescue", "--background", "--fresh",
-         "--model", model, "--effort", effort, "--pr", str(pr)],
-        ["codex", "rescue", "--background", "--fresh",
-         "--model", model, "--effort", effort, "--pr", str(pr)],
-        ["codex", "resc", "--background", "--fresh",
-         "--model", model, "--effort", effort, "--pr", str(pr)],
-    ]
-    for cmd in candidates:
-        rc, out, err = sh(cmd, cwd=wt, timeout=120)
-        if rc != 127:  # found the binary, even if it failed for other reasons
-            return rc, out, err
-    return 127, "", "no codex rescue CLI form succeeded; check codex install / PATH"
+    lock_path = manifest_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    with open(lock_path, "w") as lock_fp:
+        fcntl.flock(lock_fp, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fp, fcntl.LOCK_UN)
 
 
-def parse_rescue_job_id(stdout: str) -> str | None:
-    """Extract a rescue job id from launch stdout. Adjust regex per CLI output."""
-    patterns = [
-        r"\brescue[- ]?job[- ]?id[:=]\s*([A-Za-z0-9_-]+)",
-        r"\b(cdx[- ]?rescue[- ]?[A-Za-z0-9_-]+)",
-        r"\bjob[- ]?id[:=]\s*([A-Za-z0-9_-]+)",
-        r"\bbackground job[:=]\s*([A-Za-z0-9_-]+)",
+def update_manifest_entry(path: str, branch: str, updates: dict) -> bool:
+    """Lock-safe read-modify-write. Returns True iff a matching branch entry
+    was found and updated. Caller must check the return value."""
+    with _manifest_lock(path):
+        manifest = load_manifest(path)
+        if manifest is None:
+            return False
+        found = False
+        for entry in manifest.get("branches", []):
+            if entry.get("branch") == branch:
+                entry.update(updates)
+                entry["updated_at"] = utc_now_iso()
+                found = True
+                break
+        if not found:
+            return False
+        atomic_write(path, json.dumps(manifest, indent=2))
+        return True
+
+
+def repo_local_default(wt: Path, name: str) -> str:
+    rc, out, _ = sh(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=wt)
+    if rc == 0 and out:
+        return str(Path(out).parent / name)
+    return f"/tmp/{name}"
+
+
+# ─── Codex rescue invocation ─────────────────────────────────────────────────
+
+def write_prompt_file(prompt: str, pr: int) -> Path:
+    """Persist the rescue prompt to a stable path so codex-companion can read it.
+    Returns the path. /tmp is fine for the prompt — it's input, not state."""
+    path = Path(f"/tmp/codex-rescue-prompt-pr-{pr}.md")
+    path.write_text(prompt)
+    return path
+
+
+def invoke_rescue(pr: int, model: str, effort: str, prompt_file: Path,
+                  wt: Path, timeout: int = 120) -> tuple[int, str, str]:
+    """Spawn codex-companion task --background. Returns (rc, stdout, stderr).
+
+    The companion's `task` subcommand DOES honor --background — unlike `review`,
+    which runs synchronously regardless. Background returns
+    `{ jobId, status: "queued", title, logFile }` on stdout immediately.
+    """
+    try:
+        companion = _find_codex_companion()
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+
+    cmd = [
+        "node", str(companion), "task",
+        "--background",
+        "--write",
+        "--fresh",
+        "--model", model,
+        "--effort", effort,
+        "--prompt-file", str(prompt_file),
+        "--json",
     ]
-    for pat in patterns:
-        m = re.search(pat, stdout, flags=re.IGNORECASE)
-        if m:
-            return m.group(1)
-    return None
+    return sh(cmd, cwd=wt, timeout=timeout)
+
+
+def wait_for_rescue(job_id: str, wt: Path, timeout_ms: int) -> tuple[int, dict | None, str]:
+    """Poll codex-companion status <job-id> --wait until terminal.
+
+    Returns (rc, parsed_status_payload, stderr).
+    """
+    try:
+        companion = _find_codex_companion()
+    except FileNotFoundError as e:
+        return 127, None, str(e)
+
+    cmd = [
+        "node", str(companion), "status", job_id,
+        "--wait",
+        "--timeout-ms", str(timeout_ms),
+        "--json",
+    ]
+    rc, out, err = sh(cmd, cwd=wt, timeout=(timeout_ms / 1000) + 60)
+    if rc != 0:
+        return rc, None, err or out
+    try:
+        return rc, json.loads(out), err
+    except (ValueError, TypeError):
+        return rc, None, f"could not parse status JSON: {out[:500]}"
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def read_prompt(args) -> str:
+    if args.prompt_file:
+        return Path(args.prompt_file).read_text()
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise SystemExit("provide --prompt-file <path> or pipe the prompt on stdin")
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--pr", type=int, required=True, help="PR number")
     ap.add_argument("--branch", required=True, help="branch name (manifest entry key)")
-    ap.add_argument("--manifest", default=DEFAULT_MANIFEST)
+    ap.add_argument("--worktree", required=True, help="worktree path; codex runs from here")
+    ap.add_argument("--prompt-file",
+                    help="Path to the comprehensive review prompt for Codex. If absent, reads stdin.")
+    ap.add_argument("--manifest",
+                    help="Manifest path. Default: <repo-root>/.codex-review-manifest.json")
     ap.add_argument("--model", default=DEFAULT_MODEL)
-    ap.add_argument("--effort", default=DEFAULT_EFFORT)
+    ap.add_argument("--effort", default=DEFAULT_EFFORT,
+                    help="Codex reasoning effort: none|minimal|low|medium|high|xhigh")
+    ap.add_argument("--wait", action="store_true",
+                    help="Block until the rescue job terminates (status ∈ completed|failed|cancelled). "
+                         "Default: queue and return immediately.")
+    ap.add_argument("--timeout-ms", type=int, default=DEFAULT_TIMEOUT_MS,
+                    help=f"Total wall-clock cap when --wait is set. Default {DEFAULT_TIMEOUT_MS} ms (30 min).")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
-    manifest = load_manifest(args.manifest)
-    if manifest is None:
-        print(f"manifest absent or unreadable: {args.manifest}", file=sys.stderr)
-        return 2
-
-    entry = next((e for e in manifest.get("branches", []) if e.get("branch") == args.branch), None)
-    if entry is None:
-        print(f"branch {args.branch} not in manifest", file=sys.stderr)
-        return 2
-
-    wt = Path(entry.get("worktree_path", ""))
+    wt = Path(args.worktree)
     if not wt.is_dir():
         print(f"worktree not found: {wt}", file=sys.stderr)
         return 2
 
+    manifest_path = args.manifest or repo_local_default(wt, ".codex-review-manifest.json")
+
     if args.dry_run:
-        print(f"DRY-RUN: would invoke codex rescue for PR #{args.pr} in {wt}")
-        print(f"  branch: {args.branch}")
-        print(f"  model:  {args.model}")
-        print(f"  effort: {args.effort}")
-        print(f"  manifest entry would be updated with rescue_review_id (synthetic if no parse)")
+        try:
+            companion = _find_codex_companion()
+        except FileNotFoundError as e:
+            print(f"DRY-RUN: {e}", file=sys.stderr)
+            return 127
+        print(f"DRY-RUN: would invoke")
+        print(f"  node {companion} task --background --write --fresh "
+              f"--model {args.model} --effort {args.effort} --prompt-file <prompt> --json")
+        print(f"  cwd:        {wt}")
+        print(f"  PR:         #{args.pr}")
+        print(f"  branch:     {args.branch}")
+        print(f"  manifest:   {manifest_path}")
+        print(f"  wait:       {args.wait}")
+        if args.wait:
+            print(f"  timeout-ms: {args.timeout_ms}")
         return 0
 
-    print(f"triggering codex rescue: PR #{args.pr} in {wt} ({args.model}, effort={args.effort})...")
+    # Read the rescue prompt (file or stdin) and persist to /tmp so codex-companion
+    # can --prompt-file it. Multiline content survives this round-trip.
+    prompt = read_prompt(args)
+    if not prompt.strip():
+        print("rescue prompt is empty; aborting", file=sys.stderr)
+        return 2
+    prompt_path = write_prompt_file(prompt, args.pr)
+
+    # Pre-resolve the companion path so rc=127 from invoke_rescue can be
+    # attributed to a missing `node` binary, not a missing plugin.
+    try:
+        _find_codex_companion()
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 127
+
+    # Manifest is optional — if absent, we still queue the rescue but skip the update.
+    manifest_present = load_manifest(manifest_path) is not None
+    if not manifest_present:
+        print(f"⚠  manifest not found at {manifest_path}; rescue will queue but no manifest update", file=sys.stderr)
+
     started_at = utc_now_iso()
-    rc, out, err = invoke_rescue(args.pr, args.model, args.effort, wt)
+    print(f"queueing codex rescue: PR #{args.pr} in {wt} ({args.model}, effort={args.effort})...")
+    rc, out, err = invoke_rescue(args.pr, args.model, args.effort, prompt_path, wt)
 
     if rc == 127:
-        print(f"✗ codex CLI not found: {err}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "rescue_status": "failed",
-            "rescue_error": "codex CLI not on PATH",
-            "rescue_started_at": started_at,
-        })
+        # Plugin path was already verified above — so 127 here means `node` is missing
+        print(f"✗ `node` not on PATH (codex-companion.mjs requires Node.js): {err[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": "node not on PATH",
+                "rescue_started_at": started_at,
+            })
+        return 127
+
+    if rc != 0:
+        print(f"✗ codex task --background failed (rc={rc}): {err[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": (err or out)[:500],
+                "rescue_started_at": started_at,
+            })
         return 2
 
-    if rc not in (0, 1):  # 0 = ok, 1 sometimes used for "submitted with warnings"
-        print(f"✗ codex rescue failed (rc={rc}): {err}", file=sys.stderr)
-        update_manifest_entry(args.manifest, args.branch, {
-            "rescue_status": "failed",
-            "rescue_error": (err or out)[:500],
-            "rescue_started_at": started_at,
-        })
+    # Parse the queued-job descriptor: { jobId, status: "queued", title, logFile, summary? }
+    try:
+        payload = json.loads(out)
+    except (ValueError, TypeError):
+        print(f"✗ could not parse codex queue response: {out[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": "unparseable queue response",
+                "rescue_started_at": started_at,
+            })
         return 2
 
-    job_id = parse_rescue_job_id(out) or parse_rescue_job_id(err)
-    parse_failure = False
+    job_id = payload.get("jobId") or ""
     if not job_id:
-        job_id = f"cdx-rescue-unknown-{int(time.time())}"
-        parse_failure = True
-        print(f"⚠  no recognizable rescue job id in launch output; using synthetic: {job_id}")
+        print(f"✗ no jobId in queue response: {payload}", file=sys.stderr)
+        return 2
 
-    update_manifest_entry(args.manifest, args.branch, {
-        "rescue_review_id": job_id,
-        "rescue_started_at": started_at,
-        "rescue_status": "running",
-        "rescue_pr_number": args.pr,
-        "rescue_model": args.model,
-        "rescue_effort": args.effort,
-    })
-    print(f"  ✓ rescue triggered: job id = {job_id}")
-    print(f"  ✓ manifest updated: {args.manifest}")
-    return 1 if parse_failure else 0
+    queued_status = payload.get("status", "queued")
+    title = payload.get("title", "")
+    log_file = payload.get("logFile", "")
+    print(f"  ✓ queued: jobId={job_id} status={queued_status}")
+    if log_file:
+        print(f"    logFile: {log_file}")
+
+    if manifest_present:
+        updated = update_manifest_entry(manifest_path, args.branch, {
+            "rescue_review_id": job_id,
+            "rescue_started_at": started_at,
+            "rescue_status": "running",
+            "rescue_pr_number": args.pr,
+            "rescue_model": args.model,
+            "rescue_effort": args.effort,
+            "rescue_title": title,
+            "rescue_log_file": log_file,
+        })
+        if updated:
+            print(f"  ✓ manifest updated: {manifest_path}")
+        else:
+            # Rescue is QUEUED on Codex's side but manifest didn't update.
+            # Common cause: --branch mistyped. Surface so caller can correlate.
+            print(f"⚠  rescue queued (jobId={job_id}) but manifest entry "
+                  f"for branch '{args.branch}' not found at {manifest_path}", file=sys.stderr)
+
+    if not args.wait:
+        return 0
+
+    # --wait: block on status --wait until terminal
+    print(f"  waiting up to {args.timeout_ms / 1000:.0f}s for rescue to finish...")
+    rc, status_payload, err = wait_for_rescue(job_id, wt, args.timeout_ms)
+    finished_at = utc_now_iso()
+
+    if rc == 127:
+        print(err, file=sys.stderr)
+        return 127
+    if rc != 0 or status_payload is None:
+        print(f"✗ status --wait failed: rc={rc}: {err[:500]}", file=sys.stderr)
+        if manifest_present:
+            update_manifest_entry(manifest_path, args.branch, {
+                "rescue_status": "failed",
+                "rescue_error": (err or "wait failed")[:500],
+                "rescue_finished_at": finished_at,
+            })
+        return 2
+
+    job = status_payload.get("job") or {}
+    final_status = job.get("status", "unknown")
+    if final_status == "completed":
+        print(f"  ✓ rescue completed (jobId={job_id})")
+    elif final_status in {"failed", "cancelled"}:
+        print(f"✗ rescue {final_status} (jobId={job_id})", file=sys.stderr)
+    else:
+        # Could be 'queued' or 'running' if status --wait timed out
+        print(f"⚠  rescue not terminal yet: status={final_status} (jobId={job_id})", file=sys.stderr)
+
+    if manifest_present:
+        update_manifest_entry(manifest_path, args.branch, {
+            "rescue_status": final_status,
+            "rescue_finished_at": finished_at,
+            "rescue_phase": job.get("phase", ""),
+            "rescue_elapsed": job.get("elapsed", ""),
+        })
+
+    if final_status == "completed":
+        return 0
+    if final_status in {"queued", "running"}:
+        return 1  # timed out before terminal
+    return 2  # failed or cancelled
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Restores the wrapper content that PR #56 was meant to land but didn't, due to a GitHub squash 3-way-merge edge case after PR #56 was retargeted from `revert/run-codex-review-pr53` to `main`.

## What went wrong
PR #56's recorded squash commit `79aa934` has zero file changes. After PR #55 (revert) merged and PR #56 was retargeted to `main`, GitHub's 3-way squash used the original (pre-revert) `main` as the merge base. From that base:
- "ours" had reverted all of #53's content
- "theirs" had only re-introduced the wrapper subset

The merge resolved to "ours" for those files and the squash landed empty — so wrappers (`codex-review-contract.md`, `run-codex-review.{md,py}`, `trigger-codex-rescue.{md,py}`) stayed at the pre-#53 background-polling form on `main`, even though PRs #57 and #58 layered on top assuming the wrappers were in place.

## What this PR does
Cherry-picks the original wrapper commit (`fbd62b0`) onto current `main`. After this lands, `main:skills/run-codex-review` matches the original PR #53 squash tree (`c7c64fc:skills/run-codex-review`) exactly — the equivalence goal stated in PR #58.

## Verification
- `git diff c7c64fc HEAD -- skills/run-codex-review` → empty
- `python3 scripts/validate-skills.py` → all 43 skills valid
- 5 files changed, +1013 / -460 (matches the original wrapper diff exactly)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Codex review/rescue wrappers and switches the skill to call the Claude Code plugin’s `codex-companion.mjs` directly. This re-syncs `skills/run-codex-review` with the intended PR #53 state and fixes failures introduced by the PR #56 squash.

- **New Features**
  - Review wrapper: invokes `node codex-companion.mjs review --json` synchronously with auto-discovery (`$CLAUDE_PLUGIN_ROOT` or `~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/`), adds `--mode adversarial`, regex-parses native output, and maps `P1–P4` to `critical|high|medium|low`.
  - Rescue wrapper: queues via `node codex-companion.mjs task --background --write --fresh --json`, parses `{ jobId, status }`, supports `--wait` via `status --wait --timeout-ms`, and reads the prompt from `--prompt-file` or stdin.
  - Reliability: repo-local defaults for manifest/rounds-dir, manifest updates with file locking, clearer exits (`127` plugin missing, `1` timeout), and round logs that include item counts.

- **Bug Fixes**
  - Restores wrapper content dropped by the PR #56 squash; the `skills/run-codex-review` tree now matches the original PR #53 squash.
  - Replaces fragile background-job polling for reviews with the plugin’s synchronous JSON output to prevent empty/incorrect round logs and misclassified results.

<sup>Written for commit e0472e0df0b171de4059673ef0e850ab01711e92. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/59?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

