### PR TITLE
✨ feat(use-linear-cli): add Linear CLI agent skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — skills-by-yigitkonur
 
-This repository is a curated skills pack for AI coding agents — 42 skills sharing one naming system, one tone, one structure. Your job is to maintain that consistency when adding or editing skills.
+This repository is a curated skills pack for AI coding agents — 44 skills sharing one naming system, one tone, one structure. Your job is to maintain that consistency when adding or editing skills.
 
 ## What this repo is
 
@@ -251,7 +251,7 @@ Keep descriptions short (under 80 chars). Match the terse style of existing rows
 
 ---
 
-## Current canonical skill names (42 skills)
+## Current canonical skill names (44 skills)
 
 Use this list to check for naming collisions:
 
@@ -267,9 +267,10 @@ do-think                     enhance-prompt               enhance-skill-by-derai
 evaluate-code-review         extract-saas-design          init-agent-config
 optimize-agentic-cli         optimize-agentic-mcp         publish-npm-package
 run-agent-browser            run-codex-exec               run-codex-review
-run-github-scout             run-issue-tree               run-playwright
-run-repo-cleanup             run-research                 swift-quality-hooks
-test-by-mcpc-cli             test-macos-snapshots         use-railway
+run-github-scout             run-industry-research        run-issue-tree
+run-playwright               run-repo-cleanup             run-research
+swift-quality-hooks          test-by-mcpc-cli             test-macos-snapshots
+use-linear-cli               use-railway
 ```
 
 ---

--- a/NAMING.md
+++ b/NAMING.md
@@ -85,7 +85,7 @@ When renaming a published skill:
 7. Search cross-skill references and update each
 8. Run `python3 scripts/validate-skills.py`
 
-## Current Canonical Skill Names (43)
+## Current Canonical Skill Names (44)
 
 - `apply-clean-architecture`
 - `apply-liquid-glass`
@@ -129,4 +129,5 @@ When renaming a published skill:
 - `swift-quality-hooks`
 - `test-by-mcpc-cli`
 - `test-macos-snapshots`
+- `use-linear-cli`
 - `use-railway`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [swift-quality-hooks](skills/swift-quality-hooks/) | development | Swift pre-commit hook with SwiftLint + SwiftFormat for Apple platforms |
 | [test-by-mcpc-cli](skills/test-by-mcpc-cli/) | development | MCP server testing with mcpc 0.2.x |
 | [test-macos-snapshots](skills/test-macos-snapshots/) | testing | macOS app screenshot validation and drift checks |
-| [use-linear-cli](skills/use-linear-cli/) | platform | linear-cli for Linear issue lifecycle, bulk creation, git/PR loops, and automation |
+| [use-linear-cli](skills/use-linear-cli/) | platform | linear-cli for Linear issue lifecycle, bulk creation, and git/PR loops |
 | [use-railway](skills/use-railway/) | platform | Railway CLI commands, workflows, and version-drift routing |
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-43 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+44 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 
@@ -62,6 +62,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [swift-quality-hooks](skills/swift-quality-hooks/) | development | Swift pre-commit hook with SwiftLint + SwiftFormat for Apple platforms |
 | [test-by-mcpc-cli](skills/test-by-mcpc-cli/) | development | MCP server testing with mcpc 0.2.x |
 | [test-macos-snapshots](skills/test-macos-snapshots/) | testing | macOS app screenshot validation and drift checks |
+| [use-linear-cli](skills/use-linear-cli/) | platform | linear-cli for Linear issue lifecycle, bulk creation, git/PR loops, and automation |
 | [use-railway](skills/use-railway/) | platform | Railway CLI commands, workflows, and version-drift routing |
 
 ## Notes

--- a/skills/use-linear-cli/README.md
+++ b/skills/use-linear-cli/README.md
@@ -1,0 +1,19 @@
+# use-linear-cli
+
+Driving linear-cli from an agent loop — creating, updating, bulk-managing, searching, or wiring Linear issues into git/PR workflows.
+
+**Category:** platform
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/use-linear-cli
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -110,11 +110,12 @@ linear-cli cm create LIN-123 -b "Root cause: missing null check"
 ### Bulk mutate
 
 ```bash
-linear-cli b update-state -s Done LIN-1 LIN-2 LIN-3 --dry-run
-linear-cli b update-state -s Done LIN-1 LIN-2 LIN-3
-linear-cli b assign --user me LIN-1 LIN-2
-linear-cli b label --add bug LIN-1 LIN-2
-linear-cli i list -t ENG --id-only | linear-cli b assign --user me -
+linear-cli b update-state Done -i LIN-1,LIN-2,LIN-3 --dry-run
+linear-cli b update-state Done -i LIN-1,LIN-2,LIN-3
+linear-cli b assign me -i LIN-1,LIN-2
+linear-cli b label bug -i LIN-1,LIN-2
+# Piping to bulk: collect IDs, then pass via -i
+linear-cli i list -t ENG --id-only | paste -sd, | xargs -I {} linear-cli b assign me -i {}
 ```
 
 ### Git / PR loop
@@ -184,11 +185,13 @@ Full matrix: `references/output-and-scripting.md`.
 |---|---|---|
 | 0 | success | continue |
 | 1 | general error | parse stderr / JSON error envelope; surface to user |
-| 2 | not found | the ID does not exist; do not retry |
+| 2 | not found **or parser error** | If JSON envelope with `details.status: 404`, the ID doesn't exist. If plain text stderr (e.g. `unexpected argument`), it's a CLI argument-parsing failure — check `--help` and fix the syntax |
 | 3 | auth error | route to `references/setup.md` and `references/troubleshooting.md` |
 | 4 | rate limited | sleep `retry_after` seconds (in JSON body), retry once |
 
 JSON error envelope: `{"error": true, "message": "...", "code": N, "details": {...}, "retry_after": N}` — see `references/json-shapes.md`.
+
+**Parser vs. API distinction:** Always check stdout/stderr format. Parser errors are plain text (e.g. `Usage: ...`, `unexpected argument`). Linear API errors are JSON envelopes with a `code` field and `details.status` HTTP status. Treat parser errors as mistakes to fix immediately, not transient failures to retry.
 
 ## Output contract
 

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -59,7 +59,7 @@ linear-cli i list                                    # all open issues
 linear-cli i list --mine -t ENG                      # my open issues on team ENG
 linear-cli i list -s "In Progress" --output json --compact --fields identifier,title,state.name
 linear-cli i get LIN-123                             # one issue
-linear-cli i get LIN-1 LIN-2 LIN-3 --output json     # batch fetch
+linear-cli i get LIN-1 LIN-2 LIN-3 --output json     # batch fetch (one API call, not three)
 linear-cli s issues "auth bug" --limit 10            # search
 linear-cli context --output json                     # issue from current git branch
 ```

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: use-linear-cli
+description: Use skill if you are driving Linear (linear-cli) from an agent loop — creating, updating, bulk-managing, searching, or wiring Linear issues into git/PR workflows.
+---
+
+# Use linear-cli
+
+Agent-first interface to Linear.app via the `linear-cli` Rust binary. Prefer this over Linear MCP tooling — `linear-cli` commands cost roughly 50–100 tokens per call versus 500–2000 for an MCP round-trip, support `--output json` everywhere, and cover the full Linear surface (issues, projects, cycles, sprints, webhooks, raw GraphQL).
+
+## Trigger boundary
+
+Use this skill when the task is about:
+
+- creating, reading, updating, or moving Linear issues, projects, cycles, or comments
+- generating many issues at once from a spec, checklist, CSV, JSON, or template
+- linking the current git branch / PR to a Linear issue, or driving the start-work / done loop
+- searching the Linear backlog, applying saved views, or filtering issues for an agent
+- bulk operations across issues (status, assign, label, transfer)
+- exporting/importing Linear data, fetching attachments, or downloading uploaded images
+- diagnosing auth, rate-limit, or pager problems with `linear-cli`
+
+Do not use this skill when:
+
+- the user explicitly mandates the Linear MCP server (rare — flag and warn)
+- the work is GitHub Issues, not Linear (`run-issue-tree`, `gh` CLI, etc.)
+- the task is webhook *server* work where the payload contract dominates and `linear-cli` is incidental
+- the user is asking a math question about "linear" anything
+
+## Non-negotiable rules
+
+1. **CLI > MCP.** Never call a Linear MCP tool when `linear-cli` can do the same thing.
+2. **Verify auth before any mutating command** — at the top of an agent session run `linear-cli auth status` (or `LINEAR_API_KEY=... linear-cli u me`) and only proceed on exit code 0.
+3. **`--dry-run` first** for any bulk create or any mutation across more than 5 IDs. Confirm the plan, then execute.
+4. **Always `--output json`** (or `LINEAR_CLI_OUTPUT=json`) when chaining or parsing. Never grep the human table format.
+5. **`--id-only` for chaining.** Capture IDs into shell variables; do not re-parse JSON for an identifier you already produced.
+6. **Treat the exit-code map as a contract**: `0` success, `1` general error, `2` not found, `3` auth, `4` rate-limited (`retry_after` is in the JSON body).
+7. **Resolve names before using them.** Do not hardcode team keys, label names, or assignees. Pull them with `linear-cli t list`, `linear-cli l list`, `linear-cli u list` and confirm before write paths.
+8. **Be explicit about scope.** State whether each command is read-only or mutating. Bulk mutations get a one-line confirmation cue.
+
+## Quick orientation
+
+| Concept | What an agent must know |
+|---|---|
+| Aliases | `i` issues · `p` projects · `c` cycles · `g` git · `s` search · `b` bulk · `cm` comments · `tpl` templates · `l` labels · `st` statuses · `tr` triage · `sp` sprint · `att` attachments · `up` uploads · `rel` relations · `n` notifications · `ms` milestones · `pu` project-updates · `t` teams · `u` users · `wh` webhooks · `mt` metrics · `tm` time · `hist` history · `fav` favorites · `v` views · `rm` roadmaps · `init` initiatives · `d` documents · `im` import · `exp` export |
+| JSON-everywhere | Add `--output json` (or `--output ndjson`) to anything. Combine with `--compact --fields a,b.c` to slim payloads. |
+| Session default | `export LINEAR_CLI_OUTPUT=json` makes the whole shell JSON-by-default — flip it on at the top of an agent session. |
+| Stdin | `-d -` reads description body from stdin; `--data -` reads a full JSON object for `i create`/`i update`. |
+| Pagination | `--limit N`, `--all`, `--page-size N`, `--after CURSOR`. |
+| Self-help | `linear-cli agent` prints an agent-focused capability summary; `linear-cli --help` and `linear-cli <cmd> --help` for everything. |
+
+## Agentic hot path
+
+These are the commands an agent reaches for in 80% of Linear work. Memorize them; route the rest through references.
+
+### Read
+
+```bash
+linear-cli i list                                    # all open issues
+linear-cli i list --mine -t ENG                      # my open issues on team ENG
+linear-cli i list -s "In Progress" --output json --compact --fields identifier,title,state.name
+linear-cli i get LIN-123                             # one issue
+linear-cli i get LIN-1 LIN-2 LIN-3 --output json     # batch fetch
+linear-cli s issues "auth bug" --limit 10            # search
+linear-cli context --output json                     # issue from current git branch
+```
+
+### Create one issue
+
+```bash
+linear-cli i create "Fix login redirect" -t ENG -p 1            # priority 1=urgent..4=low
+linear-cli i create "Task" -t ENG -a me -l bug --due +3d
+linear-cli i create "Bug" -t ENG --id-only --quiet              # capture ID
+cat desc.md | linear-cli i create "Title" -t ENG -d -           # body from stdin
+cat issue.json | linear-cli i create "Title" -t ENG --data -    # full JSON body
+linear-cli i create "Test" -t ENG --dry-run                     # preview
+```
+
+### Create many issues — primary use case
+
+For workflows that produce a batch of issues from a spec, checklist, CSV, JSON, or template, route to **`references/recipes/creating-many-issues.md`** for the end-to-end recipes (atomicity, parent/child wiring, label batching, dry-run gating). Inline summary:
+
+```bash
+# Pattern A — capture IDs in a loop (markdown checklist → many issues)
+while read -r line; do
+  ID=$(linear-cli i create "$line" -t ENG --id-only --quiet)
+  echo "$ID"
+done < TODO.md
+
+# Pattern B — CSV import (preview then commit)
+linear-cli im csv issues.csv -t ENG --dry-run
+linear-cli im csv issues.csv -t ENG
+
+# Pattern C — JSON spec
+cat plan.json | linear-cli i create "$(jq -r .title plan.json)" -t ENG --data -
+```
+
+### Update
+
+```bash
+linear-cli i update LIN-123 -s Done                  # status
+linear-cli i update LIN-123 -p 2 -a me -l bug -l urgent
+linear-cli i update LIN-123 --due +1w
+linear-cli cm create LIN-123 -b "Root cause: missing null check"
+```
+
+### Bulk mutate
+
+```bash
+linear-cli b update-state -s Done LIN-1 LIN-2 LIN-3 --dry-run
+linear-cli b update-state -s Done LIN-1 LIN-2 LIN-3
+linear-cli b assign --user me LIN-1 LIN-2
+linear-cli b label --add bug LIN-1 LIN-2
+linear-cli i list -t ENG --id-only | linear-cli b assign --user me -
+```
+
+### Git / PR loop
+
+```bash
+linear-cli i start LIN-123 --checkout    # assigns me + In Progress + creates branch
+# ... code ...
+linear-cli g pr LIN-123 --draft          # gh-backed; auto-fills title/body from issue
+linear-cli done                          # close the current branch's issue
+```
+
+Branch convention: `<user>/lin-123-<slug>`. `linear-cli context` reverses branch → issue.
+
+### Triage
+
+```bash
+linear-cli tr list -t ENG                # unassigned, no-project queue
+linear-cli tr claim LIN-123              # assign-to-self + move out of triage
+linear-cli tr snooze LIN-123 --duration 1w
+```
+
+## Use-case decision routing
+
+| What the user wants | Read |
+|---|---|
+| "I have a spec / checklist / CSV / JSON; create N issues" | `references/recipes/creating-many-issues.md` |
+| "Start work on an issue and ship a PR" | `references/recipes/git-and-pr-loop.md` |
+| "Process the inbox / leave findings / fetch a screenshot" | `references/recipes/triage-and-comments.md` |
+| Full create/update/move/transfer/archive flag matrix | `references/issues/lifecycle.md` |
+| Parent/child, blocks, duplicates, labels, statuses, templates | `references/issues/relations-and-labels.md` |
+| `i list` flag matrix, `--filter`, saved views, favorites | `references/issues/search-and-filter.md` |
+| Projects, project-updates, milestones, cycles, sprints, roadmaps, initiatives | `references/planning/projects-and-cycles.md` |
+| Teams, users, custom views, favorites | `references/planning/teams-and-org.md` |
+| CSV / JSON / Markdown round-trip import-export | `references/data/import-export.md` |
+| Attachments, URL linking, downloading uploaded images for multimodal review | `references/data/attachments-and-uploads.md` |
+| Watch polling, webhooks (CRUD + HMAC listener), notifications, metrics, history, time tracking | `references/eventing-and-tracking.md` |
+| Raw GraphQL escape hatch, Linear documents | `references/advanced.md` |
+| First-time auth, OAuth + PKCE, workspace switching, doctor, completions | `references/setup.md` |
+| All output flags, exit codes, env vars, stdin patterns, pagination, chaining recipes | `references/output-and-scripting.md` |
+| Concrete JSON payload shapes for issues / comments / context / errors | `references/json-shapes.md` |
+| Auth failure, rate limit, broken pager, stale cache, missing command | `references/troubleshooting.md` |
+
+## Agent-critical flags (cheat sheet)
+
+| Flag | Use |
+|---|---|
+| `--output json` / `--output ndjson` | Machine-readable output. |
+| `--compact` | Strip pretty-print whitespace. |
+| `--fields a,b.c` | Whitelist fields (dot paths supported). |
+| `--sort field` / `--order asc\|desc` | Stable sort for JSON arrays. |
+| `--filter k=v` / `k!=v` / `k~=v` | Client-side filter (case-insensitive, dot paths). |
+| `--format tpl` | Template output, e.g. `"{{identifier}} {{title}}"`. |
+| `--id-only` | Print only the created/updated ID. |
+| `--quiet` / `-q` | Suppress decoration. |
+| `--fail-on-empty` | Non-zero exit when list is empty (great for `set -e` agents). |
+| `--dry-run` | Preview without writing. |
+| `--yes` | Auto-confirm prompts. |
+| `--no-pager` / `--no-cache` | Disable auto-pager / read-through cache. |
+| `-d -` / `--data -` | Read description body / full JSON object from stdin. |
+| `--limit N` / `--all` / `--page-size N` / `--after CURSOR` | Pagination. |
+
+Full matrix: `references/output-and-scripting.md`.
+
+## Exit codes (contract)
+
+| Code | Meaning | Agent action |
+|---|---|---|
+| 0 | success | continue |
+| 1 | general error | parse stderr / JSON error envelope; surface to user |
+| 2 | not found | the ID does not exist; do not retry |
+| 3 | auth error | route to `references/setup.md` and `references/troubleshooting.md` |
+| 4 | rate limited | sleep `retry_after` seconds (in JSON body), retry once |
+
+JSON error envelope: `{"error": true, "message": "...", "code": N, "details": {...}, "retry_after": N}` — see `references/json-shapes.md`.
+
+## Output contract
+
+When answering a Linear question, return:
+
+1. **Scope line** — read-only, mutating, or destructive.
+2. **Exact command(s)** — copy-pasteable, with `--output json` if the result will be parsed.
+3. **JSON suggestion** — show the agent-friendly variant beside the human one when both are useful.
+4. **Exit-code interpretation** — only when relevant (auth, not-found, rate-limit).
+5. **Near-neighbor distinction** — call it out when commands are easy to confuse (`b update-state` vs `i update`, `i start` vs `g checkout`, `tpl` local vs `tpl remote-*`, `cm` issue comments vs `pu` project updates).
+6. **Dry-run note** — required for any bulk create or any mutation across >5 IDs.
+
+## Reference routing
+
+### Recipes
+
+| File | When to read |
+|---|---|
+| `references/recipes/creating-many-issues.md` | Spec → many issues. Markdown checklist, CSV, JSON spec, template-driven, parent/child wiring, label batching, atomicity, idempotency. |
+| `references/recipes/git-and-pr-loop.md` | start → code → PR → done. Branch naming, `context`, jj support, draft-PR pattern, finding-comment pattern, abort-and-revert path. |
+| `references/recipes/triage-and-comments.md` | Process the triage queue, leave findings, link or fetch attachments, download upload images for multimodal review. |
+
+### Issues
+
+| File | When to read |
+|---|---|
+| `references/issues/lifecycle.md` | Full create / update / start / stop / done / move / transfer / close / archive / open / link / delete flag matrix, including `--data -` JSON shape and priority/due-date shortcuts. |
+| `references/issues/relations-and-labels.md` | `rel` parent/child/blocks/duplicates/related, label CRUD with hex colors, `st` workflow-state CRUD, template CRUD (local + Linear API). |
+| `references/issues/search-and-filter.md` | `s issues` / `s projects`, the full `i list` flag matrix, client-side `--filter`, `--group-by`, `--count-only`, saved views (`v`) CRUD + apply, favorites. |
+
+### Planning
+
+| File | When to read |
+|---|---|
+| `references/planning/projects-and-cycles.md` | Project CRUD with full create flags, project labels/members/archive, project-updates with `--health onTrack/atRisk/offTrack`, cycles, `c current`, `c complete`, sprint analytics (status / progress / plan / carry-over / burndown / velocity), milestones, roadmaps, initiatives. |
+| `references/planning/teams-and-org.md` | Teams CRUD + members, users (`u list` / `u me` / `whoami`), custom views CRUD + apply across `i list` / `p list`, favorites. |
+
+### Data
+
+| File | When to read |
+|---|---|
+| `references/data/import-export.md` | CSV column schema, JSON round-trip, Markdown export, `--dry-run` first, name-based field resolution for status/assignee/labels, projects export. |
+| `references/data/attachments-and-uploads.md` | Attachment CRUD, URL linking, `up fetch` to file vs stdout, multimodal pattern (download then `Read` tool), `uploads.linear.app` host restriction. |
+
+### Eventing, advanced, setup, output, troubleshooting
+
+| File | When to read |
+|---|---|
+| `references/eventing-and-tracking.md` | `watch` polling, webhook CRUD + local HMAC-SHA256 listener (`wh listen`), notifications (`n list/count/read/archive/read-all/archive-all`), `mt` metrics (cycle/project/velocity), `hist` issue activity, `tm` time tracking. |
+| `references/advanced.md` | `api query` / `api mutate` raw GraphQL with variables and stdin, `issueCreate` mutation example, `d` document CRUD. |
+| `references/setup.md` | First-run setup, API key vs OAuth (PKCE), `auth status/login/oauth/revoke/logout`, `--profile` and workspace switching, `doctor` / `doctor --fix`, static + dynamic shell completions, full env-var table, macOS keyring caveats. |
+| `references/output-and-scripting.md` | Every agent-relevant flag, `LINEAR_CLI_OUTPUT=json` session default, stdin patterns, pagination, chaining recipes, `--fail-on-empty` for `set -e`. |
+| `references/json-shapes.md` | Concrete JSON payloads for issue list/get, comments list, `context`, and the error envelope. |
+| `references/troubleshooting.md` | Exit code dispatch, rate-limit retry, auth recovery, the macOS pager-broken-state recovery, cache reset, "command in docs but not installed" → `linear-cli update`. |
+
+## Guardrails
+
+- Do not call Linear MCP tools when `linear-cli` is installed.
+- Do not run `b update-state`, `b assign`, `b label`, or `im csv` against more than 5 IDs without `--dry-run` first.
+- Do not pipe through pagers in CI or agent runs — set `LINEAR_CLI_NO_PAGER=1` or pass `--no-pager`.
+- Do not embed OAuth flows in agent scripts; prefer `LINEAR_API_KEY` from the environment.
+- Do not store API keys in the repo or in shell history. Pipe them in: `printf '%s\n' "$LINEAR_API_KEY" | linear-cli config set-key`.
+- Do not fabricate team keys, label names, or user names. Resolve them with `t list` / `l list` / `u list` first.
+- Do not parse human-formatted tables. Always `--output json` for chained or programmatic use.
+- Do not assume a command exists because the docs mention it; if missing, run `linear-cli update` to refresh the binary, then retry.
+- Do not chain destructive commands without confirming the IDs match what was previewed in `--dry-run`.
+
+## Recovery moves
+
+- **Auth fails (exit 3):** `linear-cli auth status` → re-run `auth login` or `auth oauth`. See `references/setup.md`.
+- **Rate-limited (exit 4):** read `retry_after` from the JSON envelope, sleep that many seconds, retry once. See `references/troubleshooting.md`.
+- **Bulk mutation hit a partial failure:** capture exit code per item with a JSON loop; rollback by inverting the mutation (e.g. `b update-state -s "In Progress"` to undo). See `references/recipes/creating-many-issues.md`.
+- **Pager left terminal in raw mode (macOS):** `reset` or `stty sane`; rerun with `--no-pager`. See `references/troubleshooting.md`.
+- **Command in upstream docs but not in your binary:** `linear-cli update` (or `linear-cli update --check` first). See `references/troubleshooting.md`.
+
+## Final checks before declaring done
+
+- [ ] auth verified (`auth status` exit 0) before mutations
+- [ ] `--dry-run` previewed for any bulk operation > 5 IDs
+- [ ] every chained command used `--output json` and `--id-only` where appropriate
+- [ ] exit code interpreted (especially 2/3/4)
+- [ ] team keys, label names, assignees resolved from list commands, not hardcoded
+- [ ] no Linear MCP fallback used when `linear-cli` was available

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -263,7 +263,7 @@ When answering a Linear question, return:
 
 - **Auth fails (exit 3):** `linear-cli auth status` → re-run `auth login` or `auth oauth`. See `references/setup.md`.
 - **Rate-limited (exit 4):** read `retry_after` from the JSON envelope, sleep that many seconds, retry once. See `references/troubleshooting.md`.
-- **Bulk mutation hit a partial failure:** capture exit code per item with a JSON loop; rollback by inverting the mutation (e.g. `b update-state -s "In Progress"` to undo). See `references/recipes/creating-many-issues.md`.
+- **Bulk mutation hit a partial failure:** capture exit code per item with a JSON loop; rollback by inverting the mutation (e.g. `b update-state "In Progress" -i LIN-1,LIN-2` to undo). See `references/recipes/creating-many-issues.md`.
 - **Pager left terminal in raw mode (macOS):** `reset` or `stty sane`; rerun with `--no-pager`. See `references/troubleshooting.md`.
 - **Command in upstream docs but not in your binary:** `linear-cli update` (or `linear-cli update --check` first). See `references/troubleshooting.md`.
 

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -34,7 +34,7 @@ Do not use this skill when:
 4. **Always `--output json`** (or `LINEAR_CLI_OUTPUT=json`) when chaining or parsing. Never grep the human table format.
 5. **`--id-only` for chaining.** Capture IDs into shell variables; do not re-parse JSON for an identifier you already produced.
 6. **Treat the exit-code map as a contract**: `0` success, `1` general error, `2` not found, `3` auth, `4` rate-limited (`retry_after` is in the JSON body).
-7. **Resolve names before using them.** Do not hardcode team keys, label names, or assignees. Pull them with `linear-cli t list`, `linear-cli l list`, `linear-cli u list` and confirm before write paths.
+7. **Resolve names before using them.** Do not invent unknown team keys, label names, or assignees. Pull them with `linear-cli t list`, `linear-cli l list`, `linear-cli u list` and confirm before write paths; once resolved, using those concrete values in commands is fine.
 8. **Be explicit about scope.** State whether each command is read-only or mutating. Bulk mutations get a one-line confirmation cue.
 
 ## Quick orientation
@@ -95,7 +95,8 @@ linear-cli im csv issues.csv -t ENG --dry-run
 linear-cli im csv issues.csv -t ENG
 
 # Pattern C — JSON spec
-cat plan.json | linear-cli i create "$(jq -r .title plan.json)" -t ENG --data -
+TITLE=$(jq -r .title plan.json)
+linear-cli i create "$TITLE" -t ENG --data - < plan.json
 ```
 
 ### Update

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -29,11 +29,11 @@ Do not use this skill when:
 ## Non-negotiable rules
 
 1. **CLI > MCP.** Never call a Linear MCP tool when `linear-cli` can do the same thing.
-2. **Verify auth before any mutating command** — at the top of an agent session run `linear-cli auth status` (or `LINEAR_API_KEY=... linear-cli u me`) and only proceed on exit code 0.
+2. **Validate auth before any mutating command** — run `linear-cli auth status --validate --output json` or `LINEAR_API_KEY=... linear-cli u me --output json` and only proceed on exit code 0. Confirm the intended workspace/profile before bulk writes.
 3. **`--dry-run` first** for any bulk create or any mutation across more than 5 IDs. Confirm the plan, then execute.
 4. **Always `--output json`** (or `LINEAR_CLI_OUTPUT=json`) when chaining or parsing. Never grep the human table format.
 5. **`--id-only` for chaining.** Capture IDs into shell variables; do not re-parse JSON for an identifier you already produced.
-6. **Treat the exit-code map as a contract**: `0` success, `1` general error, `2` not found, `3` auth, `4` rate-limited (`retry_after` is in the JSON body).
+6. **Treat the exit-code map as a contract**: `0` success, `1` general error, `2` not found or parser error, `3` auth, `4` rate-limited (`retry_after` is in the JSON body).
 7. **Resolve names before using them.** Do not invent unknown team keys, label names, or assignees. Pull them with `linear-cli t list`, `linear-cli l list`, `linear-cli u list` and confirm before write paths; once resolved, using those concrete values in commands is fine.
 8. **Be explicit about scope.** State whether each command is read-only or mutating. Bulk mutations get a one-line confirmation cue.
 
@@ -82,16 +82,25 @@ For workflows that produce a batch of issues from a spec, checklist, CSV, JSON, 
 ```bash
 # Pattern A — capture IDs in a loop (markdown checklist → many issues)
 # Extract only checklist items (lines starting with "- [ ] ")
-while IFS= read -r line; do
-  if [[ "$line" =~ ^-\ \[\ \]\ (.*)$ ]]; then
-    title="${BASH_REMATCH[1]}"
-    ID=$(linear-cli i create "$title" -t ENG --id-only --quiet)
-    echo "$ID"
-  fi
-done < TODO.md
+mapfile -t TITLES < <(grep -E '^- \[ \] ' TODO.md | sed -E 's/^- \[ \] //')
+for title in "${TITLES[@]}"; do
+  linear-cli i create "$title" -t ENG --dry-run
+done
+if [ "${#TITLES[@]}" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to create ${#TITLES[@]} issues."
+  exit 0
+fi
+for title in "${TITLES[@]}"; do
+  ID=$(linear-cli i create "$title" -t ENG --id-only --quiet)
+  echo "$ID"
+done
 
-# Pattern B — CSV import (preview then commit)
+# Pattern B — CSV import (preview, confirm, then commit)
 linear-cli im csv issues.csv -t ENG --dry-run
+if [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to import issues.csv."
+  exit 0
+fi
 linear-cli im csv issues.csv -t ENG
 
 # Pattern C — JSON spec
@@ -111,12 +120,25 @@ linear-cli cm create LIN-123 -b "Root cause: missing null check"
 ### Bulk mutate
 
 ```bash
+# Small, explicit set
 linear-cli b update-state Done -i LIN-1,LIN-2,LIN-3 --dry-run
 linear-cli b update-state Done -i LIN-1,LIN-2,LIN-3
+linear-cli b assign me -i LIN-1,LIN-2 --dry-run
 linear-cli b assign me -i LIN-1,LIN-2
-linear-cli b label bug -i LIN-1,LIN-2
-# Piping to bulk: collect IDs, then pass via -i
-linear-cli i list -t ENG --id-only | paste -sd, | xargs -I {} linear-cli b assign me -i {}
+
+# Generated set: capture, inspect, dry-run, then execute the same IDs
+linear-cli i list -t ENG -l stale --limit 25 --output json --compact \
+  --fields identifier,title,state.name > /tmp/linear-stale.json
+jq -r '.[] | "\(.identifier)\t\(.state.name)\t\(.title)"' /tmp/linear-stale.json
+COUNT=$(jq 'length' /tmp/linear-stale.json)
+IDS=$(jq -r '.[].identifier' /tmp/linear-stale.json | paste -sd,)
+[ "$COUNT" -gt 0 ] && [ "$COUNT" -le 25 ] || { echo "Unexpected count: $COUNT"; exit 1; }
+linear-cli b assign me -i "$IDS" --dry-run
+if [ "$COUNT" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b assign me -i \"$IDS\""
+  exit 0
+fi
+linear-cli b assign me -i "$IDS"
 ```
 
 ### Git / PR loop
@@ -262,7 +284,7 @@ When answering a Linear question, return:
 
 ## Recovery moves
 
-- **Auth fails (exit 3):** `linear-cli auth status` → re-run `auth login` or `auth oauth`. See `references/setup.md`.
+- **Auth fails (exit 3):** `linear-cli auth status --validate --output json` → re-run `auth login` or `auth oauth`. See `references/setup.md`.
 - **Rate-limited (exit 4):** read `retry_after` from the JSON envelope, sleep that many seconds, retry once. See `references/troubleshooting.md`.
 - **Bulk mutation hit a partial failure:** capture exit code per item with a JSON loop; rollback by inverting the mutation (e.g. `b update-state "In Progress" -i LIN-1,LIN-2` to undo). See `references/recipes/creating-many-issues.md`.
 - **Pager left terminal in raw mode (macOS):** `reset` or `stty sane`; rerun with `--no-pager`. See `references/troubleshooting.md`.
@@ -270,7 +292,8 @@ When answering a Linear question, return:
 
 ## Final checks before declaring done
 
-- [ ] auth verified (`auth status` exit 0) before mutations
+- [ ] auth validated (`auth status --validate --output json` or `u me --output json`) before mutations
+- [ ] intended workspace/profile confirmed before bulk mutations
 - [ ] `--dry-run` previewed for any bulk operation > 5 IDs
 - [ ] every chained command used `--output json` and `--id-only` where appropriate
 - [ ] exit code interpreted (especially 2/3/4)

--- a/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/SKILL.md
@@ -81,9 +81,13 @@ For workflows that produce a batch of issues from a spec, checklist, CSV, JSON, 
 
 ```bash
 # Pattern A — capture IDs in a loop (markdown checklist → many issues)
-while read -r line; do
-  ID=$(linear-cli i create "$line" -t ENG --id-only --quiet)
-  echo "$ID"
+# Extract only checklist items (lines starting with "- [ ] ")
+while IFS= read -r line; do
+  if [[ "$line" =~ ^-\ \[\ \]\ (.*)$ ]]; then
+    title="${BASH_REMATCH[1]}"
+    ID=$(linear-cli i create "$title" -t ENG --id-only --quiet)
+    echo "$ID"
+  fi
 done < TODO.md
 
 # Pattern B — CSV import (preview then commit)

--- a/skills/use-linear-cli/skills/use-linear-cli/references/advanced.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/advanced.md
@@ -6,7 +6,7 @@ The escape hatch when no `linear-cli` subcommand fits, plus Linear's `Document` 
 
 ```bash
 linear-cli api query '{ viewer { id name email } }'
-linear-cli api query -v teamId=abc '{ team(id: $teamId) { name } }'
+linear-cli api query -v teamId=abc 'query($teamId: String!) { team(id: $teamId) { name } }'
 
 linear-cli api mutate -v title="Bug" '
   mutation($title: String!) {
@@ -52,7 +52,7 @@ Always pass user-provided values via `-v` rather than splicing into the query bo
 
 ```bash
 # Good
-linear-cli api query -v id="$ISSUE_ID" '{ issue(id: $id) { title } }'
+linear-cli api query -v id="$ISSUE_ID" 'query($id: String!) { issue(id: $id) { title } }'
 
 # Bad — quoting hazards, GraphQL injection risk
 linear-cli api query "{ issue(id: \"$ISSUE_ID\") { title } }"

--- a/skills/use-linear-cli/skills/use-linear-cli/references/advanced.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/advanced.md
@@ -1,0 +1,154 @@
+# Advanced — Raw GraphQL and Documents
+
+The escape hatch when no `linear-cli` subcommand fits, plus Linear's `Document` model for long-form content.
+
+## Raw GraphQL (`api`)
+
+```bash
+linear-cli api query '{ viewer { id name email } }'
+linear-cli api query -v teamId=abc '{ team(id: $teamId) { name } }'
+
+linear-cli api mutate -v title="Bug" '
+  mutation($title: String!) {
+    issueCreate(input: { title: $title, teamId: "TEAM_UUID" }) {
+      issue { id identifier }
+    }
+  }
+'
+
+cat query.graphql | linear-cli api query -
+```
+
+| Flag | Meaning |
+|---|---|
+| `-v key=val` | GraphQL variable (repeatable) |
+| `--output json` | JSON output |
+| `--compact` | Compact JSON |
+| `-` | Read query/mutation body from stdin |
+
+### When to reach for `api`
+
+Use the raw GraphQL surface when:
+
+- you need a field that no `linear-cli` subcommand exposes (e.g. an obscure `IssueRelationHistory` query)
+- you're prototyping an integration before a built-in command exists
+- you need to batch a complex multi-resource fetch in one round-trip
+- you need to set fields that `--data -` doesn't expose
+
+Otherwise, prefer the typed subcommand — it handles auth, retries, error envelopes, and pagination for you.
+
+### Schema discovery
+
+```bash
+linear-cli api query '{ __schema { queryType { name } } }'
+linear-cli api query '{ __type(name: "Issue") { fields { name type { name } } } }'
+```
+
+Or pull the snapshot from the upstream repo's `docs/json/schema.json`.
+
+### Variables vs string interpolation
+
+Always pass user-provided values via `-v` rather than splicing into the query body:
+
+```bash
+# Good
+linear-cli api query -v id="$ISSUE_ID" '{ issue(id: $id) { title } }'
+
+# Bad — quoting hazards, GraphQL injection risk
+linear-cli api query "{ issue(id: \"$ISSUE_ID\") { title } }"
+```
+
+### Sample mutation — create an issue with full control
+
+```bash
+linear-cli api mutate \
+  -v title="Bug from agent" \
+  -v teamId="$TEAM_UUID" \
+  -v priority=1 \
+  -v labelIds='["LABEL_UUID_1","LABEL_UUID_2"]' '
+  mutation($title: String!, $teamId: String!, $priority: Int, $labelIds: [String!]) {
+    issueCreate(input: {
+      title: $title
+      teamId: $teamId
+      priority: $priority
+      labelIds: $labelIds
+    }) {
+      success
+      issue { id identifier title }
+    }
+  }
+'
+```
+
+`-v` values that look like JSON (arrays, objects, numbers, booleans) are decoded; quoted strings stay strings.
+
+## Documents
+
+Linear `Document`s are long-form pages attached to projects (RFCs, ADRs, plans). Different from issue descriptions and from project updates.
+
+```bash
+linear-cli d list
+linear-cli d list --output json
+linear-cli d get DOC_ID
+linear-cli d get DOC_ID --output json
+
+linear-cli d create "Design Doc" -p PROJECT_ID
+linear-cli d create "RFC" -p PROJECT_ID --id-only
+
+linear-cli d update DOC_ID --title "New Title"
+linear-cli d update DOC_ID --content "New content"
+```
+
+| Flag | Meaning |
+|---|---|
+| `-p PROJECT` | Project UUID (or name) |
+| `--title` | Document title |
+| `--content` | Markdown body |
+| `--id-only` | Output only new ID |
+| `--output json` | JSON output |
+
+Some binary versions also support `d delete DOC_ID --force`. Confirm with `--help`.
+
+## Recipe: post an ADR as a Linear document
+
+```bash
+PROJ=PROJECT_UUID
+ID=$(linear-cli d create "ADR-2026-04-28: Drop polling for webhooks" \
+  -p "$PROJ" --id-only --quiet)
+linear-cli d update "$ID" --content "$(cat adr.md)"
+```
+
+## Recipe: query "every issue blocking another, in any team"
+
+(No built-in command exposes this directly.)
+
+```bash
+linear-cli api query '
+  query {
+    issueRelations(filter: { type: { eq: "blocks" } }, first: 100) {
+      nodes {
+        type
+        issue { identifier title }
+        relatedIssue { identifier title }
+      }
+    }
+  }
+' --compact
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `api query` | GraphQL `query`. Read-only. |
+| `api mutate` | GraphQL mutation. Writes. |
+| `d` | Linear `Document` (long-form page). |
+| `i` | Issue (short item with workflow state). |
+| `pu` | Project update (status post). |
+
+## See also
+
+- `output-and-scripting.md` — `-v` variables and stdin patterns.
+- `json-shapes.md` — typed-command response shapes.
+- `troubleshooting.md` — error envelope when `api` calls fail.
+- `eventing-and-tracking.md` — for streaming events instead of polling raw GraphQL.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/attachments-and-uploads.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/attachments-and-uploads.md
@@ -1,0 +1,106 @@
+# Attachments and Uploads
+
+Two related but distinct surfaces:
+
+- **Attachments** — first-class metadata records on an issue (title + URL). CRUD via `att`.
+- **Uploads** — the binary asset side. Linear-hosted file URLs at `uploads.linear.app`. Read-only via `up fetch`.
+
+## Attachment CRUD
+
+```bash
+linear-cli att list LIN-123
+linear-cli att list LIN-123 --output json
+
+linear-cli att get ATTACHMENT_ID
+
+linear-cli att create LIN-123 -T "Design Doc" -u https://example.com
+linear-cli att link-url LIN-123 https://sentry.io/issues/12345     # shorthand for create
+
+linear-cli att update ATTACHMENT_ID -T "New Title"
+linear-cli att delete ATTACHMENT_ID --force
+```
+
+| Flag | Meaning |
+|---|---|
+| `-T TITLE` | Attachment title (display label) |
+| `-u URL` | Target URL |
+| `--output json` | JSON output |
+| `--force` | Skip delete confirmation |
+
+`att link-url` is sugar for `att create -T <auto> -u <URL>`.
+
+## `up fetch` — download Linear-hosted images
+
+User-uploaded images and files live at `https://uploads.linear.app/<org>/<id>/<filename>`. `up fetch` is the only way to download them safely.
+
+```bash
+linear-cli up fetch "https://uploads.linear.app/<org>/<id>/screenshot.png" -f /tmp/screenshot.png
+linear-cli up fetch "https://uploads.linear.app/..." > out.png
+linear-cli up fetch "https://uploads.linear.app/..." | base64
+```
+
+| Flag | Meaning |
+|---|---|
+| `-f FILE` / `--file FILE` | Write to file instead of stdout |
+
+### Host restriction
+
+`up fetch` rejects URLs that aren't on `uploads.linear.app`. This is a deliberate safety boundary: `linear-cli` will not act as a generic HTTP fetcher with your Linear credentials. For arbitrary hosts, use `curl` or `wget`.
+
+### Discovering upload URLs
+
+Upload URLs appear in:
+
+- Issue descriptions: `linear-cli i get LIN-123 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'`
+- Comments: `linear-cli cm list LIN-123 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'`
+
+URL pattern: `https://uploads.linear.app/{org}/{upload}/{filename}`.
+
+## Multimodal review pattern (Claude Code, Cursor, etc.)
+
+```bash
+# 1. Discover
+URL=$(linear-cli i get LIN-501 --output json \
+  | jq -r '..|strings|select(test("uploads.linear.app"))' | head -1)
+
+# 2. Download
+linear-cli up fetch "$URL" -f /tmp/repro.png
+
+# 3. Read with the agent's image-capable tool.
+#    In Claude Code: pass /tmp/repro.png to the Read tool — Claude sees the image.
+```
+
+## Recipe: copy every screenshot from an issue to a folder
+
+```bash
+mkdir -p /tmp/lin-501
+linear-cli i get LIN-501 --output json \
+  | jq -r '..|strings|select(test("uploads.linear.app"))' \
+  | while read -r url; do
+      name=$(basename "$url")
+      linear-cli up fetch "$url" -f "/tmp/lin-501/$name"
+    done
+```
+
+## Recipe: link a Sentry / Datadog / Loom URL
+
+```bash
+linear-cli att link-url LIN-501 https://sentry.io/issues/123 --output json
+```
+
+`att link-url` autogenerates a title from the URL. To set a specific title, use `att create -T "Sentry — InvalidSession" -u https://...`.
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `att list` | Linear *attachment* records (metadata + URL). |
+| `up fetch` | Download a binary asset from `uploads.linear.app`. |
+| `att link-url` | Sugar for `att create` with auto title. |
+| `--force` | Skip confirmation on delete. |
+
+## See also
+
+- `recipes/triage-and-comments.md` — fetching screenshots during triage.
+- `output-and-scripting.md` — JSON parsing patterns used to find upload URLs.
+- `troubleshooting.md` — what to do when `up fetch` rejects a non-`uploads.linear.app` URL.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/attachments-and-uploads.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/attachments-and-uploads.md
@@ -51,8 +51,8 @@ linear-cli up fetch "https://uploads.linear.app/..." | base64
 
 Upload URLs appear in:
 
-- Issue descriptions: `linear-cli i get LIN-123 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'`
-- Comments: `linear-cli cm list LIN-123 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'`
+- Issue descriptions: `linear-cli i get LIN-123 --output json | jq -r '..|strings|select(test("uploads\\.linear\\.app"))'`
+- Comments: `linear-cli cm list LIN-123 --output json | jq -r '..|strings|select(test("uploads\\.linear\\.app"))'`
 
 URL pattern: `https://uploads.linear.app/{org}/{upload}/{filename}`.
 
@@ -61,7 +61,7 @@ URL pattern: `https://uploads.linear.app/{org}/{upload}/{filename}`.
 ```bash
 # 1. Discover
 URL=$(linear-cli i get LIN-501 --output json \
-  | jq -r '..|strings|select(test("uploads.linear.app"))' | head -1)
+  | jq -r '..|strings|select(test("uploads\\.linear\\.app"))' | head -1)
 
 # 2. Download
 linear-cli up fetch "$URL" -f /tmp/repro.png
@@ -75,7 +75,7 @@ linear-cli up fetch "$URL" -f /tmp/repro.png
 ```bash
 mkdir -p /tmp/lin-501
 linear-cli i get LIN-501 --output json \
-  | jq -r '..|strings|select(test("uploads.linear.app"))' \
+  | jq -r '..|strings|select(test("uploads\\.linear\\.app"))' \
   | while read -r url; do
       name=$(basename "$url")
       linear-cli up fetch "$url" -f "/tmp/lin-501/$name"

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
@@ -68,7 +68,7 @@ Add 429 retry headers,"",2,Backlog,,api,2,
 
 ### Name resolution
 
-`status`, `assignee`, and `labels` are resolved by name within the target team. If a name doesn't match, the row fails with exit 2 (not found). Always run `--dry-run` first to surface name-resolution errors before writing.
+`status`, `assignee`, and `labels` are resolved by name within the target team. If a name doesn't match, the row fails with an exit-2 JSON not-found envelope. Always run `--dry-run` first to surface name-resolution errors before writing.
 
 ## JSON round-trip
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
@@ -1,0 +1,130 @@
+# Import and Export
+
+Round-trip Linear data through CSV, JSON, and Markdown. Use for migrations, bulk creation from spreadsheets, archival snapshots, and external reporting.
+
+## Export
+
+```bash
+linear-cli exp csv -t ENG                          # human-friendly
+linear-cli exp csv -t ENG -f issues.csv            # to file
+linear-cli exp csv --all -t ENG                    # paginate every page
+linear-cli exp csv -t ENG -s "In Progress"
+linear-cli exp csv -t ENG --assignee me
+
+linear-cli exp markdown -t ENG
+linear-cli exp markdown -t ENG -f issues.md
+
+linear-cli exp json -t ENG -f backup.json          # round-trip-compatible
+linear-cli exp projects-csv -f projects.csv
+```
+
+| Flag | Meaning |
+|---|---|
+| `-f FILE` | Output to file (otherwise stdout) |
+| `--all` | Walk every page |
+| `-t TEAM` | Filter by team |
+| `-s STATE` | Filter by state |
+| `--assignee USER` | Filter by assignee |
+
+## Import
+
+```bash
+linear-cli im csv issues.csv -t ENG
+linear-cli im csv issues.csv -t ENG --dry-run        # always preview first
+linear-cli im json issues.json -t ENG
+linear-cli im json backup.json -t ENG --dry-run
+```
+
+| Flag | Meaning |
+|---|---|
+| `-t TEAM` (req) | Target team |
+| `--dry-run` | Preview without creating |
+| `--output json` | Return created issues as JSON |
+
+## CSV column schema
+
+Header row required.
+
+| Column | Required | Notes |
+|---|---|---|
+| `title` | yes | Plain string |
+| `description` | no | Markdown body; can contain `\n` for multi-line |
+| `priority` | no | `0`–`4` (0=no priority, 1=urgent, 4=low) |
+| `status` | no | Workflow state name (resolved by name in the team) |
+| `assignee` | no | User name or email (resolved by name) |
+| `labels` | no | `;`-separated list, names (resolved by name) |
+| `estimate` | no | Story points (integer) |
+| `dueDate` | no | ISO date `YYYY-MM-DD` |
+
+Example:
+
+```csv
+title,description,priority,status,assignee,labels,estimate,dueDate
+Fix login redirect,"Multi-line\ndescription",1,Backlog,ada@example.com,bug;auth,3,2026-05-01
+Add 429 retry headers,"",2,Backlog,,api,2,
+```
+
+### Name resolution
+
+`status`, `assignee`, and `labels` are resolved by name within the target team. If a name doesn't match, the row fails with exit 2 (not found). Always run `--dry-run` first to surface name-resolution errors before writing.
+
+## JSON round-trip
+
+```bash
+linear-cli exp json -t ENG -f backup.json
+# … edit backup.json …
+linear-cli im json backup.json -t ENG --dry-run
+linear-cli im json backup.json -t ENG
+```
+
+JSON is round-trip compatible: an export → import recreates issues with the same titles, descriptions, labels, etc. (but new IDs and identifiers — Linear does not allow you to set those manually).
+
+## Markdown export
+
+Best for human-readable archives or pasting a summary into a doc.
+
+```bash
+linear-cli exp markdown -t ENG --since 30d -f sprint-archive.md
+```
+
+## Recipe: migrate from another tracker (CSV-driven)
+
+1. Export from the source tool to CSV.
+2. Map columns to the schema above. Multi-value cells (labels, etc.) need `;` separation.
+3. Map status names to your Linear team's workflow states (use `linear-cli st list -t ENG`).
+4. Run `linear-cli im csv migration.csv -t ENG --dry-run` until it reports zero name-resolution failures.
+5. Commit: `linear-cli im csv migration.csv -t ENG`.
+
+## Recipe: weekly archive
+
+```bash
+DATE=$(date +%Y-%m-%d)
+linear-cli exp json -t ENG -f "archives/$DATE.json"
+linear-cli exp markdown -t ENG -f "archives/$DATE.md"
+```
+
+## Recipe: round-trip edits
+
+When the upstream tool isn't programmatically editable but Linear is, export, edit programmatically, re-import.
+
+```bash
+linear-cli exp json -t ENG -f stale.json
+jq '.[] | select(.priority == 4) | .priority = 3' stale.json > bumped.json
+linear-cli im json bumped.json -t ENG --dry-run
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `exp` | Export |
+| `im` | Import |
+| `--dry-run` (on import) | No writes; reports name-resolution outcome. |
+| `dueDate` (CSV) | ISO `YYYY-MM-DD` only — no `+3d` shortcuts inside CSV cells. |
+| `labels` (CSV) | `;`-separated; not `,`. |
+
+## See also
+
+- `recipes/creating-many-issues.md` — full CSV/JSON-driven creation patterns.
+- `issues/lifecycle.md` — `--data -` JSON shape for one-off creates.
+- `output-and-scripting.md` — `--dry-run`, `--output json` plumbing.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
@@ -52,7 +52,7 @@ Header row required.
 | `priority` | no | `0`–`4` (0=no priority, 1=urgent, 4=low) |
 | `status` | no | Workflow state name (resolved by name in the team) |
 | `assignee` | no | User name or email (resolved by name) |
-| `labels` | no | `;`-separated list, names (resolved by name) |
+| `labels` | no | Multi-value separator (check your version: newer releases use `;`, older may use `,`). Names are resolved by label name in the team. |
 | `estimate` | no | Story points (integer) |
 | `dueDate` | no | ISO date `YYYY-MM-DD` |
 
@@ -109,7 +109,8 @@ When the upstream tool isn't programmatically editable but Linear is, export, ed
 
 ```bash
 linear-cli exp json -t ENG -f stale.json
-jq '.[] | select(.priority == 4) | .priority = 3' stale.json > bumped.json
+# Filter and modify; wrap result in an array for import
+jq '[.[] | select(.priority == 4) | .priority = 3]' stale.json > bumped.json
 linear-cli im json bumped.json -t ENG --dry-run
 ```
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
@@ -54,7 +54,7 @@ Header row required.
 | `priority` | no | `0`–`4` (0=no priority, 1=urgent, 4=low) |
 | `status` | no | Workflow state name (resolved by name in the team) |
 | `assignee` | no | User name or email (resolved by name) |
-| `labels` | no | Multi-value separator (check your version: newer releases use `;`, older may use `,`). Names are resolved by label name in the team. |
+| `labels` | no | Comma-separated label names inside one CSV cell; quote the cell when using multiple labels. |
 | `estimate` | no | Story points (integer) |
 | `dueDate` | no | ISO date `YYYY-MM-DD` |
 
@@ -62,7 +62,7 @@ Example:
 
 ```csv
 title,description,priority,status,assignee,labels,estimate,dueDate
-Fix login redirect,"Multi-line\ndescription",1,Backlog,ada@example.com,bug;auth,3,2026-05-01
+Fix login redirect,"Multi-line\ndescription",1,Backlog,ada@example.com,"bug,auth",3,2026-05-01
 Add 429 retry headers,"",2,Backlog,,api,2,
 ```
 
@@ -92,7 +92,7 @@ linear-cli exp markdown -t ENG --all -f sprint-archive.md
 ## Recipe: migrate from another tracker (CSV-driven)
 
 1. Export from the source tool to CSV.
-2. Map columns to the schema above. Multi-value cells (labels, etc.) need `;` separation.
+2. Map columns to the schema above. Multi-value cells (labels, etc.) need comma separation inside a quoted CSV cell.
 3. Map status names to your Linear team's workflow states (use `linear-cli st list -t ENG`).
 4. Run `linear-cli im csv migration.csv -t ENG --dry-run` until it reports zero name-resolution failures.
 5. Commit: `linear-cli im csv migration.csv -t ENG`.
@@ -111,8 +111,8 @@ When the upstream tool isn't programmatically editable but Linear is, export, ed
 
 ```bash
 linear-cli exp json -t ENG -f stale.json
-# Filter and modify; wrap result in an array for import
-jq '[.[] | select(.priority == 4) | .priority = 3]' stale.json > bumped.json
+# Modify matching entries while preserving the import array shape
+jq 'map(if .priority == 4 then .priority = 3 else . end)' stale.json > bumped.json
 linear-cli im json bumped.json -t ENG --dry-run
 ```
 
@@ -124,7 +124,7 @@ linear-cli im json bumped.json -t ENG --dry-run
 | `im` | Import |
 | `--dry-run` (on import) | No writes; reports name-resolution outcome. |
 | `dueDate` (CSV) | ISO `YYYY-MM-DD` only — no `+3d` shortcuts inside CSV cells. |
-| `labels` (CSV) | `;`-separated; not `,`. |
+| `labels` (CSV) | Comma-separated names inside one quoted CSV cell. |
 
 ## See also
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/data/import-export.md
@@ -8,8 +8,8 @@ Round-trip Linear data through CSV, JSON, and Markdown. Use for migrations, bulk
 linear-cli exp csv -t ENG                          # human-friendly
 linear-cli exp csv -t ENG -f issues.csv            # to file
 linear-cli exp csv --all -t ENG                    # paginate every page
-linear-cli exp csv -t ENG -s "In Progress"
-linear-cli exp csv -t ENG --assignee me
+linear-cli exp csv -t ENG --include-completed
+linear-cli exp csv -t ENG --limit 100
 
 linear-cli exp markdown -t ENG
 linear-cli exp markdown -t ENG -f issues.md
@@ -23,8 +23,10 @@ linear-cli exp projects-csv -f projects.csv
 | `-f FILE` | Output to file (otherwise stdout) |
 | `--all` | Walk every page |
 | `-t TEAM` | Filter by team |
-| `-s STATE` | Filter by state |
-| `--assignee USER` | Filter by assignee |
+| `--include-completed` | Include completed issues |
+| `--limit N` | Limit number of issues |
+
+Export commands do not accept issue-list filters like `-s`, `--assignee`, or `--since`. For filtered subsets, use `i list --output json` and shape the export with `jq` / CSV tooling.
 
 ## Import
 
@@ -84,7 +86,7 @@ JSON is round-trip compatible: an export → import recreates issues with the sa
 Best for human-readable archives or pasting a summary into a doc.
 
 ```bash
-linear-cli exp markdown -t ENG --since 30d -f sprint-archive.md
+linear-cli exp markdown -t ENG --all -f sprint-archive.md
 ```
 
 ## Recipe: migrate from another tracker (CSV-driven)

--- a/skills/use-linear-cli/skills/use-linear-cli/references/eventing-and-tracking.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/eventing-and-tracking.md
@@ -125,7 +125,8 @@ linear-cli wh create "https://my-bridge.example.com/linear" --events Issue
 linear-cli wh listen --port 8080 --secret "$SECRET" \
   | jq --unbuffered -r 'select(.action == "create") | .data.identifier' \
   | while read -r id; do
-      curl -X POST -d "{\"text\":\"new issue: $id\"}" "$SLACK_WEBHOOK"
+      curl -X POST -H "Content-Type: application/json" \
+        -d "{\"text\":\"new issue: $id\"}" "$SLACK_WEBHOOK"
     done
 ```
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/eventing-and-tracking.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/eventing-and-tracking.md
@@ -5,10 +5,10 @@ Watching for changes, webhooks (CRUD + local listener), notifications, metrics, 
 ## Watch — poll for live changes
 
 ```bash
-linear-cli watch LIN-123                       # poll every 10 seconds (default)
-linear-cli watch LIN-123 --interval 30         # every 30 seconds
-linear-cli watch LIN-123 -i 60
-linear-cli watch LIN-123 --output json         # stream changes as JSON
+linear-cli watch issue LIN-123                       # poll every 10 seconds (default)
+linear-cli watch issue LIN-123 --interval 30         # every 30 seconds
+linear-cli watch issue LIN-123 -i 60
+linear-cli watch issue LIN-123 --output json         # stream changes as JSON
 ```
 
 Use sparingly — polling consumes API quota. For real-time, use webhooks instead.
@@ -114,7 +114,7 @@ Duration format: `30m`, `1h`, `2h30m`, `1d` (= 8 hours).
 ## Recipe: watch for status changes on a critical issue
 
 ```bash
-linear-cli watch LIN-901 --interval 30 --output json \
+linear-cli watch issue LIN-901 --interval 30 --output json \
   | jq -r 'select(.event == "stateChanged") | "\(.timestamp) → \(.new.state.name)"'
 ```
 
@@ -133,7 +133,9 @@ linear-cli wh listen --port 8080 --secret "$SECRET" \
 ## Recipe: "what changed today on this issue?"
 
 ```bash
-linear-cli hist issue LIN-123 --since 1d --output json
+since="$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+linear-cli hist issue LIN-123 --limit 100 --output json \
+  | jq --arg since "$since" '[.[] | select((.createdAt // .timestamp // "") >= $since)]'
 ```
 
 ## Common confusions

--- a/skills/use-linear-cli/skills/use-linear-cli/references/eventing-and-tracking.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/eventing-and-tracking.md
@@ -1,0 +1,155 @@
+# Eventing and Tracking
+
+Watching for changes, webhooks (CRUD + local listener), notifications, metrics, history, and time tracking. Cold-path commands an agent rarely reaches for daily but needs to know exist.
+
+## Watch — poll for live changes
+
+```bash
+linear-cli watch LIN-123                       # poll every 10 seconds (default)
+linear-cli watch LIN-123 --interval 30         # every 30 seconds
+linear-cli watch LIN-123 -i 60
+linear-cli watch LIN-123 --output json         # stream changes as JSON
+```
+
+Use sparingly — polling consumes API quota. For real-time, use webhooks instead.
+
+## Webhooks — CRUD
+
+```bash
+linear-cli wh list
+linear-cli wh list --output json
+
+linear-cli wh get WEBHOOK_ID
+linear-cli wh create https://example.com/hook --events Issue
+linear-cli wh update WEBHOOK_ID --url https://new-url.example.com
+linear-cli wh delete WEBHOOK_ID --force
+
+linear-cli wh rotate-secret WEBHOOK_ID         # rotate signing secret
+```
+
+Event types are documented in Linear's webhook docs. Common: `Issue`, `IssueComment`, `Project`, `Cycle`.
+
+## Webhook local listener (HMAC-SHA256)
+
+For local development and integration testing:
+
+```bash
+linear-cli wh listen --port 8080
+linear-cli wh listen --port 8080 --secret "$WEBHOOK_SIGNING_SECRET"
+```
+
+The listener:
+
+- binds `127.0.0.1` only (not all-interfaces)
+- verifies HMAC-SHA256 on every event
+- enforces header / body size limits
+
+Combine with a tunnel (`ngrok`, `cloudflared`) to receive real Linear events on your laptop:
+
+```bash
+ngrok http 8080
+linear-cli wh create "https://abc.ngrok.io/hook" --events Issue
+linear-cli wh listen --port 8080 --secret "$SECRET"
+```
+
+Rotate the secret routinely with `linear-cli wh rotate-secret`.
+
+## Notifications
+
+Linear's per-user notification inbox.
+
+```bash
+linear-cli n list                              # unread
+linear-cli n list --output json
+linear-cli n count                             # unread count
+
+linear-cli n read NOTIFICATION_ID
+linear-cli n read-all
+
+linear-cli n archive NOTIFICATION_ID
+linear-cli n archive-all
+```
+
+## Metrics
+
+Velocity, burndown, project progress.
+
+```bash
+linear-cli mt cycle CYCLE_ID                   # cycle metrics
+linear-cli mt cycle CYCLE_ID --output json
+linear-cli mt project PROJECT_ID
+linear-cli mt velocity ENG                     # team velocity
+linear-cli mt velocity ENG --cycles 10         # last 10 cycles
+```
+
+For the friendlier sprint-analytics surface, see `planning/projects-and-cycles.md` (`linear-cli sp velocity`).
+
+## History
+
+Per-issue activity timeline.
+
+```bash
+linear-cli hist issue LIN-123
+linear-cli hist issue LIN-123 --output json
+linear-cli hist issue LIN-123 --limit 50
+linear-cli hist issue LIN-123 --all
+```
+
+Useful for "who changed this and when" and audit trails.
+
+## Time tracking
+
+```bash
+linear-cli tm log LIN-123 2h                   # log 2 hours
+linear-cli tm log LIN-123 30m                  # 30 minutes
+linear-cli tm log LIN-123 1h30m                # 1.5 hours
+
+linear-cli tm list --issue LIN-123
+linear-cli tm list --output json
+linear-cli tm delete ENTRY_ID
+```
+
+Duration format: `30m`, `1h`, `2h30m`, `1d` (= 8 hours).
+
+## Recipe: watch for status changes on a critical issue
+
+```bash
+linear-cli watch LIN-901 --interval 30 --output json \
+  | jq -r 'select(.event == "stateChanged") | "\(.timestamp) → \(.new.state.name)"'
+```
+
+## Recipe: post Linear events into Slack via webhook listener
+
+```bash
+linear-cli wh create "https://my-bridge.example.com/linear" --events Issue
+linear-cli wh listen --port 8080 --secret "$SECRET" \
+  | jq --unbuffered -r 'select(.action == "create") | .data.identifier' \
+  | while read -r id; do
+      curl -X POST -d "{\"text\":\"new issue: $id\"}" "$SLACK_WEBHOOK"
+    done
+```
+
+## Recipe: "what changed today on this issue?"
+
+```bash
+linear-cli hist issue LIN-123 --since 1d --output json
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `watch` | Poll one issue (or project / team). Quota-heavy. |
+| `wh listen` | Local HMAC-verifying listener. Real-time. |
+| `n` | User-inbox notifications, not webhook events. |
+| `hist` | Issue activity timeline. |
+| `mt` | Raw metric numbers. |
+| `sp` | Pre-rendered sprint analytics (uses `mt` internally). |
+| `tm` | Time tracking. |
+
+## See also
+
+- `setup.md` — webhook listener security defaults.
+- `troubleshooting.md` — when the listener won't start or rate limits hit.
+- `planning/projects-and-cycles.md` — `sp velocity` is friendlier than `mt velocity` for most users.
+- `output-and-scripting.md` — `--output ndjson` for streaming.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/lifecycle.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/lifecycle.md
@@ -1,0 +1,135 @@
+# Issue Lifecycle
+
+Full create / update / start / stop / done / move / transfer / archive flag matrix for `linear-cli i ...`. Pairs with `recipes/creating-many-issues.md` and `recipes/git-and-pr-loop.md`.
+
+## Create
+
+```bash
+linear-cli i create "Title" -t TEAM
+linear-cli i create "Bug" -t ENG -p 1 -a me -l bug -l urgent --due +3d
+linear-cli i create "Task" -t ENG --id-only --quiet         # capture ID
+linear-cli i create "Test" -t ENG --dry-run                 # preview
+cat desc.md  | linear-cli i create "Title" -t ENG -d -      # description body from stdin
+cat body.json | linear-cli i create "Title" -t ENG --data - # full JSON body
+```
+
+### Create flag matrix
+
+| Flag | Meaning |
+|---|---|
+| `-t TEAM` (req) | Team key (e.g. `ENG`) |
+| `-p N` | Priority — `0` no priority, `1` urgent, `2` high, `3` normal, `4` low |
+| `-a USER` | Assignee — `me` or display name or email |
+| `-l LABEL` | Label name (repeatable) |
+| `--due DATE` | Due date — `today`, `tomorrow`, `+3d`, `+2w`, `monday`, `eow`, `eom`, ISO date |
+| `-e N` | Estimate (story points) |
+| `-d -` | Description body from stdin |
+| `--data -` | Full JSON object from stdin |
+| `--id-only` | Output only the new ID |
+| `--quiet` | Suppress decoration |
+| `--dry-run` | Preview without writing |
+
+### Priority values
+
+| Value | Meaning |
+|---|---|
+| 0 | No priority |
+| 1 | Urgent |
+| 2 | High |
+| 3 | Normal |
+| 4 | Low |
+
+### Due date shortcuts
+
+`today`, `tomorrow`, `+3d`, `+2w`, `monday`, `eow` (end of week), `eom` (end of month), or any ISO date `YYYY-MM-DD`.
+
+### `--data -` JSON shape
+
+```json
+{
+  "description": "Full markdown body...",
+  "priority": 1,
+  "stateId": "WORKFLOW_STATE_UUID",
+  "assigneeId": "USER_UUID",
+  "labelIds": ["LABEL_UUID_1", "LABEL_UUID_2"],
+  "estimate": 3,
+  "dueDate": "2026-05-01",
+  "parentId": "PARENT_ISSUE_UUID",
+  "projectId": "PROJECT_UUID"
+}
+```
+
+Use this when name-resolution would be ambiguous (multiple labels with the same name, two assignees with the same display name, etc.).
+
+## Update
+
+```bash
+linear-cli i update LIN-123 -s Done                         # status (workflow state name)
+linear-cli i update LIN-123 -p 2                            # priority
+linear-cli i update LIN-123 -a me
+linear-cli i update LIN-123 -a "Ada Lovelace"
+linear-cli i update LIN-123 -l bug -l urgent                # add labels (repeatable)
+linear-cli i update LIN-123 --due tomorrow
+linear-cli i update LIN-123 -e 3                            # estimate
+linear-cli i update LIN-123 --output json
+linear-cli i update LIN-123 -s Done --dry-run
+cat patch.json | linear-cli i update LIN-123 --data -
+```
+
+`--data -` accepts the same JSON shape as create.
+
+## Lifecycle transitions
+
+| Action | Command |
+|---|---|
+| Start work (assign me + In Progress + branch) | `linear-cli i start LIN-123 --checkout` |
+| Stop work (unassign + reset) | `linear-cli i stop LIN-123` |
+| Mark Done (any issue) | `linear-cli i update LIN-123 -s Done` |
+| Mark Done (current branch) | `linear-cli done` |
+| Close (alias for Done) | `linear-cli i close LIN-123` |
+| Assign | `linear-cli i assign LIN-123 "Alice"` |
+| Move to a project | `linear-cli i move LIN-123 "Q2 Project"` |
+| Transfer to a different team | `linear-cli i transfer LIN-123 ENG` |
+| Archive | `linear-cli i archive LIN-123` |
+| Open in browser | `linear-cli i open LIN-123` |
+| Print URL | `linear-cli i link LIN-123` |
+| Delete | `linear-cli i delete LIN-123 --force` |
+
+## Comment shortcut on the issue itself
+
+```bash
+linear-cli i comment LIN-123 -b "LGTM"     # equivalent to `linear-cli cm create LIN-123 -b ...`
+```
+
+For full comment CRUD see the comments section in `recipes/triage-and-comments.md`.
+
+## Get with extra context
+
+```bash
+linear-cli i get LIN-123                        # full body
+linear-cli i get LIN-123 --history              # activity timeline inline
+linear-cli i get LIN-123 --comments             # inline comments
+linear-cli i get LIN-1 LIN-2 LIN-3              # batch fetch — one API call
+linear-cli i get LIN-123 --output json          # parse-friendly
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `i close` | Alias for `i update -s Done`. |
+| `i archive` | Removes from default views; preserves history. Reversible via `i unarchive` (when supported). |
+| `i delete` | Hard delete — irreversible. Requires `--force`. |
+| `i stop` | Inverse of `i start`. Does not revert recent edits. |
+| `i transfer` | Moves the issue to a different team key (and re-numbers). |
+| `i move` | Moves the issue to a project; team unchanged. |
+| `i comment` | One-liner sugar for `cm create`. |
+
+## See also
+
+- `recipes/creating-many-issues.md` — bulk creation patterns using the flags above.
+- `recipes/git-and-pr-loop.md` — `i start --checkout` deep dive.
+- `issues/relations-and-labels.md` — wiring relations after create.
+- `issues/search-and-filter.md` — finding issues to update.
+- `output-and-scripting.md` — `--id-only`, `--dry-run`, `--data -` patterns.
+- `json-shapes.md` — the `i get` payload.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
@@ -57,7 +57,7 @@ linear-cli b label --add bug LIN-1 LIN-2 LIN-3
 linear-cli b label --add urgent --add bug LIN-1 LIN-2
 ```
 
-To remove a label, use the dedicated label delete or `i update` against each issue with the label removed (Linear's API does not currently expose a "remove specific label" bulk; confirm with `linear-cli b label --help` on your binary version).
+To remove a label from an issue, use `i update` with the remaining labels explicitly listed. Warning: `l delete` deletes the label definition globally (not just from issues); use it only to remove obsolete label types, not to remove labels from specific issues.
 
 ### Color hex format
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
@@ -75,7 +75,7 @@ linear-cli st get "In Progress" -t ENG             # one state's details
 linear-cli st update STATE_ID --name "Reviewing" --color "#3B82F6"
 ```
 
-When a team has custom states (e.g. `In Beta`, `Blocked`), confirm names with `st list` before using them in `i update -s ...` — typos return exit 2 (not found).
+When a team has custom states (e.g. `In Beta`, `Blocked`), confirm names with `st list` before using them in `i update -s ...` — typos return an exit-2 JSON not-found envelope.
 
 ## Templates
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
@@ -1,0 +1,131 @@
+# Relations, Labels, Statuses, Templates
+
+The "structural" surface around an issue: relations (parent/child/blocks), labels, workflow states, and templates.
+
+## Relations
+
+```bash
+linear-cli rel list LIN-123                          # show all relations
+linear-cli rel add LIN-1 -r blocks LIN-2             # LIN-1 blocks LIN-2
+linear-cli rel add LIN-1 -r related LIN-2            # related (non-directional)
+linear-cli rel add LIN-1 -r duplicate LIN-2          # duplicate-of
+linear-cli rel remove LIN-1 -r blocks LIN-2          # remove relation
+linear-cli rel parent LIN-2 LIN-1                    # set LIN-1 as parent of LIN-2
+linear-cli rel unparent LIN-2                        # remove parent
+```
+
+### Relation types
+
+| Type | Meaning | Direction |
+|---|---|---|
+| `blocks` | A blocks B | A → B |
+| `blocked-by` | A is blocked by B | A ← B |
+| `related` | A is related to B | undirected |
+| `duplicate` | A is a duplicate of B | A → B |
+
+`rel parent` is separate — it sets a true parent-child hierarchy used by Linear sub-issue rendering.
+
+### Wiring many sub-issues to one parent
+
+```bash
+PARENT=LIN-1
+for CHILD in LIN-101 LIN-102 LIN-103; do
+  linear-cli rel parent "$CHILD" "$PARENT"
+done
+```
+
+## Labels
+
+```bash
+linear-cli l list                              # list project + team labels
+linear-cli l list --type issue                 # issue labels only
+linear-cli l list --output json --compact
+
+linear-cli l create "Feature" --color "#10B981"
+linear-cli l create "Bug" --color "#EF4444" --id-only
+
+linear-cli l delete LABEL_ID
+linear-cli l delete LABEL_ID --force
+```
+
+### Apply / remove labels on issues
+
+Already covered in `lifecycle.md` for single issues. Bulk variant:
+
+```bash
+linear-cli b label --add bug LIN-1 LIN-2 LIN-3
+linear-cli b label --add urgent --add bug LIN-1 LIN-2
+```
+
+To remove a label, use the dedicated label delete or `i update` against each issue with the label removed (Linear's API does not currently expose a "remove specific label" bulk; confirm with `linear-cli b label --help` on your binary version).
+
+### Color hex format
+
+`#RRGGBB`. Linear accepts any 6-digit hex. Common semantic palette: `#EF4444` red (bug), `#F59E0B` amber (review), `#10B981` green (done/feature), `#3B82F6` blue (info).
+
+## Statuses (workflow states)
+
+Linear teams have a configurable workflow. Default states: `Backlog`, `Triage`, `In Progress`, `In Review`, `Done`, `Cancelled`.
+
+```bash
+linear-cli st list -t ENG                          # all states for the team
+linear-cli st list -t ENG --output json --compact
+linear-cli st get "In Progress" -t ENG             # one state's details
+linear-cli st update STATE_ID --name "Reviewing" --color "#3B82F6"
+```
+
+When a team has custom states (e.g. `In Beta`, `Blocked`), confirm names with `st list` before using them in `i update -s ...` — typos return exit 2 (not found).
+
+## Templates
+
+Two flavors:
+
+| Kind | Storage | Sharable | Command prefix |
+|---|---|---|---|
+| Local | Filesystem (your machine) | No | `linear-cli tpl ...` |
+| Remote (Linear API) | Linear workspace | Yes (whole team) | `linear-cli tpl remote-...` |
+
+### Local templates
+
+```bash
+linear-cli tpl list
+linear-cli tpl show bug
+linear-cli tpl create bug                          # interactive
+linear-cli tpl delete bug
+```
+
+### Remote templates
+
+```bash
+linear-cli tpl remote-list
+linear-cli tpl remote-list --output json
+linear-cli tpl remote-get TEMPLATE_ID
+linear-cli tpl remote-create "Bug Report" -t ENG
+linear-cli tpl remote-update TEMPLATE_ID --name "Updated"
+linear-cli tpl remote-delete TEMPLATE_ID --force
+```
+
+### Using a template when creating
+
+```bash
+linear-cli i create "Login bug" -t ENG --template "Bug Report"
+```
+
+Some binary versions resolve `--template` by ID rather than name — confirm with `linear-cli i create --help`.
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `rel parent` | Hierarchy (sub-issues). One parent per child. |
+| `rel add -r related` | Soft link, undirected. |
+| `l create --color` | Color is a hex string, including `#`. |
+| `st update` | Renames or recolors a workflow state — affects the whole team. |
+| `tpl` | Local templates on your machine. |
+| `tpl remote-*` | Linear workspace templates, visible to the whole team. |
+
+## See also
+
+- `issues/lifecycle.md` — applying labels/states during create/update.
+- `recipes/creating-many-issues.md` — bulk label batching, parent wiring.
+- `output-and-scripting.md` — `--id-only` for capturing label IDs to use in `--data -`.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/relations-and-labels.md
@@ -53,8 +53,9 @@ linear-cli l delete LABEL_ID --force
 Already covered in `lifecycle.md` for single issues. Bulk variant:
 
 ```bash
-linear-cli b label --add bug LIN-1 LIN-2 LIN-3
-linear-cli b label --add urgent --add bug LIN-1 LIN-2
+linear-cli b label bug -i LIN-1,LIN-2,LIN-3
+linear-cli b label urgent -i LIN-1,LIN-2
+linear-cli b label bug -i LIN-1,LIN-2
 ```
 
 To remove a label from an issue, use `i update` with the remaining labels explicitly listed. Warning: `l delete` deletes the label definition globally (not just from issues); use it only to remove obsolete label types, not to remove labels from specific issues.
@@ -100,7 +101,7 @@ linear-cli tpl delete bug
 linear-cli tpl remote-list
 linear-cli tpl remote-list --output json
 linear-cli tpl remote-get TEMPLATE_ID
-linear-cli tpl remote-create "Bug Report" -t ENG
+linear-cli tpl remote-create --name "Bug Report" --type issue -t ENG
 linear-cli tpl remote-update TEMPLATE_ID --name "Updated"
 linear-cli tpl remote-delete TEMPLATE_ID --force
 ```

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
@@ -1,0 +1,161 @@
+# Search and Filter
+
+Find issues fast — search, list flags, client-side filter, saved views, favorites, and the chaining patterns to feed results into other commands.
+
+## Free-text search
+
+```bash
+linear-cli s issues "authentication bug"
+linear-cli s issues "login" --limit 5
+linear-cli s issues "crash" --output json --fields identifier,title,state.name
+
+linear-cli s projects "backend"
+linear-cli s projects "api" --limit 10 --output json
+```
+
+Search is case-insensitive, scans titles and descriptions, and is best for keyword discovery rather than precise filters.
+
+## `i list` flag matrix
+
+```bash
+linear-cli i list                                  # everything you can see
+linear-cli i list --mine                           # assigned to me
+linear-cli i list -t ENG                           # team
+linear-cli i list -t ENG --mine
+linear-cli i list -s "In Progress"                 # status (workflow state name)
+linear-cli i list --assignee "Ada Lovelace"
+linear-cli i list --project "Q1 Roadmap"
+linear-cli i list --label bug
+linear-cli i list --since 7d                       # updated in the last 7 days
+linear-cli i list --view "My Sprint"               # apply a saved view
+linear-cli i list --group-by state                 # group by state / priority / assignee / project
+linear-cli i list --count-only --label bug         # count, no rows
+linear-cli i list --archived                       # include archived
+```
+
+| Flag | Filter |
+|---|---|
+| `--mine` | assigned to me |
+| `-t TEAM` / `--team` | team key |
+| `-s STATE` / `--state` | workflow state name |
+| `--assignee NAME` | name or `me` |
+| `--project NAME` | project name or ID |
+| `--label NAME` | label name (single) |
+| `--since DURATION` | `1d`, `7d`, `2w`, etc. |
+| `--view NAME` | apply a saved custom view |
+| `--group-by FIELD` | `state`, `priority`, `assignee`, `project` |
+| `--count-only` | return count, no rows |
+| `--archived` | include archived |
+| `--limit N` | hard cap |
+| `--all` / `--page-size N` / `--after CURSOR` | pagination |
+
+## Client-side `--filter`
+
+Server-side flags are first; `--filter` runs after the API result lands.
+
+```bash
+linear-cli i list -t ENG --filter priority=1
+linear-cli i list -t ENG --filter "state.name=In Progress"
+linear-cli i list -t ENG --filter "assignee.email~=@vendor.com"
+linear-cli i list -t ENG --filter "title~=login"
+linear-cli i list -t ENG --filter "priority!=4"
+```
+
+Operators:
+
+| Op | Meaning |
+|---|---|
+| `=` | equals (case-insensitive) |
+| `!=` | not equals |
+| `~=` | substring contains (case-insensitive) |
+
+Dot paths supported (e.g. `state.name`, `assignee.email`).
+
+`--filter` is **client-side** — it does not save API quota. Use the dedicated server-side flags first, then `--filter` for the long tail.
+
+## Output for chaining
+
+```bash
+linear-cli i list -t ENG --output json --compact \
+  --fields identifier,title,state.name,priority
+
+linear-cli i list -t ENG -s "In Progress" --id-only
+linear-cli i list -t ENG --format '{{identifier}} {{state.name}} {{title}}'
+```
+
+Pipe `--id-only` straight into `b ...` for bulk mutations:
+
+```bash
+linear-cli i list -t ENG -l stale --id-only \
+  | linear-cli b update-state -s "Cancelled" -
+```
+
+## Saved views
+
+Saved Linear views encode complex filters once and apply them everywhere.
+
+```bash
+linear-cli v list                              # all my views
+linear-cli v list --shared                     # shared views only
+linear-cli v get "Bug Triage"
+linear-cli v create "Open Bugs" -t ENG --shared
+linear-cli v update VIEW_ID --name "Open Bugs (P0–P2)"
+linear-cli v delete VIEW_ID --force
+```
+
+Apply a view to `i list` or `p list`:
+
+```bash
+linear-cli i list --view "Bug Triage"
+linear-cli p list --view "Active Projects"
+```
+
+## Favorites
+
+Personal shortcuts to issues / projects.
+
+```bash
+linear-cli fav list
+linear-cli fav add LIN-123
+linear-cli fav add PROJECT_UUID
+linear-cli fav remove LIN-123
+```
+
+## Recipe: "show me my urgent in-progress bugs"
+
+```bash
+linear-cli i list --mine -s "In Progress" -l bug \
+  --filter priority=1 \
+  --output json --fields identifier,title,project.name --compact
+```
+
+## Recipe: "issues stale > 14 days, group by assignee"
+
+```bash
+linear-cli i list -t ENG -s "In Progress" --since 14d --group-by assignee
+```
+
+## Recipe: "fail the build if there are no open bugs"
+
+```bash
+linear-cli i list -l bug -s "In Progress" --fail-on-empty \
+  || echo "no open bugs — nothing to triage"
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `s issues` | Free-text search across the workspace. |
+| `i list` | Filter-based listing. Faster, more precise. |
+| `--filter` | Client-side post-filter. |
+| `--state` | Server-side state filter. |
+| `--view NAME` | Apply a *saved* (server-side) view. |
+| `fav` | Personal pinning, not a query. |
+
+## See also
+
+- `output-and-scripting.md` — `--output ndjson`, `--fields`, `--filter` semantics.
+- `recipes/creating-many-issues.md` — using `i list --id-only` in idempotency checks.
+- `recipes/triage-and-comments.md` — using `s issues` to surface inbound work.
+- `planning/teams-and-org.md` — managing the saved views themselves.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
@@ -83,11 +83,12 @@ linear-cli i list -t ENG -s "In Progress" --id-only
 linear-cli i list -t ENG --format '{{identifier}} {{state.name}} {{title}}'
 ```
 
-Pipe `--id-only` straight into `b ...` for bulk mutations:
+For bulk mutations, convert `--id-only` output to a comma-separated `-i` value:
 
 ```bash
 linear-cli i list -t ENG -l stale --id-only \
-  | linear-cli b update-state -s "Cancelled" -
+  | paste -sd, \
+  | xargs -I {} linear-cli b update-state "Cancelled" -i {}
 ```
 
 ## Saved views

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
@@ -132,14 +132,19 @@ linear-cli i list --mine -s "In Progress" -l bug \
 ## Recipe: "issues stale > 14 days, group by assignee"
 
 ```bash
-linear-cli i list -t ENG -s "In Progress" --since 14d --group-by assignee
+# Find issues last updated more than 14 days ago (use --before, not --since)
+linear-cli i list -t ENG -s "In Progress" --before 14d --group-by assignee
 ```
 
-## Recipe: "fail the build if there are no open bugs"
+## Recipe: "fail CI if there are no open bugs"
 
 ```bash
-linear-cli i list -l bug -s "In Progress" --fail-on-empty \
-  || echo "no open bugs — nothing to triage"
+if linear-cli i list -l bug -s "In Progress" --fail-on-empty --quiet; then
+  echo "Found open bugs — triage required"
+else
+  echo "No open bugs — stopping"
+  exit 1
+fi
 ```
 
 ## Common confusions

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
@@ -83,12 +83,21 @@ linear-cli i list -t ENG -s "In Progress" --id-only
 linear-cli i list -t ENG --format '{{identifier}} {{state.name}} {{title}}'
 ```
 
-For bulk mutations, convert `--id-only` output to a comma-separated `-i` value:
+For bulk mutations, capture and inspect the generated ID set before passing it to `-i`:
 
 ```bash
-linear-cli i list -t ENG -l stale --id-only \
-  | paste -sd, \
-  | xargs -I {} linear-cli b update-state "Cancelled" -i {}
+linear-cli i list -t ENG -l stale --limit 25 --output json --compact \
+  --fields identifier,title,state.name > /tmp/linear-stale.json
+jq -r '.[] | "\(.identifier)\t\(.state.name)\t\(.title)"' /tmp/linear-stale.json
+COUNT=$(jq 'length' /tmp/linear-stale.json)
+IDS=$(jq -r '.[].identifier' /tmp/linear-stale.json | paste -sd,)
+[ "$COUNT" -gt 0 ] && [ "$COUNT" -le 25 ] || { echo "Unexpected count: $COUNT"; exit 1; }
+linear-cli b update-state "Cancelled" -i "$IDS" --dry-run
+if [ "$COUNT" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b update-state \"Cancelled\" -i \"$IDS\""
+  exit 0
+fi
+linear-cli b update-state "Cancelled" -i "$IDS"
 ```
 
 ## Saved views

--- a/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/issues/search-and-filter.md
@@ -132,8 +132,12 @@ linear-cli i list --mine -s "In Progress" -l bug \
 ## Recipe: "issues stale > 14 days, group by assignee"
 
 ```bash
-# Find issues last updated more than 14 days ago (use --before, not --since)
-linear-cli i list -t ENG -s "In Progress" --before 14d --group-by assignee
+# Fetch all In Progress issues with updatedAt, then filter client-side
+CUTOFF=$(node -e "console.log(new Date(Date.now() - 14*86400000).toISOString())")
+linear-cli i list -t ENG -s "In Progress" --output json --all \
+  --fields identifier,title,updatedAt,assignee.name \
+  | jq ".[] | select(.updatedAt < \"$CUTOFF\")" \
+  | jq -rs 'group_by(.assignee.name)[] | {assignee: .[0].assignee.name, issues: map(.identifier)}'
 ```
 
 ## Recipe: "fail CI if there are no open bugs"

--- a/skills/use-linear-cli/skills/use-linear-cli/references/json-shapes.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/json-shapes.md
@@ -1,0 +1,173 @@
+# JSON Shapes
+
+Concrete payload examples for the most-parsed `linear-cli` commands. Use these to know exactly which keys you can rely on without round-tripping to the upstream `docs/json/` samples.
+
+These shapes are stable as of `linear-cli` 0.35+. Always validate against the live binary if a key is load-bearing — `linear-cli i get LIN-123 --output json | jq keys`.
+
+## `linear-cli i list`
+
+```json
+[
+  {
+    "id": "issue_uuid",
+    "identifier": "LIN-123",
+    "title": "Fix login bug",
+    "priority": 2,
+    "state": { "name": "In Progress" },
+    "assignee": { "name": "Ada Lovelace" }
+  }
+]
+```
+
+Common `--fields` shortlist for agent token-frugality:
+
+```bash
+--fields identifier,title,state.name,priority,assignee.name
+```
+
+## `linear-cli i get LIN-123`
+
+```json
+{
+  "id": "issue_uuid",
+  "identifier": "LIN-123",
+  "title": "Fix login bug",
+  "description": "Steps to reproduce...",
+  "priority": 2,
+  "url": "https://linear.app/team/issue/LIN-123",
+  "createdAt": "2024-01-01T12:00:00.000Z",
+  "updatedAt": "2024-01-02T12:00:00.000Z",
+  "state": { "name": "In Progress" },
+  "team": { "name": "Engineering" },
+  "assignee": { "name": "Ada Lovelace", "email": "ada@example.com" },
+  "labels": { "nodes": [ { "name": "bug", "color": "#F59E0B" } ] },
+  "project": { "name": "Auth" },
+  "parent": { "identifier": "LIN-1", "title": "Auth workstream" }
+}
+```
+
+Key gotchas:
+
+- `priority` is `0`–`4` (Linear sets `0` = "no priority", `1` = urgent, `2` = high, `3` = normal, `4` = low).
+- `labels` is `{ "nodes": [...] }` — connection style. Use `labels.nodes.name` in `--fields`.
+- `assignee`, `project`, `parent` are `null` when unset.
+- `state.name` is the human label; `state.id` is the workflow-state UUID.
+
+## `linear-cli i get LIN-1 LIN-2 LIN-3` (batch)
+
+Returns a JSON array shaped like `i get`, one element per ID. Order matches argv order.
+
+## `linear-cli cm list LIN-123`
+
+```json
+[
+  {
+    "id": "comment_uuid",
+    "body": "LGTM",
+    "createdAt": "2024-01-02T12:00:00.000Z",
+    "user": { "name": "Ada Lovelace", "email": "ada@example.com" },
+    "issue": { "identifier": "LIN-123" }
+  }
+]
+```
+
+## `linear-cli context`
+
+The most useful command for an agent on a working branch — extracts the current issue from the git branch name.
+
+```json
+{
+  "branch": "feature/LIN-123-fix-login",
+  "issue_id": "LIN-123",
+  "found": true,
+  "issue": {
+    "id": "issue_uuid",
+    "identifier": "LIN-123",
+    "title": "Fix login bug",
+    "state": { "name": "In Progress" },
+    "assignee": { "name": "Ada Lovelace" },
+    "priority": 2,
+    "url": "https://linear.app/team/issue/LIN-123"
+  }
+}
+```
+
+When the branch does not encode an issue, `found: false` and `issue: null`. Always gate on `.found`:
+
+```bash
+linear-cli context --output json | jq -e '.found' >/dev/null \
+  || { echo "no Linear issue on this branch"; exit 1; }
+```
+
+## Error envelope (every command, when `--output json` is set)
+
+```json
+{
+  "error": true,
+  "message": "Issue not found: LIN-999",
+  "code": 2,
+  "details": { "status": 404, "reason": "Not Found", "request_id": null },
+  "retry_after": null
+}
+```
+
+| Field | Notes |
+|---|---|
+| `error` | `true` on failure. Always present on failed commands. |
+| `message` | Human-readable error. |
+| `code` | Same as the process exit code (1/2/3/4). |
+| `details.status` | HTTP status when relevant. |
+| `details.reason` | HTTP reason phrase. |
+| `details.request_id` | Linear request id — surface to users when reporting bugs. |
+| `retry_after` | Seconds to wait before retrying. Non-null only when `code == 4`. |
+
+## `linear-cli p list`
+
+```json
+[
+  {
+    "id": "project_uuid",
+    "name": "Q1 Roadmap",
+    "state": "started",
+    "icon": "🚀",
+    "priority": 1,
+    "startDate": "2025-01-01",
+    "targetDate": "2025-03-31",
+    "lead": { "name": "Ada Lovelace" }
+  }
+]
+```
+
+## `linear-cli t list`
+
+```json
+[
+  { "id": "team_uuid", "key": "ENG", "name": "Engineering" },
+  { "id": "team_uuid", "key": "DES", "name": "Design" }
+]
+```
+
+`key` is what you pass to most commands as `-t TEAM` (e.g. `ENG`).
+
+## `linear-cli sp velocity`
+
+```json
+{
+  "team": "ENG",
+  "cycles": [
+    { "name": "Sprint 4", "completed": 18, "planned": 22, "completion_rate": 0.82 }
+  ],
+  "average_completion_rate": 0.85,
+  "trend": "stable"
+}
+```
+
+## `linear-cli api query`
+
+Returns the raw GraphQL response body as-is. The CLI does not add a wrapper. See `advanced.md`.
+
+## See also
+
+- `output-and-scripting.md` — flags that produce these shapes.
+- `troubleshooting.md` — what to do when the error envelope appears.
+- `issues/lifecycle.md` — `--data -` JSON input shapes for create/update.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
@@ -1,0 +1,185 @@
+# Output and Scripting
+
+Every agent-relevant flag, exit code, env var, stdin pattern, and chaining recipe for `linear-cli`. This is the single source of truth for `--output`, pagination, and exit-code handling in agent scripts.
+
+## Output flags
+
+| Flag | Purpose |
+|---|---|
+| `--output json` | Machine-readable JSON. |
+| `--output ndjson` | Newline-delimited JSON (stream-friendly). |
+| `--compact` | Strip pretty-print whitespace. |
+| `--fields a,b,c` | Whitelist fields. Dot paths supported (`state.name`, `labels.nodes.name`). |
+| `--sort field` | Sort JSON arrays by field (default: `identifier` / `id`). |
+| `--order asc\|desc` | Sort direction. |
+| `--filter k=v` | Client-side filter. Operators: `=`, `!=`, `~=` (substring). Dot paths. Case-insensitive. |
+| `--format tpl` | Template output, e.g. `"{{identifier}} {{title}}"`. |
+| `--id-only` | Emit only the created/updated resource ID. |
+| `--quiet` / `-q` | Suppress decoration / progress output. |
+| `--fail-on-empty` | Exit non-zero when an array result is empty (great for `set -e` agents). |
+| `--no-pager` | Bypass auto-pager (use in CI / agent runs). |
+| `--no-cache` | Bypass read-through cache. |
+| `--dry-run` | Preview a mutation without writing. |
+| `--yes` / `-y` | Auto-confirm interactive prompts. |
+| `--no-color` | Strip ANSI color codes (also good for log capture). |
+| `--width N` / `--no-truncate` | Table width control. |
+
+## Session defaults
+
+```bash
+export LINEAR_CLI_OUTPUT=json     # all commands default to JSON
+export LINEAR_CLI_NO_PAGER=1      # no pager
+export LINEAR_CLI_YES=1           # auto-confirm prompts (dangerous if mutating; opt in deliberately)
+```
+
+## Stdin patterns
+
+| Pattern | Use |
+|---|---|
+| `linear-cli i create "Title" -t ENG -d -` | Read **description body** from stdin. |
+| `linear-cli i create "Title" -t ENG --data -` | Read a **full JSON object** as the issue body. Useful for templated batch creation. |
+| `linear-cli i update LIN-123 --data -` | Same JSON-body pattern for updates. |
+| `linear-cli api query -` | Read a GraphQL query from stdin. |
+| `linear-cli b assign --user me -` | Read whitespace-separated IDs from stdin (combine with `i list --id-only`). |
+
+Example chains:
+
+```bash
+# Description from a file
+cat findings.md | linear-cli i create "Investigate prod 500" -t ENG -d -
+
+# Full JSON body
+cat <<EOF | linear-cli i create "Bug" -t ENG --data -
+{
+  "priority": 1,
+  "description": "Repro steps...",
+  "labelIds": ["LABEL_UUID_1"]
+}
+EOF
+
+# IDs piped from one command into another
+linear-cli i list -t ENG -s "In Progress" --id-only \
+  | linear-cli b label --add review
+```
+
+## Pagination
+
+```bash
+linear-cli i list --limit 25
+linear-cli i list --all                        # walk every page
+linear-cli i list --all --page-size 100
+linear-cli i list --after CURSOR_TOKEN
+```
+
+Use `--all` cautiously — large workspaces produce many pages. Prefer narrow filters first.
+
+## Exit codes (contract)
+
+| Code | Meaning | What an agent should do |
+|---|---|---|
+| 0 | success | continue |
+| 1 | general error | parse stderr / JSON error envelope; surface to user |
+| 2 | not found | the ID does not exist; do not retry |
+| 3 | auth error | route to `setup.md` and re-auth |
+| 4 | rate limited | sleep `retry_after` seconds (in JSON body), retry once |
+
+JSON error envelope (when `--output json` is set on a failing command):
+
+```json
+{
+  "error": true,
+  "message": "Issue not found: LIN-999",
+  "code": 2,
+  "details": { "status": 404, "reason": "Not Found", "request_id": null },
+  "retry_after": null
+}
+```
+
+`retry_after` is non-null when `code == 4`.
+
+Agent retry pattern (rate limit only):
+
+```bash
+out=$(linear-cli i list --output json 2>/dev/null)
+code=$?
+if [ "$code" = 4 ]; then
+  sleep "$(echo "$out" | jq -r '.retry_after // 5')"
+  out=$(linear-cli i list --output json)
+fi
+```
+
+## Chaining recipes
+
+### Capture an ID for later commands
+
+```bash
+ID=$(linear-cli i create "Bug" -t ENG --id-only --quiet)
+linear-cli rel parent "$ID" LIN-100
+linear-cli i update "$ID" -l bug -p 1
+```
+
+### Field-selected JSON for token efficiency
+
+```bash
+linear-cli i list -t ENG --output json --compact \
+  --fields identifier,title,state.name,assignee.name
+```
+
+### Group + count (no JSON parsing needed)
+
+```bash
+linear-cli i list -t ENG --group-by state --count-only
+```
+
+### Streaming many results
+
+```bash
+linear-cli i list --all --output ndjson \
+  | jq -r 'select(.priority == 1) | .identifier'
+```
+
+### Templates for one-line summaries
+
+```bash
+linear-cli i list -t ENG --format '{{identifier}} {{state.name}} {{title}}'
+```
+
+### Pipe IDs into a bulk mutation
+
+```bash
+linear-cli s issues "stale" --output json --fields identifier --compact \
+  | jq -r '.[].identifier' \
+  | linear-cli b label --add stale -
+```
+
+### Fail loudly on empty result
+
+```bash
+linear-cli i list --mine --state "In Progress" --fail-on-empty \
+  || echo "no work in progress — nothing to report"
+```
+
+## Common pitfalls
+
+- `--output json` is per-command; set `LINEAR_CLI_OUTPUT=json` once per session to avoid re-typing.
+- `--fields` accepts dot paths but **not** `nodes.*` shorthand — use `labels.nodes.name`.
+- `--filter` is *client-side* — it does not reduce API cost. For server-side narrowing, use the dedicated flags (`--state`, `--label`, `--assignee`, `--project`, `--team`, `--since`, `--view`).
+- `--id-only` returns just the ID; an empty result still produces empty stdout — check exit code.
+- `--dry-run` is supported on create/update/import/bulk/sprint commands. Read each `--help` to confirm.
+- `LINEAR_CLI_YES=1` auto-confirms destructive prompts. Use `--force` per-command instead when you want explicit opt-in.
+
+## Pagination + JSON together
+
+```bash
+linear-cli i list --all --page-size 100 \
+  --output ndjson \
+  --fields identifier,title,state.name,priority \
+  | jq -s 'sort_by(.priority)'
+```
+
+## See also
+
+- `setup.md` for env vars and profile switching.
+- `json-shapes.md` for the actual payload shapes you will be parsing.
+- `troubleshooting.md` for exit-code-by-exit-code recovery.
+- `recipes/creating-many-issues.md` for a worked example using these flags end-to-end.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
@@ -100,11 +100,11 @@ JSON error envelope (when `--output json` is set on a failing command):
 Agent retry pattern (rate limit only):
 
 ```bash
-out=$(linear-cli i list --output json 2>/dev/null)
+out=$(linear-cli i list --output json 2>&1)
 code=$?
 if [ "$code" = 4 ]; then
   sleep "$(echo "$out" | jq -r '.retry_after // 5')"
-  out=$(linear-cli i list --output json)
+  out=$(linear-cli i list --output json 2>&1)
 fi
 ```
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
@@ -71,7 +71,7 @@ linear-cli i list --all --page-size 100
 linear-cli i list --after CURSOR_TOKEN
 ```
 
-Use `--all` cautiously — large workspaces produce many pages. Prefer narrow filters first.
+Use `--all` cautiously — large workspaces can produce hundreds of pages. Prefer narrow filters first (e.g., `-s "In Progress" -t ENG`). If you must use `--all`, prefer higher `--page-size N` (e.g., 500) to reduce the number of API calls.
 
 ## Exit codes (contract)
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
@@ -40,7 +40,7 @@ export LINEAR_CLI_YES=1           # auto-confirm prompts (dangerous if mutating;
 | `linear-cli i create "Title" -t ENG --data -` | Read a **full JSON object** as the issue body. Useful for templated batch creation. |
 | `linear-cli i update LIN-123 --data -` | Same JSON-body pattern for updates. |
 | `linear-cli api query -` | Read a GraphQL query from stdin. |
-| `linear-cli i list --id-only \| paste -sd, \| xargs -I {} linear-cli b assign me -i {}` | Collect IDs from stdin, convert to comma-separated form, then pass them via `-i`. |
+| `linear-cli i list ... --output json > /tmp/linear-ids.json` | Capture generated ID sets before any bulk mutation; inspect, count, dry-run, then execute against the same IDs. |
 
 Example chains:
 
@@ -57,10 +57,19 @@ cat <<EOF | linear-cli i create "Bug" -t ENG --data -
 }
 EOF
 
-# IDs piped from one command into another
-linear-cli i list -t ENG -s "In Progress" --id-only \
-  | paste -sd, \
-  | xargs -I {} linear-cli b label review -i {}
+# IDs from one command into a bulk mutation: capture first
+linear-cli i list -t ENG -s "In Progress" --limit 25 --output json --compact \
+  --fields identifier,title > /tmp/linear-review-ids.json
+jq -r '.[] | "\(.identifier)\t\(.title)"' /tmp/linear-review-ids.json
+COUNT=$(jq 'length' /tmp/linear-review-ids.json)
+IDS=$(jq -r '.[].identifier' /tmp/linear-review-ids.json | paste -sd,)
+[ "$COUNT" -gt 0 ] && [ "$COUNT" -le 25 ] || { echo "Unexpected count: $COUNT"; exit 1; }
+linear-cli b label review -i "$IDS" --dry-run
+if [ "$COUNT" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b label review -i \"$IDS\""
+  exit 0
+fi
+linear-cli b label review -i "$IDS"
 ```
 
 ## Pagination
@@ -72,7 +81,7 @@ linear-cli i list --all --page-size 100
 linear-cli i list --after CURSOR_TOKEN
 ```
 
-Use `--all` cautiously — large workspaces can produce hundreds of pages. Prefer narrow filters first (e.g., `-s "In Progress" -t ENG`). If you must use `--all`, prefer higher `--page-size N` (e.g., 500) to reduce the number of API calls.
+Use `--all` cautiously — large workspaces can produce hundreds of pages. Prefer narrow server-side filters and field selection first (e.g., `-s "In Progress" -t ENG --fields identifier,title`). Linear query complexity is multiplied by pagination size for connection fields, so do not blindly raise `--page-size`. Use the default or `50`-`100` for broad scans; only raise page size after checking the payload shape is narrow enough.
 
 ## Exit codes (contract)
 
@@ -80,7 +89,7 @@ Use `--all` cautiously — large workspaces can produce hundreds of pages. Prefe
 |---|---|---|
 | 0 | success | continue |
 | 1 | general error | parse stderr / JSON error envelope; surface to user |
-| 2 | not found | the ID does not exist; do not retry |
+| 2 | not found or parser error | If JSON with `details.status: 404`, the ID/object does not exist; do not retry. If plain stderr/usage text, fix the command syntax via `--help`. |
 | 3 | auth error | route to `setup.md` and re-auth |
 | 4 | rate limited | sleep `retry_after` seconds (in JSON body), retry once |
 
@@ -97,6 +106,17 @@ JSON error envelope (when `--output json` is set on a failing command):
 ```
 
 `retry_after` is non-null when `code == 4`.
+
+Parser errors can also exit 2. Regression check:
+
+```bash
+set +e
+out=$(linear-cli i list --state 2>&1)
+code=$?
+set -e
+test "$code" = 2
+printf '%s\n' "$out" | grep -E "value is required|Usage:|unexpected argument"
+```
 
 Agent retry pattern (rate limit only):
 
@@ -148,10 +168,18 @@ linear-cli i list -t ENG --format '{{identifier}} {{state.name}} {{title}}'
 ### Pipe IDs into a bulk mutation
 
 ```bash
-linear-cli s issues "stale" --output json --fields identifier --compact \
-  | jq -r '.[].identifier' \
-  | paste -sd, \
-  | xargs -I {} linear-cli b label stale -i {}
+linear-cli s issues "stale" --limit 25 --output json --fields identifier,title --compact \
+  > /tmp/linear-stale-issues.json
+jq -r '.[] | "\(.identifier)\t\(.title)"' /tmp/linear-stale-issues.json
+COUNT=$(jq 'length' /tmp/linear-stale-issues.json)
+IDS=$(jq -r '.[].identifier' /tmp/linear-stale-issues.json | paste -sd,)
+[ "$COUNT" -gt 0 ] && [ "$COUNT" -le 25 ] || { echo "Unexpected count: $COUNT"; exit 1; }
+linear-cli b label stale -i "$IDS" --dry-run
+if [ "$COUNT" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b label stale -i \"$IDS\""
+  exit 0
+fi
+linear-cli b label stale -i "$IDS"
 ```
 
 ### Fail loudly on empty result

--- a/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/output-and-scripting.md
@@ -40,7 +40,7 @@ export LINEAR_CLI_YES=1           # auto-confirm prompts (dangerous if mutating;
 | `linear-cli i create "Title" -t ENG --data -` | Read a **full JSON object** as the issue body. Useful for templated batch creation. |
 | `linear-cli i update LIN-123 --data -` | Same JSON-body pattern for updates. |
 | `linear-cli api query -` | Read a GraphQL query from stdin. |
-| `linear-cli b assign --user me -` | Read whitespace-separated IDs from stdin (combine with `i list --id-only`). |
+| `linear-cli i list --id-only \| paste -sd, \| xargs -I {} linear-cli b assign me -i {}` | Collect IDs from stdin, convert to comma-separated form, then pass them via `-i`. |
 
 Example chains:
 
@@ -59,7 +59,8 @@ EOF
 
 # IDs piped from one command into another
 linear-cli i list -t ENG -s "In Progress" --id-only \
-  | linear-cli b label --add review
+  | paste -sd, \
+  | xargs -I {} linear-cli b label review -i {}
 ```
 
 ## Pagination
@@ -149,7 +150,8 @@ linear-cli i list -t ENG --format '{{identifier}} {{state.name}} {{title}}'
 ```bash
 linear-cli s issues "stale" --output json --fields identifier --compact \
   | jq -r '.[].identifier' \
-  | linear-cli b label --add stale -
+  | paste -sd, \
+  | xargs -I {} linear-cli b label stale -i {}
 ```
 
 ### Fail loudly on empty result

--- a/skills/use-linear-cli/skills/use-linear-cli/references/planning/projects-and-cycles.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/planning/projects-and-cycles.md
@@ -1,0 +1,199 @@
+# Projects, Cycles, Sprints, Milestones, Roadmaps, Initiatives
+
+The Linear planning surface — everything above the issue level. One file because most of these commands are read-mostly and have similar shape.
+
+## Projects
+
+```bash
+linear-cli p list
+linear-cli p list --archived
+linear-cli p list --view "Active"
+
+linear-cli p get PROJECT_ID                              # or by name
+linear-cli p open "Q1 Roadmap"                           # browser
+
+linear-cli p create "Q1 Roadmap" -t ENG
+linear-cli p create "Feature" -t ENG \
+  --icon "🚀" --priority 1 \
+  --start-date 2025-01-01 --target-date 2025-03-31 \
+  --lead USER_ID --status planned \
+  --content "Project description"
+
+linear-cli p update PROJECT_ID --name "New Name" --status completed
+linear-cli p update PROJECT_ID --lead USER_ID --priority 2
+
+linear-cli p archive PROJECT_ID
+linear-cli p unarchive PROJECT_ID
+linear-cli p delete PROJECT_ID --force
+
+linear-cli p add-labels PROJECT_ID -l label1 -l label2
+linear-cli p remove-labels PROJECT_ID -l label1
+linear-cli p set-labels PROJECT_ID -l label1 -l label2
+
+linear-cli p members PROJECT_ID
+```
+
+### Project create flag matrix
+
+| Flag | Meaning |
+|---|---|
+| `-t TEAM` (req) | Team key |
+| `--icon EMOJI` | Project icon |
+| `--priority N` | 1=urgent..4=low |
+| `--start-date DATE` | ISO date or `+Nw` |
+| `--target-date DATE` | ISO date or `+Nw` |
+| `--lead USER` | Lead (UUID, name, or email) |
+| `--status STATE` | `planned`, `started`, `paused`, `completed`, `canceled` |
+| `--content "..."` | Project description |
+| `--id-only` | Output only the new ID |
+
+## Project updates (status reports on a project)
+
+Different from `i update`. These are *project health updates*.
+
+```bash
+linear-cli pu list "My Project"
+linear-cli pu list "My Project" --output json
+linear-cli pu get UPDATE_ID
+
+linear-cli pu create "My Project" -b "On track this sprint"
+linear-cli pu create "My Project" -b "Blocked on API" --health atRisk
+
+linear-cli pu update UPDATE_ID -b "Updated status"
+linear-cli pu archive UPDATE_ID
+linear-cli pu unarchive UPDATE_ID
+```
+
+### Health values
+
+| Value | Meaning |
+|---|---|
+| `onTrack` | Green — on schedule |
+| `atRisk` | Yellow — slipping |
+| `offTrack` | Red — won't make it |
+
+## Milestones
+
+```bash
+linear-cli ms list -p "My Project"
+linear-cli ms list -p "My Project" --output json
+linear-cli ms get MILESTONE_ID
+
+linear-cli ms create "Beta Release" -p "My Project"
+linear-cli ms create "GA" -p PROJ --target-date 2025-06-01
+linear-cli ms update MILESTONE_ID --target-date +2w
+linear-cli ms update MILESTONE_ID --name "Renamed"
+linear-cli ms delete MILESTONE_ID --force
+```
+
+`--target-date` accepts ISO `YYYY-MM-DD` or relative `+Nw`/`+Nd`.
+
+## Cycles (Linear's name for sprints)
+
+```bash
+linear-cli c list -t ENG
+linear-cli c list -t ENG --output json
+linear-cli c current -t ENG                            # the active cycle
+linear-cli c get CYCLE_ID                              # detail incl. issues
+
+linear-cli c create -t ENG --name "Sprint 5"
+linear-cli c create -t ENG --name "Sprint 5" \
+  --starts-at 2024-01-01 --ends-at 2024-01-14
+
+linear-cli c update CYCLE_ID --name "Sprint 5b"
+linear-cli c update CYCLE_ID --description "Updated goals" --dry-run
+
+linear-cli c complete CYCLE_ID
+linear-cli c delete CYCLE_ID --force
+```
+
+## Sprint analytics
+
+Built on top of cycles. The most commonly used live commands.
+
+```bash
+linear-cli sp status -t ENG                            # current sprint summary
+linear-cli sp progress -t ENG                          # visual completion bar
+linear-cli sp plan -t ENG                              # next cycle's planned issues
+linear-cli sp carry-over -t ENG --force                # move incomplete to next cycle
+linear-cli sp burndown -t ENG                          # ASCII burndown chart
+linear-cli sp velocity -t ENG                          # last 6 cycles by default
+linear-cli sp velocity -t ENG --cycles 10              # last 10 cycles
+linear-cli sp velocity -t ENG --output json
+```
+
+| Subcommand | What it shows |
+|---|---|
+| `status` | Current sprint overview |
+| `progress` | Completion bar |
+| `plan` | Next cycle's planned issues |
+| `carry-over` | Move incomplete to next cycle |
+| `burndown` | ASCII burndown chart |
+| `velocity` | Sprint velocity + trend |
+
+## Roadmaps
+
+Read-mostly today.
+
+```bash
+linear-cli rm list
+linear-cli rm get ROADMAP_ID
+linear-cli rm list --output json
+```
+
+Some binary versions support `rm create`/`rm update`/`rm delete`. Run `linear-cli rm --help` to confirm before using.
+
+## Initiatives
+
+High-level tracking spanning multiple projects. Read-mostly.
+
+```bash
+linear-cli init list
+linear-cli init get INITIATIVE_ID
+linear-cli init list --output json
+```
+
+## Recipe: "what cycle am I in and how am I tracking?"
+
+```bash
+linear-cli sp status -t ENG
+linear-cli sp progress -t ENG
+linear-cli sp burndown -t ENG
+```
+
+## Recipe: "carry over and start next sprint"
+
+```bash
+linear-cli c current -t ENG --output json
+linear-cli sp carry-over -t ENG --force
+linear-cli c create -t ENG --name "Sprint $(date +%V)" \
+  --starts-at "$(date +%Y-%m-%d)" \
+  --ends-at "$(date -v +14d +%Y-%m-%d)"
+```
+
+## Recipe: "post a project health update"
+
+```bash
+linear-cli pu create "Auth Workstream" \
+  -b "Slipped one week — vendor SLA blocker." \
+  --health atRisk
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `pu` | *Project* updates — health reports on projects. |
+| `cm` | *Issue* comments. |
+| `c` | Cycles (Linear's sprint primitive). |
+| `sp` | Sprint analytics layered over cycles. |
+| `rm` | Roadmaps. |
+| `init` | Initiatives. |
+| `ms` | Milestones (project-scoped). |
+
+## See also
+
+- `planning/teams-and-org.md` — teams, users, custom views.
+- `data/import-export.md` — exporting projects to CSV.
+- `recipes/creating-many-issues.md` — using `--project NAME` to attach issues during bulk creation.
+- `output-and-scripting.md` — `--output json` and `--fields` for plumbing.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/planning/projects-and-cycles.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/planning/projects-and-cycles.md
@@ -166,9 +166,12 @@ linear-cli sp burndown -t ENG
 ```bash
 linear-cli c current -t ENG --output json
 linear-cli sp carry-over -t ENG --force
+
+# Cross-platform 14-day-ahead date calculation
+END_DATE=$(node -e "console.log(new Date(Date.now() + 14*86400000).toISOString().split('T')[0])")
 linear-cli c create -t ENG --name "Sprint $(date +%V)" \
   --starts-at "$(date +%Y-%m-%d)" \
-  --ends-at "$(date -v +14d +%Y-%m-%d)"
+  --ends-at "$END_DATE"
 ```
 
 ## Recipe: "post a project health update"

--- a/skills/use-linear-cli/skills/use-linear-cli/references/planning/projects-and-cycles.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/planning/projects-and-cycles.md
@@ -26,9 +26,9 @@ linear-cli p archive PROJECT_ID
 linear-cli p unarchive PROJECT_ID
 linear-cli p delete PROJECT_ID --force
 
-linear-cli p add-labels PROJECT_ID -l label1 -l label2
-linear-cli p remove-labels PROJECT_ID -l label1
-linear-cli p set-labels PROJECT_ID -l label1 -l label2
+linear-cli p add-labels PROJECT_ID label1 label2
+linear-cli p remove-labels PROJECT_ID label1
+linear-cli p set-labels PROJECT_ID label1 label2
 
 linear-cli p members PROJECT_ID
 ```

--- a/skills/use-linear-cli/skills/use-linear-cli/references/planning/teams-and-org.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/planning/teams-and-org.md
@@ -77,15 +77,14 @@ linear-cli fav remove LIN-123
 linear-cli fav list --output json
 ```
 
-## Recipe: "list every team I belong to"
+## Recipe: "list all teams in my workspace"
 
 ```bash
-linear-cli u me --output json --fields id --compact \
-  | jq -r .id \
-  | xargs -I{} linear-cli u get {} --output json
-# Or simpler:
+# List all teams accessible in the current workspace
 linear-cli t list --output json
 ```
+
+Note: This lists all teams in the workspace, not just those you belong to. `linear-cli` does not currently expose a "teams I'm a member of" filter; to check membership, review the `members` field in the JSON output for each team.
 
 ## Recipe: "resolve a label by name to its UUID"
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/planning/teams-and-org.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/planning/teams-and-org.md
@@ -1,0 +1,118 @@
+# Teams, Users, Views, Favorites
+
+Org-level surface — teams, users (incl. `me`), custom views, and personal favorites.
+
+## Teams
+
+```bash
+linear-cli t list
+linear-cli t list --output json --compact
+
+linear-cli t get ENG                          # by team key
+linear-cli t members ENG
+
+linear-cli t create "Platform" -k PLT
+linear-cli t create "Mobile" -k MOB --description "Mobile team" --private
+
+linear-cli t update ENG --name "Engineering" --timezone "America/New_York"
+
+linear-cli t delete TEAM_ID --force
+```
+
+### Team keys
+
+A team key is the short prefix used in identifiers (e.g. `LIN`, `ENG`, `MOB`). Pass it as `-t KEY` everywhere — `i list -t ENG`, `i create "..." -t ENG`, `c list -t ENG`, etc.
+
+Resolve unknowns:
+
+```bash
+linear-cli t list --output json --compact --fields key,name
+```
+
+## Users
+
+```bash
+linear-cli u list                             # all workspace users
+linear-cli u list --team ENG                  # team members only
+linear-cli u me                               # the calling user
+linear-cli whoami                             # alias for u me
+linear-cli u get "ada@example.com"            # lookup
+```
+
+### Resolve "me" once per session
+
+```bash
+ME=$(linear-cli u me --output json --fields id,name,email --compact)
+echo "$ME" | jq -r '.email'
+```
+
+## Custom views
+
+Saved filter sets, applied to `i list` / `p list`.
+
+```bash
+linear-cli v list
+linear-cli v list --shared                    # shared views only
+linear-cli v get "Bug Triage"
+
+linear-cli v create "Open Bugs" -t ENG --shared
+linear-cli v update VIEW_ID --name "Open Bugs (P0–P2)"
+linear-cli v delete VIEW_ID --force
+
+linear-cli i list --view "Bug Triage"
+linear-cli p list --view "Active Projects"
+```
+
+Use views to encode the team's blessed filters once and have agents reference them by name instead of re-deriving filter logic.
+
+## Favorites
+
+Personal pinning to issues / projects.
+
+```bash
+linear-cli fav list
+linear-cli fav add LIN-123                    # add issue
+linear-cli fav add PROJECT_UUID               # add project
+linear-cli fav remove LIN-123
+linear-cli fav list --output json
+```
+
+## Recipe: "list every team I belong to"
+
+```bash
+linear-cli u me --output json --fields id --compact \
+  | jq -r .id \
+  | xargs -I{} linear-cli u get {} --output json
+# Or simpler:
+linear-cli t list --output json
+```
+
+## Recipe: "resolve a label by name to its UUID"
+
+```bash
+LABEL_ID=$(linear-cli l list --output json --compact \
+  | jq -r '.[] | select(.name == "bug") | .id')
+```
+
+## Recipe: "find every issue assigned to a teammate"
+
+```bash
+linear-cli i list --assignee "Ada Lovelace" \
+  --output json --fields identifier,title,state.name --compact
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `t` | Teams |
+| `u` | Users |
+| `v` | Custom views |
+| `fav` | Favorites (personal pins) |
+| `whoami` | Alias for `u me` |
+
+## See also
+
+- `issues/search-and-filter.md` — applying views to `i list`.
+- `setup.md` — workspaces vs teams; profiles vs accounts.
+- `planning/projects-and-cycles.md` — assigning issues to projects.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
@@ -16,7 +16,8 @@ End-to-end patterns for "I have a spec / checklist / CSV / JSON, create N Linear
 ## Setup gate (do this first, every time)
 
 ```bash
-linear-cli auth status                              # exit 0 required
+linear-cli auth status --validate --output json     # exit 0 required
+linear-cli config workspace-current                 # confirm intended workspace/profile
 TEAM=ENG                                            # team key
 linear-cli t get "$TEAM" --output json --fields id,key,name   # confirm team exists
 export LINEAR_CLI_OUTPUT=json
@@ -47,6 +48,11 @@ for t in "${TITLES[@]}"; do
   linear-cli i create "$t" -t "$TEAM" --dry-run
 done
 
+if [ "${#TITLES[@]}" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to create ${#TITLES[@]} issues."
+  exit 0
+fi
+
 # Commit + capture IDs
 CREATED=()
 for t in "${TITLES[@]}"; do
@@ -61,6 +67,11 @@ done
 
 # Batch label
 IDS=$(IFS=,; echo "${CREATED[*]}")
+linear-cli b label backlog -i "$IDS" --dry-run
+if [ "${#CREATED[@]}" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b label backlog -i \"$IDS\""
+  exit 0
+fi
 linear-cli b label backlog -i "$IDS"
 
 # Report
@@ -229,11 +240,22 @@ done
 If you've already created the issues and just want to retro-fit a label:
 
 ```bash
+linear-cli b label review -i LIN-101,LIN-102,LIN-103 --dry-run
 linear-cli b label review -i LIN-101,LIN-102,LIN-103
-# or pipe IDs from a query
-linear-cli i list -t ENG -s "Backlog" --id-only \
-  | paste -sd, \
-  | xargs -I {} linear-cli b label unreviewed -i {}
+
+# Or capture IDs from a query
+linear-cli i list -t ENG -s "Backlog" --limit 25 --output json --compact \
+  --fields identifier,title > /tmp/linear-backlog.json
+jq -r '.[] | "\(.identifier)\t\(.title)"' /tmp/linear-backlog.json
+COUNT=$(jq 'length' /tmp/linear-backlog.json)
+IDS=$(jq -r '.[].identifier' /tmp/linear-backlog.json | paste -sd,)
+[ "$COUNT" -gt 0 ] && [ "$COUNT" -le 25 ] || { echo "Unexpected count: $COUNT"; exit 1; }
+linear-cli b label unreviewed -i "$IDS" --dry-run
+if [ "$COUNT" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b label unreviewed -i \"$IDS\""
+  exit 0
+fi
+linear-cli b label unreviewed -i "$IDS"
 ```
 
 ## Rollback
@@ -247,6 +269,10 @@ IDS=$(IFS=,; echo "${BATCH[*]}")
 
 # Mark them cancelled (preserves history)
 linear-cli b update-state "Cancelled" -i "$IDS" --dry-run
+if [ "${#BATCH[@]}" -gt 5 ] && [ "${CONFIRMED_BULK_LINEAR:-}" != 1 ]; then
+  echo "Review the dry-run output, then rerun with CONFIRMED_BULK_LINEAR=1 to execute: linear-cli b update-state \"Cancelled\" -i \"$IDS\""
+  exit 0
+fi
 linear-cli b update-state "Cancelled" -i "$IDS"
 
 # Or archive (heavier — hides from default views)

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
@@ -84,11 +84,11 @@ There is **no transactional create**. If item 7/12 fails, items 1–6 are alread
 
 ```csv
 title,description,priority,status,assignee,labels,estimate,dueDate
-Fix login redirect,"Multi-line\ndescription",1,Backlog,ada@example.com,bug;auth,3,2026-05-01
+Fix login redirect,"Multi-line\ndescription",1,Backlog,ada@example.com,"bug,auth",3,2026-05-01
 Add 429 retry headers,"",2,Backlog,,api,2,
 ```
 
-`status`, `assignee`, and `labels` resolve by name automatically. Multi-value cells are `;`-separated.
+`status`, `assignee`, and `labels` resolve by name automatically. Multi-value label cells use comma separation inside a quoted CSV cell.
 
 ### Recipe
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
@@ -60,7 +60,8 @@ for ID in "${CREATED[@]}"; do
 done
 
 # Batch label
-linear-cli b label --add backlog "${CREATED[@]}"
+IDS=$(IFS=,; echo "${CREATED[*]}")
+linear-cli b label backlog -i "$IDS"
 
 # Report
 printf 'Created %d issues:\n' "${#CREATED[@]}"
@@ -72,8 +73,8 @@ printf '  %s\n' "${CREATED[@]}"
 There is **no transactional create**. If item 7/12 fails, items 1–6 are already in Linear. Three mitigations:
 
 1. **Always dry-run first** to confirm titles, team, priority.
-2. **Capture IDs as you go** so you can roll back with `b update-state -s "Cancelled"` or `i archive`.
-3. **Set a single batch label** (e.g. `--add batch:2026-04-28`) so you can find every issue from the run later.
+2. **Capture IDs as you go** so you can roll back with `b update-state "Cancelled" -i "$IDS"` or `i archive`.
+3. **Set a single batch label** (e.g. `b label batch:2026-04-28 -i "$IDS"`) so you can find every issue from the run later.
 
 ## Pattern B — CSV import
 
@@ -161,7 +162,7 @@ linear-cli tpl delete bug
 
 ```bash
 # Create a remote template tied to a team
-linear-cli tpl remote-create "Bug Report" -t ENG
+linear-cli tpl remote-create --name "Bug Report" --type issue -t ENG
 
 # List + get
 linear-cli tpl remote-list
@@ -228,10 +229,11 @@ done
 If you've already created the issues and just want to retro-fit a label:
 
 ```bash
-linear-cli b label --add review LIN-101 LIN-102 LIN-103
+linear-cli b label review -i LIN-101,LIN-102,LIN-103
 # or pipe IDs from a query
 linear-cli i list -t ENG -s "Backlog" --id-only \
-  | linear-cli b label --add unreviewed
+  | paste -sd, \
+  | xargs -I {} linear-cli b label unreviewed -i {}
 ```
 
 ## Rollback
@@ -241,10 +243,11 @@ If a run goes wrong:
 ```bash
 # Capture the IDs from the run
 BATCH=( "${CREATED[@]}" )
+IDS=$(IFS=,; echo "${BATCH[*]}")
 
 # Mark them cancelled (preserves history)
-linear-cli b update-state -s "Cancelled" "${BATCH[@]}" --dry-run
-linear-cli b update-state -s "Cancelled" "${BATCH[@]}"
+linear-cli b update-state "Cancelled" -i "$IDS" --dry-run
+linear-cli b update-state "Cancelled" -i "$IDS"
 
 # Or archive (heavier — hides from default views)
 for ID in "${BATCH[@]}"; do linear-cli i archive "$ID"; done

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/creating-many-issues.md
@@ -1,0 +1,269 @@
+# Recipe — Creating Many Issues at Once
+
+End-to-end patterns for "I have a spec / checklist / CSV / JSON, create N Linear issues from it." This is the single hottest agent workflow and the reason most agents reach for `linear-cli`.
+
+## Decision: which pattern?
+
+| Input shape | Pattern |
+|---|---|
+| Markdown checklist (`- [ ] item`) or bullet list | A — Loop with `i create --id-only` |
+| CSV with title/description/priority columns | B — `im csv` (preview then commit) |
+| JSON spec with structured per-issue fields | C — `i create --data -` per row |
+| You'll re-use this issue shape many times | D — Local or remote template + `i create --template` |
+| Issues are children of one parent / linked together | E — Pattern A or C + `rel parent` |
+| Long list pre-existing in another tracker | F — Convert to CSV, run B |
+
+## Setup gate (do this first, every time)
+
+```bash
+linear-cli auth status                              # exit 0 required
+TEAM=ENG                                            # team key
+linear-cli t get "$TEAM" --output json --fields id,key,name   # confirm team exists
+export LINEAR_CLI_OUTPUT=json
+export LINEAR_CLI_NO_PAGER=1
+```
+
+## Pattern A — Markdown checklist → many issues
+
+### Input
+
+```markdown
+# TODO
+
+- [ ] Replace deprecated auth middleware
+- [ ] Add rate-limit headers to public endpoints
+- [ ] Backfill audit log for 2025
+```
+
+### Recipe
+
+```bash
+TEAM=ENG
+PARENT=LIN-1                  # optional umbrella issue
+mapfile -t TITLES < <(grep -E '^- \[ \] ' TODO.md | sed -E 's/^- \[ \] //')
+
+# Dry-run preview
+for t in "${TITLES[@]}"; do
+  linear-cli i create "$t" -t "$TEAM" --dry-run
+done
+
+# Commit + capture IDs
+CREATED=()
+for t in "${TITLES[@]}"; do
+  ID=$(linear-cli i create "$t" -t "$TEAM" -p 3 --id-only --quiet) || break
+  CREATED+=("$ID")
+done
+
+# Wire to a parent issue (optional)
+for ID in "${CREATED[@]}"; do
+  linear-cli rel parent "$ID" "$PARENT"
+done
+
+# Batch label
+linear-cli b label --add backlog "${CREATED[@]}"
+
+# Report
+printf 'Created %d issues:\n' "${#CREATED[@]}"
+printf '  %s\n' "${CREATED[@]}"
+```
+
+### Atomicity note
+
+There is **no transactional create**. If item 7/12 fails, items 1–6 are already in Linear. Three mitigations:
+
+1. **Always dry-run first** to confirm titles, team, priority.
+2. **Capture IDs as you go** so you can roll back with `b update-state -s "Cancelled"` or `i archive`.
+3. **Set a single batch label** (e.g. `--add batch:2026-04-28`) so you can find every issue from the run later.
+
+## Pattern B — CSV import
+
+### Input
+
+`issues.csv`:
+
+```csv
+title,description,priority,status,assignee,labels,estimate,dueDate
+Fix login redirect,"Multi-line\ndescription",1,Backlog,ada@example.com,bug;auth,3,2026-05-01
+Add 429 retry headers,"",2,Backlog,,api,2,
+```
+
+`status`, `assignee`, and `labels` resolve by name automatically. Multi-value cells are `;`-separated.
+
+### Recipe
+
+```bash
+TEAM=ENG
+
+# 1. Preview — surface name resolution failures before committing
+linear-cli im csv issues.csv -t "$TEAM" --dry-run
+
+# 2. Commit
+linear-cli im csv issues.csv -t "$TEAM" --output json
+
+# Output is a JSON array of created issue objects (see json-shapes.md).
+```
+
+### Round-trip
+
+Export → tweak → re-import:
+
+```bash
+linear-cli exp json -t "$TEAM" -f backup.json
+# … edit backup.json …
+linear-cli im json backup.json -t "$TEAM" --dry-run
+linear-cli im json backup.json -t "$TEAM"
+```
+
+CSV columns are documented in `data/import-export.md`.
+
+## Pattern C — JSON spec, one create per row
+
+Use when each issue needs distinct rich fields (description body, parent issue, label IDs).
+
+### Input
+
+`plan.ndjson`:
+
+```ndjson
+{"title":"Replace auth mw","description":"…","priority":1,"labelIds":["LBL_UUID"],"parentId":"PARENT_UUID"}
+{"title":"Add rate headers","description":"…","priority":2}
+```
+
+### Recipe
+
+```bash
+TEAM=ENG
+while IFS= read -r row; do
+  title=$(jq -r '.title' <<<"$row")
+  ID=$(printf '%s' "$row" \
+    | linear-cli i create "$title" -t "$TEAM" --data - --id-only --quiet) \
+    || { echo "FAIL: $title" >&2; break; }
+  echo "$ID"
+done < plan.ndjson
+```
+
+`--data -` reads a full JSON object. Combine with `--id-only` to capture the new identifier.
+
+## Pattern D — Templates
+
+When the same issue shape recurs (post-mortem, RFC, bug, customer-onboarding), define a template and reuse it.
+
+### Local template (filesystem only)
+
+```bash
+linear-cli tpl create bug                 # interactive
+linear-cli tpl list
+linear-cli tpl show bug
+linear-cli tpl delete bug
+```
+
+### Remote template (Linear workspace)
+
+```bash
+# Create a remote template tied to a team
+linear-cli tpl remote-create "Bug Report" -t ENG
+
+# List + get
+linear-cli tpl remote-list
+linear-cli tpl remote-get TEMPLATE_ID
+```
+
+Then create issues *from* the template:
+
+```bash
+linear-cli i create "..." -t ENG --template "Bug Report"
+```
+
+(Confirm the exact `--template` flag with `linear-cli i create --help`; some versions resolve by ID rather than name.)
+
+## Pattern E — Parent / child wiring
+
+Use after Pattern A or C to nest the new issues under an umbrella issue.
+
+```bash
+PARENT=LIN-1
+for CHILD in LIN-101 LIN-102 LIN-103; do
+  linear-cli rel parent "$CHILD" "$PARENT"
+done
+```
+
+For non-parent links, use `rel add`:
+
+```bash
+linear-cli rel add LIN-101 -r blocks LIN-200
+linear-cli rel add LIN-101 -r related LIN-300
+linear-cli rel add LIN-101 -r duplicate LIN-400
+```
+
+See `issues/relations-and-labels.md` for the full relation type list.
+
+## Pattern F — Convert from another tracker
+
+If you're migrating from GitHub Issues, Jira, or a markdown export:
+
+1. Coerce to the CSV columns in Pattern B.
+2. Map status/assignee/label names to Linear's by hand or with a `sed`/`jq` pass.
+3. Run `im csv --dry-run` until name resolution is clean.
+4. Commit.
+
+## Idempotency
+
+Linear has **no native idempotency key**. To make a batch resumable:
+
+1. Tag every issue from the run with a unique batch label (e.g. `batch:2026-04-28-foo`).
+2. Before re-running, `linear-cli i list -l batch:2026-04-28-foo --output json --fields title` to see what already exists.
+3. Skip titles that already match.
+
+```bash
+EXISTING=$(linear-cli i list -l batch:2026-04-28-foo --output json --fields title \
+  --compact | jq -r '.[].title')
+for t in "${TITLES[@]}"; do
+  grep -Fxq "$t" <<<"$EXISTING" && continue
+  linear-cli i create "$t" -t ENG -l "batch:2026-04-28-foo" --id-only --quiet
+done
+```
+
+## Batch labelling without re-creating
+
+If you've already created the issues and just want to retro-fit a label:
+
+```bash
+linear-cli b label --add review LIN-101 LIN-102 LIN-103
+# or pipe IDs from a query
+linear-cli i list -t ENG -s "Backlog" --id-only \
+  | linear-cli b label --add unreviewed
+```
+
+## Rollback
+
+If a run goes wrong:
+
+```bash
+# Capture the IDs from the run
+BATCH=( "${CREATED[@]}" )
+
+# Mark them cancelled (preserves history)
+linear-cli b update-state -s "Cancelled" "${BATCH[@]}" --dry-run
+linear-cli b update-state -s "Cancelled" "${BATCH[@]}"
+
+# Or archive (heavier — hides from default views)
+for ID in "${BATCH[@]}"; do linear-cli i archive "$ID"; done
+```
+
+## Reporting back to the user
+
+End every batch with a short summary:
+
+```text
+Created 12 issues in ENG (3 urgent, 7 normal, 2 low). Batch label: batch:2026-04-28-todo.
+First: LIN-451 — "Replace deprecated auth middleware"
+Last: LIN-462 — "Backfill audit log for 2025"
+```
+
+## See also
+
+- `output-and-scripting.md` — every `--output`, `--id-only`, `--dry-run`, stdin pattern used here.
+- `data/import-export.md` — full CSV/JSON column schemas.
+- `issues/lifecycle.md` — full create/update flag matrix.
+- `issues/relations-and-labels.md` — full relation types and label CRUD.
+- `troubleshooting.md` — recovery when a batch hits rate limits or partial failures.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/git-and-pr-loop.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/git-and-pr-loop.md
@@ -117,14 +117,14 @@ git branch -D "$BRANCH_NAME"                        # optional cleanup
 
 ## Jujutsu (jj) support
 
-For jj users, every Git command has a parallel:
+For jj users, use the existing `git` commands and force `--vcs jj` when auto-detection is not enough:
 
 ```bash
-linear-cli j checkout LIN-123          # bookmark + check out
-linear-cli j bookmark LIN-123          # show bookmark name
-linear-cli j create LIN-123            # bookmark without check out
-linear-cli j pr LIN-123                # PR via jj git push
-linear-cli g commits                   # show commits with Linear trailers
+linear-cli g checkout LIN-123 --vcs jj       # bookmark + check out
+linear-cli g branch LIN-123 --vcs jj         # show bookmark name
+linear-cli g create LIN-123 --vcs jj         # bookmark without check out
+linear-cli g pr LIN-123                      # PR via GitHub CLI
+linear-cli g commits --vcs jj                # show commits with Linear trailers
 ```
 
 ## Draft → ready

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/git-and-pr-loop.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/git-and-pr-loop.md
@@ -1,0 +1,157 @@
+# Recipe — Git and PR Loop
+
+The full start → code → PR → done cycle for an agent picking up a Linear issue. Covers Git, Jujutsu, draft PRs, branch naming, and the auto-revert path when work is abandoned mid-flow.
+
+## The five-line happy path
+
+```bash
+linear-cli i start LIN-123 --checkout       # 1. assign me + In Progress + create + checkout branch
+# ... edit code, run tests ...
+git add . && git commit -m "fix: handle null session in /login"
+linear-cli g pr LIN-123 --draft             # 2. open a draft PR; auto-fills title + body
+linear-cli done                             # 3. read current branch, mark issue Done
+```
+
+## What `i start --checkout` does
+
+Atomically:
+
+1. Assigns the issue to you (`me`).
+2. Sets state to the team's "In Progress" workflow state.
+3. Creates the branch `<user>/lin-123-<title-slug>` (or matches the team's branch convention).
+4. Checks it out.
+
+If the branch already exists, `i start --checkout` re-uses it. To override the branch name:
+
+```bash
+linear-cli g checkout LIN-123 -b custom-branch-name
+```
+
+To create the branch without checking out:
+
+```bash
+linear-cli g create LIN-123
+```
+
+To just print the canonical branch name:
+
+```bash
+linear-cli g branch LIN-123
+```
+
+## Reverse direction: branch → issue
+
+```bash
+linear-cli context                          # human-readable
+linear-cli context --output json            # parse with jq
+```
+
+`context` reads the current branch, extracts the Linear identifier (e.g. `feat/SCW-123-foo` → `SCW-123`), and fetches the issue. See `json-shapes.md` for the payload.
+
+Gate any branch-driven workflow on `context`:
+
+```bash
+ISSUE=$(linear-cli context --output json | jq -r '.issue_id // empty')
+[ -n "$ISSUE" ] || { echo "no Linear issue on this branch"; exit 1; }
+```
+
+## Creating the PR
+
+```bash
+linear-cli g pr LIN-123                     # PR with auto-filled title/body from issue
+linear-cli g pr LIN-123 --draft             # draft PR
+linear-cli g pr LIN-123 --base main         # specify base
+linear-cli g pr LIN-123 --web               # open in browser after creation
+```
+
+Requires the GitHub `gh` CLI authenticated to the same repo. The PR title and body are auto-generated from the Linear issue (title, description, identifier in the body).
+
+## Closing the loop
+
+```bash
+linear-cli done                             # marks current branch's issue as Done
+linear-cli done --status "In Review"        # set a different state
+linear-cli done -s "In Progress"            # short flag
+```
+
+`done` reads the current branch, extracts the issue identifier, and updates state. Equivalent to:
+
+```bash
+ISSUE=$(linear-cli context --output json | jq -r .issue_id)
+linear-cli i update "$ISSUE" -s Done
+```
+
+## Leaving a finding in passing
+
+When you discover something during the work, comment on the issue without leaving the branch:
+
+```bash
+linear-cli cm create "$(linear-cli context --output json | jq -r .issue_id)" \
+  -b "Root cause: missing null check in handler.go:412 — fix in commit abc123."
+```
+
+Useful for handoff notes, partial fixes, or "I split this off into LIN-201".
+
+## Splitting work mid-flow
+
+If the issue grows new scope, split it:
+
+```bash
+PARENT=$(linear-cli context --output json | jq -r .issue_id)
+CHILD=$(linear-cli i create "Follow-up: extract retry helper" -t ENG --id-only --quiet)
+linear-cli rel parent "$CHILD" "$PARENT"
+linear-cli cm create "$PARENT" -b "Split out retry-helper extraction → $CHILD."
+```
+
+## Abort and revert
+
+If you start work but realize it's the wrong issue or the work isn't viable:
+
+```bash
+linear-cli i stop LIN-123              # unassign + reset to previous state
+git checkout main                      # leave the branch
+git branch -D <user>/lin-123-...       # optional cleanup
+```
+
+`i stop` is the inverse of `i start` (without the `--checkout`).
+
+## Jujutsu (jj) support
+
+For jj users, every Git command has a parallel:
+
+```bash
+linear-cli j checkout LIN-123          # bookmark + check out
+linear-cli j bookmark LIN-123          # show bookmark name
+linear-cli j create LIN-123            # bookmark without check out
+linear-cli j pr LIN-123                # PR via jj git push
+linear-cli g commits                   # show commits with Linear trailers
+```
+
+## Draft → ready
+
+When a draft PR is ready for review, mark it with `gh` (no Linear-specific command needed) and add a comment to the issue:
+
+```bash
+gh pr ready                                                    # convert draft → ready
+linear-cli cm create "$(linear-cli context --output json | jq -r .issue_id)" \
+  -b "PR is ready for review."
+linear-cli i update "$(linear-cli context --output json | jq -r .issue_id)" -s "In Review"
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `i start LIN-123 --checkout` | Atomic: assign + In Progress + branch + checkout. |
+| `g checkout LIN-123` | Just the branch part. Doesn't change assignment or state. |
+| `i update LIN-123 -s Done` | Generic. Safe for any issue. |
+| `linear-cli done` | Convenience for "the branch I'm on right now". |
+| `g pr LIN-123` | Creates a GitHub PR. Needs `gh` authenticated. |
+| `g branch LIN-123` | Prints the branch name; does not create or check out. |
+
+## See also
+
+- `issues/lifecycle.md` for the full `i start`/`i stop`/`i update` flag matrix.
+- `recipes/triage-and-comments.md` for handling inbound comments and screenshots.
+- `recipes/creating-many-issues.md` for spawning sub-issues.
+- `output-and-scripting.md` for the chaining patterns used above.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/git-and-pr-loop.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/git-and-pr-loop.md
@@ -108,12 +108,12 @@ linear-cli cm create "$PARENT" -b "Split out retry-helper extraction → $CHILD.
 If you start work but realize it's the wrong issue or the work isn't viable:
 
 ```bash
-linear-cli i stop LIN-123              # unassign + reset to previous state
-git checkout main                      # leave the branch
-git branch -D <user>/lin-123-...       # optional cleanup
+linear-cli i stop LIN-123                           # unassign + reset to previous state
+git checkout "$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
+git branch -D "$BRANCH_NAME"                        # optional cleanup
 ```
 
-`i stop` is the inverse of `i start` (without the `--checkout`).
+`i stop` is the inverse of `i start` (without the `--checkout`). Use `git symbolic-ref` to detect the workspace's default branch rather than hardcoding `main`.
 
 ## Jujutsu (jj) support
 

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/triage-and-comments.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/triage-and-comments.md
@@ -14,11 +14,12 @@ linear-cli tr list --output json --compact \
 For each item:
 
 ```bash
-# Read the body + any attachments
+# Read the body and issue metadata
 linear-cli i get LIN-501 --output json --fields title,description,labels.nodes.name
 
-# Read existing comments
+# Read existing comments and attachments
 linear-cli cm list LIN-501 --output json
+linear-cli att list LIN-501 --output json
 ```
 
 Then act:
@@ -62,9 +63,9 @@ linear-cli att delete ATTACHMENT_ID --force
 Linear stores user-uploaded images at `https://uploads.linear.app/...`. Use `up fetch` to bring one local for inspection.
 
 ```bash
-# Find URLs in the issue body or comments
-linear-cli i get LIN-501 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'
-linear-cli cm list LIN-501 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'
+# Find URLs in the issue body or comments (dots in regex must be escaped)
+linear-cli i get LIN-501 --output json | jq -r '..|strings|select(test("uploads\\.linear\\.app"))'
+linear-cli cm list LIN-501 --output json | jq -r '..|strings|select(test("uploads\\.linear\\.app"))'
 
 # Download to file
 linear-cli up fetch "https://uploads.linear.app/<org>/<id>/screenshot.png" -f /tmp/screenshot.png

--- a/skills/use-linear-cli/skills/use-linear-cli/references/recipes/triage-and-comments.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/recipes/triage-and-comments.md
@@ -1,0 +1,131 @@
+# Recipe — Triage, Comments, and Image Fetch
+
+Process an inbound triage queue, leave findings as comments, link or fetch attachments, and pull screenshots into a multimodal review.
+
+## Daily triage
+
+```bash
+linear-cli tr list                          # all unassigned, no-project items
+linear-cli tr list -t ENG                   # filter to a team
+linear-cli tr list --output json --compact \
+  --fields identifier,title,createdAt
+```
+
+For each item:
+
+```bash
+# Read the body + any attachments
+linear-cli i get LIN-501 --output json --fields title,description,labels.nodes.name
+
+# Read existing comments
+linear-cli cm list LIN-501 --output json
+```
+
+Then act:
+
+```bash
+linear-cli tr claim LIN-501                 # assign to me, leave triage
+linear-cli tr snooze LIN-501 --duration 1d  # come back tomorrow (1d, 2d, 1w, 2w, 1m)
+```
+
+## Snooze durations
+
+`1d`, `2d`, `1w`, `2w`, `1m`. After the duration the issue reappears in the triage queue.
+
+## Leaving findings as comments
+
+```bash
+linear-cli cm create LIN-501 -b "Reproduces on Safari 17.4. Tag: macOS-only."
+linear-cli cm create LIN-501 -b "$(cat findings.md)"     # body from a file
+```
+
+Update or delete:
+
+```bash
+linear-cli cm update COMMENT_ID -b "Updated text"
+linear-cli cm delete COMMENT_ID --force
+```
+
+## Attachments — link a URL
+
+```bash
+linear-cli att link-url LIN-501 https://sentry.io/issues/12345
+linear-cli att create LIN-501 -T "Repro recording" -u https://drive.example.com/abc
+linear-cli att list LIN-501
+linear-cli att get ATTACHMENT_ID
+linear-cli att update ATTACHMENT_ID -T "New title"
+linear-cli att delete ATTACHMENT_ID --force
+```
+
+## Fetching screenshots / uploaded images
+
+Linear stores user-uploaded images at `https://uploads.linear.app/...`. Use `up fetch` to bring one local for inspection.
+
+```bash
+# Find URLs in the issue body or comments
+linear-cli i get LIN-501 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'
+linear-cli cm list LIN-501 --output json | jq -r '..|strings|select(test("uploads.linear.app"))'
+
+# Download to file
+linear-cli up fetch "https://uploads.linear.app/<org>/<id>/screenshot.png" -f /tmp/screenshot.png
+
+# Pipe to stdout
+linear-cli up fetch "https://uploads.linear.app/..." > out.png
+linear-cli up fetch "https://uploads.linear.app/..." | base64
+```
+
+### Multimodal pattern (Claude Code, Cursor, etc.)
+
+```bash
+# 1. Download
+linear-cli up fetch "https://uploads.linear.app/..." -f /tmp/repro.png
+
+# 2. Read the file with the agent's image-capable tool (Claude Code: the Read tool).
+#    The agent sees the screenshot directly.
+```
+
+`up fetch` only accepts `uploads.linear.app` URLs — other hosts are rejected for safety. Use `curl` for arbitrary hosts.
+
+## Bulk-claim everything in your queue
+
+```bash
+linear-cli tr list -t ENG --output json --fields identifier --compact \
+  | jq -r '.[].identifier' \
+  | xargs -I{} linear-cli tr claim {}
+```
+
+(Use cautiously. Prefer reading and snoozing item-by-item for real triage work.)
+
+## Status check during triage
+
+```bash
+linear-cli st list -t ENG --output json --compact --fields name,type
+```
+
+Useful when the team has custom workflow states beyond the default `Triage / Backlog / In Progress / Done / Cancelled`.
+
+## End-of-shift report
+
+```bash
+linear-cli i list --mine --since 1d --output json \
+  --fields identifier,title,state.name --compact \
+  | jq -r '.[] | "\(.identifier) — \(.state.name) — \(.title)"'
+```
+
+## Common confusions
+
+| Looks like | Is actually |
+|---|---|
+| `tr list` | Unassigned + no project — the *triage* queue specifically. |
+| `i list` | Every visible issue. Bigger, less focused. |
+| `cm create` | Issue comment. |
+| `pu create` | *Project* update (status update on a project). Different command. |
+| `att create` | Attachment object on an issue. |
+| `up fetch` | Download from `uploads.linear.app`. Read-only side. |
+
+## See also
+
+- `issues/search-and-filter.md` — `i list` flag matrix and `--filter` for triage views.
+- `data/attachments-and-uploads.md` — full attachment CRUD and URL handling.
+- `recipes/git-and-pr-loop.md` — promote a triage finding into a tracked work item.
+- `output-and-scripting.md` — the JSON / `xargs` plumbing.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
@@ -38,7 +38,7 @@ Get an API key at <https://linear.app/settings/api>.
 linear-cli auth oauth                    # opens browser
 linear-cli auth oauth --secure           # store tokens in OS keyring
 linear-cli auth oauth --client-id ID     # custom OAuth app
-linear-cli auth status                   # show auth type, expiry
+linear-cli auth status --validate --output json  # show auth type and validate API access
 linear-cli auth revoke                   # revoke tokens
 linear-cli auth logout                   # remove credentials
 ```
@@ -111,8 +111,9 @@ For agent runs, the canonical opener:
 ```bash
 export LINEAR_CLI_OUTPUT=json
 export LINEAR_CLI_NO_PAGER=1
-export LINEAR_CLI_YES=1            # only when you're sure no destructive prompts
-linear-cli auth status             # gate on exit code 0
+# Leave LINEAR_CLI_YES unset until a specific destructive command needs it.
+linear-cli auth status --validate --output json  # gate writes on exit code 0
+linear-cli config workspace-current              # confirm intended profile/workspace
 ```
 
 ## Shell completions
@@ -143,12 +144,15 @@ linear-cli completions dynamic powershell >> $PROFILE
 # 1. Confirm binary
 linear-cli --version
 
-# 2. Confirm or set auth
-linear-cli auth status || linear-cli auth login
+# 2. Confirm or set auth, then validate live API access
+linear-cli auth status --validate --output json || {
+  linear-cli auth login
+  linear-cli auth status --validate --output json
+}
 
 # 3. Confirm workspace
 linear-cli config workspace-current
-linear-cli u me                    # who am I in this workspace?
+linear-cli u me --output json       # who am I in this workspace?
 
 # 4. Confirm default team, or resolve the first visible team key
 TEAM=$(linear-cli config get default_team 2>/dev/null)

--- a/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
@@ -150,8 +150,12 @@ linear-cli auth status || linear-cli auth login
 linear-cli config workspace-current
 linear-cli u me                    # who am I in this workspace?
 
-# 4. Confirm default team
-TEAM=$(linear-cli config get default_team || echo "ENG")
+# 4. Confirm default team, or resolve the first visible team key
+TEAM=$(linear-cli config get default_team 2>/dev/null)
+if [ -z "$TEAM" ]; then
+  TEAM=$(linear-cli t list --output json --compact --fields key | jq -r '.[0].key // empty')
+fi
+[ -n "$TEAM" ] || { echo "No team key found; run linear-cli t list and choose one"; exit 1; }
 
 # 5. Confirm we can read
 linear-cli i list --mine --limit 1 --output json --compact

--- a/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
@@ -1,0 +1,163 @@
+# Setup, Auth, Workspaces
+
+First-run setup, authentication, profile/workspace switching, doctor, and shell completions for `linear-cli`.
+
+## First-run wizard
+
+```bash
+linear-cli setup       # guided onboarding (auth + default team + completions)
+linear-cli doctor      # check config + connectivity
+linear-cli doctor --fix
+```
+
+## Authentication
+
+Two methods. Both work per-profile and per-workspace.
+
+### API key (simplest, agent-friendly)
+
+```bash
+# Pipe in (don't echo a secret to argv / shell history)
+printf '%s\n' "$LINEAR_API_KEY" | linear-cli config set-key
+
+# Interactive prompt
+linear-cli auth login
+
+# Store in OS keyring (requires --features secure-storage build)
+linear-cli auth login --secure
+
+# Highest-priority override at runtime
+export LINEAR_API_KEY=lin_api_xxx
+```
+
+Get an API key at <https://linear.app/settings/api>.
+
+### OAuth 2.0 (Authorization Code + PKCE)
+
+```bash
+linear-cli auth oauth                    # opens browser
+linear-cli auth oauth --secure           # store tokens in OS keyring
+linear-cli auth oauth --client-id ID     # custom OAuth app
+linear-cli auth status                   # show auth type, expiry
+linear-cli auth revoke                   # revoke tokens
+linear-cli auth logout                   # remove credentials
+```
+
+The callback server binds `127.0.0.1` only and validates `state` plus PKCE before token exchange. Tokens auto-refresh.
+
+### Auth priority
+
+`LINEAR_API_KEY` env var > OS keyring > OAuth tokens > config file API key.
+
+For agent loops, prefer `LINEAR_API_KEY` from the environment — the same key works across containers, CI, and local shells without keyring prompts.
+
+### macOS keyring caveats
+
+`--secure` works best on signed release binaries (`cargo binstall linear-cli`). Locally rebuilt binaries can trigger repeated Keychain prompts and may fail readback verification. If that happens, fall back to `linear-cli auth oauth` (no keyring) or `LINEAR_API_KEY`.
+
+## Workspaces and profiles
+
+Multiple Linear workspaces, named profiles, switch on the fly.
+
+```bash
+linear-cli config workspace-add work KEY      # add a workspace profile
+linear-cli config workspace-list
+linear-cli config workspace-switch work
+linear-cli config workspace-current
+linear-cli config workspace-remove work
+
+# Per-invocation override
+linear-cli --profile work i list
+
+# Session override
+export LINEAR_CLI_PROFILE=work
+```
+
+## Config file
+
+Stored at `~/.config/linear-cli/config.toml` (Linux/macOS) or `%APPDATA%\linear-cli\config.toml` (Windows).
+
+```bash
+linear-cli config show
+linear-cli config get default_team
+linear-cli config set default_team ENG
+```
+
+## Diagnostics
+
+```bash
+linear-cli doctor                # connectivity, auth, config sanity
+linear-cli doctor --fix          # auto-remediate common issues
+linear-cli cache status          # cache hit rate / size
+linear-cli cache clear           # nuke cache
+linear-cli update                # self-update the binary
+linear-cli update --check        # report current vs latest, no install
+linear-cli agent                 # print agent-focused capability summary
+```
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `LINEAR_API_KEY` | API key; highest-priority auth source. |
+| `LINEAR_CLI_OUTPUT` | Default output format for the session (`json`, `ndjson`, etc.). |
+| `LINEAR_CLI_PROFILE` | Default workspace profile name. |
+| `LINEAR_CLI_YES` | Auto-confirm all prompts (`--yes` everywhere). |
+| `LINEAR_CLI_NO_PAGER` | Disable auto-paging through `less`. |
+| `LINEAR_CLI_TRUST_PAGER` | Trust an absolute `PAGER` path you set explicitly. |
+
+For agent runs, the canonical opener:
+
+```bash
+export LINEAR_CLI_OUTPUT=json
+export LINEAR_CLI_NO_PAGER=1
+export LINEAR_CLI_YES=1            # only when you're sure no destructive prompts
+linear-cli auth status             # gate on exit code 0
+```
+
+## Shell completions
+
+### Static (command names + flags)
+
+```bash
+linear-cli completions static bash       > ~/.bash_completion.d/linear-cli
+linear-cli completions static zsh        > ~/.zfunc/_linear-cli
+linear-cli completions static fish       > ~/.config/fish/completions/linear-cli.fish
+linear-cli completions static powershell > linear-cli.ps1
+```
+
+Legacy alias: `linear-cli config completions <shell>` also works.
+
+### Dynamic (queries Linear API for team / project / issue / status names)
+
+```bash
+linear-cli completions dynamic bash       >> ~/.bashrc
+linear-cli completions dynamic zsh        >> ~/.zshrc
+linear-cli completions dynamic fish       >> ~/.config/fish/completions/linear-cli.fish
+linear-cli completions dynamic powershell >> $PROFILE
+```
+
+## First-time setup checklist (agent)
+
+```bash
+# 1. Confirm binary
+linear-cli --version
+
+# 2. Confirm or set auth
+linear-cli auth status || linear-cli auth login
+
+# 3. Confirm workspace
+linear-cli config workspace-current
+linear-cli u me                    # who am I in this workspace?
+
+# 4. Confirm default team
+linear-cli config get default_team || linear-cli t list --output json
+
+# 5. Confirm we can read
+linear-cli i list --mine --limit 1 --output json --compact
+
+# 6. Confirm we can write (dry-run)
+linear-cli i create "agent-smoke-test" -t "$TEAM" --dry-run
+```
+
+If any step fails, route to `troubleshooting.md`.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/setup.md
@@ -151,7 +151,7 @@ linear-cli config workspace-current
 linear-cli u me                    # who am I in this workspace?
 
 # 4. Confirm default team
-linear-cli config get default_team || linear-cli t list --output json
+TEAM=$(linear-cli config get default_team || echo "ENG")
 
 # 5. Confirm we can read
 linear-cli i list --mine --limit 1 --output json --compact

--- a/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
@@ -8,8 +8,8 @@ Failure-mode catalog for `linear-cli`. Diagnose by exit code first; route to the
 |---|---|---|
 | 0 | success | n/a |
 | 1 | general error | parse JSON error envelope; check the `details.request_id` and surface it |
-| 2 | not found | the ID/key/name doesn't exist in this workspace; verify with `i get`, `t list`, `l list` |
-| 3 | auth error | `linear-cli auth status` → re-auth (see Auth recovery) |
+| 2 | not found or parser error | JSON with `details.status: 404` means missing object; plain usage/stderr means fix command syntax via `--help` |
+| 3 | auth error | `linear-cli auth status --validate --output json` → re-auth (see Auth recovery) |
 | 4 | rate limited | sleep `retry_after`, retry once (see Rate-limit recovery) |
 
 Always combine `--output json` with `2>&1` capture so you have the envelope:
@@ -22,15 +22,33 @@ if [ $code -ne 0 ]; then
 fi
 ```
 
+If exit 2 returns plain stderr like `unexpected argument`, `a value is required`, or `Usage: ...`, it is not a missing Linear object. Correct the command flags before retrying:
+
+```bash
+linear-cli i list --help
+linear-cli b assign --help
+```
+
+Small regression check for this distinction:
+
+```bash
+set +e
+out=$(linear-cli i list --state 2>&1)
+code=$?
+set -e
+test "$code" = 2
+printf '%s\n' "$out" | grep -E "value is required|Usage:|unexpected argument"
+```
+
 ## Auth recovery (exit 3)
 
 ```bash
-linear-cli auth status                      # show current auth + expiry
+linear-cli auth status --validate --output json  # validate current auth + API access
 # If empty / expired:
 linear-cli auth login                       # API key
 #   or
 linear-cli auth oauth                       # OAuth + PKCE
-linear-cli u me                             # confirm
+linear-cli u me --output json               # confirm identity/workspace
 ```
 
 For agent runs, prefer the `LINEAR_API_KEY` env var (highest priority) over keyring or config-file storage:
@@ -63,7 +81,7 @@ If a script pauses between commands and the OAuth token expires before the next 
 - **Transparent refresh:** Newer releases of linear-cli auto-refresh before the token is fully expired; no agent action needed.
 - **Manual refresh:** If you see exit code 3 mid-script after a long pause, the token expired during the gap.
   ```bash
-  linear-cli auth status                    # check current token + expiry
+  linear-cli auth status --validate --output json  # check token + live API access
   linear-cli auth oauth                     # refresh with OAuth flow
   # or (if using LINEAR_API_KEY):
   export LINEAR_API_KEY=lin_api_xxx         # set a fresh API key
@@ -183,9 +201,9 @@ When in doubt, run:
 
 ```bash
 linear-cli --version
-linear-cli auth status
+linear-cli auth status --validate --output json
 linear-cli doctor
-linear-cli u me
+linear-cli u me --output json
 linear-cli config workspace-current
 linear-cli cache status
 ```

--- a/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
@@ -1,0 +1,185 @@
+# Troubleshooting
+
+Failure-mode catalog for `linear-cli`. Diagnose by exit code first; route to the right recovery from there.
+
+## Exit-code dispatch
+
+| Exit | Symptom | First move |
+|---|---|---|
+| 0 | success | n/a |
+| 1 | general error | parse JSON error envelope; check the `details.request_id` and surface it |
+| 2 | not found | the ID/key/name doesn't exist in this workspace; verify with `i get`, `t list`, `l list` |
+| 3 | auth error | `linear-cli auth status` → re-auth (see Auth recovery) |
+| 4 | rate limited | sleep `retry_after`, retry once (see Rate-limit recovery) |
+
+Always combine `--output json` with `2>&1` capture so you have the envelope:
+
+```bash
+out=$(linear-cli i get LIN-999 --output json 2>&1)
+code=$?
+if [ $code -ne 0 ]; then
+  echo "$out" | jq -r '"\(.code) \(.message) (req \(.details.request_id))"'
+fi
+```
+
+## Auth recovery (exit 3)
+
+```bash
+linear-cli auth status                      # show current auth + expiry
+# If empty / expired:
+linear-cli auth login                       # API key
+#   or
+linear-cli auth oauth                       # OAuth + PKCE
+linear-cli u me                             # confirm
+```
+
+For agent runs, prefer the `LINEAR_API_KEY` env var (highest priority) over keyring or config-file storage:
+
+```bash
+export LINEAR_API_KEY=lin_api_xxx
+linear-cli u me
+```
+
+If `auth status` reports OAuth tokens that won't refresh:
+
+```bash
+linear-cli auth revoke
+linear-cli auth oauth
+```
+
+If you suspect the wrong workspace:
+
+```bash
+linear-cli config workspace-current
+linear-cli config workspace-list
+linear-cli config workspace-switch <profile>
+```
+
+See `setup.md` for the full auth model.
+
+## Rate-limit recovery (exit 4)
+
+The JSON error envelope contains `retry_after` (seconds). Sleep and retry once.
+
+```bash
+attempt() {
+  out=$(linear-cli "$@" --output json 2>/dev/null) ; code=$?
+  if [ "$code" = 4 ]; then
+    sleep "$(echo "$out" | jq -r '.retry_after // 5')"
+    out=$(linear-cli "$@" --output json) ; code=$?
+  fi
+  echo "$out"
+  return $code
+}
+```
+
+If you keep tripping rate limits, you're probably hammering `i get` in a loop. Use **batch fetch** instead — `linear-cli i get LIN-1 LIN-2 LIN-3 ...` is one API call.
+
+## "Command in upstream docs but not in my binary"
+
+Your installed CLI is older than the docs.
+
+```bash
+linear-cli update --check       # report current vs latest, no install
+linear-cli update               # self-update via Cargo
+# or
+cargo install linear-cli --force
+```
+
+If `linear-cli update` fails (some release builds skip the asset upload step), use `cargo install linear-cli --force` directly. See the project's release-asset note in upstream `AGENTS.md`.
+
+## macOS pager leaves the terminal raw
+
+Symptom: after a successful table-output command on macOS, the shell acts raw-ish until you run `reset` or `stty sane`. `stty -a` after the command may show `pendin`.
+
+Recovery:
+
+```bash
+reset       # or: stty sane
+```
+
+Workaround for agent runs (stable):
+
+```bash
+export LINEAR_CLI_NO_PAGER=1
+# or per command
+linear-cli i list --no-pager
+```
+
+This is a known regression involving an early `std::process::exit` skipping pager `Drop` cleanup. Stay on `--no-pager` until a fixed release lands.
+
+## Stale cache
+
+Symptom: list / get returns data older than expected.
+
+```bash
+linear-cli cache status
+linear-cli cache clear
+# or per command
+linear-cli i list --no-cache
+```
+
+## Empty result, want to fail loudly
+
+```bash
+linear-cli i list --mine --state "In Progress" --fail-on-empty
+# exits non-zero when array is empty
+```
+
+## "Linear MCP says X, CLI says Y"
+
+Trust the CLI for any task this skill covers. Linear MCP and `linear-cli` query the same Linear API but the CLI is closer to the raw GraphQL surface and far cheaper in tokens. If the MCP path is mandated by the user, flag the cost difference and continue.
+
+## Webhook listener won't start
+
+```bash
+# Confirm the port is free
+lsof -nP -iTCP:8080 -sTCP:LISTEN
+
+# Confirm the secret is set
+linear-cli wh listen --port 8080 --secret "$WEBHOOK_SECRET"
+```
+
+The listener defaults to `127.0.0.1`, verifies HMAC-SHA256, and enforces header/body size limits. See `eventing-and-tracking.md`.
+
+## Bulk operation hit a partial failure
+
+`b update-state`, `b assign`, `b label`, etc. process IDs sequentially. On a partial failure:
+
+1. Re-run with `--dry-run` to confirm which IDs would be touched again.
+2. Inspect each via `linear-cli i get <ID> --output json` to see actual state.
+3. Roll back by inverting the mutation (e.g. `b update-state -s "In Progress"` after a botched `Done` run).
+4. Use `recipes/creating-many-issues.md` "atomicity" pattern next time.
+
+## OAuth callback never returns
+
+The OAuth flow binds `127.0.0.1:<random-port>` and waits for a redirect. If the browser never returns:
+
+- check that `127.0.0.1` is reachable from the browser (corporate VPN sometimes blocks loopback)
+- check firewall / `pf` rules
+- fall back to API key auth
+
+## "Permission denied on uploads.linear.app"
+
+`linear-cli up fetch` only accepts URLs from `uploads.linear.app`. Other hosts are rejected for safety. Use plain `curl` if you need to fetch from elsewhere.
+
+## Diagnostic checklist
+
+When in doubt, run:
+
+```bash
+linear-cli --version
+linear-cli auth status
+linear-cli doctor
+linear-cli u me
+linear-cli config workspace-current
+linear-cli cache status
+```
+
+…and surface all five results in the bug report.
+
+## See also
+
+- `setup.md` — full auth model, env vars, keyring caveats.
+- `output-and-scripting.md` — exit-code contract, JSON envelope.
+- `json-shapes.md` — exact error-envelope keys.

--- a/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
@@ -162,7 +162,7 @@ The listener defaults to `127.0.0.1`, verifies HMAC-SHA256, and enforces header/
 
 1. Re-run with `--dry-run` to confirm which IDs would be touched again.
 2. Inspect each via `linear-cli i get <ID> --output json` to see actual state.
-3. Roll back by inverting the mutation (e.g. `b update-state -s "In Progress"` after a botched `Done` run).
+3. Roll back by inverting the mutation (e.g. `b update-state "In Progress" -i LIN-1,LIN-2` after a botched `Done` run).
 4. Use `recipes/creating-many-issues.md` "atomicity" pattern next time.
 
 ## OAuth callback never returns

--- a/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
@@ -57,16 +57,30 @@ linear-cli config workspace-switch <profile>
 
 See `setup.md` for the full auth model.
 
+### OAuth token refresh during long scripts
+
+If a script pauses between commands and the OAuth token expires before the next command:
+- **Transparent refresh:** Newer releases of linear-cli auto-refresh before the token is fully expired; no agent action needed.
+- **Manual refresh:** If you see exit code 3 mid-script after a long pause, the token expired during the gap.
+  ```bash
+  linear-cli auth status                    # check current token + expiry
+  linear-cli auth oauth                     # refresh with OAuth flow
+  # or (if using LINEAR_API_KEY):
+  export LINEAR_API_KEY=lin_api_xxx         # set a fresh API key
+  ```
+
+For agent loops, prefer `LINEAR_API_KEY` from the environment (it doesn't expire) over OAuth tokens.
+
 ## Rate-limit recovery (exit 4)
 
 The JSON error envelope contains `retry_after` (seconds). Sleep and retry once.
 
 ```bash
 attempt() {
-  out=$(linear-cli "$@" --output json 2>/dev/null) ; code=$?
+  out=$(linear-cli "$@" --output json 2>&1) ; code=$?
   if [ "$code" = 4 ]; then
     sleep "$(echo "$out" | jq -r '.retry_after // 5')"
-    out=$(linear-cli "$@" --output json) ; code=$?
+    out=$(linear-cli "$@" --output json 2>&1) ; code=$?
   fi
   echo "$out"
   return $code

--- a/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
+++ b/skills/use-linear-cli/skills/use-linear-cli/references/troubleshooting.md
@@ -190,7 +190,7 @@ linear-cli config workspace-current
 linear-cli cache status
 ```
 
-…and surface all five results in the bug report.
+…and surface all six results in the bug report.
 
 ## See also
 


### PR DESCRIPTION
## Summary

- New skill `use-linear-cli` (verb `use`, category `platform`) that lets agents drive `linear-cli` for the full Linear.app surface — issue lifecycle, bulk creation, git/PR loops, search, planning, and automation.
- Distilled from the upstream pack of 38 narrowly-scoped per-command skills at `Finesssee/linear-cli`. One repo-fit skill instead of 38 file-per-command stubs that would have failed our validator.
- SKILL.md (270 lines) keeps the agentic hot path inline; 13 references absorb the long tail with explicit routing.
- Primary user use case (creating many issues at once) is first-class — covered by an inline summary in SKILL.md and a dedicated `references/recipes/creating-many-issues.md` (269 lines) with markdown-checklist / CSV / JSON / template patterns plus atomicity, idempotency, and rollback.

## What lands

- `skills/use-linear-cli/SKILL.md` — trigger boundary, hot-path commands, use-case decision table, agent-flag cheat sheet, exit-code contract, full reference routing, guardrails, recovery moves.
- `skills/use-linear-cli/skills/use-linear-cli/references/`
  - Cross-cutting: `setup.md`, `output-and-scripting.md`, `json-shapes.md`, `troubleshooting.md`
  - Recipes: `creating-many-issues.md`, `git-and-pr-loop.md`, `triage-and-comments.md`
  - Issues: `lifecycle.md`, `relations-and-labels.md`, `search-and-filter.md`
  - Planning: `projects-and-cycles.md`, `teams-and-org.md`
  - Data: `import-export.md`, `attachments-and-uploads.md`
  - `eventing-and-tracking.md`, `advanced.md`
- `skills/use-linear-cli/README.md` — install card.
- Root `README.md` — alphabetical row added between `test-macos-snapshots` and `use-railway`; total bumped to 44.
- `NAMING.md` — canonical name added; total bumped to 44.

## Coverage

Every one of the 38 upstream Linear-cli skills is preserved — either inline in the SKILL.md hot path or routed to a reference. Net new content beyond the upstream surface (lifted from upstream `CLAUDE.md`/`AGENTS.md`/`docs/` but missing from per-skill SKILL.md): `--id-only`, `--data -` stdin JSON, `LINEAR_CLI_OUTPUT=json` session default, `--filter`, `--format tpl`, `--fail-on-empty`, exit-code 4 + `retry_after`, the macOS pager-broken-state recovery, JSON error-envelope shape, multimodal image-fetch pattern.

## Test plan

- [x] `python3 scripts/validate-skills.py` → 44/44 skills pass
- [x] Orphan-reference grep inside the skill directory → no orphans (every `references/*.md` mentioned in SKILL.md)
- [x] All 16 distinct `references/...` paths in SKILL.md resolve to real files on disk
- [x] Frontmatter — name matches dir, description starts with "Use skill if you are", 24 words (≤30), no `<`/`>`, no "claude"/"anthropic"
- [x] SKILL.md 270 lines (≤500 cap; ≤450 target)
- [x] Manual trigger review — 5/5 should-trigger and 5/5 should-NOT-trigger phrases route as expected (Linear-issue, branch-driven Done, bulk-assign, search, draft-PR-linked-to-LIN should fire; GitHub-issue, generic PR review, MCP-server build, "linear algebra" math, React refactor should NOT fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `use-linear-cli`, a single agent skill to drive `linear-cli` across Linear for issues, bulk creation, git/PR loops, search, and planning. Replaces 38 per-command skills with one repo-fit skill and tight guidance on auth, rate limits, batching, and pagination.

- **New Features**
  - Adds `skills/use-linear-cli/SKILL.md` with trigger boundary, hot-path commands, exit‑code contract, guardrails, and reference routing.
  - Adds 13 references (setup, output/scripting, JSON shapes, troubleshooting; recipes for bulk create, git/PR loop, triage; issues, planning, data). Bulk creation is first‑class with markdown/CSV/JSON/template patterns plus atomicity, idempotency, and rollback.
  - Updates `README.md`, `AGENTS.md`, and `NAMING.md` to include `use-linear-cli` (skills now 44), and adds the skill install card. Validation passes (`scripts/validate-skills.py`, paths, frontmatter).

- **Bug Fixes**
  - Auth and limits: adds OAuth token expiry/refresh guidance for long-running scripts; unifies rate-limit retry with consistent stderr capture; clarifies exit code 2 vs API 404.
  - Bulk/read paths: fixes batch‑mutation `-i` syntax for state/assign/labels; emphasizes batch‑fetch patterns; corrects pagination misuse (`--all` then filter) with concrete examples.
  - Safety and recipes: clarifies label deletion scope; fixes `--fail-on-empty`; corrects stale filtering; cross‑platform date calc; improves team listing and abort recipes; adds Slack JSON header; triage adds `att list`; uploads host regex; documents CSV labels delimiter; wraps JSON round‑trip in an array.
  - Consistency: reconciles SKILL.md and references for wording and flag alignment; applies adversarial‑review findings; resolves minor nits.

<sup>Written for commit 5515fc403a69ff7aa47163de6706718f24d92d4e. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/60?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

