### PR TITLE
docs(mcp-use): clarify tool result response surfaces

### DIFF
--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/SKILL.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/SKILL.md
@@ -97,16 +97,17 @@ Do not use this skill when:
 
 1. `tool.widget.name` must match `resources/<name>/widget.tsx` exactly.
 2. Always give the LLM and text-only clients a useful `message` or `output`; `props` alone is not enough.
-3. Always guard widget rendering with `isPending` before you trust `props`.
-4. Treat streaming preview as optional. ChatGPT does not expose `partialToolInput`, so the widget must still work with only `isPending`.
-5. Use `useCallTool()` or `useWidget().callTool()` for widget-to-tool calls. Do not use raw `fetch()` against MCP endpoints.
-6. Wrap the widget root in `McpUseProvider`. If the widget uses React Router, add `BrowserRouter` manually inside that provider.
-7. Declare every external domain in `widgetMetadata.metadata.csp`. Missing domains fail silently in hosted widget iframes.
-8. Set `baseUrl` or `MCP_URL` for deployed builds so widget assets and CSP resolve correctly.
-9. Use `Image` for files from `public/` instead of raw `<img>`.
-10. Keep secrets, tokens, and other sensitive data out of widget props and widget state.
-11. Prefer `type: "mcpApps"` for dual-protocol compatibility; do not start new work with `type: "appsSdk"`.
-12. Keep shared code browser-safe if you import it into widget bundles; otherwise keep it server-only in `src/lib/`.
+3. Treat `props`/`structuredContent` as potentially model-visible, especially in ChatGPT/OpenAI Apps. Put only model-safe data there; put private, bulky, or UI-only hydration data in `metadata`/`_meta`.
+4. Always guard widget rendering with `isPending` before you trust `props`.
+5. Treat streaming preview as optional. ChatGPT does not expose `partialToolInput`, so the widget must still work with only `isPending`.
+6. Use `useCallTool()` or `useWidget().callTool()` for widget-to-tool calls. Do not use raw `fetch()` against MCP endpoints.
+7. Wrap the widget root in `McpUseProvider`. If the widget uses React Router, add `BrowserRouter` manually inside that provider.
+8. Declare every external domain in `widgetMetadata.metadata.csp`. Missing domains fail silently in hosted widget iframes.
+9. Set `baseUrl` or `MCP_URL` for deployed builds so widget assets and CSP resolve correctly.
+10. Use `Image` for files from `public/` instead of raw `<img>`.
+11. Keep secrets, tokens, and other sensitive data out of widget props and widget state.
+12. Prefer `type: "mcpApps"` for dual-protocol compatibility; do not start new work with `type: "appsSdk"`.
+13. Keep shared code browser-safe if you import it into widget bundles; otherwise keep it server-only in `src/lib/`.
 
 ## Reference routing
 

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/examples/server-recipes.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/examples/server-recipes.md
@@ -555,9 +555,9 @@ await server.listen();
 **widget() response** — always use `message` (not `output`) for the LLM-visible summary:
 ```typescript
 return widget({
-  props: { ... },           // → structuredContent (widget only)
+  props: { ... },           // → structuredContent (model-safe widget props)
   message: "Summary...",    // → content[0].text (LLM sees this)
-  metadata: { ... },        // → _meta (optional extra data)
+  metadata: { ... },        // → _meta (private/client-only widget data)
 });
 ```
 

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/advanced-features.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/advanced-features.md
@@ -70,15 +70,15 @@ The `widget()` helper maps to different transport fields:
 
 ```typescript
 return widget({
-  props: { city, temperature, conditions },     // → structuredContent (widget only, LLM does NOT see)
+  props: { city, temperature, conditions },     // → structuredContent (model-safe widget props)
   message: `Weather in ${city}: ${conditions}`, // → content[0].text (LLM sees this)
-  metadata: { totalCount: 5, cursor: "abc" },   // → _meta (accessible as useWidget().metadata)
+  metadata: { totalCount: 5, cursor: "abc" },   // → _meta (private/client-only widget data)
 });
 ```
 
-- **`props`** → available in `useWidget().props` — the data the widget renders.
+- **`props`** → available in `useWidget().props` — model-safe data the widget renders.
 - **`message`** → the human-readable summary passed to the LLM as `content`.
-- **`metadata`** → optional extra data accessible via `useWidget().metadata`.
+- **`metadata`** → private, bulky, or UI-only data accessible via `useWidget().metadata`.
 
 ---
 

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/chatgpt-apps-flow.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/chatgpt-apps-flow.md
@@ -333,19 +333,19 @@ server.uiResource({
 
 ## Data Flow: props vs toolInput vs metadata
 
-The tool result has three fields with different visibility. Understanding them prevents a common mistake of using the wrong field in a widget.
+The tool result has three fields with different visibility. Understanding them prevents a common mistake of using the wrong field in a widget. In ChatGPT/OpenAI Apps, `structuredContent` is model-visible, so use `props` only for model-safe widget data and use `_meta` for private or bulky UI hydration.
 
 | Field | LLM sees it? | Widget sees it? | Purpose |
 |-------|-------------|-----------------|---------|
 | `content` | Yes | Yes | Text summary for the model's context |
-| `structuredContent` | No | Yes (as `props`) | Rendering data for the widget |
+| `structuredContent` | Yes in ChatGPT/OpenAI Apps; host-dependent elsewhere | Yes (as `props`) | Rendering data for the widget |
 | `_meta` | No | Yes (as `metadata`) | Protocol and custom metadata |
 
 ```typescript
-// Server side — split between what the LLM sees and what the widget sees
+// Server side — keep props model-safe; put private hydration in metadata/_meta
 return widget({
-  props: { query: "mango", results: [...] }, // → useWidget().props (LLM does NOT see this)
-  metadata: { totalCount: 1000, nextCursor: "abc123" }, // → useWidget().metadata
+  props: { query: "mango", results: [...] }, // → useWidget().props (structuredContent)
+  metadata: { totalCount: 1000, nextCursor: "abc123" }, // → useWidget().metadata (_meta)
   output: text(`Found 16 products matching "mango"`), // → content (LLM sees this)
 });
 

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/response-helpers.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/response-helpers.md
@@ -90,7 +90,7 @@ server.resource({ name: "script", uri: "asset://main.js" }, async () =>
 
 ### `object(data)`
 
-Typed JSON with both pretty-printed text and `structuredContent`. Preferred when the LLM will process the data.
+Typed JSON with both pretty-printed text and `structuredContent`. Use it when a typed client, widget, Code Mode workflow, or downstream parser needs fields. For broad conversational compatibility, a concise `text()` or `markdown()` response is usually the default.
 
 ```typescript
 import { object } from "mcp-use/server";
@@ -260,9 +260,9 @@ Creates a response for tools that render UI widgets (MCP Apps spec). Handles **r
 
 | Field | Type | Required | Visibility |
 |---|---|---|---|
-| `props` | `Record<string, any>` | Yes | Widget only (`structuredContent`) — LLM does **not** see |
+| `props` | `Record<string, any>` | Yes | Widget props (`structuredContent`) — treat as model-visible unless the exact host proves otherwise |
 | `output` | `CallToolResult` | No* | LLM sees (`content`) — use any response helper |
-| `metadata` | `Record<string, unknown>` | No | Widget only (`_meta`) |
+| `metadata` | `Record<string, unknown>` | No | Private/client-only widget data (`_meta`) |
 | `message` | `string` | No* | LLM sees — plain-text shorthand instead of `output` |
 
 *Provide either `output` or `message` to give text-only clients (and the LLM) a meaningful description. If both are omitted, the LLM sees no tool output text.
@@ -337,7 +337,7 @@ server.resourceTemplate(
 | `xml` | `xml(str)` | `CallToolResult` | `text/xml` |
 | `css` | `css(str)` | `CallToolResult` | `text/css` |
 | `javascript` | `javascript(str)` | `CallToolResult` | `text/javascript` |
-| `object` | `object(obj)` | `TypedCallToolResult<T>` | `application/json` — includes `structuredContent` |
+| `object` | `object(obj)` | `TypedCallToolResult<T>` | `application/json` — includes `structuredContent`; use when typed/programmatic consumers need it |
 | `array` | `array(items)` | `TypedCallToolResult<{ data: T }>` | `application/json` — wraps in `{ data }` |
 | `image` | `image(base64, mime?)` | `CallToolResult` | Default `image/png` |
 | `audio` | `audio(dataOrPath, mime?)` | `CallToolResult \| Promise<…>` | Async for file paths; infers MIME |
@@ -345,7 +345,7 @@ server.resourceTemplate(
 | `resource` | `resource(uri, mime, text)` or `resource(uri, helper)` | `CallToolResult` | Embedded resource content |
 | `error` | `error(str)` | `CallToolResult` | Sets `isError: true` |
 | `mix` | `mix(...results)` | `CallToolResult` | Merges content, structuredContent, _meta |
-| `widget` | `widget({ props, output?, message?, metadata? })` | `CallToolResult` | Props hidden from LLM; use `message` or `output` for LLM-visible text |
+| `widget` | `widget({ props, output?, message?, metadata? })` | `CallToolResult` | Props become `structuredContent`; keep them model-safe. Use `message` or `output` for content-first clients |
 
 ---
 
@@ -353,8 +353,10 @@ server.resourceTemplate(
 
 | Mistake | Problem | Fix |
 |---|---|---|
-| Returning raw objects without a helper | Missing MIME types, no `structuredContent` | Use `object()` for data, `text()` for messages |
-| Using `text()` for structured data | LLM can't parse free-text JSON reliably | Use `object()` — provides both text and `structuredContent` |
+| Returning raw objects without a helper | Missing MCP content wrappers and MIME metadata | Use `text()` / `markdown()` by default; use `object()` when typed consumers need structured fields |
+| Using `text()` for data a program must parse | Downstream code may need stable fields instead of prose | Use `object()` only when a typed client, widget, Code Mode workflow, or parser needs it |
+| Putting private widget data in `props` | ChatGPT/OpenAI Apps may expose `structuredContent` to the model/transcript | Put private, bulky, or UI-only data in `metadata` / `_meta` |
+| Returning only `props` with no `message` or `output` | Text-only and content-first clients lose useful context | Always include a concise `message` or `output` |
 | Throwing instead of `error()` for expected failures | Server exception vs. graceful tool failure | `return error("...")` for not-found, validation, limits |
 | Forgetting to `await` file-based `audio()` | Returns a Promise instead of the result | Always `await audio("./path/to/file.wav")` |
 | Building `CallToolResult` manually | Verbose, easy to miss fields | Use helpers — they exist to prevent this |
@@ -754,8 +756,8 @@ server.tool(
 
 ## Recommended defaults
 
-1. Use `object()` for data.
-2. Use `text()` or `markdown()` for summaries.
+1. Use `text()` or `markdown()` for the default conversational answer.
+2. Use `object()` only when typed/programmatic consumers need structured fields.
 3. Use `error()` for expected failures.
 4. Use `mix()` sparingly and intentionally.
 5. Let helpers set `_meta.mimeType` for you.

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/streaming-and-preview.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/streaming-and-preview.md
@@ -121,7 +121,7 @@ const { isStreaming, partialToolInput, isPending, props, toolInput } = useWidget
 |-------|---------------|----------|
 | `partialToolInput` | During streaming (`isStreaming = true`) | Growing partial args from the LLM |
 | `toolInput` | After streaming ends | Complete args the model sent to the tool |
-| `props` | After server responds | Server-computed data (`structuredContent`) — LLM does not see this |
+| `props` | After server responds | Server-computed widget data (`structuredContent`); keep model-safe because some hosts expose it |
 
 ### Field Arrival Order
 

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/tools-and-schemas.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/tools-and-schemas.md
@@ -283,14 +283,14 @@ When returning `widget()`, the tool result has three fields with different visib
 | Field | LLM sees it? | Widget sees it? | Purpose |
 |---|---|---|---|
 | `content` (from `output` / `message`) | **Yes** | Yes | Text summary for the model's context window |
-| `structuredContent` (from `props`) | **No** | Yes (as `props`) | Rich rendering data for the widget |
+| `structuredContent` (from `props`) | **Host-dependent; yes in ChatGPT/OpenAI Apps** | Yes (as `props`) | Rich rendering data for the widget |
 | `_meta` | **No** | Yes (as `metadata`) | Protocol + custom metadata |
 
-This separation lets you pass rich data to the widget without polluting the model's context.
+This separation gives the widget rich data, but it is not a privacy boundary. Keep `props` model-safe and put private, bulky, or UI-only hydration data in `_meta`.
 
 ```typescript
 return widget({
-  // Widget rendering data — LLM does NOT see this
+  // Widget rendering data — model-safe structuredContent
   props: { city, temperature, humidity },
   // Text summary — LLM sees this (use `message` or `output: text(...)`)
   message: `Weather in ${city}: ${temperature}°C`,

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/widgets-and-ui.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/widgets-and-ui.md
@@ -18,9 +18,10 @@ Server fetches weather data, returns widget({ props, output })
 Client renders WeatherWidget with temperature, conditions, etc.
 ```
 
-The server controls two independent channels:
-- **`content`** (LLM sees) — text/markdown the LLM uses for conversation
-- **`structuredContent`** (Widget sees) — JSON props the React widget renders
+The server controls three channels:
+- **`content`** — text/markdown used by the conversation and by text-only clients; keep it concise and complete.
+- **`structuredContent`** — JSON props the React widget renders; treat it as potentially model-visible, especially in ChatGPT/OpenAI Apps.
+- **`_meta`** — private, bulky, or UI-only widget hydration data.
 
 ### Dual-Protocol Support
 
@@ -239,16 +240,16 @@ The `widget()` function creates a `CallToolResult` with three visibility channel
 | Field | LLM sees? | Widget sees? | Populated by |
 |-------|-----------|-------------|-------------|
 | `content` | **Yes** | Yes | `output`, `message`, or `text()` |
-| `structuredContent` | **No** | Yes (as `props`) | `props` |
+| `structuredContent` | **Host-dependent; yes in ChatGPT/OpenAI Apps** | Yes (as `props`) | `props` |
 | `_meta` | **No** | Yes (as `metadata`) | `metadata` |
 
 ```typescript
 import { widget, text } from "mcp-use/server";
 
 return widget({
-  props: { city: "Paris", temperature: 22 },       // → useWidget().props
+  props: { city: "Paris", temperature: 22 },       // → useWidget().props; model-safe
   output: text("Weather in Paris: 22°C, Sunny"),    // → LLM sees this
-  metadata: { lastUpdated: Date.now() },            // → useWidget().metadata
+  metadata: { lastUpdated: Date.now() },            // → useWidget().metadata; private/client-only
 });
 
 // Shorthand — message is equivalent to text()
@@ -449,7 +450,7 @@ return widget({ props: data, output: text(`Found ${data.length} results`) });
 // Message shorthand (equivalent to text)
 return widget({ props: data, message: `Found ${data.length} items` });
 
-// Structured JSON output
+// Structured JSON output: use only when the model/client needs typed fields
 return widget({ props: data, output: object({ count: data.length, summary }) });
 ```
 

--- a/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/patterns/mcp-apps-patterns.md
+++ b/skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/patterns/mcp-apps-patterns.md
@@ -170,7 +170,7 @@ server.tool(
     return widget({
       // LLM-visible text summary (goes into conversation context)
       output: text(`Current weather in ${city}: ${weather.conditions}, ${weather.temperature}°C`),
-      // Widget-only data (goes into structuredContent; the LLM never sees this)
+      // Model-safe widget data (goes into structuredContent)
       props: { city, ...weather },
     });
   }
@@ -182,8 +182,8 @@ server.tool(
 | Field | LLM sees? | Widget sees? | Purpose |
 |-------|-----------|--------------|---------|
 | `output` (via `content`) | Yes | Yes (`props` fallback) | Text summary for model context |
-| `props` (via `structuredContent`) | No | Yes (as `props`) | Rich data for widget rendering |
-| `_meta` | No | Yes (as `metadata`) | Protocol metadata |
+| `props` (via `structuredContent`) | Host-dependent; yes in ChatGPT/OpenAI Apps | Yes (as `props`) | Model-safe data for widget rendering |
+| `_meta` | No | Yes (as `metadata`) | Private/client-only protocol metadata |
 
 ---
 

--- a/skills/build-mcp-use-client/skills/build-mcp-use-client/SKILL.md
+++ b/skills/build-mcp-use-client/skills/build-mcp-use-client/SKILL.md
@@ -36,7 +36,7 @@ When you do use subagents, write each prompt as a bounded audit brief: why the a
 Explore constructor options, server entries, transport types, `loadConfigFile` / `MCPClient.fromConfigFile` / `MCPClient.fromDict` usage, environment-specific imports. Cross-reference with `references/guides/client-configuration.md` and `references/guides/environments.md`. Surface: what is correctly configured, what violates best practices, what is missing.
 
 **Subagent 2 — Tool, resource, and prompt usage audit**
-Explore how tools are listed/called, how resources are read, how prompts are retrieved, completion usage, timeout/abort config. Cross-reference with `references/guides/tools.md`, `references/guides/resources.md`, `references/guides/prompts.md`, and `references/guides/completion.md`. Surface: correct patterns, missing error handling, timeout gaps.
+Explore how tools are listed/called, how tool results handle both `content` and `structuredContent`, how resources are read, how prompts are retrieved, completion usage, timeout/abort config. Cross-reference with `references/guides/tools.md`, `references/guides/resources.md`, `references/guides/prompts.md`, and `references/guides/completion.md`. Surface: correct patterns, missing error handling, timeout gaps, and clients that accidentally drop one result surface.
 
 **Subagent 3 — Callbacks and lifecycle audit**
 Explore sampling callbacks, elicitation callbacks, notification handlers, logging setup, session cleanup, reconnection config. Cross-reference with `references/guides/sampling.md`, `references/guides/elicitation.md`, `references/guides/notifications-and-logging.md`, and `references/guides/authentication.md`. Surface: missing callbacks, wrong precedence, cleanup gaps.
@@ -94,7 +94,7 @@ Each trigger below tells you exactly when and why to open a reference file. Read
 
 **Core protocol operations:**
 
-- If you are listing or calling tools, setting timeouts, using AbortSignal, or handling `CallToolResult` — read `references/guides/tools.md`. It has `CallToolOptions`, `maxTotalTimeout`, `resetTimeoutOnProgress`, and the `isError` handling pattern.
+- If you are listing or calling tools, setting timeouts, using AbortSignal, or handling `CallToolResult` — read `references/guides/tools.md`. It has `CallToolOptions`, `maxTotalTimeout`, `resetTimeoutOnProgress`, result-surface handling for `content` / `structuredContent` / `_meta`, and the `isError` handling pattern.
 - If you are reading resources, working with resource templates, or handling binary vs text content — read `references/guides/resources.md`. It has `listResources()`, `readResource()`, `ResourceContent[]` shape, and MIME type handling.
 - If you are retrieving prompt templates with arguments or building multi-message prompt flows — read `references/guides/prompts.md`. It has `listPrompts()`, `getPrompt()`, `PromptResult` structure, and argument passing.
 - If you are implementing autocomplete for prompt arguments or resource template URIs — read `references/guides/completion.md`. It has `session.complete()`, `CompleteRequestParams`, debouncing strategy, and capability checking.

--- a/skills/build-mcp-use-client/skills/build-mcp-use-client/references/guides/cli-reference.md
+++ b/skills/build-mcp-use-client/skills/build-mcp-use-client/references/guides/cli-reference.md
@@ -486,8 +486,10 @@ All commands support these global flags.
 >
 > ```bash
 > RESULT=$(npx mcp-use client tools call get_data '{}' --json)
-> echo "$RESULT" | jq '.content[0].text'
+> echo "$RESULT" | jq '{text: .content[0].text, structuredContent}'
 > ```
+
+For scripting, prefer `.content[0].text` as the human-readable fallback but preserve `.structuredContent` when present. Do not assume all successful tools return only text.
 
 ---
 

--- a/skills/build-mcp-use-client/skills/build-mcp-use-client/references/guides/tools.md
+++ b/skills/build-mcp-use-client/skills/build-mcp-use-client/references/guides/tools.md
@@ -81,7 +81,9 @@ Each element returned by `listTools()` has the following structure:
 
 ## Calling Tools
 
-Pass the tool name and a parameter object to `session.callTool()`. The client serializes the arguments, sends the request, and returns a structured result.
+Pass the tool name and a parameter object to `session.callTool()`. The client serializes the arguments, sends the request, and returns a result that may include `content`, `structuredContent`, and `_meta`.
+
+For broad interoperability, prefer `content` as the default human/model-facing answer, but preserve `structuredContent` when it exists. Some MCP clients and adapters are content-first, some are structured-first, and some drop one surface. Client code should not assume `content[0].text` is the only successful payload.
 
 ```typescript
 import { MCPClient } from "mcp-use";
@@ -121,6 +123,8 @@ Every call returns a `CallToolResult` (from `@modelcontextprotocol/sdk/types.js`
 ```typescript
 interface CallToolResult {
   content: Array<TextContent | ImageContent | EmbeddedResource>;
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
   isError?: boolean; // true when the tool reported an error (may be absent on success)
 }
 
@@ -133,9 +137,27 @@ interface EmbeddedResource { type: "resource"; resource: { uri: string; mimeType
 | Field | Type | Description |
 |---|---|---|
 | `content` | `Array<TextContent \| ImageContent \| EmbeddedResource>` | Array of content items. Text responses appear as `{ type: "text", text: "..." }` entries. |
+| `structuredContent` | `Record<string, unknown> \| undefined` | Typed JSON result when the server provides structured output. Treat as model-visible unless the exact host proves otherwise. |
+| `_meta` | `Record<string, unknown> \| undefined` | Private/client-only metadata. Do not forward to the model by default. |
 | `isError` | `boolean \| undefined` | Present and `true` when the tool executed but reported an error. Absent or `false` on success. |
 
 Always inspect `isError` before consuming `content`. When `isError` is `true`, content items typically carry a text error message.
+
+When normalizing a result for an LLM or UI, keep both compatible surfaces available:
+
+```typescript
+const result = await session.callTool("search_web", { query: "MCP protocol" });
+
+const textContent = result.content
+  .filter((item) => item.type === "text")
+  .map((item) => item.text)
+  .join("\n");
+
+const normalized = {
+  text: textContent || JSON.stringify(result.structuredContent ?? result.content),
+  structuredContent: result.structuredContent,
+};
+```
 
 ```typescript
 const result = await session.callTool("search_web", { query: "MCP protocol" });

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/SKILL.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/SKILL.md
@@ -164,6 +164,9 @@ For plan-only runs, provide:
 - Prefer improving an existing server over replacing it.
 - Keep the host app's entrypoint when adding MCP to an existing app; use `src/mcp-server.ts` unless there is a strong reason not to.
 - Use `text()`, `object()`, `error()`, `mix()`, `widget()`, and the other helpers instead of hand-built MCP payloads.
+- Default to a concise, complete `content` response for broad conversational compatibility. Add `structuredContent` only when the tool has an `outputSchema`, typed/programmatic consumers, Code Mode, widget props, or another real downstream parser requirement.
+- If a tool returns both `content` and `structuredContent`, keep them semantically equivalent and put every essential result in both surfaces. MCP hosts diverge: some prefer `content`, some prefer `structuredContent`, some expose both, and some drop one.
+- Use `_meta` only for private, large, or UI-only data. Treat `structuredContent` as potentially model-visible, including for ChatGPT/OpenAI Apps.
 - Use `error()` for expected failures and `throw` for truly unexpected failures.
 - Treat notifications as stateful-only unless you have explicitly verified the transport model supports them.
 - Guard `ctx.elicit()` with `ctx.client.can("elicitation")`.
@@ -180,6 +183,7 @@ For plan-only runs, provide:
 - Never claim success in a blocked environment.
 - Never put secrets in source or logs.
 - Never skip `allowedOrigins` and CORS decisions for public HTTP servers.
+- Never put the primary answer only in one result surface when returning both `content` and `structuredContent`; mirror the essential fields so content-first and structured-first clients see the same answer.
 
 ## Output contract
 

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/response-helpers.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/response-helpers.md
@@ -90,7 +90,7 @@ server.resource({ name: "script", uri: "asset://main.js" }, async () =>
 
 ### `object(data)`
 
-Typed JSON with both pretty-printed text and `structuredContent`. Preferred when the LLM will process the data.
+Typed JSON with both pretty-printed text and `structuredContent`. Use it when a typed client, widget, Code Mode workflow, or downstream parser needs fields. For broad conversational compatibility, prefer concise `text()` or `markdown()` unless structured output has a real consumer.
 
 ```typescript
 import { object } from "mcp-use/server";
@@ -105,6 +105,58 @@ server.tool(
 ```
 
 **Return type:** `TypedCallToolResult<T>` — MIME: `application/json`
+
+### Structured Visibility Contract
+
+MCP tool responses have two result surfaces that may become model-visible depending on the host:
+
+- `content[0].text` — text/markdown that full MCP clients usually show.
+- `structuredContent` — typed JSON that many agent hosts, bridges, and tool adapters prefer or exclusively surface.
+
+For broad conversational compatibility, default to a concise, complete `content` response. Add `structuredContent` only when you need typed/programmatic output: `outputSchema`, Code Mode, machine parsing, widget props, or a client contract that explicitly consumes structured data.
+
+The 2025-11-25 MCP spec says structured results belong in `structuredContent`, and for backward compatibility servers that return structured content SHOULD also return serialized JSON in a `TextContent` block. It does not guarantee a universal model-visibility policy. Current hosts differ, so when both fields are present, the safest server pattern is semantic equivalence: both surfaces contain the essential answer in the best form for that surface.
+
+| Host / source | Observed or documented pattern | Server-side implication |
+|---|---|---|
+| [MCP spec 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) | `structuredContent` is the typed result; `content` is the backward-compatible/unstructured result | Use `content` by default; when structured output is needed, return both and validate `structuredContent` against `outputSchema` |
+| [ChatGPT / OpenAI Apps SDK](https://developers.openai.com/apps-sdk/reference) | `content` and `structuredContent` appear in the transcript; `_meta` is hidden from the model | Never put secrets in `structuredContent`; use `_meta` for private widget hydration |
+| [VS Code issue report](https://github.com/microsoft/vscode/issues/290063) | `structuredContent` can override `content[].text` for model input | Put the answer body in `structuredContent`, not just metadata |
+| [Claude Code](https://github.com/anthropics/claude-code/issues/15412) / [Codex](https://github.com/openai/codex/issues/10334) issue reports | Some versions display or surface `structuredContent` while hiding `content[]` when both exist | Duplicate essential text and media references into structured output when possible |
+| [LangChain adapter issue report](https://github.com/langchain-ai/langchain-mcp-adapters/issues/283) | Some adapters process only `content` and drop `structuredContent` | Keep `content` readable and complete enough for content-only clients |
+| [MCP SEP-1624 proposal](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624) | Cursor/Claude Code/Windsurf/VS Code behavior diverged; clients should choose one surface, not forward both verbatim | Do not rely on a single client behavior; make both surfaces equivalent |
+
+If a tool defines `outputSchema`, returns custom `structuredContent`, or will be consumed through bridge clients, do not leave the primary result only in `content[0].text` while `structuredContent` contains only counters or metadata. That shape is valid MCP, but structured-first clients will see a successful call as metadata-only. The inverse is also risky: structured-only answers can disappear in content-first adapters.
+
+❌ **BAD** — scraped body only in markdown text, structured output only metadata:
+
+```typescript
+const markdownBody = renderScrape(results);
+
+return {
+  ...markdown(markdownBody),
+  structuredContent: {
+    metadata: { successful: results.length },
+  },
+};
+```
+
+✅ **GOOD** — mirror essential result data into structured output:
+
+```typescript
+const markdownBody = renderScrape(results);
+
+return {
+  ...markdown(markdownBody),
+  structuredContent: {
+    content: markdownBody,
+    results,
+    metadata: { successful: results.length },
+  },
+};
+```
+
+When the whole result is naturally JSON, prefer `object({ ... })`. When you need readable markdown plus machine-readable fields, use `mix(markdown(summary), object({ ... }))` or return a typed result with matching `outputSchema`. The structured object must contain the essential answer body, not just counts, pagination, status, or timing metadata; the text/markdown content must remain useful without parsing `structuredContent`.
 
 ### `array(items)`
 
@@ -260,9 +312,9 @@ Creates a response for tools that render UI widgets (MCP Apps spec). Handles **r
 
 | Field | Type | Required | Visibility |
 |---|---|---|---|
-| `props` | `Record<string, any>` | No | Widget only (`structuredContent`) — LLM does **not** see |
+| `props` | `Record<string, any>` | No | Widget props (`structuredContent`) — treat as model-visible unless the exact host proves otherwise |
 | `output` | `CallToolResult` | No | LLM sees (`content`) — use any response helper |
-| `metadata` | `Record<string, unknown>` | No | Widget only (`_meta`) |
+| `metadata` | `Record<string, unknown>` | No | Private/client-only widget data (`_meta`) |
 | `message` | `string` | No | LLM sees — text override instead of `output` |
 
 ```typescript
@@ -326,7 +378,7 @@ server.resourceTemplate(
 
 | Helper | Signature | Return Type | MIME / Notes |
 |---|---|---|---|
-| `text` | `text(str)` | `CallToolResult` | `text/plain` |
+| `text` | `text(str)` | `CallToolResult` | `text/plain`; use only when the result is not meant to be parsed as structured data |
 | `markdown` | `markdown(str)` | `CallToolResult` | `text/markdown` |
 | `html` | `html(str)` | `CallToolResult` | `text/html` |
 | `xml` | `xml(str)` | `CallToolResult` | `text/xml` |
@@ -339,8 +391,8 @@ server.resourceTemplate(
 | `binary` | `binary(base64, mime)` | `CallToolResult` | Any binary MIME type |
 | `resource` | `resource(uri, mime, text)` or `resource(uri, helper)` | `CallToolResult` | Embedded resource content |
 | `error` | `error(str)` | `CallToolResult` | Sets `isError: true` |
-| `mix` | `mix(...results)` | `CallToolResult` | Merges content, structuredContent, _meta |
-| `widget` | `widget({ props?, output?, metadata?, message? })` | `CallToolResult` | Props hidden from LLM; `props` defaults to `{}` if omitted |
+| `mix` | `mix(...results)` | `CallToolResult` | Merges content, structuredContent, _meta; ensure the object part carries essential result fields |
+| `widget` | `widget({ props?, output?, metadata?, message? })` | `CallToolResult` | `props` become `structuredContent`; treat them as model-visible unless the exact host proves otherwise. Use `metadata`/`_meta` for private widget data |
 
 ---
 
@@ -348,8 +400,11 @@ server.resourceTemplate(
 
 | Mistake | Problem | Fix |
 |---|---|---|
-| Returning raw objects without a helper | Missing MIME types, no `structuredContent` | Use `object()` for data, `text()` for messages |
-| Using `text()` for structured data | LLM can't parse free-text JSON reliably | Use `object()` — provides both text and `structuredContent` |
+| Returning raw objects without a helper | Missing MCP content wrappers and MIME metadata | Use `text()` / `markdown()` by default; use `object()` when typed consumers need structured fields |
+| Using `text()` for data a program must parse | Downstream code may need stable fields instead of prose | Use `object()` only when a typed client, widget, Code Mode workflow, or parser needs it |
+| Putting the primary result only in `content[0].text` while `structuredContent` has metadata only | Structured-first clients see an empty-looking success | Mirror essential content/results into `structuredContent`, or use `object()` / `mix(markdown(...), object(...))` |
+| Putting the primary result only in `structuredContent` | Content-first adapters and older clients can lose the answer | Add readable `content` with the same essential facts |
+| Putting secrets or bulky UI hydration in `structuredContent` | Some hosts expose `structuredContent` to the model/transcript | Put private or large UI-only data in `_meta` |
 | Throwing instead of `error()` for expected failures | Server exception vs. graceful tool failure | `return error("...")` for not-found, validation, limits |
 | Forgetting to `await` file-based `audio()` | Returns a Promise instead of the result | Always `await audio("./path/to/file.wav")` |
 | Building `CallToolResult` manually | Verbose, easy to miss fields | Use helpers — they exist to prevent this |
@@ -497,7 +552,7 @@ return xml('<?xml version="1.0"?><status><state>ok</state></status>')
 return text(JSON.stringify({ total: 42 }))
 ```
 
-✅ **GOOD** — Use `object()` for structured data:
+✅ **GOOD** — Use `object()` when a typed client, widget, Code Mode workflow, or downstream parser needs structured fields:
 
 ```typescript
 return object({ total: 42 })
@@ -739,6 +794,7 @@ server.tool(
 |---|---|
 | Do I want the model to reason over typed data? | `object()` or `array()` |
 | Do I want the user to read a concise summary? | `text()` or `markdown()` |
+| Will a bridge or agent host consume `structuredContent`? | Include all essential result fields in `structuredContent` |
 | Do I need a file-like binary payload? | `binary()`, `image()`, or `audio()` |
 | Is this a known failure? | `error()` |
 | Do I need more than one content form? | `mix()` |
@@ -747,8 +803,8 @@ server.tool(
 
 ## Recommended defaults
 
-1. Use `object()` for data.
-2. Use `text()` or `markdown()` for summaries.
+1. Use `text()` or `markdown()` for the default conversational answer.
+2. Use `object()` only when typed/programmatic consumers need structured fields.
 3. Use `error()` for expected failures.
 4. Use `mix()` sparingly and intentionally.
 5. Let helpers set `_meta.mimeType` for you.

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/testing-and-debugging.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/testing-and-debugging.md
@@ -138,6 +138,18 @@ curl -s -X POST http://localhost:3000/mcp \
   -H "MCP-Protocol-Version: 2025-11-25" \
   -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"greet","arguments":{"name":"World"}},"id":3}' | jq .
 
+# For tools with outputSchema or custom structuredContent, verify both surfaces.
+# content[0].text should be readable, and structuredContent must include the
+# same essential result body, not only metadata. Do not put secrets in
+# structuredContent; use _meta for private/client-only data.
+curl -s -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -H "MCP-Protocol-Version: 2025-11-25" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"greet","arguments":{"name":"World"}},"id":6}' \
+  | jq '.result | {text: .content[0].text, structuredContent, metaKeys: (._meta // {} | keys)}'
+
 # 4. Resources and prompts
 curl -s -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/tools-and-schemas.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/tools-and-schemas.md
@@ -88,7 +88,7 @@ server.tool(
 | `outputSchema` | `z.ZodTypeAny` | No | Zod schema for structured output; enables type inference in `useCallTool()` |
 | `annotations` | `ToolAnnotations` | No | Behavioral hints for clients (read-only, destructive, etc.) |
 | `cb` | `ToolCallback` | No | Inline handler (alternative to separate callback argument) |
-| `_meta` | `Record<string, unknown>` | No | Opaque metadata passed through to MCP protocol (used for OpenAI Apps SDK integration) |
+| `_meta` | `Record<string, unknown>` | No | Opaque private/client metadata passed through MCP; use for OpenAI Apps wiring and widget-only data |
 | `widget` | `ToolWidgetConfig` | No | Widget config for tools returning `widget()` responses |
 | `inputs` | `InputDefinition[]` | No | **Deprecated.** Use `schema` (Zod) instead. |
 
@@ -337,7 +337,7 @@ server.tool({
 
   // Return widget with runtime data only
   return widget({
-    props: weatherData,              // Widget-only data passed to useWidget().props (hidden from model)
+    props: weatherData,              // Model-safe data passed to useWidget().props (structuredContent)
     output: text(`Weather in ${city}: ${weatherData.temp}°C`),  // What the model sees
     message: `Current weather in ${city}`  // Optional text message override
   });
@@ -350,7 +350,9 @@ See the [UI Widgets guide](./ui-widgets) for complete widget creation and regist
 
 ## OpenAI Apps SDK Integration (`_meta`)
 
-For ChatGPT and OpenAI-compatible clients, use `_meta` on the tool definition and in the handler return value to wire up widget rendering:
+For ChatGPT and OpenAI-compatible clients, use `_meta` on the tool definition and in the handler return value to wire up widget rendering or private widget hydration. Keep model-visible data in `content` and `structuredContent`; keep secrets, large lookup maps, and UI-only state in `_meta`.
+
+For maximum client compatibility, do not add `outputSchema` or `structuredContent` just because JSON is convenient. Use them when a typed consumer, widget, Code Mode workflow, or downstream parser needs structured fields. Otherwise return concise `content` with `text()` or `markdown()`.
 
 ```typescript
 server.tool({
@@ -685,6 +687,8 @@ server.tool({
 | Generic names: `process`, `handle` | LLM can't choose the right tool | Specific verbs: `search-users`, `create-ticket` |
 | Missing `.describe()` on fields | LLM guesses at field purposes | Add `.describe()` to every schema field |
 | Returning raw API responses | Bloated context, confusing nesting | Curate with `object()` — only relevant fields |
+| Declaring `outputSchema` but returning only metadata in `structuredContent` | Structured-first clients may hide `content[0].text`, so the model sees no result body | Put the essential answer/result body in `structuredContent` and cover it in `outputSchema` |
+| Returning structured data without readable `content` | Content-first clients and older adapters can lose the result | Include a concise text/markdown representation with the same essential facts |
 | No error handling in handler | Unhandled throws crash the server | Wrap in `try/catch`, return `error()` |
 | Too many parameters (>6) | LLM struggles with complex schemas | Split into multiple focused tools |
 | Giant catch-all tools | One tool doing 5 things via "mode" param | One tool per action |

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/widgets-and-ui.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/widgets-and-ui.md
@@ -6,7 +6,7 @@ Guide to building interactive UI widgets (MCP Apps) on the server and consuming 
 
 ## Server-Side: MCP Apps / Widgets
 
-MCP Apps are interactive UI widgets returned by tools. The LLM calls a tool, the server returns structured data, and a client-side widget renders it. The server controls what the LLM sees (`content`) separately from what the widget sees (`structuredContent`).
+MCP Apps are interactive UI widgets returned by tools. The LLM calls a tool, the server returns structured data, and a client-side widget renders it. Host visibility differs, so treat `content` and `structuredContent` as potentially model-visible. Use `_meta`/`metadata` for private, large, or widget-only hydration data.
 
 ### The `widget()` Response Helper
 
@@ -15,14 +15,14 @@ Import from `mcp-use/server`. Returns a `CallToolResult` with three visibility c
 | Field | LLM sees? | Widget sees? | Populated by |
 |---|---|---|---|
 | `content` | **Yes** | Yes | `output` or `message` |
-| `structuredContent` | **No** | Yes (as `props`) | `props` |
+| `structuredContent` | **Host-dependent; yes in ChatGPT/OpenAI Apps** | Yes (as `props`) | `props` |
 | `_meta` | **No** | Yes (as `metadata`) | `metadata` |
 
 ```typescript
 import { widget, text } from "mcp-use/server";
 
 return widget({
-  props: { city: "Paris", temperature: 22 },       // → useWidget().props
+  props: { city: "Paris", temperature: 22 },       // → useWidget().props; not secret
   output: text("Weather in Paris: 22°C, Sunny"),    // → LLM sees this
   metadata: { lastUpdated: Date.now() },            // → useWidget().metadata
   message: undefined,                               // optional text override (instead of output)
@@ -203,10 +203,12 @@ This single configuration automatically generates metadata for **both protocols*
 
 ### Data Flow: What the LLM Sees vs What the Widget Sees
 
+This table describes widget delivery, not a privacy boundary. ChatGPT/OpenAI Apps documents `structuredContent` as model-visible; other hosts vary. Put only model-safe data in `props`.
+
 | Field | LLM sees it? | Widget sees it? | Purpose |
 |---|---|---|---|
 | `content` | **Yes** | Yes | Text summary for the model's context |
-| `structuredContent` | **No** | Yes (as `props`) | Rendering data for the widget |
+| `structuredContent` | **Host-dependent; yes in ChatGPT/OpenAI Apps** | Yes (as `props`) | Rendering data for the widget |
 | `_meta` | **No** | Yes (as `metadata`) | Protocol + custom metadata |
 
 ```typescript
@@ -219,7 +221,7 @@ server.tool({
   const results = await db.search(query);
 
   return widget({
-    // Widget rendering data — LLM does NOT see this
+    // Widget rendering data — model-safe; do not include secrets or bulky private state
     props: { query, results },
     // Text summary — LLM sees this
     output: text(`Found ${results.length} products matching "${query}"`),
@@ -286,7 +288,7 @@ When running inside ChatGPT (Apps SDK), only the text content of the blocks is u
 
 ### Response Metadata
 
-The tool result's `_meta` field is available as `metadata` in `useWidget`. Use the `metadata` option in the `widget()` helper to pass extra data that doesn't belong in `structuredContent`:
+The tool result's `_meta` field is available as `metadata` in `useWidget`. Use the `metadata` option in the `widget()` helper to pass private, large, or UI-only data that the model should not read:
 
 ```typescript
 // Server side
@@ -1118,10 +1120,10 @@ Most widgets won't need the bridge directly. The `useWidget()` hook provides a s
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `props` | `Record<string, any>` | No | Sent to the widget as `props`. Stored in `structuredContent`. LLM does NOT see this. Defaults to `{}` if omitted. |
+| `props` | `Record<string, any>` | No | Sent to the widget as `props`. Stored in `structuredContent`; treat as model-visible unless the exact host proves otherwise. Defaults to `{}` if omitted. |
 | `output` | `CallToolResult` | No | LLM-visible content (`text`, `object`, etc.). If neither `output` nor `message` is set, an empty text content block is used. |
 | `message` | `string` | No | Shorthand for a plain text content entry. Takes precedence over `output` when both are set. |
-| `metadata` | `Record<string, unknown>` | No | Extra data for the widget. Exposed as `useWidget().metadata`. Stored in `_meta`. |
+| `metadata` | `Record<string, unknown>` | No | Private, large, or UI-only data for the widget. Exposed as `useWidget().metadata`. Stored in `_meta`. |
 
 ---
 

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/references/patterns/anti-patterns.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/references/patterns/anti-patterns.md
@@ -187,6 +187,32 @@ server.tool({
 });
 ```
 
+### Metadata-Only or Contentless Structured Results
+
+```typescript
+// ❌ BAD — structured-first clients see only bookkeeping, not the answer body
+const body = renderMarkdown(results);
+return {
+  ...markdown(body),
+  structuredContent: { metadata: { count: results.length } },
+};
+
+// ❌ BAD — content-first clients and older adapters can lose the answer
+return {
+  structuredContent: { content: body, results },
+};
+
+// ✅ GOOD — both surfaces carry the same essential result
+return {
+  ...markdown(body),
+  structuredContent: {
+    content: body,
+    results,
+    metadata: { count: results.length },
+  },
+};
+```
+
 ---
 
 ## 3. Schema Anti-Patterns

--- a/skills/build-mcp-use-server/skills/build-mcp-use-server/references/troubleshooting/common-errors.md
+++ b/skills/build-mcp-use-server/skills/build-mcp-use-server/references/troubleshooting/common-errors.md
@@ -746,7 +746,7 @@ npx @mcp-use/inspector --url http://localhost:3000/mcp
 - **Tool Listing**: Ensure `tools/list` returns what you expect. Check `schema` structures.
 - **Tool Execution**: Call a tool. Watch the JSON-RPC trace.
   - **Request**: `tools/call`. Check `name` and `arguments`.
-  - **Response**: `content` array. Check `type` ("text", "image", "resource").
+  - **Response**: Check both `content` and `structuredContent`. For tools with `outputSchema` or custom structured output, both surfaces should carry the same essential result; `_meta` should contain only private/client-only data.
   - **Error**: Check `code` and `message`.
 
 ### 3. Common Traces
@@ -756,6 +756,19 @@ npx @mcp-use/inspector --url http://localhost:3000/mcp
 -> {"jsonrpc": "2.0", "method": "tools/call", "params": { ... }, "id": 1}
 <- {"jsonrpc": "2.0", "result": { "content": [{ "type": "text", "text": "OK" }] }, "id": 1}
 ```
+
+**Success that looks empty in structured-output clients:**
+```json
+<- {
+  "jsonrpc": "2.0",
+  "result": {
+    "content": [{ "type": "text", "text": "# Full scraped markdown..." }],
+    "structuredContent": { "metadata": { "successful": 1 } }
+  },
+  "id": 1
+}
+```
+Fix by mirroring the primary result into `structuredContent` and covering it in `outputSchema`, for example `{ "content": "...", "results": [...], "metadata": {...} }`. Also keep `content[0].text` useful, because content-first clients and adapters may ignore `structuredContent`.
 
 **Failure (Application Error):**
 ```json


### PR DESCRIPTION
## Summary

This updates the mcp-use skill family to make MCP tool result guidance match current cross-client behavior. The core recommendation is now content-first for broad conversational compatibility, with `structuredContent` reserved for output schemas, typed/programmatic consumers, Code Mode, widget props, or explicit downstream parser contracts.

The change also removes stale widget guidance that implied `structuredContent`/`props` are always hidden from the model. ChatGPT/OpenAI Apps documents `structuredContent` as transcript-visible, so the widget skills now teach `props` as model-safe data and `_meta`/`metadata` as the private client-only lane.

## Context / Why now

Recent MCP client behavior is divergent: some clients/adapters prefer `content`, some prefer `structuredContent`, some expose both, and some drop one surface. The previous skill docs could lead server authors to put scraped or widget data only in `content[0].text` while leaving `structuredContent` as metadata-only, or to put private widget data into `props` under the assumption that the model cannot see it.

## The 3 items

1. Server skill response guidance

Files:
- `skills/build-mcp-use-server/skills/build-mcp-use-server/SKILL.md`
- `skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/response-helpers.md`
- `skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/tools-and-schemas.md`
- `skills/build-mcp-use-server/skills/build-mcp-use-server/references/guides/testing-and-debugging.md`
- `skills/build-mcp-use-server/skills/build-mcp-use-server/references/patterns/anti-patterns.md`
- `skills/build-mcp-use-server/skills/build-mcp-use-server/references/troubleshooting/common-errors.md`

Rationale:
- Default to complete `content` for broad compatibility.
- Add `structuredContent` only for real typed/programmatic/widget/parser consumers.
- When both result surfaces exist, keep them semantically equivalent.
- Use `_meta` only for private, bulky, or UI-only data.

2. Apps/widgets skill visibility guidance

Files:
- `skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/SKILL.md`
- `skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/guides/*.md`
- `skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/examples/server-recipes.md`
- `skills/build-mcp-use-apps-widgets/skills/build-mcp-use-apps-widgets/references/patterns/mcp-apps-patterns.md`

Rationale:
- Replace “props/structuredContent are widget-only and the LLM does not see them” with host-dependent visibility.
- Teach that ChatGPT/OpenAI Apps can expose `structuredContent` to the model/transcript.
- Move private, bulky, or UI-only hydration guidance to `_meta` / `metadata`.
- Keep `message` / `output` required for text-only and content-first clients.

3. Client skill result-surface handling

Files:
- `skills/build-mcp-use-client/skills/build-mcp-use-client/SKILL.md`
- `skills/build-mcp-use-client/skills/build-mcp-use-client/references/guides/tools.md`
- `skills/build-mcp-use-client/skills/build-mcp-use-client/references/guides/cli-reference.md`

Rationale:
- Client code should preserve both `content` and `structuredContent` when present.
- Docs should not imply `content[0].text` is the only success payload.
- CLI examples now show how to preserve structured output in JSON scripting.

## Files touched

| Area | Files | Purpose |
|---|---:|---|
| `build-mcp-use-server` | 7 | Content-first server defaults, semantic equivalence, `_meta` privacy lane |
| `build-mcp-use-apps-widgets` | 9 | Correct widget `structuredContent` visibility and private metadata guidance |
| `build-mcp-use-client` | 3 | Preserve both tool result surfaces in client code and CLI scripting |

## Verification

Ran:
- `git diff --check`
- Targeted stale-guidance scan for phrases such as `LLM does NOT see`, `structuredContent **No**`, `Widget-only`, `hidden from model`, and `Preferred when the LLM`
- Targeted positive-guidance scan for `content-first`, `structured-first`, `broad conversational compatibility`, `model-safe`, `private/client-only`, and `ChatGPT/OpenAI Apps`

Not run:
- No automated test suite was found at repo root.
- These are skill documentation changes, so validation is text/diff based.

## Weaknesses and open questions

Weakness 1: The compatibility matrix cites issue reports for some client behaviors, not only final product documentation. That is intentional because current MCP host behavior is still uneven, but reviewer should check whether any issue-specific behavior has since been fixed.

Weakness 2: The docs now prefer `content` by default for conversational compatibility. This is safer for general agents, but projects with strongly typed downstream consumers may want to lean more heavily on `structuredContent`.

Question for reviewer: Should the server skill include an even stricter rule that `outputSchema` must not be added unless there is a named typed/programmatic consumer, or is the current “real downstream parser requirement” wording enough?

## Request to reviewer

Please review especially for consistency across the three mcp-use skills: server, apps/widgets, and client. The important invariant is that `content` is the broad compatibility path, `structuredContent` is model-safe typed data when needed, and `_meta` is the private/client-only path.

## Follow-ups

- Add a compact helper snippet later for normalizing MCP client results into `{ text, structuredContent }` across all client examples.
- Revisit this guidance when the MCP spec or major hosts converge on a single result-surface policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
