### PR TITLE
feat(skills): make-local, make-railway, make-vercel deployment trilogy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Anchor on this set of plain-English verbs:
 | `extract` | Pull data, design, or assets from existing artifacts | `extract-saas-design` |
 | `init` | Generate config or instruction files | `init-agent-config` |
 | `enhance` | Improve a prompt, skill, or instruction | `enhance-prompt`, `enhance-skill-by-derailment` |
+| `make` | Author Makefile targets / `make X` deployment & workflow scaffolding | `make-local`, `make-railway`, `make-vercel` |
 | `optimize` | Tune for a constraint (e.g. agentic) | `optimize-agentic-cli`, `optimize-agentic-mcp` |
 | `develop` | Apply language-level patterns and standards | `develop-typescript` |
 | `publish` | Release to a registry | `publish-npm-package` |
@@ -236,6 +237,7 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
 | `testing` | Skills that automate browser testing or verification |
 | `orchestration` | Skills for multi-agent coordination |
 | `platform` | Skills for a specific platform ecosystem (e.g., Railway) |
+| `workflow` | Skills that author Makefile targets / multi-step scaffolding workflows for deployment, CI, or local dev |
 
 ---
 
@@ -251,7 +253,7 @@ Keep descriptions short (under 80 chars). Match the terse style of existing rows
 
 ---
 
-## Current canonical skill names (45 skills)
+## Current canonical skill names (48 skills)
 
 Use this list to check for naming collisions:
 
@@ -265,6 +267,7 @@ build-skills                 check-completion             convert-url-to-nextjs
 develop-typescript           do-debug                     do-review
 do-think                     enhance-prompt               enhance-skill-by-derailment
 evaluate-code-review         extract-saas-design          init-agent-config
+make-local                   make-railway                 make-vercel
 optimize-agentic-cli         optimize-agentic-mcp         publish-npm-package
 run-agent-browser            run-batch-codex-research     run-codex-exec
 run-codex-review             run-github-scout             run-industry-research

--- a/NAMING.md
+++ b/NAMING.md
@@ -24,6 +24,7 @@ Anchor on this set of plain-English intent verbs:
 | `evaluate` | Triage existing feedback or input | `evaluate-code-review` |
 | `extract` | Pull data, design, or assets from existing artifacts | `extract-saas-design` |
 | `init` | Generate config or instruction files | `init-agent-config` |
+| `make` | Author Makefile targets / `make X` workflow scaffolding | `make-local`, `make-railway`, `make-vercel` |
 | `enhance` | Improve a prompt, skill, or instruction | `enhance-prompt`, `enhance-skill-by-derailment` |
 | `optimize` | Tune for a constraint (e.g. agentic) | `optimize-agentic-cli`, `optimize-agentic-mcp` |
 | `develop` | Apply language-level patterns and standards | `develop-typescript` |

--- a/NAMING.md
+++ b/NAMING.md
@@ -86,7 +86,7 @@ When renaming a published skill:
 7. Search cross-skill references and update each
 8. Run `python3 scripts/validate-skills.py`
 
-## Current Canonical Skill Names (44)
+## Current Canonical Skill Names (47)
 
 - `apply-clean-architecture`
 - `apply-liquid-glass`
@@ -114,6 +114,9 @@ When renaming a published skill:
 - `evaluate-code-review`
 - `extract-saas-design`
 - `init-agent-config`
+- `make-local`
+- `make-railway`
+- `make-vercel`
 - `optimize-agentic-cli`
 - `optimize-agentic-mcp`
 - `publish-npm-package`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/<skill-name>
 | [evaluate-code-review](skills/evaluate-code-review/) | productivity | Evaluate PR/session/markdown review feedback with verify-before-implement discipline and multi-agent consolidation |
 | [extract-saas-design](skills/extract-saas-design/) | design | SaaS dashboard visual system extraction |
 | [init-agent-config](skills/init-agent-config/) | configuration | AGENTS + REVIEW standardization hierarchies |
+| [make-local](skills/make-local/) | workflow | `make local` / `make tunnel` for Next.js/Node — Tailscale Serve, portless, LAN bind |
+| [make-railway](skills/make-railway/) | workflow | `make prod` Railway deploy with parallel multi-service uploads + git-hook CI/CD |
+| [make-vercel](skills/make-vercel/) | workflow | `make deploy` Vercel with find-or-create, env scoping, 50MB function limit |
 | [optimize-agentic-cli](skills/optimize-agentic-cli/) | development | Audit or design agent-ready CLIs with iterative feedback loops |
 | [optimize-agentic-mcp](skills/optimize-agentic-mcp/) | development | Audit, optimize, or architect new MCP servers |
 | [publish-npm-package](skills/publish-npm-package/) | development | npm publishing via GitHub Actions |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-47 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
+50 skills for AI coding agents -- code review, planning, research, browser automation, multi-agent orchestration, framework guides, SDK guides, design extraction, and more.
 
 ## Install
 

--- a/skills/make-local/README.md
+++ b/skills/make-local/README.md
@@ -1,0 +1,19 @@
+# make-local
+
+Authoring a `make local` or `make tunnel` target for Next.js/Node projects, picking between Tailscale Serve, portless, and plain LAN binding.
+
+**Category:** workflow
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/make-local
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/make-local/skills/make-local/SKILL.md
+++ b/skills/make-local/skills/make-local/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: make-local
+description: Use skill if you are authoring a `make local` or `make tunnel` target for Next.js/Node projects, picking between Tailscale Serve, portless, and plain LAN binding.
+---
+
+# Make Local
+
+Author the Makefile that gives a developer a stable, friendly URL for local dev — across reboots, across worktrees, across devices on their tailnet. Replaces `localhost:3000` with `https://<name>.localhost` (portless) or `http://<node>.ts.net` (Tailscale Serve).
+
+## How to think about this
+
+The default `next dev` flow has three real problems:
+1. **Port memorization.** Devs end up with sticky-notes mapping projects to ports because OrbStack/Postgres/Redis/another dev server collide.
+2. **Loopback isolation.** `localhost` and `*.localhost` are bound to `127.0.0.1` per RFC 6761 — phones, tablets, secondary laptops can't reach them.
+3. **Cookie/storage pollution.** Multiple projects on `localhost` share cookies and IndexedDB, leaking auth state.
+
+The fix is a per-project named URL backed by a real cert. Two paths:
+
+- **portless** (single machine, daily driver) — installs a local CA, binds :443, gives you `https://<name>.localhost` with HTTP/2. First-run sudo prompt for cert trust + port bind, silent thereafter.
+- **Tailscale Serve** (cross-device) — proxies `http://<node>.ts.net` to your local port, reachable from any device signed into your tailnet. Real Let's Encrypt cert if you opt into HTTPS.
+
+The third path (`make local-lan`, plain `0.0.0.0:PORT`) is the universal fallback for headless CI, phones on the same Wi-Fi when MagicDNS isn't resolving, and tools that can't follow `.localhost` certs.
+
+## Use this skill when
+
+- The user asks for "make local", "local dev script", "tunnel for dev server", "share my dev server with phone/teammate", "stable URL for development".
+- A Next.js / Node project needs cross-device dev access (mobile testing, remote pair, demo to a stakeholder on the same tailnet).
+- Port conflicts or auth-cookie collisions are recurring pain.
+
+## Do not use this skill when
+
+- The user wants production deployment — route to `make-railway` or `make-vercel`.
+- The user wants to set up Tailscale itself or troubleshoot tailnet connectivity — that's outside scope; this skill assumes Tailscale is signed in.
+- The project is already shipping; this is a dev-experience skill, not a runtime change.
+
+## Workflow
+
+### 1. Detect what you're working with
+
+Before writing a single Make target, capture the project's current state:
+
+```bash
+# Framework + dev script
+cat package.json | jq -r '.scripts.dev'
+
+# What port the app currently uses (default 3000 / 3107 / 3456 / etc.)
+grep -rE '"dev":|--port|PORT' package.json next.config.* 2>/dev/null | head -5
+
+# Auth library (matters for the dev-bypass section)
+grep -E '"@clerk/nextjs"|"next-auth"|"@auth/" ' package.json | head
+
+# Tailscale state
+tailscale status --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); s=d['Self']; print(s.get('HostName'), '·', s.get('DNSName','').rstrip('.'))"
+
+# Is portless installed
+which portless || echo "(install: npm install -D portless)"
+```
+
+If any check fails, that's a precondition — surface it to the user before generating the Makefile, don't generate something that will break on first run.
+
+### 2. Pick the path based on requirements
+
+Use the decision tree in `references/path-decision.md`. Default ranking:
+
+1. If user wants HTTPS + cross-device → **Tailscale Serve** (`make tunnel`)
+2. If user wants stable name on this machine only → **portless** (`make local`)
+3. If user wants raw LAN-IP access for phone-on-Wi-Fi → **plain bind** (`make local-lan`)
+
+The strongest Makefile gives all three — let the user pick per invocation. The zeo-radar Makefile (this skill's canonical example) ships all three side-by-side.
+
+### 3. Generate the Makefile
+
+Use the template in `references/makefile-template.md`. Replace these placeholders:
+
+| Placeholder | What to replace with |
+|---|---|
+| `PROJECT_NAME` | The portless URL prefix → `<name>.localhost`. Use the npm package name without scope. |
+| `PORT` | The dev port for `make local-lan`. Pick something far from 3000 (OrbStack squat zone). |
+| `TUNNEL_PORT` | The dev port for `make tunnel`. Different from `PORT` so both can run. |
+| `TS_HOSTNAME` | Output of `tailscale set --hostname=...` — defaults to current hostname. |
+| `DEV_CMD` | Usually `npm run dev`. Adjust for `pnpm dev` / `bun dev`. |
+
+### 4. Wire portless config
+
+Create `portless.json` at repo root with the project name:
+
+```json
+{ "name": "PROJECT_NAME" }
+```
+
+That alone makes the URL `https://PROJECT_NAME.localhost`. Don't pass `--name` flags everywhere; the config is single-source-of-truth.
+
+### 5. Wire `next.config.ts` allowedDevOrigins (Next 16+)
+
+For tunnel hostnames to load HMR/_next assets, they MUST be listed verbatim in `next.config.ts`:
+
+```ts
+allowedDevOrigins: [
+  "PROJECT_NAME",                       // portless short
+  "PROJECT_NAME.localhost",             // portless FQDN
+  "TS_HOSTNAME",                        // tailnet short MagicDNS
+  "TS_HOSTNAME.<tailnet>.ts.net",       // tailnet FQDN
+],
+```
+
+Next 16 does **exact-match** (not suffix-match), so list every form the agent might hit. Without this, the dev overlay flashes "Blocked cross-origin request to /_next/webpack-hmr" and HMR breaks silently.
+
+### 6. Address auth gating if present
+
+If the project uses Clerk or another auth wall, the Make targets must give the user a path to skip it for local work. See `references/dev-bypass-recipes.md` for Clerk's `AUTH_ENABLED=false` + `SOFT_GATE_PASSWORD` pattern.
+
+### 7. Run detection + first-launch test
+
+```bash
+make local
+# Should print all reachable URLs, start docker (postgres/redis) if compose exists, hand off to dev server
+```
+
+Verify each printed URL actually loads in the user's browser before declaring done.
+
+## Decision rules
+
+- Two paths is wrong; three paths is right. Always ship `local`, `tunnel`, `local-lan` together. Each one fails for situations the other two cover.
+- Default `make local` to portless, not Tailscale. Reason: portless requires zero account/sign-in. Tailscale needs a signed-in tailnet. Beginner devs hit portless and it works; if they want cross-device, they discover `make tunnel` from the help screen.
+- Default `make tunnel` to **HTTP**, not HTTPS. **`*.ts.net` is on Chrome's HSTS preload list** — Chrome will refuse plain HTTP and emit `ERR_BLOCKED_BY_CLIENT`. But TLS-fronted-HTTP-backend triggers Next.js EPROTO crashes on every middleware self-fetch. The right default depends on the framework — see `references/hsts-preload-trap.md` for the full decision matrix.
+- Never blindly `kill -9` whatever's on a port. Only reclaim if the holder is `node`/`next`/`turbopack`/`next-server`. Anything else (OrbStack, postgres, browser tunnel, GitHub Actions runner) gets reported and refused. See `references/port-hygiene.md`.
+- Print every URL up-front. Devs shouldn't have to `ifconfig` or `tailscale status`. The banner is part of the contract.
+
+## Recovery paths
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `make local` fails with "Cannot bind to :443" | portless first-run, sudo timed out | Re-run; the system dialog appears once per session |
+| Browser shows `ERR_BLOCKED_BY_CLIENT` on tailnet URL | HSTS preload of `*.ts.net` rejects HTTP | Either switch tunnel to HTTPS (`tailscale serve --bg --https=443`) or fix the upstream proxy headers — see `references/hsts-preload-trap.md` |
+| Dev server returns 500 with `EPROTO ... wrong version number` | TLS fronting an HTTP backend, middleware self-fetches `https://localhost:PORT` | Switch to `--http=80` mode, OR set `X-Forwarded-Proto: http` rewriting at proxy. See `references/eproto-tls-mismatch.md` |
+| Dev overlay: `Blocked cross-origin request to /_next/webpack-hmr from "<host>"` | `allowedDevOrigins` doesn't list this exact host | Add the exact hostname (both short + FQDN forms) to `next.config.ts` |
+| `make tunnel` says "tailscale not signed in" | Tailscale daemon up but account not linked | `tailscale up` interactively; this skill doesn't drive that flow |
+| Page renders "Internal Server Error" through tunnel but works on `localhost:PORT` | Same crash on both — not a tunnel issue | `tail -f` the dev log; tunnel is innocent |
+| Page renders blank with `<html id="__next_error__">` | Next.js error boundary served | Read dev log for the actual error — usually missing DB table, missing env var, mismatched auth keys |
+| Port-conflict refusal: "port :PORT held by orbstack" | Something legit is squatting | Pick a different port (`make local PORT=4000`), don't kill OrbStack |
+
+## Customizing the recipe
+
+- **Non-Next frameworks (Express, Hono, Fastify, plain Node):** drop the `allowedDevOrigins` section entirely. The Makefile structure is identical.
+- **Vite/SvelteKit/Remix:** Vite reads `--host` not `HOSTNAME`. Adjust the `make local-lan` recipe accordingly. Same banner pattern works.
+- **Monorepo with multiple dev servers:** generate one Make target per app (`make local-web`, `make local-admin`). Pick distinct ports + portless names to avoid cookie collision.
+- **Project has no Clerk/auth wall:** drop the dev-bypass section entirely.
+- **Headless CI:** add a `make ci` that just binds plain `0.0.0.0:PORT`. No tunnel, no portless, no banner.
+
+## Reference routing
+
+| File | Read when |
+|---|---|
+| `references/path-decision.md` | Choosing between portless, Tailscale Serve, and plain LAN bind for a specific user need. |
+| `references/makefile-template.md` | Generating the Make targets — the full template with every placeholder annotated. |
+| `references/portless-setup.md` | Wiring portless: `portless.json`, first-run sudo, version pinning via package.json devDependency. |
+| `references/tailscale-serve-setup.md` | Wiring Tailscale Serve: HTTP vs HTTPS, Funnel-off enforcement, hostname customization (`tailscale set --hostname=`), MagicDNS resolution. |
+| `references/hsts-preload-trap.md` | Why `*.ts.net` HTTPS is mandatory for Chrome but breaks Next 16 middleware via EPROTO; the decision matrix. |
+| `references/eproto-tls-mismatch.md` | The Next.js TLS-fronted-HTTP-backend crash, signature, and three workarounds. |
+| `references/port-hygiene.md` | Stale-process detection, kill-only-our-own rule, banner conventions, multi-LAN-IP enumeration. |
+| `references/dev-bypass-recipes.md` | Clerk soft-gate (`AUTH_ENABLED=false` + `SOFT_GATE_PASSWORD`), env precedence, "all-Next-pages-500" diagnostic. |
+| `references/next-config-allowed-origins.md` | The exact-match Next 16 CORS rule, common forms to enumerate, hostname-rename procedure. |
+| `references/cross-skill-handoffs.md` | When to hand off to `make-railway` (production), `make-vercel` (alt prod), `use-railway` (CLI commands). |
+
+## Cross-skill handoffs
+
+- After dev works, the user usually wants to deploy. Route to `make-railway` (long-running processes, BullMQ workers, SSE) or `make-vercel` (pure-static + serverless). See `references/cross-skill-handoffs.md` for the decision.
+- For raw `railway` CLI questions, defer to `use-railway`.
+- For tooling Railway operations beyond deploy (logs, scale, SSH), `use-railway`.
+
+## Guardrails
+
+- Don't write a Makefile that silently kills processes. Always classify the holder first.
+- Don't promise HTTPS without checking HSTS implications for the chosen domain.
+- Don't generate `next.config.ts` edits without preserving the user's existing `allowedDevOrigins` entries — append, never replace.
+- Don't enable Tailscale Funnel by default. Funnel exposes the dev server to the public internet; it must be opt-in with explicit user consent.
+
+## Final checks
+
+Before declaring done:
+
+- [ ] `make help` shows all three targets (`local`, `local-lan`, `tunnel`) with one-line descriptions
+- [ ] `make local` actually starts the dev server and prints reachable URLs
+- [ ] Every printed URL loads in a real browser (not just curl — Chrome's HSTS rules matter)
+- [ ] If the project has auth: a documented path to bypass it for local dev (`/gate` or equivalent)
+- [ ] `next.config.ts allowedDevOrigins` contains every tunnel hostname form used
+- [ ] `make stop` and `make tunnel-stop` work and clean up serve/funnel config
+- [ ] No process is killed unless it's our own (`node`/`next`/`turbopack`)

--- a/skills/make-local/skills/make-local/references/cross-skill-handoffs.md
+++ b/skills/make-local/skills/make-local/references/cross-skill-handoffs.md
@@ -1,0 +1,55 @@
+# Cross-skill handoffs
+
+Where to route the user after `make local` works.
+
+## "I want to deploy this somewhere"
+
+Decision tree:
+
+| Project shape | Skill |
+|---|---|
+| Pure-static + serverless Next.js, Edge runtime, marketing sites | **make-vercel** |
+| Next.js with BullMQ workers, SSE keep-alives, long-running jobs | **make-railway** |
+| Backend service (Express/Hono/Fastify), background workers | **make-railway** |
+| Worker + web split (zeo-radar pattern) | **make-railway** |
+| Mixed: Vercel for web + Railway for workers | both — see `make-vercel` for the split-pattern caveat |
+
+Detail:
+
+- **make-railway** — long-running processes, BullMQ workers, SSE that exceeds Vercel's serverless time limits, Docker-based deploys, Postgres/Redis sidecars
+- **make-vercel** — Next.js with Edge runtime, serverless functions, automatic preview deploys per-PR, custom domains via DNS
+
+## "How do I run a Railway CLI command I forgot"
+
+Route to **use-railway**. That skill is the canonical CLI reference (deploy, logs, environments, linking, scaling, SSH, database access). `make-railway` covers the *workflow* of authoring deploy targets; `use-railway` covers the *CLI* itself.
+
+## "My phone can't reach my dev server"
+
+Stay in **make-local**:
+
+- Phone on tailnet → `make tunnel` (HTTPS via Let's Encrypt, real cert)
+- Phone on Wi-Fi only → `make local-lan` then open `http://<lan-ip>:PORT/`
+
+## "I want to share dev with a stakeholder outside my tailnet"
+
+Tailscale Funnel exposes `tailscale serve` to the public internet:
+
+```bash
+tailscale funnel --bg PORT
+```
+
+⚠️ Requires explicit user consent — never default to this. The dev server is now on the open internet with whatever security the app provides. Reset before exiting:
+
+```bash
+tailscale funnel reset
+```
+
+`make tunnel-stop` already resets both serve and funnel. Use it religiously.
+
+## "I want a stable URL for browser-based AI agents to test"
+
+`make tunnel` (with `TUNNEL_TLS=1` if the agent uses Chrome — HSTS preload of `*.ts.net` requires HTTPS). The URL is stable across reboots, so the agent doesn't need to re-discover it each session.
+
+## "I want CI/CD via git hooks instead of GitHub Actions"
+
+That's in **make-railway**'s scope (`make install-hooks`). The pattern works for Vercel too but Vercel's auto-deploy from GitHub is usually preferred there.

--- a/skills/make-local/skills/make-local/references/dev-bypass-recipes.md
+++ b/skills/make-local/skills/make-local/references/dev-bypass-recipes.md
@@ -1,0 +1,152 @@
+# Dev-bypass recipes for auth-gated apps
+
+When the project has Clerk/NextAuth/Auth.js + a soft-gate password, the dev server will 500 on every page until the bypass is configured. This is the "all-Next-pages-blank" diagnostic.
+
+## Clerk + soft-gate (zeo-radar pattern)
+
+Two env vars required, BOTH must be present:
+
+```sh
+# .env.local
+AUTH_ENABLED=false
+SOFT_GATE_PASSWORD=<any-non-empty-string>
+```
+
+`AUTH_ENABLED=false` ALONE is insufficient — the dev-bypass predicate requires the password too:
+
+```ts
+export function isDevBypassActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.AUTH_ENABLED !== "false") return false;
+  if (!env.SOFT_GATE_PASSWORD?.trim()) return false;
+  return true;
+}
+```
+
+Without the password, Clerk's middleware takes over with possibly-mismatched keys → infinite redirect loop → every page returns 500.
+
+## Diagnostic: "every page is 500/blank"
+
+Symptoms in dev log:
+
+```
+Clerk: Refreshing the session token resulted in an infinite redirect loop.
+This usually means that your Clerk instance keys do not match — make sure
+to copy the correct publishable and secret keys from the Clerk dashboard.
+```
+
+OR:
+
+```
+PrismaClientKnownRequestError P1001 DatabaseNotReachable
+  at readStoredTheme (src/lib/theme/server.ts:61)
+  at RootLayout (src/app/layout.tsx:50)
+```
+
+OR:
+
+```
+PrismaClientKnownRequestError P2021
+The table `public.user_preferences` does not exist in the current database.
+```
+
+The first is auth misconfig. The second is DB unreachable. The third is migrations not applied. All three present as "blank page / Internal Server Error" in the browser.
+
+## Fix order
+
+1. **Auth bypass** — set `AUTH_ENABLED=false` + `SOFT_GATE_PASSWORD=...` in `.env.local`. Pull the password from a sibling deploy if available:
+
+   ```bash
+   # Pull SOFT_GATE_PASSWORD from a Railway noauth deploy so local matches prod
+   railway variables --service noauth --kv | grep "^SOFT_GATE_PASSWORD=" | cut -d= -f2-
+   ```
+
+2. **DB reachability** — ensure `docker compose up -d` has been run (or OrbStack daemon is running). Local Postgres on `:5434`, Redis on `:6379`. Check `nc -z 127.0.0.1 5434`.
+
+3. **Schema** — apply migrations against the correct DB:
+
+   ```bash
+   DATABASE_URL=$(grep ^DATABASE_URL= .env.local | cut -d= -f2-) npx prisma migrate deploy
+   ```
+
+   Critical: use `.env.local`'s `DATABASE_URL`, NOT `.env`'s. Prisma's default config-file resolution may pick the wrong one.
+
+4. **Theme reader resilience** — the root layout's theme resolver should NOT crash the app on DB outage. Wrap the prisma call in try/catch:
+
+   ```ts
+   async function readStoredTheme(): Promise<ThemeId | null> {
+     const userId = await readAuthenticatedUserId();
+     if (!userId) return null;
+     try {
+       const pref = await prisma.userPreference.findUnique({ where: { userId }, select: { theme: true } });
+       return isThemeId(pref?.theme) ? pref.theme : null;
+     } catch {
+       return null;  // UI hint, not load-bearing
+     }
+   }
+   ```
+
+   Without this, a transient DB blip 500s every page.
+
+## Walking the gate in tests
+
+To verify the dev-bypass works end-to-end via real browser:
+
+```bash
+# Open the gate page
+agent-browser --session test open "http://<host>/gate"
+# Submit the password
+agent-browser --session test type 'input[type="password"]' "$SOFT_GATE_PASSWORD"
+agent-browser --session test click 'button[type="submit"]'
+sleep 6  # wait for redirect + cookie set + first compile
+# Verify landed on the real app
+agent-browser --session test get url
+agent-browser --session test screenshot /tmp/post-gate.png
+```
+
+Expected: URL becomes `/projects` (or the project's home), page renders the actual app.
+
+## Pointing local at remote DB (for read-only debugging)
+
+Sometimes the cleanest way to verify the local dev server works is to skip docker entirely and point at the production DB:
+
+```sh
+# .env.local
+# REMOTE-DB MODE — local dev hits Railway production data
+DATABASE_URL=postgresql://...@shortline.proxy.rlwy.net:NNNNN/railway
+REDIS_URL=redis://...@interchange.proxy.rlwy.net:NNNNN
+```
+
+⚠️ **All mutations land on production.** Reads safe; writes dangerous. Document this in `.env.local` with a banner comment.
+
+Pull the URLs from Railway:
+
+```bash
+railway variables --service postgres-service-name --kv | grep "DATABASE_PUBLIC_URL"
+railway variables --service redis-service-name --kv | grep "REDIS_PUBLIC_URL"
+```
+
+## Other auth systems
+
+| Library | Bypass pattern |
+|---|---|
+| **NextAuth / Auth.js** | Set `NEXTAUTH_SECRET` + `NEXTAUTH_URL` to dummy values; auth-protected routes still redirect to /signin but render. No silent infinite-loop. |
+| **Lucia** | Mock the session cookie in middleware for `NODE_ENV === 'development'`. |
+| **Custom JWT middleware** | Add a `DEV_BYPASS=1` env check at the top of middleware that short-circuits with a fake user. |
+| **No auth** | Skip this section entirely. |
+
+## Verification before declaring done
+
+```bash
+# Walking the gate via real Chrome ─ the only definitive test
+make tunnel  # or make local
+# In another terminal:
+PASS=$(grep ^SOFT_GATE_PASSWORD= .env.local | cut -d= -f2-)
+agent-browser --session t open "http://<tunnel-host>/gate"
+agent-browser --session t type 'input[type="password"]' "$PASS"
+agent-browser --session t click 'button[type="submit"]'
+sleep 6
+agent-browser --session t get url    # MUST be the post-gate route, not /gate
+agent-browser --session t screenshot /tmp/verify.png   # MUST show the app, not "Internal Server Error"
+```
+
+curl is insufficient — server actions and the gate cookie flow don't work via plain HTTP POST.

--- a/skills/make-local/skills/make-local/references/eproto-tls-mismatch.md
+++ b/skills/make-local/skills/make-local/references/eproto-tls-mismatch.md
@@ -1,0 +1,92 @@
+# EPROTO TLS-fronted-HTTP mismatch
+
+Distinct from the HSTS trap, but adjacent. Triggers when TLS terminates upstream but the local server is HTTP.
+
+## Symptom
+
+Page returns 500. Dev server log shows:
+
+```
+Failed to proxy https://localhost:3001/sign-in
+Error: write EPROTO C09841F801000000:error:0A00010B:SSL routines:tls_validate_record_header:wrong version number:ssl/record/methods/tlsany_meth.c:78:
+    errno: -100,
+    code: 'EPROTO',
+    syscall: 'write'
+```
+
+## Cause
+
+Tailscale Serve / nginx / Cloudflare Tunnel terminate TLS at :443, then forward the request to your local Next.js dev server on :PORT (HTTP). The forwarded request carries:
+
+- `X-Forwarded-Proto: https`
+- `X-Forwarded-Host: <tunnel-host>`
+- `Host: localhost:<PORT>` (the proxy rewrites Host)
+
+When Next.js middleware (Clerk, custom proxy.ts, etc.) does an internal self-fetch — for example to validate a session — it constructs the URL as `<X-Forwarded-Proto>://<Host>/<path>`:
+
+```
+https://localhost:3001/sign-in
+```
+
+But your local server speaks plain HTTP on :3001. The `https://` connection attempt sends a TLS Client Hello to an HTTP server → "wrong version number" → EPROTO.
+
+## Three fixes
+
+### 1. Use HTTP all the way (simplest)
+
+Configure the upstream proxy to NOT terminate TLS. For Tailscale Serve:
+
+```bash
+tailscale serve --bg --http=80 PORT   # HTTP-only mode
+```
+
+WireGuard already encrypts the link end-to-end; the HTTPS layer is belt-on-belt. **Caveat:** browsers will reject this for `.ts.net` (HSTS preload — see `hsts-preload-trap.md`).
+
+### 2. Use HTTPS all the way
+
+Run the local dev server with TLS:
+
+```bash
+# Next.js doesn't natively support HTTPS dev. Use a local HTTPS proxy:
+npx local-ssl-proxy --source 3443 --target 3001
+# Then point Tailscale Serve at :3443
+```
+
+Heavyweight but bulletproof.
+
+### 3. Make middleware respect X-Forwarded-Proto correctly
+
+The cleanest fix: tell Next.js middleware that internal self-fetches should use the *protocol of the inbound request*, not blindly `https://`. Patch the proxy/middleware:
+
+```ts
+// proxy.ts
+export default clerkMiddleware((auth, req) => {
+  // Force internal self-fetches to use HTTP locally
+  if (req.headers.get("x-forwarded-host")?.includes(".ts.net")) {
+    req.headers.set("x-forwarded-proto", "http");
+  }
+  // ... rest of middleware
+});
+```
+
+This is project-specific and brittle; recommend (1) or (2) first.
+
+## Why this is Next-specific
+
+Most frameworks (Express, Hono, Fastify) don't internally self-fetch. The middleware just runs synchronously against the inbound request. Next.js does this because of its server-component → server-action protocol — internal RSC streaming sometimes does an internal HTTP call to the same server.
+
+## Diagnostic test
+
+Probe via curl on the host:
+
+```bash
+# Should both return 200/307 (or whatever the route returns)
+curl -sLk -o /dev/null -w "%{http_code}\n" http://localhost:3001/
+curl -sLk -o /dev/null -w "%{http_code}\n" https://<tunnel-host>/
+```
+
+If localhost works but tunnel returns 500 + EPROTO in dev log → you've hit this.
+
+## When to mention this in user-facing output
+
+Bake the explanation into your commit message and the Makefile's `make tunnel` doc-comment. Devs hit this once and lose hours; documenting it is a force multiplier.

--- a/skills/make-local/skills/make-local/references/hsts-preload-trap.md
+++ b/skills/make-local/skills/make-local/references/hsts-preload-trap.md
@@ -1,0 +1,86 @@
+# HSTS preload trap — why `*.ts.net` HTTP fails in browsers
+
+This is the single highest-impact gotcha when wiring `make tunnel` to Tailscale.
+
+## Symptom
+
+User opens `http://<host>.ts.net/anything` in Chrome. Result:
+
+```
+ERR_BLOCKED_BY_CLIENT
+```
+
+Curl on the same machine returns HTTP 200 fine. Confusing.
+
+## Cause
+
+Tailscale enrolled the entire `.ts.net` zone on Chrome's HSTS preload list (and Firefox's, Safari's). The browser refuses to issue any HTTP request to `*.ts.net` and rewrites it to HTTPS internally — which then fails because we're serving HTTP.
+
+curl ignores HSTS preload, which is why command-line probes mislead you.
+
+## Decision matrix
+
+| Tunnel scheme | Browser works? | Next.js middleware works? | Verdict |
+|---|---|---|---|
+| `--http=80` | ❌ Chrome `ERR_BLOCKED_BY_CLIENT` | ✓ Clean | Wrong for `.ts.net` |
+| `--https=443` (TLS-front, HTTP backend) | ✓ Real cert | ❌ EPROTO on middleware self-fetches | Wrong for Next without proxy headers |
+| `--https=443` + `--bg` + `X-Forwarded-Proto: https` honored by app | ✓ | ✓ | Right answer for Next |
+| `--http=80` + non-`.ts.net` domain (e.g. plain LAN bind) | ✓ | ✓ | Right answer when not using Tailscale |
+
+## What to do
+
+For Next.js + Tailscale Serve, the only correct production-grade config is:
+
+1. `tailscale serve --bg --https=443 PORT` (HTTPS, real Let's Encrypt cert)
+2. App must trust `X-Forwarded-Proto` header so middleware self-fetches go to `http://localhost:PORT` (not `https://`)
+3. `next.config.ts` must list the FQDN in `allowedDevOrigins`
+
+For non-Next frameworks (Express/Hono/Fastify): use HTTPS too, but test EPROTO doesn't bite. Most frameworks don't have Next.js's "middleware self-fetches with X-Forwarded-Proto" behavior.
+
+For dev mode where you don't care about the EPROTO crashes (favicon-only, static-asset, public-only routes): HTTP works on Chrome only via the bare hostname workaround:
+
+```bash
+# This works because Chrome HSTS-preloads the FQDN, not the bare hostname
+tailscale serve --bg --http=80 PORT
+# Open http://<short-hostname>/  ← bypass HSTS preload
+# But http://<short>.<tailnet>.ts.net/ is still blocked
+```
+
+That's brittle. Don't rely on it.
+
+## Why our Makefile defaults to HTTP
+
+The zeo-radar Makefile defaults `make tunnel` to `--http=80` despite this trap, with `TUNNEL_TLS=1` as an opt-in. Reasoning:
+
+- The default user (typing `make tunnel` for the first time) is on this machine, opening `http://localhost:PORT` directly. No HSTS issue.
+- Cross-device users (typing `make tunnel` to share with a phone/MacBook) hit the HSTS wall and discover `TUNNEL_TLS=1` from the banner.
+- Making HTTPS the default would mean every Next.js dev session starts with EPROTO crashes and a blank-page user experience that's hard to debug.
+
+If the project uses a non-`.ts.net` custom domain (Tailscale lets you BYO), HTTP is fine — no HSTS preload outside `.ts.net`.
+
+## Testing
+
+curl is **insufficient** for verifying tunnel reachability. Always test in a real browser:
+
+```bash
+agent-browser --session test open "http://<host>.ts.net/"
+agent-browser --session test get url
+agent-browser --session test get text body
+```
+
+If the URL changes to `https://...` or you get `ERR_BLOCKED_BY_CLIENT`, you've hit the HSTS trap.
+
+## Resetting Chrome HSTS for testing
+
+Useful only for *non*-`.ts.net` domains. `.ts.net` is on the static preload list and CANNOT be reset:
+
+```
+chrome://net-internals/#hsts
+```
+
+Type the host into "Delete domain security policies" — works for opt-in HSTS, no-op for preload list.
+
+## References
+
+- Chrome HSTS preload list: https://hstspreload.org/
+- Tailscale's enrollment: https://tailscale.com/blog/letting-everyone-use-https

--- a/skills/make-local/skills/make-local/references/makefile-template.md
+++ b/skills/make-local/skills/make-local/references/makefile-template.md
@@ -1,0 +1,196 @@
+# Makefile template — copy and customize
+
+This is the canonical zeo-radar Makefile, sanitized to placeholders. Targets at GNU Make 3.81 (macOS system default — no `.ONESHELL`, no fancy 4.x features). Works on Linux too.
+
+## Placeholders to replace
+
+| Placeholder | Default | Notes |
+|---|---|---|
+| `PROJECT_NAME` | from `package.json` `"name"` | Sans npm scope. Becomes `<NAME>.localhost`. |
+| `PORT` | `3456` | For `make local-lan`. Pick far from 3000 (OrbStack squat zone). |
+| `TUNNEL_PORT` | `3001` | For `make tunnel`. Different from `PORT` so both can run. |
+| `DEV_CMD` | `npm run dev` | `pnpm dev` / `bun dev` if applicable. |
+| `URL_PROD` (optional) | — | Production URL for `make verify`. |
+
+## Full template
+
+```makefile
+SHELL := /bin/bash
+
+# ── Local dev defaults ─────────────────────────────────────────
+PORT        ?= 3456
+HOST        ?= 0.0.0.0
+TUNNEL_PORT ?= 3001
+
+# ── ANSI palette (no-op on dumb terminals) ────────────────────
+B := \033[1m
+D := \033[2m
+G := \033[32m
+Y := \033[33m
+R := \033[31m
+C := \033[36m
+Z := \033[0m
+
+.DEFAULT_GOAL := help
+
+.PHONY: help local local-lan tunnel tunnel-stop stop clean \
+        _ensure-portless _ensure-services _free-port \
+        _print-portless-banner _print-local-lan-banner
+
+# ── help ──────────────────────────────────────────────────────
+help:
+	@printf "$(B)PROJECT_NAME$(Z)  $(D)— make targets$(Z)\n\n"
+	@printf "  $(B)$(G)make local$(Z)         portless → $(B)https://PROJECT_NAME.localhost$(Z) $(D)(daily driver)$(Z)\n"
+	@printf "  $(C)make local-lan$(Z)     direct $(HOST):$(PORT) for phone-on-Wi-Fi\n"
+	@printf "  $(C)make tunnel$(Z)        Tailscale Serve → http://<node>.ts.net (cross-device)\n"
+	@printf "  $(C)make tunnel-stop$(Z)   reset Tailscale serve/funnel + stop dev on :$(TUNNEL_PORT)\n"
+	@printf "  $(C)make stop$(Z)          kill dev server on :$(PORT)\n"
+	@printf "  $(C)make clean$(Z)         stop + wipe Turbopack cache\n"
+	@printf "\n$(D)Override port:  make local-lan PORT=4000$(Z)\n"
+
+# ── make local — portless, primary ────────────────────────────
+local: _ensure-portless _ensure-services _print-portless-banner
+	@npx portless
+
+# ── make local-lan — direct binding, fallback ─────────────────
+local-lan: _free-port _ensure-services _print-local-lan-banner
+	@HOSTNAME=$(HOST) PORT=$(PORT) DEV_CMD -- --hostname $(HOST) --port $(PORT)
+
+# ── make tunnel — Tailscale Serve ─────────────────────────────
+# Default HTTP — see references/hsts-preload-trap.md for why HTTPS often makes things WORSE.
+tunnel: _ensure-services
+	@command -v tailscale >/dev/null 2>&1 || { \
+	  printf "$(R)tailscale CLI not found — brew install --cask tailscale$(Z)\n"; exit 1; }
+	@tailscale status >/dev/null 2>&1 || { \
+	  printf "$(R)Tailscale not signed in — open the menu-bar icon and log in$(Z)\n"; exit 1; }
+	@pid=$$(lsof -ti :$(TUNNEL_PORT) 2>/dev/null || true); \
+	if [ -n "$$pid" ]; then \
+	  cmd=$$(ps -p $$pid -o comm= 2>/dev/null | tr -d ' \t'); \
+	  case "$$cmd" in \
+	    *node|*node\ *|*next*|*turbopack*|next-server) \
+	      printf "$(Y)→ port $(TUNNEL_PORT) busy with stale dev (pid $$pid, $$cmd) — reclaiming$(Z)\n"; \
+	      kill -9 $$pid 2>/dev/null || true; sleep 0.4 ;; \
+	    *) \
+	      printf "$(R)port $(TUNNEL_PORT) held by $$cmd (pid $$pid). Won't clobber.$(Z)\n"; \
+	      printf "$(D)  override:  make tunnel TUNNEL_PORT=3002$(Z)\n"; exit 1 ;; \
+	  esac; \
+	fi
+	@printf "$(D)→ resetting Tailscale serve/funnel (security: turning off any prior public exposure)$(Z)\n"
+	@tailscale funnel reset >/dev/null 2>&1 || true
+	@tailscale serve  reset >/dev/null 2>&1 || true
+	@if [ "$(TUNNEL_TLS)" = "1" ]; then \
+	  tailscale serve --bg --https=443 $(TUNNEL_PORT) >/dev/null; \
+	  scheme=https; \
+	else \
+	  tailscale serve --bg --http=80 $(TUNNEL_PORT) >/dev/null; \
+	  scheme=http; \
+	fi; \
+	node=$$(tailscale status --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['Self']['DNSName'].rstrip('.'))" 2>/dev/null); \
+	short=$${node%%.*}; \
+	printf "\n$(B)$(G)PROJECT_NAME dev$(Z)  $(D)Tailscale Serve · tailnet only$(Z)\n"; \
+	printf "  $(C)→$(Z) $(B)$$scheme://$$node$(Z)\n"; \
+	printf "  $(C)→$(Z) $$scheme://$$short  $(D)(short MagicDNS)$(Z)\n"; \
+	printf "  $(C)→$(Z) http://localhost:$(TUNNEL_PORT)\n"
+	@printf "  $(D)stop:  make tunnel-stop      Funnel is OFF      try TUNNEL_TLS=1 for HTTPS$(Z)\n\n"
+	@PORT=$(TUNNEL_PORT) HOSTNAME=127.0.0.1 DEV_CMD -- --port $(TUNNEL_PORT) --hostname 127.0.0.1
+
+tunnel-stop:
+	@tailscale serve  reset >/dev/null 2>&1 || true
+	@tailscale funnel reset >/dev/null 2>&1 || true
+	@pid=$$(lsof -ti :$(TUNNEL_PORT) 2>/dev/null || true); \
+	if [ -n "$$pid" ]; then kill -9 $$pid 2>/dev/null || true; fi
+	@printf "$(D)tailscale serve + funnel reset; dev on :$(TUNNEL_PORT) stopped$(Z)\n"
+
+# ── housekeeping ──────────────────────────────────────────────
+stop:
+	@pid=$$(lsof -ti :$(PORT) 2>/dev/null || true); \
+	if [ -n "$$pid" ]; then \
+	  kill -9 $$pid 2>/dev/null || true; \
+	  printf "$(Y)killed pid $$pid on :$(PORT)$(Z)\n"; \
+	else \
+	  printf "$(D)nothing on :$(PORT)$(Z)\n"; \
+	fi
+
+clean: stop
+	@rm -rf .next/cache && printf "$(G)wiped .next/cache$(Z)\n"
+
+# ── private helpers ───────────────────────────────────────────
+_ensure-portless:
+	@if [ ! -x node_modules/.bin/portless ]; then \
+	  if [ -d node_modules ]; then npm install --silent; \
+	  else printf "$(R)node_modules not present — npm install first$(Z)\n"; exit 1; \
+	  fi; \
+	fi
+
+# Best-effort docker-compose start. Non-fatal — UI-only work doesn't need DB.
+_ensure-services:
+	@if docker info >/dev/null 2>&1; then \
+	  if [ -f docker-compose.yml ] || [ -f compose.yml ]; then \
+	    if ! docker compose ps --services --filter status=running 2>/dev/null | grep -q .; then \
+	      printf "$(D)→ starting compose services...$(Z)\n"; \
+	      docker compose up -d >/dev/null 2>&1 || true; \
+	    fi; \
+	  fi; \
+	else \
+	  printf "$(Y)Docker not running — DB-backed pages may error.$(Z)\n"; \
+	fi
+
+# Free port: only kill OUR processes (node/next/turbopack), refuse strangers.
+_free-port:
+	@pid=$$(lsof -ti :$(PORT) 2>/dev/null || true); \
+	if [ -z "$$pid" ]; then exit 0; fi; \
+	cmd=$$(ps -p $$pid -o comm= 2>/dev/null | tr -d ' \t'); \
+	case "$$cmd" in \
+	  *node|*node\ *|*next*|*turbopack*|next-server) \
+	    printf "$(Y)→ port $(PORT) busy with stale dev (pid $$pid, $$cmd) — reclaiming$(Z)\n"; \
+	    kill -9 $$pid 2>/dev/null || true; \
+	    sleep 0.4 ;; \
+	  *) \
+	    next=$$(( $(PORT) + 10 )); \
+	    printf "$(R)port $(PORT) held by $$cmd (pid $$pid). Won't clobber.$(Z)\n"; \
+	    printf "$(D)  • If you know it's safe:  kill -9 $$pid$(Z)\n"; \
+	    printf "$(D)  • Or pick another port:    make local-lan PORT=$$next$(Z)\n"; \
+	    exit 1 ;; \
+	esac
+
+_print-portless-banner:
+	@printf "\n$(B)$(G)PROJECT_NAME dev$(Z)  $(D)portless · HTTPS$(Z)\n"
+	@printf "  $(C)→$(Z) $(B)https://PROJECT_NAME.localhost$(Z)\n"
+	@if [ ! -d $$HOME/.portless ] && [ ! -d "$$HOME/Library/Application Support/portless" ]; then \
+	  printf "  $(Y)first run on this machine — sudo prompts incoming for cert + :443$(Z)\n"; \
+	fi
+	@printf "  $(D)stop:  Ctrl+C$(Z)\n\n"
+
+_print-local-lan-banner:
+	@printf "\n$(B)$(G)PROJECT_NAME dev$(Z)  $(D)direct $(HOST):$(PORT) (LAN)$(Z)\n"
+	@printf "  $(C)→$(Z) http://localhost:$(PORT)\n"
+	@ifconfig 2>/dev/null | awk '/inet / && $$2 != "127.0.0.1" {print $$2}' | head -4 \
+	  | while read ip; do printf "  $(C)→$(Z) http://$$ip:$(PORT)  $(D)(LAN)$(Z)\n"; done
+	@printf "  $(D)stop:  make stop      cache panic:  make clean$(Z)\n\n"
+```
+
+## Companion `portless.json`
+
+```json
+{ "name": "PROJECT_NAME" }
+```
+
+That's it. Don't pass `--name` flags everywhere; the config is single-source-of-truth.
+
+## Companion `package.json` change
+
+```json
+{
+  "devDependencies": {
+    "portless": "^0.12.0"
+  }
+}
+```
+
+Pin via lockfile so contributors get the same proxy version.
+
+## Notes on adapting
+
+- For `pnpm`/`bun`: replace `DEV_CMD` and the `npm install` calls.
+- For non-Next frameworks: drop the `--hostname` and `--port` flag passing — most frameworks read `HOST`/`PORT` env vars (which are already set).
+- For monorepos: define `PROJECT_NAME`/`PORT`/`TUNNEL_PORT` once per app and namespace the targets (`make local-web`, `make local-admin`).

--- a/skills/make-local/skills/make-local/references/next-config-allowed-origins.md
+++ b/skills/make-local/skills/make-local/references/next-config-allowed-origins.md
@@ -1,0 +1,119 @@
+# Next 16 `allowedDevOrigins` — exact-match CORS
+
+Next.js 16 added strict cross-origin checks for dev/HMR resources. Without explicit allowlisting, Turbopack blocks `/_next/webpack-hmr` and similar from any host other than `localhost`/`127.0.0.1`.
+
+## Symptom
+
+Dev overlay flashes:
+
+```
+⚠ Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "host.example.com".
+
+To allow this host in development, add it to "allowedDevOrigins" in next.config.js and restart the dev server:
+
+// next.config.js
+module.exports = {
+  allowedDevOrigins: ['host.example.com'],
+}
+```
+
+HMR breaks silently. Page renders but no hot updates.
+
+## Fix
+
+`next.config.ts`:
+
+```ts
+const nextConfig: NextConfig = {
+  allowedDevOrigins: [
+    "http://127.0.0.1:3107",
+    "http://localhost:3107",
+    "https://mc-poc.example.com",
+    "mc-poc.example.com",
+    // Tailscale Serve hostnames for `make tunnel`. Both forms (short
+    // MagicDNS + FQDN). Must be listed verbatim — Next 16's CORS check
+    // does exact-match (not suffix). If you `tailscale set --hostname=foo`,
+    // add foo + foo.<tailnet>.ts.net here.
+    "PROJECT_NAME",
+    "PROJECT_NAME.<tailnet>.ts.net",
+  ],
+  // ...rest of config
+};
+```
+
+## The exact-match rule
+
+Next 16's CORS check is exact-match, not suffix-match. List every form the user might hit:
+
+| Hostname form | Notes |
+|---|---|
+| `<short>` | Short MagicDNS — works on tailnet peers |
+| `<short>.<tailnet>.ts.net` | FQDN — required for HTTPS cert |
+| `<short>.localhost` | portless |
+| `localhost:<port>` | classic local |
+| `127.0.0.1:<port>` | classic local IP |
+| `<lan-ip>:<port>` | for `make local-lan` cross-device |
+
+Not listing each one → silent HMR breakage on that exact host.
+
+## Append, don't replace
+
+When automating this edit, ALWAYS append to the existing array — never replace. The user may have entries you don't know about (Tailscale node aliases, custom domains, staging tunnels):
+
+```bash
+# WRONG: clobbers existing entries
+sed -i '' 's/allowedDevOrigins:.*$/allowedDevOrigins: ["new-host"],/' next.config.ts
+
+# RIGHT: insert new entries into the existing array
+# Use a proper TS-aware edit, not regex
+```
+
+In the build-skills context, edit the file with `Edit` tool's `old_string`/`new_string` mode, matching enough surrounding context to insert into the existing array literal.
+
+## Hostname rename procedure
+
+When the user runs `tailscale set --hostname=newname`, the URL changes from `oldname.ts.net` to `newname.ts.net`. The Makefile picks this up dynamically (it reads `tailscale status --json`), but `next.config.ts` won't.
+
+Procedure:
+1. Add `newname` and `newname.<tailnet>.ts.net` to `allowedDevOrigins`
+2. Optionally remove `oldname` and `oldname.<tailnet>.ts.net` if no longer used
+3. Restart dev (`make tunnel-stop && make tunnel`)
+
+Document this in a code comment so future contributors know to update both:
+
+```ts
+allowedDevOrigins: [
+  // ... existing entries
+  // Tailscale Serve hostnames for `make tunnel`. If you rename via
+  // `tailscale set --hostname=NAME`, add NAME + NAME.<tailnet>.ts.net here.
+  "NAME",
+  "NAME.<tailnet>.ts.net",
+],
+```
+
+## Cross-origin server actions
+
+Next 15+ has separate CORS for server actions (`experimental.serverActions.allowedOrigins`). If the project uses server actions called from a non-local host, that needs its own allowlist:
+
+```ts
+experimental: {
+  serverActions: {
+    allowedOrigins: ['my.tunnel.host', 'localhost:3000'],
+  },
+},
+```
+
+Same exact-match rule.
+
+## Verification
+
+After adding hostnames, hit the dev overlay manually:
+
+```bash
+# Open the URL in a real browser, look for the warning in console
+# Or check the dev server log for "Blocked cross-origin request"
+make tunnel
+# Open https://host.in.allowedDevOrigins/ in browser, then check terminal
+```
+
+If the warning still appears, the hostname isn't matching exactly — check for trailing slashes, port numbers (Next 16 ignores port for matching), and protocol prefixes.

--- a/skills/make-local/skills/make-local/references/path-decision.md
+++ b/skills/make-local/skills/make-local/references/path-decision.md
@@ -1,0 +1,46 @@
+# Path decision — portless vs Tailscale Serve vs plain LAN bind
+
+Three local-dev paths exist for a reason. Pick by the user's actual constraint, not by what sounds modern.
+
+## Decision matrix
+
+| User need | Path | URL | Cert | First-run cost |
+|---|---|---|---|---|
+| "I want a stable URL on my Mac, no setup" | **portless** | `https://<name>.localhost` | Local CA (auto-trusted) | sudo prompt × 1 |
+| "I want my phone/MacBook to reach my dev server" | **Tailscale Serve** | `http://<node>.ts.net` | Let's Encrypt (real CA) | `tailscale serve --bg --http=80 PORT` |
+| "I want LAN access without DNS, or CI" | **plain bind** | `http://0.0.0.0:PORT` | none | nothing |
+| "I want a stakeholder demo over the public internet" | **Tailscale Funnel** | `https://<node>.ts.net` (public) | Let's Encrypt | `tailscale funnel --bg PORT` — explicit opt-in only |
+
+## Short version
+
+- **`make local`** → portless. Daily driver.
+- **`make tunnel`** → Tailscale Serve. Cross-device (phone, MacBook, iPad).
+- **`make local-lan`** → plain bind. Headless CI, phone-on-Wi-Fi when MagicDNS fails, wget/curl from another machine.
+
+## Why three, not one
+
+Each path has a hard failure mode:
+
+| Path | Hard failure |
+|---|---|
+| portless | `*.localhost` resolves to 127.0.0.1 *on every machine in the world* per RFC 6761 — your phone hits its own loopback, not yours |
+| Tailscale Serve | Requires Tailscale signed in. Phone-on-cellular-not-on-tailnet can't reach |
+| plain bind | No HTTPS, no friendly URL, has to know the IP, port can collide |
+
+The Makefile that ships all three lets the user pick the right one at the moment of need without re-deciding.
+
+## When NOT to use each
+
+- **Skip portless** when the project's auth/cookies break across `.localhost` siblings (rare, but happens with strict `SameSite` + cookie domain rules).
+- **Skip Tailscale Serve** when the user isn't on a tailnet at all. Don't try to install Tailscale for them — that's outside this skill.
+- **Skip plain bind** when the user explicitly wants HTTPS (some Next.js features and Web APIs require secure contexts: `navigator.clipboard`, `Notification`, service workers).
+
+## Funnel is opt-in only
+
+Tailscale Funnel exposes the dev server **to the public internet**. Reset it on every `make tunnel` run:
+
+```sh
+tailscale funnel reset >/dev/null 2>&1 || true
+```
+
+Never default `make tunnel` to Funnel. If a user explicitly asks for "share my dev with someone outside my tailnet" — that's the only context where `tailscale funnel --bg PORT` is appropriate, and it should require explicit confirmation.

--- a/skills/make-local/skills/make-local/references/port-hygiene.md
+++ b/skills/make-local/skills/make-local/references/port-hygiene.md
@@ -1,0 +1,99 @@
+# Port hygiene — kill our own only
+
+Inspired by `vercel-labs/portless`'s philosophy: stable named URLs eliminate port juggling, but when you DO bind a port directly (`make local-lan`), be smart about what's already there.
+
+## The rule
+
+1. Inspect what's holding the port before clobbering.
+2. If it's `node` / `next` / `next-server` / `turbopack` → it's our stale process; kill it.
+3. If it's anything else (OrbStack, Postgres, Redis, browser tunnel, GitHub Actions runner) → refuse and tell the user.
+
+## Implementation
+
+```sh
+_free-port:
+	@pid=$$(lsof -ti :$(PORT) 2>/dev/null || true); \
+	if [ -z "$$pid" ]; then exit 0; fi; \
+	cmd=$$(ps -p $$pid -o comm= 2>/dev/null | tr -d ' \t'); \
+	case "$$cmd" in \
+	  *node|*node\ *|*next*|*turbopack*|next-server) \
+	    printf "→ port $(PORT) busy with stale dev (pid $$pid, $$cmd) — reclaiming\n"; \
+	    kill -9 $$pid 2>/dev/null || true; \
+	    sleep 0.4 ;; \
+	  *) \
+	    next=$$(( $(PORT) + 10 )); \
+	    printf "port $(PORT) held by $$cmd (pid $$pid). Won't clobber.\n"; \
+	    printf "  • If you know it's safe:  kill -9 $$pid\n"; \
+	    printf "  • Or pick another port:    make local-lan PORT=$$next\n"; \
+	    exit 1 ;; \
+	esac
+```
+
+## Why this matters
+
+Without classification, `make local-lan` would silently kill OrbStack's helper, Postgres, or whatever is on the port. Beginner devs run `make local`, get inscrutable database errors 30 minutes later, blame the project.
+
+## Banner conventions
+
+Print every URL the dev server is reachable at — the user shouldn't `ifconfig`:
+
+```sh
+_print-local-lan-banner:
+	@printf "PROJECT dev  direct $(HOST):$(PORT) (LAN)\n"
+	@printf "  → http://localhost:$(PORT)\n"
+	@ifconfig 2>/dev/null | awk '/inet / && $$2 != "127.0.0.1" {print $$2}' | head -4 \
+	  | while read ip; do printf "  → http://$$ip:$(PORT)  (LAN)\n"; done
+	@printf "  stop:  make stop      cache panic:  make clean\n"
+```
+
+This enumerates every IPv4 interface (LAN, tailnet, USB-C ethernet, virtual). The phone-on-Wi-Fi user picks the matching IP without thinking.
+
+## Override pattern
+
+Every fixed port must be overridable per-invocation:
+
+```sh
+make local-lan PORT=4000
+```
+
+Implementation: `PORT ?= 3456` in the Makefile (the `?=` makes it overridable from environment or command line).
+
+## Multi-port targets
+
+When the Makefile has multiple targets binding different ports (`PORT` for `local-lan`, `TUNNEL_PORT` for `tunnel`), each gets its own variable:
+
+```makefile
+PORT        ?= 3456
+TUNNEL_PORT ?= 3001
+```
+
+Both can run simultaneously without collision (different ports, different upstream targets).
+
+## "Stop" target convention
+
+```makefile
+stop:
+	@pid=$$(lsof -ti :$(PORT) 2>/dev/null || true); \
+	if [ -n "$$pid" ]; then kill -9 $$pid 2>/dev/null; printf "killed pid $$pid on :$(PORT)\n"; \
+	else printf "nothing on :$(PORT)\n"; fi
+
+clean: stop
+	@rm -rf .next/cache && printf "wiped .next/cache\n"
+```
+
+`make clean` is the recovery-from-Turbopack-panic command. Mention it in the help banner — devs hit `Every task must have a task type` panics often enough that this is worth the muscle-memory.
+
+## Choosing default ports
+
+Avoid these on macOS dev machines:
+
+| Port | Common squatter |
+|---|---|
+| 3000 | OrbStack helper, default for many tools |
+| 5000 | macOS AirPlay Receiver |
+| 5432 | Postgres (host or docker) |
+| 6379 | Redis |
+| 8080 | many alternative dev servers |
+| 8000 | python -m http.server, default Django |
+
+Pick a non-obvious 4-digit port (`3456`, `4321`, `5174`). Don't pick something cute that another dev already uses.

--- a/skills/make-local/skills/make-local/references/portless-setup.md
+++ b/skills/make-local/skills/make-local/references/portless-setup.md
@@ -1,0 +1,67 @@
+# Portless setup
+
+[portless](https://github.com/vercel-labs/portless) replaces port numbers with stable named `.localhost` URLs on a real local cert. Default for `make local`.
+
+## Install
+
+**Pin via project devDependency** (preferred — every contributor gets the same version):
+
+```bash
+npm install -D portless
+```
+
+Then `npx portless` runs the project's pinned binary. No global install drift.
+
+## Configure
+
+`portless.json` at repo root:
+
+```json
+{ "name": "PROJECT_NAME" }
+```
+
+URL becomes `https://PROJECT_NAME.localhost`. Change `name` → restart → URL changes.
+
+## First-run sudo
+
+On first run on a fresh machine, portless does two privileged operations:
+
+1. **Trust the local CA** — generates a CA, adds to system keychain. macOS sudo dialog. One-time.
+2. **Bind port 443** — needed for HTTPS. macOS sudo dialog. One-time per reboot (then cached).
+
+After both prompts succeed, subsequent runs are silent.
+
+## How it picks the upstream port
+
+Portless sets `PORT` env to a random port in 4000-4999. Most frameworks (Next.js, Express, Nuxt) respect that. For frameworks that ignore `PORT` (Vite, Astro, React Router), portless auto-injects `--port` + `--host` flags.
+
+## Worktree behavior
+
+In a git worktree, the URL becomes `https://<worktree>.<project>.localhost` automatically. Lets you have multiple branches running side-by-side without port juggling.
+
+## Reset
+
+```bash
+npx portless clean   # removes state, trust entry, hosts block
+npx portless prune   # kills orphaned dev servers from crashed sessions
+```
+
+## Detecting first run for the banner
+
+Portless writes state to one of:
+- `~/.portless/state.json`
+- `~/Library/Application Support/portless/state.json`
+
+The Makefile banner detects absence and warns about incoming sudo prompts:
+
+```sh
+@if [ ! -d $$HOME/.portless ] && [ ! -d "$$HOME/Library/Application Support/portless" ]; then \
+  printf "first run on this machine — sudo prompts incoming for cert + :443\n"; \
+fi
+```
+
+## Caveats
+
+- Portless is pre-1.0. State directory format may change between versions; pinning via package.json prevents surprise.
+- `*.localhost` is loopback per RFC 6761 → does NOT work cross-device. For phones/tablets, route to `make tunnel`.
+- Some browser extensions (corporate VPN clients, ad blockers) interfere with `*.localhost` resolution. Switch off, or use `make local-lan`.

--- a/skills/make-local/skills/make-local/references/tailscale-serve-setup.md
+++ b/skills/make-local/skills/make-local/references/tailscale-serve-setup.md
@@ -1,0 +1,89 @@
+# Tailscale Serve setup
+
+[Tailscale Serve](https://tailscale.com/kb/1242/tailscale-serve) proxies a port from this machine to `<hostname>.<tailnet>.ts.net`, reachable from any device signed into the same tailnet. Real Let's Encrypt cert if you opt into HTTPS.
+
+## Hostname customization
+
+The URL uses your Tailscale node hostname. To rename:
+
+```bash
+tailscale set --hostname=PROJECT_NAME
+```
+
+URL becomes `<scheme>://PROJECT_NAME.<tailnet>.ts.net`. Change is reversible (`tailscale set --hostname=<previous>`), no sudo required, instant.
+
+The Makefile reads the current hostname dynamically from `tailscale status --json`, so no recipe edits are needed when the user renames.
+
+## HTTP vs HTTPS — pick deliberately
+
+The default in `make tunnel` is **HTTP** (`tailscale serve --bg --http=80 PORT`). Counter-intuitive, but for Next.js dev:
+
+- HTTPS via Tailscale terminates TLS at :443, then proxies to your HTTP dev server. Next.js middleware sees `X-Forwarded-Proto: https` but `Host: localhost:PORT` and tries to internally proxy `https://localhost:PORT/...` → **EPROTO crash on every Clerk-protected route**.
+- HTTP avoids the protocol mismatch. The tailnet itself is end-to-end encrypted by WireGuard, so HTTPS would be belt-on-belt anyway.
+- See `references/hsts-preload-trap.md` and `references/eproto-tls-mismatch.md` for the full reasoning.
+
+Set `TUNNEL_TLS=1 make tunnel` to opt into HTTPS — only useful if you've fixed the upstream proxy-protocol handling first (or for non-Next frameworks).
+
+## Funnel is opt-in only
+
+Tailscale Funnel exposes the dev server **to the public internet**. Reset it on every `make tunnel` run:
+
+```sh
+tailscale funnel reset >/dev/null 2>&1 || true
+```
+
+Never default `make tunnel` to Funnel. If a user explicitly asks for "share my dev with someone outside my tailnet" — that's the only context where `tailscale funnel --bg PORT` is appropriate.
+
+## Idempotent re-wiring
+
+Always reset before adding a new route. Otherwise stale routes accumulate from previous sessions:
+
+```sh
+tailscale serve  reset >/dev/null 2>&1 || true
+tailscale funnel reset >/dev/null 2>&1 || true
+tailscale serve --bg --http=80 PORT
+```
+
+## Pre-flight checks
+
+```sh
+command -v tailscale >/dev/null 2>&1 || exit 1   # CLI installed
+tailscale status >/dev/null 2>&1   || exit 1     # account signed in
+```
+
+If either fails, surface an actionable message:
+- "tailscale CLI not found — brew install --cask tailscale"
+- "Tailscale not signed in — open the menu-bar icon and log in"
+
+## DNS resolution from peer devices
+
+MagicDNS resolves `<short>` AND `<short>.<tailnet>.ts.net` from any signed-in peer. If MagicDNS isn't enabled in the admin console, only the FQDN works.
+
+```bash
+# Confirm MagicDNS suffix
+tailscale status --json | jq -r '.MagicDNSSuffix'
+```
+
+If empty, the user needs to enable MagicDNS in https://login.tailscale.com/admin/dns.
+
+## Troubleshooting cross-device unreachability
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Phone shows `ERR_NAME_NOT_RESOLVED` for `<host>.ts.net` | MagicDNS off, or phone not on tailnet | Enable MagicDNS, or sign phone into tailnet |
+| MacBook gets HTTP 200 but blank/Internal Server Error | Tunnel fine; app crash | Check dev server log on the host; same crash via `localhost:PORT` |
+| Chrome shows `ERR_BLOCKED_BY_CLIENT` for HTTP `.ts.net` URL | HSTS preload of `*.ts.net` rejects HTTP | Switch to HTTPS (`TUNNEL_TLS=1 make tunnel`), accept EPROTO if Next | 
+| `make tunnel` says "tailscale not signed in" | Daemon up but account not linked | `tailscale up` interactively |
+| Funnel left on from previous session | Public exposure persisted | `tailscale funnel reset` |
+
+## Stop / clean
+
+`make tunnel-stop` resets both serve and funnel and kills the dev process:
+
+```sh
+tailscale serve  reset
+tailscale funnel reset
+lsof -ti :$(TUNNEL_PORT) | xargs -r kill -9
+```
+
+Always reset both — funnel state is independent of serve state.

--- a/skills/make-railway/README.md
+++ b/skills/make-railway/README.md
@@ -1,0 +1,19 @@
+# make-railway
+
+Authoring a `make prod` target that deploys a Next.js or Node project to Railway with parallel multi-service deploys, env wiring, and optional git-hook CI/CD.
+
+**Category:** workflow
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/make-railway
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/make-railway/skills/make-railway/SKILL.md
+++ b/skills/make-railway/skills/make-railway/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: make-railway
+description: Use skill if you are authoring a `make prod` target that deploys a Next.js or Node project to Railway with parallel multi-service deploys, env wiring, and optional git-hook CI/CD.
+---
+
+# Make Railway
+
+Author the `make prod` target that ships any Next.js / Node project to Railway, plus the git-hook scaffolding for local CI/CD without GitHub Actions. The deploy contract: parallel multi-service uploads, terminal-status poll, annotated deploy messages, public-URL probe.
+
+## How to think about this
+
+Railway is the right home for **anything with a long-running process**: Next.js apps with BullMQ workers, SSE keep-alives that exceed Vercel's serverless 5-minute window, background queue consumers, DB-tier services. Vercel handles pure-static + serverless edge — Railway handles everything Vercel can't.
+
+The `make prod` workflow is opinionated:
+
+1. **Pre-flight** the toolchain (`railway whoami`, `railway status`) and refuse early with an actionable hint if anything's missing.
+2. **Annotate** the deploy message with `branch@sha[+dirty]` so the Railway deploy log doubles as a forensic trail.
+3. **Parallel upload** every service (web + worker + cron) in one pass — Railway's `--detach` makes this safe.
+4. **Poll** until every service exits BUILDING/DEPLOYING and lands at SUCCESS or FAILED.
+5. **Probe** the public URLs to confirm HTTP reachability post-deploy.
+
+For CLI command reference, defer to the **`use-railway`** skill. This skill covers the *workflow* — how to compose a deploy contract, when to find vs create, how to handle the multi-service case.
+
+## Use this skill when
+
+- The user asks for "make prod", "deploy to Railway", "Railway deploy script", "git hooks for CI/CD without GitHub Actions".
+- Project has Docker, BullMQ workers, SSE/WebSocket keep-alives, or any long-running process.
+- The team wants a one-command production deploy from any contributor's machine.
+
+## Do not use this skill when
+
+- The user wants to deploy a pure-static Next.js app or marketing site → route to **make-vercel** (it has tighter Next.js integration and free preview deploys per PR).
+- The user is asking how to use a specific `railway` CLI command → route to **use-railway**.
+- The user wants GitHub Actions CI/CD — that's a different shape; this skill covers local git-hook CI/CD as the explicit alternative.
+
+## Workflow
+
+### 1. Pre-flight detection
+
+Before generating Make targets, capture project state:
+
+```bash
+# Railway toolchain
+command -v railway >/dev/null 2>&1 || echo "MISSING: brew install railway"
+railway whoami 2>&1 | head -3                # auth state
+railway status 2>&1 | head -3                # project link
+
+# What services exist (find-or-create planning)
+railway service status --all 2>&1
+
+# Dockerfile vs Nixpacks
+ls Dockerfile docker-compose.yml 2>/dev/null
+
+# Worker pattern detection
+grep -rE "ZEO_ROLE|BullMQ|Worker\\(|new Worker\\b" src/ 2>/dev/null | head -3
+
+# Existing env vars on the primary service
+railway variables --service <name> --kv 2>&1 | grep -iE "DATABASE_URL|REDIS_URL|PORT" | head
+```
+
+If pre-flight fails, surface the exact missing piece. Don't generate Make targets that crash on first run.
+
+### 2. Decide the service shape
+
+Use the decision tree in `references/service-topology.md`. Common shapes:
+
+- **Single web service** — most projects start here
+- **Web + worker** — Next.js app + BullMQ background processor (zeo-radar pattern)
+- **Web + worker + cron** — add a cron service for scheduled jobs
+- **Multi-tenant** — `app-prod`, `app-staging`, `app-noauth` from the same image
+
+The decision shapes the Makefile: one service in `WEB_SERVICES :=`, or many.
+
+### 3. Find-or-create services
+
+Railway's CLI doesn't have a single "find or create" verb. The workflow:
+
+```bash
+# Find: check if a named service exists
+EXISTS=$(railway service status --all 2>&1 | awk '{print $1}' | grep -x "MY_SERVICE" || true)
+if [ -z "$EXISTS" ]; then
+  railway service create --name MY_SERVICE
+fi
+```
+
+See `references/find-or-create.md` for the full pattern, including handling both interactive (TTY) and CI (non-TTY) cases.
+
+### 4. Generate the Makefile
+
+Use the template in `references/makefile-template.md`. Replace these placeholders:
+
+| Placeholder | What to replace with |
+|---|---|
+| `WEB_SERVICES` | Space-separated Railway service names (`web` or `web worker` or `web worker cron`) |
+| `URL_PROD_PRIMARY` | Primary public URL (`https://app.example.com` or `https://<svc>.up.railway.app`) |
+| `URL_PROD_SECONDARY` | Optional second URL (when there's auth + noauth deploys) |
+
+### 5. Wire env vars (find-or-update pattern)
+
+Railway env vars are per-service. The Makefile should NOT hard-code values — those are secrets. Instead, document the required keys and provide an interactive setup target:
+
+```makefile
+env-pull:
+	@for svc in $(WEB_SERVICES); do \
+	  printf "→ pulling env from $$svc\n"; \
+	  railway variables --service $$svc --kv > .env.railway.$$svc; \
+	done
+
+env-push:
+	@printf "Use: railway variables --service NAME --set KEY=VAL\n"
+	@printf "or:  railway variables --service NAME --set-from-env <FILE>\n"
+```
+
+See `references/env-management.md` for the full env workflow including secret rotation, public/private URLs, and inter-service refs (`RAILWAY_PRIVATE_DOMAIN` for in-tailnet, `DATABASE_PUBLIC_URL` for local-dev).
+
+### 6. Wire git-hook CI/CD (the optional but recommended layer)
+
+Three hooks cover the entire pre-push lifecycle. See `references/git-hooks.md` for the full installer.
+
+```makefile
+install-hooks:
+	@bash scripts/install-hooks.sh
+```
+
+Hooks installed:
+
+- **`pre-commit`** — format + lint-staged (fast, blocks broken commits)
+- **`pre-push`** — typecheck + lint + test (slow, blocks broken pushes)
+- **`post-merge`** — auto-`npm install` if package.json changed (silent fix-up)
+
+The `make install-hooks` target makes them idempotent and discoverable. Hooks live in `scripts/git-hooks/` (committed) and are symlinked into `.git/hooks/` (not committed).
+
+### 7. Generate the actual deploy
+
+End-to-end test:
+
+```bash
+make prod   # should pre-flight, upload in parallel, poll until SUCCESS, print URLs
+make verify # should HTTP-probe every URL_PROD_*
+```
+
+If parts fail, the recovery paths in this SKILL.md cover the common cases.
+
+## Decision rules
+
+- **Pre-flight refuses, never crashes.** `command -v railway` + `railway whoami` + `railway status` all succeed before any state-changing operation. Each failure prints a one-line actionable hint.
+- **Parallel deploys, sequential polling.** `railway up --detach -s name` for each service in a `&`-backgrounded loop, then `wait` to join. Then poll status until terminal.
+- **Annotate every deploy.** `-m "branch@sha[+dirty]"` makes the Railway deploy log a forensic trail. `+dirty` means the working tree had uncommitted changes — surface this to the user as a yellow warning.
+- **Don't kill the deploy on a dirty tree.** Warn, but proceed. Sometimes the user knows what they're doing.
+- **Don't silently push secrets.** `railway variables --set` requires explicit user intent. Never `--set` from a Makefile recipe.
+- **Don't try to recover from failed builds inside the Makefile.** A failed build needs human eyes on `railway logs --service NAME --tail 100`. Print that hint and exit non-zero.
+
+## Recovery paths
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `railway: command not found` | CLI not installed | `brew install railway` (or `npm install -g @railway/cli`) |
+| `Unauthorized` from `railway whoami` | Not logged in | `railway login` (opens browser; manual step) |
+| `Project not linked` | No `.railway/` in repo | `railway link` (interactive picker) — if non-TTY, `railway link --project <id>` |
+| One service hangs in BUILDING for 10+ min | Build genuinely slow, OR Dockerfile has an infinite step | `railway logs --service NAME --tail 100` — usually a Prisma/migration step blocking |
+| `Bind for 0.0.0.0:PORT failed: port is already allocated` (deploy log) | Multiple replicas, or app hard-codes a port | Make sure app reads `process.env.PORT` and binds `0.0.0.0`, not `localhost` |
+| Deploy SUCCESS but URL returns 502 | App crashed at startup | `railway logs --service NAME` — usually missing env var or migration |
+| Deploy SUCCESS but DB queries fail | App pointing at `RAILWAY_PRIVATE_DOMAIN` from a different service group | Use `${{Postgres.DATABASE_URL}}` reference in env, not literal URLs |
+| `make verify` returns 404 on the URL | Service exists but no domain assigned | `railway domain` (interactive) or `railway domain --service NAME --port 3000` |
+| Worker service deploys but never picks up jobs | `ZEO_ROLE` env not set, or wrong start command | Web service: default `CMD`. Worker: override `CMD` in `railway.toml` or via Settings → Custom Start Command |
+| Multi-service deploy: web+worker version skew | Deployed simultaneously, web hits worker before worker rolls | Deploy worker first, wait for SUCCESS, then deploy web. BullMQ dedup handles the crossover |
+| Public URL probe times out | DNS hasn't propagated yet (custom domain) | Wait 60s for Railway's edge to pick up; `make verify` again. Built-in `*.up.railway.app` should be instant |
+
+## Customizing the recipe
+
+- **Non-Next frameworks (Express, Hono, Fastify, plain Node):** structure unchanged. The `WEB_SERVICES` list still applies. Pick a Dockerfile or let Nixpacks auto-detect.
+- **Backend-only project (no UI):** drop the `URL_PROD_*` probes; the deploy is the contract.
+- **Monorepo with multiple apps:** generate one `make prod-<app>` per app, each with its own `WEB_SERVICES`. Or one umbrella `make prod` that fans out — see `references/monorepo.md`.
+- **Worker-only deploy:** same pattern, just `WEB_SERVICES := worker`.
+- **Cron via Railway Cron:** create the service, set the schedule in the Railway UI (no CLI), point the start command at your cron entrypoint. See `references/cron-services.md`.
+- **GitHub Actions CI/CD instead of git hooks:** out-of-scope here; see GitHub's docs. The git-hook approach is for teams that want zero-CI-vendor lock-in.
+
+## Reference routing
+
+| File | Read when |
+|---|---|
+| `references/makefile-template.md` | Generating the Make targets — full template with every placeholder annotated. |
+| `references/find-or-create.md` | Detecting existing services, creating new ones, handling TTY vs non-TTY contexts. |
+| `references/service-topology.md` | Picking the service shape: single web, web+worker, multi-tenant, etc. |
+| `references/env-management.md` | Setting env vars, pulling them locally for `.env.local`, secret rotation, public vs private DB URLs. |
+| `references/dockerfile-vs-nixpacks.md` | Choosing build mode, Dockerfile recipes for Next.js + Prisma, when standalone output breaks server actions. |
+| `references/port-binding.md` | The `process.env.PORT` rule, `0.0.0.0` binding, why `localhost` binding fails on Railway. |
+| `references/cross-service-refs.md` | `RAILWAY_PRIVATE_DOMAIN` vs `DATABASE_PUBLIC_URL`, in-cluster networking, env var references. |
+| `references/migration-strategy.md` | When `prisma migrate deploy` runs, baselining a `db push`-provisioned legacy DB, idempotent boot scripts. |
+| `references/git-hooks.md` | The pre-commit/pre-push/post-merge installer + hook scripts; idempotence guarantees. |
+| `references/monorepo.md` | Multi-app monorepos: per-app service mapping, shared Dockerfile vs per-app Dockerfile, root vs subdir builds. |
+| `references/cron-services.md` | Railway Cron setup, schedule syntax, why CLI doesn't manage schedules. |
+| `references/observability.md` | `railway logs` + `railway logs --tail`, structured logging, when to wire Sentry/PostHog. |
+| `references/cross-skill-handoffs.md` | When to defer to `use-railway` (CLI), `make-local` (dev), `make-vercel` (alt prod). |
+
+## Cross-skill handoffs
+
+- For raw `railway` CLI questions (`railway logs`, `railway scale`, `railway run`, `railway connect <db>`, `railway ssh`) — defer to **use-railway**.
+- For local dev with the same project — **make-local**.
+- For deciding Vercel vs Railway — **make-vercel** (the decision matrix lives there).
+
+## Guardrails
+
+- Never `--set` env vars from a Makefile recipe. Document the keys; let the user run the command.
+- Never push to production without `railway whoami` + `railway status` + a clean working-tree warning shown.
+- Never poll forever. Cap polling at ~10 minutes (80 × 8s); past that, surface the deploy URL and exit non-zero so the user can investigate.
+- Never assume single-service. The Makefile must use a `WEB_SERVICES :=` list and a `for svc in $(WEB_SERVICES)` loop, even if there's only one service today.
+- Never silently overwrite `.git/hooks/*`. The installer must back up existing hooks (`*.bak`) and warn.
+
+## Final checks
+
+Before declaring done:
+
+- [ ] `make prod` completes end-to-end against a real Railway project (with the user's auth)
+- [ ] Pre-flight refuses cleanly when railway CLI is missing/unauthenticated/unlinked
+- [ ] Deploy message includes `branch@sha[+dirty]` annotation visible in Railway dashboard
+- [ ] Polling exits in under 10 minutes; if longer, prints the deploy log URL and exits non-zero
+- [ ] `make verify` HTTP-probes every URL with 2xx/3xx as success
+- [ ] Worker service (if present) starts with the right `ZEO_ROLE`-style env or override
+- [ ] Git hooks install cleanly (`make install-hooks`); pre-existing hooks are backed up to `*.bak`
+- [ ] `make prod` runs cleanly on a clean working tree (no `+dirty`)

--- a/skills/make-railway/skills/make-railway/references/cron-services.md
+++ b/skills/make-railway/skills/make-railway/references/cron-services.md
@@ -1,0 +1,119 @@
+# Cron services on Railway
+
+Railway Cron is a service type that runs your container on a schedule, not continuously.
+
+## Setup
+
+CLI doesn't manage cron schedules — only the Railway UI does.
+
+1. Railway dashboard → New Service → from existing source (same repo as web/worker)
+2. Service Settings → Cron Schedule → enter cron expression (e.g., `0 * * * *` for hourly)
+3. Custom Start Command → entrypoint (e.g., `node scripts/cron.js`)
+4. Deploy via CLI normally: `railway up --service cron --detach`
+
+## Scheduling syntax
+
+Standard cron, 5 fields:
+
+```
+* * * * *
+│ │ │ │ └── day of week (0-7, Sun=0 or 7)
+│ │ │ └──── month (1-12)
+│ │ └────── day of month (1-31)
+│ └──────── hour (0-23, UTC)
+└────────── minute (0-59)
+```
+
+Examples:
+
+| Schedule | Meaning |
+|---|---|
+| `0 * * * *` | Every hour at :00 |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 9 * * 1` | Monday at 09:00 UTC |
+| `0 0 1 * *` | Midnight UTC on the 1st of each month |
+
+All times are **UTC**. Compute the offset to your timezone manually.
+
+## Writing the entrypoint
+
+A cron service runs your start command, then exits. The container is killed when the script returns. Make it idempotent — Railway may invoke twice if the previous run hasn't exited.
+
+```js
+// scripts/cron.js
+import { sweep } from '../src/lib/cron-jobs/sweep.js';
+
+(async () => {
+  try {
+    await sweep();
+    console.log('✓ cron sweep complete');
+    process.exit(0);
+  } catch (err) {
+    console.error('✗ cron sweep failed:', err);
+    process.exit(1);
+  }
+})();
+```
+
+Exit 0 = success in logs; exit non-zero = failure (Railway shows it red but doesn't retry automatically).
+
+## Cron vs long-running worker
+
+| Use cron when | Use a worker when |
+|---|---|
+| Job runs on a schedule, doesn't react to events | Job processes a queue or stream |
+| < 5min runtime | Job needs warm state (DB connections, in-memory cache) |
+| You want Railway to handle invocation | You're using BullMQ / similar queue library |
+
+For zeo-radar's `RunEnqueueOutbox` dispatcher: that's a **worker** (continuously polls), not a cron. For "send weekly summary email": that's a **cron**.
+
+## Cron service in `WEB_SERVICES`
+
+The Makefile treats it like any other service:
+
+```makefile
+WEB_SERVICES := web worker cron
+
+prod: _check-prod-prereqs
+	@for svc in $(WEB_SERVICES); do \
+	  railway up --detach --service $$svc -m "..." & \
+	done; \
+	wait
+```
+
+Deploy is identical. Railway just invokes the container on schedule instead of continuously.
+
+## Logs
+
+```bash
+# See past cron runs
+railway logs --service cron --tail 100
+```
+
+Each invocation shows up as a separate deployment-like entry in Railway dashboard (different from continuous-process logs).
+
+## Local testing
+
+Run the cron entrypoint as a one-shot:
+
+```bash
+npm run cron
+# or
+node scripts/cron.js
+```
+
+Same code path; different invoker.
+
+## Don't use cron for queue processing
+
+The temptation: "just run a cron every minute that pulls from BullMQ". Wrong:
+
+- Cold start every invocation (slow)
+- Race conditions if a previous invocation is still running
+- No backpressure (cron doesn't know if you're swamped)
+
+Use a worker service for queue processing. Use cron for time-driven jobs only.
+
+## Schedule in code, not in CLI
+
+Some libraries (`node-cron`, `agenda`) let you schedule from code. **Don't** — that means a long-running process holds the schedule, Railway can't see it, you can't change without redeploy. Use Railway Cron instead and let the platform manage scheduling.

--- a/skills/make-railway/skills/make-railway/references/cross-service-refs.md
+++ b/skills/make-railway/skills/make-railway/references/cross-service-refs.md
@@ -1,0 +1,105 @@
+# Cross-service references
+
+Services within a Railway project communicate via:
+
+1. **Env templating** in the Railway dashboard (`${{Service.VAR}}`)
+2. **Private domain** for in-cluster networking (`<svc>.railway.internal`)
+3. **Public domain** for cross-environment / local dev (`<svc>.up.railway.app` or custom)
+
+## The three hostnames
+
+| Hostname | Resolves to | When to use |
+|---|---|---|
+| `<svc>.railway.internal` | Private IPv6 inside Railway's network | Inter-service calls within same project + environment |
+| `<svc>.up.railway.app` | Public Railway edge | External traffic from anywhere |
+| `<custom-domain>` | Public Railway edge | Production user-facing URL |
+
+The DB equivalents:
+
+| Var | Provided by | Form |
+|---|---|---|
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | `postgresql://...@postgres.railway.internal:5432/railway` |
+| `DATABASE_PUBLIC_URL` | `${{Postgres.DATABASE_PUBLIC_URL}}` | `postgresql://...@shortline.proxy.rlwy.net:NNNNN/railway` |
+
+## Env templating syntax
+
+In Railway dashboard → Service → Variables:
+
+```
+DATABASE_URL = ${{Postgres.DATABASE_URL}}
+REDIS_URL    = ${{Redis.REDIS_URL}}
+APP_URL      = ${{web.RAILWAY_PUBLIC_DOMAIN}}
+```
+
+Templates resolve at deploy time (not at runtime). Variables not in the same project return empty.
+
+The CLI sees the resolved values:
+
+```bash
+railway variables --service web --kv | grep "^DATABASE_URL="
+# DATABASE_URL=postgresql://...@postgres.railway.internal:5432/railway
+```
+
+## When private vs public matters
+
+**Use private (`*.railway.internal`):**
+- Web service → DB
+- Web service → Redis
+- Worker service → DB
+- Inter-service HTTP within Railway
+
+Why: faster (no Railway edge hop), free (no egress charges), more secure (not on public internet).
+
+**Use public (`shortline.proxy.rlwy.net` / `*.up.railway.app`):**
+- Local dev pointing at production data (`.env.local`)
+- Migrations from a contributor's laptop (`prisma migrate deploy` against prod)
+- External services that need to call your API
+- CI/CD runners outside Railway
+
+## Pulling public URL for local dev
+
+```bash
+# DB
+railway variables --service postgres --kv | grep "^DATABASE_PUBLIC_URL=" | cut -d= -f2-
+
+# Redis
+railway variables --service redis --kv | grep "^REDIS_PUBLIC_URL=" | cut -d= -f2-
+```
+
+Save to `.env.local` for local-against-prod debugging:
+
+```sh
+# .env.local
+# REMOTE-DB MODE — local dev hits Railway production data
+DATABASE_URL=postgresql://...@shortline.proxy.rlwy.net:NNNNN/railway
+REDIS_URL=redis://...@interchange.proxy.rlwy.net:NNNNN
+```
+
+⚠️ All mutations land on production. Mark this clearly in `.env.local`.
+
+## Worker → Web HTTP (rare)
+
+If `worker` needs to call `web`'s API directly (rare — usually they share Redis), use the private domain:
+
+```ts
+// In worker code
+const webUrl = `http://${process.env.WEB_PRIVATE_HOST || 'web.railway.internal'}:${process.env.WEB_PRIVATE_PORT || 3000}`;
+fetch(`${webUrl}/api/internal/something`);
+```
+
+Set `WEB_PRIVATE_HOST` and `WEB_PRIVATE_PORT` in Railway env via templating. Don't hard-code.
+
+## DNS gotchas
+
+- `*.railway.internal` resolves to **IPv6 only**. If your code uses Node's default DNS resolver, IPv6 should work. If you've forced IPv4 somewhere (`socket.connect({ family: 4 })`), it'll fail.
+- DNS changes (new service, renamed) propagate within seconds inside Railway. Externally (custom domain), expect 60s-5m for new domains.
+
+## When NOT to use cross-service refs
+
+- One-off scripts (use the public URL or `railway run -- npm run script`)
+- Local dev (always use public URL)
+- Cross-environment (private domains don't span environments)
+
+## Multi-project
+
+Cross-project refs aren't supported. If `project-a` needs `project-b`'s DB, expose a public URL on `project-b` and configure `project-a` to consume it via plain env.

--- a/skills/make-railway/skills/make-railway/references/cross-skill-handoffs.md
+++ b/skills/make-railway/skills/make-railway/references/cross-skill-handoffs.md
@@ -1,0 +1,51 @@
+# Cross-skill handoffs
+
+## "I want to run a `railway` CLI command"
+
+Defer to **`use-railway`**. That skill is the canonical CLI reference (deploys, logs, environments, linking, scaling, SSH, database access). `make-railway` covers the *workflow* of authoring deploy targets; `use-railway` covers the *CLI* itself.
+
+Examples that route to use-railway:
+- "How do I `railway link` to a project?"
+- "What does `railway run` do?"
+- "How do I open a Postgres shell?"
+- "Difference between `railway service status` and `railway status`?"
+
+## "I want a friendly local URL"
+
+Route to **`make-local`**. Tailscale Serve / portless / plain LAN bind, with the HSTS-preload trap, port-conflict detection, and dev-bypass recipes.
+
+## "Should this go on Vercel instead?"
+
+Route to **`make-vercel`** — the decision matrix lives there. Quick rule:
+
+| Workload | Pick |
+|---|---|
+| Pure-static + serverless Next.js, Edge runtime | Vercel |
+| Long-running process (BullMQ, SSE keep-alive > 5min, WebSocket) | Railway |
+| Background queue consumer | Railway |
+| Cron jobs | Railway Cron (no Vercel equivalent that's free) |
+| Marketing/blog Next.js | Vercel (preview deploys per PR are killer) |
+| Mixed: web + workers | Both — web on Vercel, workers on Railway |
+
+## "I want CI/CD via GitHub Actions instead of git hooks"
+
+Out of scope here. The git-hook approach is documented because it's the zero-CI-vendor-lock-in alternative. Actions has its own conventions.
+
+If you're adding both: have hooks call the same scripts Actions calls (`scripts/test.sh`, `scripts/lint.sh`). Don't drift.
+
+## "I want to deploy from CI to Railway"
+
+Use `RAILWAY_TOKEN` (project token) in CI:
+
+```yaml
+# .github/workflows/deploy.yml (sketched)
+- run: railway up --service web --detach
+  env:
+    RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+```
+
+The `make prod` Makefile works in CI too — no different from local invocation. CI just exports `RAILWAY_TOKEN` instead of using `railway login`.
+
+## "I need to migrate from Heroku / Render / Fly to Railway"
+
+Out of scope. The destination is the same (Makefile + `railway up`), the source decommission is per-platform.

--- a/skills/make-railway/skills/make-railway/references/dockerfile-vs-nixpacks.md
+++ b/skills/make-railway/skills/make-railway/references/dockerfile-vs-nixpacks.md
@@ -1,0 +1,126 @@
+# Dockerfile vs Nixpacks
+
+Railway can build via:
+
+1. **Dockerfile** — explicit, reproducible, you control everything
+2. **Nixpacks** — auto-detection from package.json, framework hints, no Dockerfile needed
+
+Pick by the project's complexity.
+
+## Decision
+
+| Project shape | Use |
+|---|---|
+| Vanilla Next.js, no Prisma/migrations, no native deps | Nixpacks |
+| Next.js + Prisma + multi-step boot (migrations, seed, baseline) | Dockerfile |
+| BullMQ worker + web split from same image | Dockerfile |
+| Custom Node version, custom env, custom packages at OS level | Dockerfile |
+| Bun, Deno, non-Node runtime | Dockerfile (Nixpacks supports limited set) |
+| You want to test the same build locally (`docker build .`) | Dockerfile |
+
+## When Nixpacks is fine
+
+```bash
+# Just deploy — Railway auto-detects Next.js
+railway up --service web --detach
+```
+
+Railway will:
+1. Detect framework from `package.json`
+2. Run `npm ci` + `npm run build`
+3. Start with `npm start`
+
+No config needed. But:
+
+- You can't add a custom boot script (e.g., `prisma migrate deploy` before `npm start`)
+- You can't add native packages
+- You can't share the same build with a worker service
+
+## When you NEED a Dockerfile
+
+Anything more than vanilla. Canonical Next.js + Prisma:
+
+```Dockerfile
+FROM node:24-alpine
+WORKDIR /app
+
+# Install deps (cached layer)
+COPY package.json package-lock.json ./
+RUN npm ci --omit=optional
+
+# Copy source
+COPY . .
+
+# Generate Prisma client (output: src/generated/prisma)
+RUN npx prisma generate
+
+# Build Next.js
+RUN npm run build
+
+# Migrations + start
+CMD ["sh", "-c", "./scripts/start.sh && npm start"]
+```
+
+`scripts/start.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply migrations (idempotent)
+echo "→ applying Prisma migrations"
+npx prisma migrate deploy
+
+# Optional: baseline a legacy db push-provisioned DB
+# npx prisma migrate resolve --applied <migration-name>
+
+echo "→ migrations complete; handing off to npm start"
+```
+
+## CRITICAL: never `output: "standalone"` with `npm start`
+
+Next.js standalone mode produces a minimal server in `.next/standalone/server.js`. It's incompatible with `next start` and silently breaks server actions, returning "Failed to find Server Action" on client invocations.
+
+```ts
+// next.config.ts
+const nextConfig: NextConfig = {
+  // output: "standalone",  ← DON'T (breaks server actions when using `npm start`)
+  // ...
+};
+```
+
+If you need standalone (e.g., to ship a smaller image), invoke it directly:
+
+```Dockerfile
+CMD ["node", ".next/standalone/server.js"]
+```
+
+But for the typical Next.js + Railway deploy, `output: "standalone"` is the wrong choice.
+
+## Sharing one Dockerfile across services
+
+Railway services from the same source repo all build the same Dockerfile. Differentiate at runtime via env or custom start command:
+
+| Service | Custom Start Command (Railway UI) |
+|---|---|
+| `web` | (default — uses `CMD` from Dockerfile) |
+| `worker` | `sh -c "./scripts/start.sh && ZEO_ROLE=worker npm run worker"` |
+
+The Dockerfile builds once per service deploy; `CMD` runs per process start.
+
+## Nixpacks gotchas
+
+- Nixpacks uses `nixpacks.toml` (optional) for overrides. Quickly outgrows Dockerfile usefulness — at that point, switch.
+- Build cache is opaque; you can't `docker history <image>` to inspect.
+- Prisma `generate` runs (Nixpacks detects), but `migrate` doesn't — you'd need a `nixpacks.toml` `[start]` hook to run it before `npm start`. At that point, just write a Dockerfile.
+
+## Local parity
+
+The killer feature of Dockerfile: identical build locally + on Railway.
+
+```bash
+docker build -t myapp .
+docker run --env-file .env.local -p 3000:3000 myapp
+```
+
+Whatever works in this `docker run` will work on Railway. Whatever breaks here breaks there too. This shortens the deploy-fail-debug cycle dramatically.

--- a/skills/make-railway/skills/make-railway/references/env-management.md
+++ b/skills/make-railway/skills/make-railway/references/env-management.md
@@ -1,0 +1,172 @@
+# Env var management
+
+Railway env vars are per-service. The Makefile manages workflow; the CLI manages values.
+
+## Reading
+
+```bash
+# Pretty (with sections)
+railway variables --service WEB
+
+# Key=value (parse-friendly)
+railway variables --service WEB --kv
+
+# Specific key
+railway variables --service WEB --kv | grep "^DATABASE_URL=" | cut -d= -f2-
+```
+
+## Writing
+
+Single key:
+
+```bash
+railway variables --service WEB --set "FEATURE_FLAG=true"
+```
+
+Multiple keys at once:
+
+```bash
+railway variables --service WEB \
+  --set "FOO=bar" \
+  --set "BAZ=qux"
+```
+
+From a file (one `KEY=VALUE` per line):
+
+```bash
+railway variables --service WEB --set-from-env-file .env.production
+```
+
+## Deleting
+
+```bash
+railway variables --service WEB --remove FEATURE_FLAG
+```
+
+## Pulling for local dev
+
+The most common workflow: pull production env into `.env.local` so dev mirrors prod:
+
+```bash
+railway variables --service web-noauth --kv > .env.local
+```
+
+⚠️ Caution: this pulls **production secrets** into a local file. The file MUST be gitignored. Verify:
+
+```bash
+git check-ignore .env.local && echo "✓ gitignored" || echo "✗ NOT gitignored"
+```
+
+Pattern: pull only the keys you need:
+
+```bash
+# Pull just DATABASE_URL + REDIS_URL for local-against-prod debugging
+railway variables --service postgres --kv | grep "DATABASE_PUBLIC_URL"
+railway variables --service redis    --kv | grep "REDIS_PUBLIC_URL"
+```
+
+## Inter-service refs (Railway env templating)
+
+Railway's env-var dashboard supports `${{ServiceName.VAR}}` references that resolve per-environment:
+
+```
+DATABASE_URL = ${{Postgres.DATABASE_URL}}
+REDIS_URL    = ${{Redis.REDIS_URL}}
+```
+
+These resolve to the Railway-internal URLs (`postgres.railway.internal:5432`), which only work from inside Railway's private network.
+
+For local dev, use the public URLs (different env values):
+
+```
+DATABASE_PUBLIC_URL = postgresql://...@shortline.proxy.rlwy.net:NNNNN/railway
+REDIS_PUBLIC_URL    = redis://...@interchange.proxy.rlwy.net:NNNNN
+```
+
+The CLI reads both:
+
+```bash
+# Internal (only works inside Railway)
+railway variables --service postgres --kv | grep "^DATABASE_URL="
+
+# Public (works anywhere on the internet)
+railway variables --service postgres --kv | grep "^DATABASE_PUBLIC_URL="
+```
+
+## The "missing env" diagnostic
+
+Most Railway production failures are missing env vars. Pre-flight check before deploy:
+
+```bash
+# Required keys; fail if any missing
+REQUIRED="DATABASE_URL REDIS_URL CLERK_SECRET_KEY NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"
+for svc in $WEB_SERVICES; do
+  for key in $REQUIRED; do
+    val=$(railway variables --service $svc --kv | grep "^$key=" | cut -d= -f2-)
+    if [ -z "$val" ]; then
+      echo "✗ $svc missing $key"
+    fi
+  done
+done
+```
+
+This is the fastest way to catch the "deploy SUCCESS but app crashes at startup" class of bug.
+
+## Secret rotation
+
+When a secret leaks (DB password in a transcript, OAuth token committed):
+
+```bash
+# 1. Rotate at the source (DB dashboard, OAuth provider, etc.)
+# 2. Update Railway
+railway variables --service WEB --set "DATABASE_URL=postgresql://NEW_PASSWORD@..."
+# 3. Redeploy if app caches the env at boot
+make prod
+```
+
+Some env values (`PORT`, `RAILWAY_*`) are managed by Railway and not user-settable. The CLI errors politely if you try.
+
+## Env scoping
+
+Railway has per-environment vars (`production`, `staging`, etc.). Switch:
+
+```bash
+railway environment production
+railway variables --service web --set "FOO=prod-value"
+
+railway environment staging
+railway variables --service web --set "FOO=staging-value"
+```
+
+The Makefile assumes the user has the right environment selected. Don't auto-switch from a recipe.
+
+## Common env keys for Next.js + Railway
+
+| Key | Source | Notes |
+|---|---|---|
+| `PORT` | Railway-managed | Always `process.env.PORT` in code |
+| `NODE_ENV` | Set explicitly | `production` for prod services |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | Internal URL |
+| `REDIS_URL` | `${{Redis.REDIS_URL}}` | Internal URL |
+| `RAILWAY_SERVICE_NAME` | Railway-managed | Useful for logging context |
+| `RAILWAY_PRIVATE_DOMAIN` | Railway-managed | `<svc>.railway.internal` |
+| `RAILWAY_PUBLIC_DOMAIN` | Railway-managed | `<svc>.up.railway.app` (or custom) |
+| Build-time vars | Set on the service that builds | Inlined into the build, can't be changed without redeploy |
+
+## Don't bake secrets into the Makefile
+
+Tempting:
+
+```makefile
+deploy-staging:
+	railway variables --service web --set "API_KEY=sk-..."
+	railway up --service web --detach
+```
+
+Wrong. The Makefile is committed; secrets aren't. Use `--set-from-env-file` and gitignore the file:
+
+```makefile
+push-env:
+	@if [ ! -f .env.railway ]; then echo "✗ .env.railway missing"; exit 1; fi
+	railway variables --service web --set-from-env-file .env.railway
+```

--- a/skills/make-railway/skills/make-railway/references/find-or-create.md
+++ b/skills/make-railway/skills/make-railway/references/find-or-create.md
@@ -1,0 +1,101 @@
+# Find-or-create services
+
+Railway's CLI doesn't have one verb for "find this service or create it if missing". Compose it yourself.
+
+## The contract
+
+```bash
+ensure_service() {
+  local name="$1"
+  if railway service status --all 2>/dev/null | awk '{print $1}' | grep -qx "$name"; then
+    echo "  ✓ service $name exists"
+  else
+    echo "  → creating service $name"
+    railway service create --name "$name"
+  fi
+}
+
+for svc in $WEB_SERVICES; do
+  ensure_service "$svc"
+done
+```
+
+## Detection details
+
+`railway service status --all` output (TSV-like):
+
+```
+geo-tracker-redis    | 84f85c61-... | SUCCESS
+zeo-radar-auth       | 2630c15e-... | SUCCESS
+zeo-radar-noauth     | 08d9ae66-... | SUCCESS
+geo-tracker-db       | 2ca0d760-... | SUCCESS
+```
+
+Use `awk '{print $1}'` to extract names. `grep -qx "$name"` for exact match (the `x` flag prevents `app` from matching `app-staging`).
+
+## TTY vs non-TTY
+
+`railway service create` is non-interactive when `--name` is provided. Without `--name`, it prompts → fails in CI. Always pass `--name` from a script.
+
+```bash
+# Right
+railway service create --name web
+
+# Wrong (will hang in non-TTY)
+railway service create
+```
+
+## Linking after create
+
+A new service starts with no source linked. The next `railway up --service web` from a project root will use the local source. Make sure the user's `railway link` is current:
+
+```bash
+railway status 2>&1 | head -3
+# Project: my-project
+# Environment: production
+# Service: None    ← no service linked, but `up --service NAME` overrides
+```
+
+You don't need to `railway service NAME` (the linker) before `up --service NAME`. The `--service` flag on `up` is sufficient.
+
+## Domain assignment after create
+
+A new service has no public URL by default. After first `railway up --detach -s web`:
+
+```bash
+railway domain --service web        # interactive: prompts for port + custom domain
+railway domain --service web --port 3000   # non-interactive
+```
+
+This generates a `<svc>.up.railway.app` URL. For custom domains:
+
+```bash
+railway domain add example.com --service web
+# follow Railway's instructions for DNS records
+```
+
+## Cross-environment shape
+
+Services exist per-environment. `production` and `staging` are separate registries:
+
+```bash
+railway environment production
+railway service status --all          # production services
+
+railway environment staging
+railway service status --all          # different list
+```
+
+The Makefile's `WEB_SERVICES` list applies to whichever environment is currently active. Switch with `railway environment <name>` before `make prod` if needed, or pass `-e <env>` per command.
+
+## When to NOT create
+
+- The user already has services and just wants to deploy. Don't auto-create — that confuses team setups.
+- Generic name guessing (`web`, `api`) collides with existing patterns. Always confirm with the user before creating.
+- In monorepos with established service-per-app conventions.
+
+The right default: detect existing, refuse to create unless the user explicitly asks (`make prod CREATE_MISSING=1` or similar).
+
+## Service deletion
+
+Out of scope. The CLI has `railway service delete --service NAME` but that's destructive. Never bake into a Makefile.

--- a/skills/make-railway/skills/make-railway/references/git-hooks.md
+++ b/skills/make-railway/skills/make-railway/references/git-hooks.md
@@ -1,0 +1,183 @@
+# Git-hook CI/CD without GitHub Actions
+
+For teams that want zero-CI-vendor lock-in: run the same checks Actions would, locally on every commit/push. Faster feedback, no Actions minutes burned.
+
+## The hook trio
+
+| Hook | Runs | Blocks | Speed |
+|---|---|---|---|
+| `pre-commit` | format + lint-staged | Bad commits | Fast (< 5s) |
+| `pre-push` | typecheck + lint + test | Bad pushes | Slow (30s-2min) |
+| `post-merge` | `npm install` if package.json changed | Nothing — silent fixup | < 1s detection |
+
+Hooks live in `scripts/git-hooks/` (committed to repo) and are symlinked into `.git/hooks/` (not committed).
+
+## Installer
+
+`scripts/install-hooks.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_SRC="$REPO_ROOT/scripts/git-hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$HOOKS_SRC" ]; then
+  echo "✗ $HOOKS_SRC not found"; exit 1
+fi
+
+mkdir -p "$HOOKS_DST"
+
+for hook in "$HOOKS_SRC"/*; do
+  name=$(basename "$hook")
+  dst="$HOOKS_DST/$name"
+
+  # Backup existing non-symlinked hooks
+  if [ -f "$dst" ] && [ ! -L "$dst" ]; then
+    mv "$dst" "$dst.bak"
+    echo "→ backed up existing $name to $name.bak"
+  fi
+
+  ln -sf "../../scripts/git-hooks/$name" "$dst"
+  chmod +x "$hook"
+  echo "✓ installed $name"
+done
+
+echo ""
+echo "Done. Hooks active. Uninstall: rm .git/hooks/{pre-commit,pre-push,post-merge}"
+```
+
+`make install-hooks` calls this. Idempotent: re-running re-creates symlinks (no-op if unchanged), preserves any pre-existing user hooks as `.bak`.
+
+## pre-commit hook
+
+`scripts/git-hooks/pre-commit`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Format staged files only (lint-staged style)
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|json|css|md)$' || true)
+if [ -z "$STAGED" ]; then exit 0; fi
+
+# Run prettier on the staged files
+echo "→ formatting $(echo "$STAGED" | wc -l | tr -d ' ') files"
+echo "$STAGED" | xargs npx prettier --write --log-level warn
+
+# Re-stage what we just formatted
+echo "$STAGED" | xargs git add
+
+# Lint the staged files (cheaper than whole-repo lint)
+echo "→ linting"
+echo "$STAGED" | grep -E '\.(ts|tsx|js|jsx)$' | xargs --no-run-if-empty npx eslint --max-warnings=0
+```
+
+Bypass with `git commit --no-verify` (devs do this in emergencies).
+
+## pre-push hook
+
+`scripts/git-hooks/pre-push`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Skip checks for --no-verify or specific protected branches
+if [ -n "${SKIP_HOOKS:-}" ]; then exit 0; fi
+
+echo "→ typecheck"
+npx tsc --noEmit
+
+echo "→ lint"
+npm run lint --silent
+
+echo "→ test"
+npm test --silent
+
+echo "✓ pre-push checks passed"
+```
+
+Bypass with `git push --no-verify` or `SKIP_HOOKS=1 git push`.
+
+For long-running test suites, gate the test step:
+
+```bash
+# Skip tests when pushing to a non-main branch (faster)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  npm test --silent
+fi
+```
+
+## post-merge hook
+
+`scripts/git-hooks/post-merge`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect changes to package.json or lockfile in the just-merged commit
+if git diff HEAD@{1} HEAD --name-only | grep -qE '^(package(-lock)?\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$'; then
+  echo "→ package.json/lockfile changed — running npm install"
+  npm install
+fi
+
+# Detect Prisma schema changes; regenerate client
+if git diff HEAD@{1} HEAD --name-only | grep -qE '^prisma/schema\.prisma$'; then
+  echo "→ prisma/schema.prisma changed — running prisma generate"
+  npx prisma generate
+fi
+```
+
+Silent unless something changed. Saves the "huh, nothing's working — oh, I forgot npm install" cycle.
+
+## Discoverability
+
+Mention the installer in the project's CLAUDE.md / AGENTS.md / README:
+
+> **First-time setup:** `make install-hooks` — installs pre-commit, pre-push, post-merge hooks.
+
+And in the Makefile help:
+
+```
+make install-hooks    install pre-commit / pre-push / post-merge git hooks
+```
+
+## Husky-free philosophy
+
+These hooks don't need [husky](https://github.com/typicode/husky). Husky's value is auto-installation on `npm install` — but that hides what's running and adds a dependency. The explicit `make install-hooks` makes it obvious + auditable.
+
+If you DO want auto-install, add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "postinstall": "make install-hooks 2>/dev/null || true"
+  }
+}
+```
+
+The `|| true` keeps `npm install` from failing in environments where `make` isn't available (some CI runners).
+
+## CI parity
+
+If the team also has GitHub Actions, the workflows should run the same commands as the hooks (typecheck, lint, test). Don't drift — when a hook updates, update the workflow.
+
+## Hook bypass discipline
+
+Allow but track bypasses:
+
+```bash
+# In pre-push:
+if [ -n "${SKIP_HOOKS:-}" ]; then
+  echo "⚠ skipping checks (SKIP_HOOKS=1)" >&2
+  echo "$(date -u +%FT%TZ) $USER skipped pre-push" >> "$REPO_ROOT/.git/hook-bypasses.log"
+  exit 0
+fi
+```
+
+Then occasionally `tail .git/hook-bypasses.log` to see who's pushing past checks. Cultural, not enforced.

--- a/skills/make-railway/skills/make-railway/references/makefile-template.md
+++ b/skills/make-railway/skills/make-railway/references/makefile-template.md
@@ -1,0 +1,127 @@
+# Makefile template — copy and customize
+
+The canonical zeo-radar `make prod` block, sanitized to placeholders. GNU Make 3.81 compatible.
+
+## Placeholders
+
+| Placeholder | Default | Notes |
+|---|---|---|
+| `WEB_SERVICES` | `app` | Space-separated Railway service names. Multi-service: `web worker`. |
+| `URL_PROD_PRIMARY` | `https://<svc>.up.railway.app` | First URL probed by `make verify`. |
+| `URL_PROD_SECONDARY` | (omit if single service) | Second URL probed by `make verify`. |
+
+## Full template
+
+```makefile
+SHELL := /bin/bash
+
+# ── Railway service registry ───────────────────────────────────
+WEB_SERVICES := app
+
+# ── Public URLs (post-deploy reachability check) ──────────────
+URL_PROD_PRIMARY := https://app-production.up.railway.app
+# URL_PROD_SECONDARY := https://noauth.example.com
+
+# ── ANSI palette ──────────────────────────────────────────────
+B := \033[1m
+D := \033[2m
+G := \033[32m
+Y := \033[33m
+R := \033[31m
+C := \033[36m
+Z := \033[0m
+
+.PHONY: prod verify status logs install-hooks _check-prod-prereqs
+
+# ── make prod ─────────────────────────────────────────────────
+# Parallel `railway up` for every web service. Each upload is fire-
+# and-forget (--detach); we wait on all forks via `wait`, then poll
+# for terminal status. Deploy message embeds git sha + branch +
+# dirty marker so Railway's deploy log is forensically useful.
+prod: _check-prod-prereqs
+	@sha=$$(git rev-parse --short HEAD); \
+	branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ -n "$$(git status --porcelain 2>/dev/null | head -1)" ]; then \
+	  dirty="+dirty"; \
+	  printf "$(Y)WARN$(Z) deploying with uncommitted changes\n"; \
+	else \
+	  dirty=""; \
+	fi; \
+	tag="$$branch@$$sha$$dirty"; \
+	printf "$(B)→ Deploying $$tag to Railway$(Z)\n"; \
+	for svc in $(WEB_SERVICES); do \
+	  log=/tmp/railway-deploy-$$svc.log; \
+	  rm -f $$log; \
+	  printf "  $(D)$$svc — uploading...$(Z)\n"; \
+	  ( railway up --detach --service $$svc -m "make prod $$tag" >$$log 2>&1; \
+	    code=$$?; \
+	    if [ $$code -ne 0 ]; then \
+	      printf "  $(R)✗ $$svc upload failed (exit $$code) — see $$log$(Z)\n"; \
+	    fi ) & \
+	done; \
+	wait; \
+	for svc in $(WEB_SERVICES); do \
+	  log=/tmp/railway-deploy-$$svc.log; \
+	  url=$$(grep -oE 'https://railway\.com[^ ]*id=[a-f0-9-]+' $$log | head -1); \
+	  if [ -n "$$url" ]; then \
+	    printf "  $(G)✓$(Z) $$svc uploaded — build log: $$url\n"; \
+	  fi; \
+	done; \
+	printf "\n$(D)→ Polling Railway until services reach a terminal status...$(Z)\n"; \
+	tries=0; max=80; \
+	while [ $$tries -lt $$max ]; do \
+	  s=$$(railway service status --all 2>/dev/null); \
+	  pending=$$(printf "%s\n" "$$s" | grep -E "$$(echo $(WEB_SERVICES) | tr ' ' '|')" \
+	    | grep -iE 'BUILDING|DEPLOYING|INITIALIZING|QUEUED|REMOVING|WAITING' | wc -l | tr -d ' '); \
+	  if [ "$$pending" = "0" ]; then break; fi; \
+	  sleep 8; tries=$$((tries+1)); \
+	done; \
+	printf "\n$(B)Final status$(Z)\n"; \
+	railway service status --all | grep -E "NAME|$$(echo $(WEB_SERVICES) | tr ' ' '|')" || true; \
+	printf "\n$(B)Live URLs$(Z)\n"; \
+	printf "  $(G)→$(Z) $(URL_PROD_PRIMARY)\n"; \
+	if [ -n "$(URL_PROD_SECONDARY)" ]; then \
+	  printf "  $(G)→$(Z) $(URL_PROD_SECONDARY)\n"; \
+	fi; \
+	printf "\n$(D)HTTP check:  make verify$(Z)\n"
+
+# ── verification ──────────────────────────────────────────────
+verify:
+	@printf "$(D)→ HTTP probe$(Z)\n"
+	@for u in $(URL_PROD_PRIMARY) $(URL_PROD_SECONDARY); do \
+	  if [ -z "$$u" ]; then continue; fi; \
+	  code=$$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 12 $$u/ || echo "ERR"); \
+	  case $$code in \
+	    2*|3*) printf "  $(G)$$code$(Z) $$u\n" ;; \
+	    *)     printf "  $(R)$$code$(Z) $$u\n" ;; \
+	  esac; \
+	done
+
+# ── observability ─────────────────────────────────────────────
+status:
+	@railway service status --all
+
+logs:
+	@railway logs --service $(firstword $(WEB_SERVICES)) --tail 50
+
+# ── git hooks installer ───────────────────────────────────────
+install-hooks:
+	@bash scripts/install-hooks.sh
+
+# ── pre-flight ────────────────────────────────────────────────
+_check-prod-prereqs:
+	@command -v railway >/dev/null 2>&1 || { \
+	  printf "$(R)railway CLI not found$(Z)  $(D)brew install railway$(Z)\n"; exit 1; }
+	@railway whoami >/dev/null 2>&1 || { \
+	  printf "$(R)not logged into Railway$(Z)  $(D)railway login$(Z)\n"; exit 1; }
+	@railway status >/dev/null 2>&1 || { \
+	  printf "$(R)no Railway project linked$(Z)  $(D)railway link$(Z)\n"; exit 1; }
+```
+
+## Notes on adapting
+
+- **Single service:** drop `URL_PROD_SECONDARY` and the conditional probe.
+- **Many services (3+):** the loop already handles arbitrary count; just add to `WEB_SERVICES`.
+- **Custom domains:** set `URL_PROD_PRIMARY` to the custom domain. Railway's edge resolves both.
+- **Deploy on push:** wire `prod` from `.git/hooks/post-receive` if the repo is a bare-mirror style; otherwise prefer `make prod` invoked manually from the contributor's machine.
+- **Dry-run:** add a `--dry-run` flag detection at the top of `prod`; just print "would run: railway up --detach -s X" without executing.

--- a/skills/make-railway/skills/make-railway/references/migration-strategy.md
+++ b/skills/make-railway/skills/make-railway/references/migration-strategy.md
@@ -1,0 +1,114 @@
+# Migration strategy
+
+Schema changes on Railway need an idempotent boot script. The pattern: `prisma migrate deploy` runs on every container start, applies pending migrations, then hands off to `npm start`.
+
+## The `start.sh` pattern
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "→ Prisma migrate deploy ($(date -u +%H:%M:%S))"
+npx prisma migrate deploy
+
+echo "→ migrations done; handing off"
+```
+
+In `Dockerfile`:
+
+```Dockerfile
+CMD ["sh", "-c", "./scripts/start.sh && npm start"]
+```
+
+`migrate deploy` is **idempotent** — it only applies migrations not yet recorded in `_prisma_migrations`. Safe to re-run on every boot.
+
+## Legacy `db push`-provisioned DB
+
+If the prod DB was provisioned via `prisma db push` (no migration history), `migrate deploy` will refuse because the schema state doesn't match any migration.
+
+Bootstrap with `migrate resolve` to mark the existing schema as "applied":
+
+```bash
+# In start.sh, before migrate deploy:
+echo "→ baselining legacy migrations"
+npx prisma migrate resolve --applied 20260101000000_initial    || true
+npx prisma migrate resolve --applied 20260201000000_add_users  || true
+# ... one per legacy migration
+echo "→ applying new migrations"
+npx prisma migrate deploy
+```
+
+Each `resolve` is idempotent (errors if already applied; the `|| true` swallows). After the first successful boot, future boots skip the resolves and go straight to `migrate deploy`.
+
+## Force-replay an idempotent migration
+
+If a post-`db push` migration was already applied via `db push` but exists as a migration file (DDL is idempotent), force replay:
+
+```bash
+# In start.sh:
+psql "$DATABASE_URL" -c "DELETE FROM _prisma_migrations WHERE migration_name = '20260301000000_add_indexes';" 2>/dev/null || true
+npx prisma migrate deploy   # will re-apply the deleted row's migration
+```
+
+Only works if the migration's DDL is `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` style. Otherwise you'll get duplicate-object errors.
+
+## Web vs worker timing
+
+If both web and worker boot simultaneously and both call `migrate deploy`, Postgres advisory locks (Prisma's default) serialize them. Safe.
+
+But: if migration takes >30s and the web service has a faster health-check timeout, web will be killed mid-migration. Mitigate by running migrations in a separate one-shot service before web/worker:
+
+```bash
+# Or skip worker's migrate call if web handles it:
+[ "$ZEO_ROLE" = "worker" ] && {
+  # Wait for migrations to complete (poll)
+  until psql "$DATABASE_URL" -c "SELECT 1 FROM _prisma_migrations LIMIT 1" >/dev/null 2>&1; do sleep 2; done
+} || npx prisma migrate deploy
+```
+
+## Don't `db push` to prod, ever
+
+`prisma db push` writes the schema directly without recording a migration. Catastrophic for shared prod DBs:
+
+- No history of changes
+- Can't roll back
+- Other contributors can't reproduce
+
+Only `db push` to a private dev DB (your local docker postgres). For shared anything: `prisma migrate dev` locally, commit the migration, `migrate deploy` on Railway.
+
+## Migration drift detection
+
+If someone hot-fixed prod via SQL outside of migrations, the schema drifts from the migration history. Detect:
+
+```bash
+npx prisma migrate status
+# Database schema is out of sync with the migration history.
+```
+
+Recover:
+
+1. Capture the drift: `prisma db pull` writes the live schema to `prisma/schema.prisma`
+2. Generate a new migration: `prisma migrate dev --name capture_drift`
+3. Review the generated SQL, edit if needed, commit
+
+This re-aligns history with reality.
+
+## Staging-first deploys
+
+For risky migrations:
+
+1. Deploy migration + code to `staging` first
+2. Verify nothing broke
+3. Then deploy to `production`
+
+The Makefile pattern: separate `make prod-staging` and `make prod` targets, each with their own `railway environment` switch:
+
+```makefile
+prod-staging: _check-prod-prereqs
+	@railway environment staging
+	@$(MAKE) prod
+
+prod: _check-prod-prereqs
+	@railway environment production
+	@... (deploy logic)
+```

--- a/skills/make-railway/skills/make-railway/references/monorepo.md
+++ b/skills/make-railway/skills/make-railway/references/monorepo.md
@@ -1,0 +1,147 @@
+# Monorepo deploys
+
+Railway builds whatever's at the project root by default. For monorepos with multiple apps, you need either:
+
+1. One Railway project per app (recommended)
+2. One Railway project with per-service root directory overrides
+
+## Option 1: project-per-app (cleaner)
+
+Each app gets its own Railway project, linked to a subdirectory:
+
+```
+my-monorepo/
+├── apps/
+│   ├── web/        ← Railway project A, linked here
+│   ├── api/        ← Railway project B, linked here
+│   └── admin/      ← Railway project C, linked here
+└── packages/
+```
+
+Setup per app:
+
+```bash
+cd apps/web
+railway init   # or railway link to existing
+make prod
+```
+
+Each subdirectory has its own `railway.json` / `Dockerfile` / `Makefile`.
+
+**Pros:** Clean separation, simpler env management per app.
+**Cons:** Cross-app refs (web → api URL) need manual env wiring.
+
+## Option 2: single project, per-service root override
+
+One Railway project, each service has a custom root directory:
+
+```
+my-monorepo/
+├── apps/
+│   ├── web/
+│   ├── api/
+│   └── admin/
+└── packages/
+```
+
+In Railway dashboard → Service `web` → Settings → Root Directory: `apps/web`. Same for `api` (`apps/api`), `admin` (`apps/admin`).
+
+Each service still builds with the project-root-relative `Dockerfile` (or per-app Dockerfile under `apps/web/Dockerfile`).
+
+**Pros:** Single project, shared envs at the service group level.
+**Cons:** Complex; can't easily test per-app deploys.
+
+## The Makefile pattern
+
+For option 1 (recommended), put the Makefile in each app's directory:
+
+```
+apps/web/Makefile     # WEB_SERVICES := web
+apps/api/Makefile     # WEB_SERVICES := api
+apps/admin/Makefile   # WEB_SERVICES := admin
+```
+
+Each `make prod` operates on its own subdir. Run from the right directory.
+
+For an umbrella `make prod-all` at repo root:
+
+```makefile
+# my-monorepo/Makefile
+APPS := web api admin
+
+prod-all:
+	@for app in $(APPS); do \
+	  printf "→ deploying $$app\n"; \
+	  $(MAKE) -C apps/$$app prod & \
+	done; \
+	wait
+```
+
+## Shared dependencies
+
+If apps share a `packages/shared` workspace, the Dockerfile must:
+
+1. Copy the entire monorepo (not just the app subdir)
+2. Run `npm install` from the monorepo root (resolves workspaces)
+3. Build the specific app
+
+```Dockerfile
+FROM node:24-alpine
+WORKDIR /app
+
+# Copy whole monorepo (npm workspaces need full context)
+COPY package.json package-lock.json ./
+COPY packages ./packages
+COPY apps ./apps
+
+RUN npm ci --workspaces --include-workspace-root
+
+# Build the specific app
+WORKDIR /app/apps/web
+RUN npm run build
+
+CMD ["npm", "start"]
+```
+
+For Turborepo / Nx, lean on their cached-build features:
+
+```Dockerfile
+RUN npx turbo build --filter=web
+```
+
+## Nixpacks + monorepo
+
+Nixpacks struggles with monorepos. Auto-detection picks the wrong app, env scoping is unclear. **Always use Dockerfile for monorepos.**
+
+## Per-app env
+
+Each Railway service has its own env. With option 1 (project-per-app), envs are isolated by default. With option 2, services share the env namespace within the project — careful naming required:
+
+```
+WEB_DATABASE_URL = ...
+API_DATABASE_URL = ...
+ADMIN_DATABASE_URL = ...
+```
+
+Or use Railway env-var references to a shared `Postgres` service:
+
+```
+DATABASE_URL = ${{Postgres.DATABASE_URL}}    # all three apps share
+```
+
+## Deploy order
+
+When apps depend on each other (e.g., `web` calls `api`), deploy in dependency order:
+
+```makefile
+prod-all:
+	@$(MAKE) -C apps/api prod
+	@$(MAKE) -C apps/admin prod
+	@$(MAKE) -C apps/web prod
+```
+
+Sequential, not parallel — `web` shouldn't deploy until `api` is up.
+
+## Worktree consideration
+
+If contributors use git worktrees, each worktree is a separate filesystem path. Each needs its own `railway link`. The `.railway/` directory is in `.gitignore` for this reason — never commit it.

--- a/skills/make-railway/skills/make-railway/references/observability.md
+++ b/skills/make-railway/skills/make-railway/references/observability.md
@@ -1,0 +1,165 @@
+# Observability
+
+After deploy, you need to see what's happening. Railway provides logs + service status; for app-level observability, wire Sentry/Logtail/PostHog.
+
+## `make logs` and friends
+
+```makefile
+logs:
+	@railway logs --service $(firstword $(WEB_SERVICES)) --tail 50
+
+logs-worker:
+	@railway logs --service worker --tail 50
+
+logs-tail:
+	@railway logs --service $(firstword $(WEB_SERVICES))   # follows
+```
+
+`--tail N` shows last N lines. Without `--tail`, follows live (no exit). Press Ctrl+C to stop.
+
+## Filtering logs
+
+`railway logs` doesn't have grep built in. Pipe:
+
+```bash
+railway logs --service web --tail 1000 | grep -iE "error|throw|exception" | head
+```
+
+For structured logs (pino/winston JSON output):
+
+```bash
+railway logs --service web --tail 1000 | jq -c 'select(.level == "error")'
+```
+
+## Service status
+
+```makefile
+status:
+	@railway service status --all
+```
+
+Output shape:
+
+```
+geo-tracker-redis    | 84f85c61-... | SUCCESS
+zeo-radar-auth       | 3b2816d6-... | SUCCESS
+zeo-radar-noauth     | fd132c0d-... | SUCCESS
+geo-tracker-db       | 2ca0d760-... | SUCCESS
+```
+
+States: `SUCCESS`, `FAILED`, `BUILDING`, `DEPLOYING`, `INITIALIZING`, `QUEUED`, `REMOVING`, `WAITING`, `CRASHED`.
+
+## Health checks
+
+Configure in Railway dashboard → Service → Settings → Health Check:
+
+| Field | Notes |
+|---|---|
+| Path | `/api/health` (or any 200-returning route that doesn't require auth) |
+| Healthcheck timeout | 60s (default; raise for slow boots) |
+| Restart policy | `ALWAYS` for production; `ON_FAILURE` for cron |
+
+Implementing `/api/health`:
+
+```ts
+// app/api/health/route.ts
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // Optional: ping DB to verify it's reachable
+  return NextResponse.json({ status: 'ok', uptime: process.uptime() });
+}
+```
+
+Don't put auth on this route. Don't query DB unless cheap.
+
+## Memory + CPU
+
+Railway dashboard shows RSS/CPU per service. CLI:
+
+```bash
+railway service status --all --json | jq '.[] | {name, cpu, memory}'
+```
+
+If you see frequent OOM kills (memory > limit), either:
+
+1. Optimize the app (Node memory leak, image processing without streaming)
+2. Increase the service's memory limit in Railway dashboard
+
+Default limits depend on your plan. Hobby tier: 512MB. Pro: configurable.
+
+## Wire Sentry
+
+For error tracking:
+
+```bash
+npm install @sentry/nextjs
+npx @sentry/wizard@latest -i nextjs
+```
+
+Set `SENTRY_DSN` env in Railway. Sentry captures unhandled exceptions + custom `Sentry.captureException(err)` calls.
+
+For dev-mode opt-out (skip Sentry overhead in `make local`), see the make-local skill's references/dev-bypass-recipes.md and the `next.config.ts` conditional `withSentryConfig` pattern.
+
+## Wire Logtail / Better Stack / Axiom
+
+For log aggregation outside Railway's web UI:
+
+```bash
+# Logtail/Better Stack: sink Railway logs via webhook
+# Axiom: similar
+```
+
+Set up via Railway dashboard → Project Settings → Webhooks → add the log sink URL.
+
+## Custom dashboards
+
+Railway exposes minimal metrics. For dashboards, ship metrics to:
+
+- **Grafana Cloud** — Prometheus-style, push from app via prom-client
+- **Datadog** — agent or HTTP API, more enterprise
+- **New Relic** — APM-style, agent-based
+
+Add the agent/SDK to your Dockerfile + env. Out of scope for `make-railway` proper; mention in your project's runbook.
+
+## Deploy webhooks
+
+Railway can POST to a webhook on deploy events:
+
+- Slack (deploy notifications)
+- PagerDuty (failure alerts)
+- Custom endpoint (analytics)
+
+Configure: Project Settings → Webhooks → Add URL + event types.
+
+For `make prod` to wait for the webhook before declaring done is overkill. Polling `railway service status --all` is sufficient and built into the Makefile template.
+
+## Querying production DB safely
+
+```bash
+# Open a Postgres shell against production
+railway connect postgres
+
+# Or run a one-off query
+railway run -- psql "$DATABASE_URL" -c "SELECT count(*) FROM users;"
+```
+
+`railway run` injects all env vars from the linked service into the local command. Useful for ad-hoc scripts:
+
+```bash
+railway run -- node scripts/backfill.js
+```
+
+Be careful — these are PRODUCTION env vars. Treat any output as production data.
+
+## Quiet observability for `make local`
+
+Local dev shouldn't ship to Sentry/Logtail. Gate the SDK init:
+
+```ts
+if (process.env.NODE_ENV === 'production' && process.env.SENTRY_DSN) {
+  Sentry.init({ dsn: process.env.SENTRY_DSN });
+}
+```
+
+Or skip the entire SDK in dev — see make-local's `dev-bypass-recipes.md`.

--- a/skills/make-railway/skills/make-railway/references/port-binding.md
+++ b/skills/make-railway/skills/make-railway/references/port-binding.md
@@ -1,0 +1,74 @@
+# Port binding on Railway
+
+Railway sets `PORT` env at runtime. The app must:
+
+1. **Read `process.env.PORT`** — never hard-code a port
+2. **Bind `0.0.0.0`** — never bind `localhost`/`127.0.0.1`
+
+## Why
+
+Railway runs your container on a randomly-assigned host port and proxies. The container must:
+
+- Listen on whatever `PORT` Railway gave it (varies per deploy)
+- Listen on all interfaces (`0.0.0.0`), not just loopback (or the proxy can't reach you)
+
+## Symptoms of wrong binding
+
+| Wrong code | Result |
+|---|---|
+| `app.listen(3000)` | Railway tries to proxy to `PORT` (say, 8080) → connection refused → deploy fails health check |
+| `app.listen(process.env.PORT, 'localhost')` | App binds 127.0.0.1 only → Railway proxy can't connect → 502 |
+| `app.listen(process.env.PORT)` (Node default `0.0.0.0`) | ✓ Works |
+| `next start` | Reads `PORT` env, binds `0.0.0.0` by default | ✓ Works |
+| `next start --hostname localhost` | Binds 127.0.0.1 → Railway 502 | ✗ Don't pass `--hostname` |
+
+## Right pattern for Next.js
+
+```Dockerfile
+# Don't pass --hostname; let Next bind 0.0.0.0 by default
+CMD ["npm", "start"]
+```
+
+In `package.json`:
+
+```json
+{
+  "scripts": {
+    "start": "next start"
+  }
+}
+```
+
+Next.js reads `PORT` env automatically. No flag passing needed.
+
+## Right pattern for Express/Hono/Fastify
+
+```ts
+const port = Number(process.env.PORT) || 3000;
+app.listen(port, '0.0.0.0', () => console.log(`Listening on :${port}`));
+```
+
+Or shorter (Node defaults to `0.0.0.0` if you omit the host):
+
+```ts
+app.listen(Number(process.env.PORT) || 3000);
+```
+
+## Local dev binding (different concern)
+
+For `make local-lan` (cross-device on Wi-Fi), bind `0.0.0.0` explicitly so phones can reach. Same rule as Railway.
+
+For `make local` via portless or `make tunnel` via Tailscale, bind `127.0.0.1` or `localhost` — the proxy is local. Doesn't conflict with the Railway rule (different deploys, different env).
+
+## Health checks
+
+Railway sends GET `/` (or a configured path) to verify the app is responding. If your app:
+
+- Doesn't respond on `/` (e.g., requires auth) → Railway will mark it as failed health
+- Takes > 60s to start → Railway gives up, marks as failed
+
+Configure health check via Railway dashboard → Service → Settings → Health Check Path. Set to a route that returns 200 without auth (`/api/health`, `/health`, `/_next/static/foo`).
+
+## Multiple ports per service
+
+Railway containers expose ONE port (the one mapped to `PORT` env). If your app needs a second port (admin UI, gRPC), you need a second service or proxy from the main one. Don't try to expose two ports from one container — Railway doesn't support it.

--- a/skills/make-railway/skills/make-railway/references/service-topology.md
+++ b/skills/make-railway/skills/make-railway/references/service-topology.md
@@ -1,0 +1,96 @@
+# Service topology — pick the shape
+
+Pick the service shape based on the project's runtime needs. The Makefile's `WEB_SERVICES :=` line follows from this decision.
+
+## Shape decision tree
+
+| Project shape | `WEB_SERVICES` | Why |
+|---|---|---|
+| Stateless Next.js, no background jobs | `web` | One process, one URL |
+| Next.js + BullMQ workers / SSE keep-alives | `web worker` | Workers need long-running process; web tier shouldn't run them |
+| Next.js + workers + scheduled jobs | `web worker cron` | Cron is a separate service in Railway (no `--cron` flag) |
+| Multi-tenant: auth + noauth deploys from same image | `web web-noauth` | Different env per service, same Dockerfile |
+| Microservices: web + api + worker | `web api worker` | Each service has its own URL, env, logs |
+
+## The web + worker pattern (zeo-radar canonical)
+
+Two services from the **same image**, distinguished by an env var:
+
+```Dockerfile
+# Single Dockerfile builds both
+FROM node:24-alpine
+# ... build steps ...
+CMD ["./scripts/start.sh", "&&", "npm", "start"]
+```
+
+Service config:
+
+| Service | Env | Custom Start Command (Railway UI) |
+|---|---|---|
+| `web` | `ZEO_ROLE=web` | (default) `./scripts/start.sh && npm start` |
+| `worker` | `ZEO_ROLE=worker` | `sh -c "./scripts/start.sh && ZEO_ROLE=worker npm run worker"` |
+
+The app code branches on `ZEO_ROLE` to decide which queue consumers to attach. The web tier short-circuits worker registration via:
+
+```ts
+function shouldRunWorkers(): boolean {
+  if (process.env.ZEO_ROLE === "worker") return true;
+  if (process.env.ZEO_ROLE === "web") return false;
+  // Legacy fallback for unset env
+  return process.env.RAILWAY_SERVICE_NAME?.includes("worker") ?? false;
+}
+```
+
+Deploy order: **worker first, then web**. BullMQ dedup + outbox patterns make the crossover safe.
+
+## Multi-tenant: auth + noauth
+
+Two services, same image, different `AUTH_ENABLED`:
+
+| Service | `AUTH_ENABLED` | `SOFT_GATE_PASSWORD` | Use case |
+|---|---|---|---|
+| `web` | `true` | (unset) | Production users, Clerk-gated |
+| `web-noauth` | `false` | `<password>` | Internal demos, staging, QA |
+
+Both use the same `WEB_SERVICES := web web-noauth` and deploy in parallel.
+
+## When NOT to add a worker service
+
+- The job is idempotent and < 1 second → run inline in the request handler.
+- The job runs on a cron schedule with no event triggers → use Railway Cron service, not a long-running worker.
+- The job is truly one-off (data backfill) → `railway run -- npm run backfill` from the CLI, no service needed.
+
+## Cron service shape
+
+Railway Cron is a service type that runs your container on a schedule (instead of as a long-running process). Setup:
+
+1. Create the service via Railway UI (CLI doesn't manage cron schedule).
+2. Set the start command to your cron entrypoint.
+3. Set the schedule in Railway UI → Service Settings → Cron.
+
+The Makefile pattern is the same — just include the cron service in `WEB_SERVICES`. It deploys identically; Railway invokes it on schedule, not continuously.
+
+See `references/cron-services.md` for setup details.
+
+## Naming conventions
+
+- Lowercase, dash-separated (`zeo-radar-auth`, `web-noauth`)
+- Avoid generic names (`app`, `api`) in shared organizations — they collide
+- Suffix the role (`web`, `worker`, `cron`, `noauth`) for clarity in `railway service status`
+- For multi-tenant: prefix with the tenant (`acme-web`, `acme-worker`)
+
+## Inter-service references
+
+When `web` needs to reach `worker` directly (rare — usually they communicate via shared Redis), use the Railway-internal hostname:
+
+```
+http://worker.railway.internal:PORT
+```
+
+For `web` → DB, use the env var Railway injects:
+
+```
+${{Postgres.DATABASE_URL}}    # in Railway env config
+```
+
+See `references/cross-service-refs.md` for the full reference syntax and when to use private vs public URLs.

--- a/skills/make-vercel/README.md
+++ b/skills/make-vercel/README.md
@@ -1,0 +1,19 @@
+# make-vercel
+
+Authoring a `make deploy` target that ships Next.js to Vercel — covers find-or-create, env scoping, custom domains, function size limits, and when Vercel is wrong.
+
+**Category:** workflow
+
+## Install
+
+Install this skill individually:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/make-vercel
+```
+
+Or install the full pack:
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/make-vercel/skills/make-vercel/SKILL.md
+++ b/skills/make-vercel/skills/make-vercel/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: make-vercel
+description: Use skill if you are authoring a `make deploy` target that ships Next.js to Vercel — covers find-or-create, env scoping, custom domains, function size limits, and when Vercel is wrong.
+---
+
+# Make Vercel
+
+Author the `make deploy` target that ships a Next.js project to Vercel. Cover the find-or-create flow, env scoping per environment, monorepo root selection, custom domains, and the workloads where Vercel is the wrong choice.
+
+## How to think about this
+
+Vercel is purpose-built for Next.js. Static + edge + serverless function deploys are basically free, preview deploys per-PR are automatic, custom domains take 5 minutes. The CLI (`vercel`) is small and well-shaped.
+
+Vercel is the wrong choice when the project needs:
+- **Long-running processes** — BullMQ workers, SSE that exceeds 5 minutes, WebSocket servers
+- **Background queue consumers** — Vercel functions are stateless; consume + ack patterns don't survive
+- **Heavy native dependencies** — function bundle size limit is 50MB compressed; Sharp + ffmpeg + native crypto blow past it
+- **Frequent stateful jobs** — Vercel cron exists but is paid past the free tier and has 10s timeout in hobby
+
+For those: route to **make-railway** (the decision matrix is in `references/vercel-vs-railway.md`).
+
+The `make deploy` workflow:
+
+1. Pre-flight: `vercel whoami`, project linked
+2. Pull env from Vercel into `.env.local` for parity (optional)
+3. `vercel --prod` for production deploys; `vercel deploy` for preview
+4. HTTP-probe the deployment URL
+
+## Use this skill when
+
+- The user asks for "make deploy", "deploy to Vercel", "Vercel deploy script", "ship this Next.js project".
+- Project is pure-static or serverless-Next.js shape.
+- The user wants automatic per-PR preview deploys (Vercel's killer feature).
+
+## Do not use this skill when
+
+- The project has BullMQ workers / SSE / WebSocket / any long-running process → route to **make-railway**.
+- The user wants raw `vercel` CLI commands → defer to Vercel docs (no first-party "use-vercel" skill exists yet).
+- The project is a backend service (Express/Hono) without a frontend → make-railway.
+
+## Workflow
+
+### 1. Pre-flight detection
+
+```bash
+# Vercel toolchain
+command -v vercel >/dev/null 2>&1 || echo "MISSING: npm install -g vercel"
+vercel whoami 2>&1 | head -3              # auth state
+[ -d .vercel ] && cat .vercel/project.json | jq -c '{projectId, orgId, projectName}'
+
+# Framework detection (Vercel auto-detects but worth knowing)
+cat package.json | jq -r '.dependencies.next // "no-next"'
+cat next.config.* 2>/dev/null | head -5
+
+# Monorepo check
+[ -f turbo.json ] || [ -f pnpm-workspace.yaml ] && echo "MONOREPO"
+```
+
+If pre-flight fails, surface the missing piece. Don't generate Make targets that crash.
+
+### 2. Find-or-create via `vercel link`
+
+`vercel link` is interactive by default — picks an existing project from a list, or creates a new one with framework defaults. To make it CI-friendly:
+
+```bash
+# Interactive (devs first time):
+vercel link
+
+# Non-interactive (CI / scripts): use the .vercel/project.json from a manual run, OR:
+vercel link --confirm --yes  # picks defaults: project name = directory name, framework = auto
+```
+
+The `.vercel/` directory holds the link state. **Add to `.gitignore`** (Vercel does this on new projects). Each contributor links separately.
+
+See `references/find-or-create.md` for the full pattern, including listing existing projects (`vercel projects ls`) and naming conventions.
+
+### 3. Generate the Makefile
+
+Use the template in `references/makefile-template.md`. Replace these placeholders:
+
+| Placeholder | What to replace with |
+|---|---|
+| `PROD_URL` | Production URL — typically the custom domain. Default: `https://<project>.vercel.app`. |
+| `PREVIEW_URL_PATTERN` | Used to compute the per-deploy preview URL after `vercel deploy`. Default: parse from CLI output. |
+
+### 4. Wire env vars (per-environment)
+
+Vercel scopes env vars to one of: `development`, `preview`, `production`. The CLI:
+
+```bash
+# Pull env for local dev (matches `development` scope)
+vercel env pull .env.local
+
+# Add a key to one or more environments
+vercel env add API_KEY production         # prompts for value
+vercel env add API_KEY preview            # different value for preview
+vercel env add API_KEY development        # different value for dev
+```
+
+See `references/env-management.md` for the full env workflow including encrypted secrets, scope precedence, and parity with `.env.local`.
+
+### 5. Custom domains
+
+```bash
+vercel domains add example.com
+vercel alias https://my-project-abc123.vercel.app example.com
+```
+
+Or set in dashboard. Domain assignment to production deploys is automatic if configured.
+
+See `references/domains-and-aliases.md`.
+
+### 6. Wire monorepo root if needed
+
+If the Next.js app lives under `apps/web` in a monorepo, set the project root in Vercel:
+
+- Dashboard: Settings → General → Root Directory → `apps/web`
+- Or via `vercel.json`:
+
+```json
+{
+  "buildCommand": "cd apps/web && npm run build",
+  "outputDirectory": "apps/web/.next"
+}
+```
+
+See `references/monorepo.md` for Turborepo/Nx specifics.
+
+### 7. Generate the deploy
+
+```bash
+make deploy            # → vercel --prod
+make preview           # → vercel deploy
+make verify            # → curl probe
+```
+
+End-to-end test against a real Vercel project before declaring done.
+
+## Decision rules
+
+- **Vercel auto-detects Next.js.** Don't override `framework`, `buildCommand`, or `installCommand` unless you have a specific reason. Defaults are correct ~99% of the time.
+- **Use `vercel --prod` for production.** Bare `vercel deploy` creates a preview (unique URL, not aliased to your domain). Easy to confuse.
+- **Pull env via `vercel env pull`, don't hand-type.** This file is `.env.local` by default — already gitignored by `vercel link`.
+- **Don't commit `.vercel/`.** That's the per-contributor link state. Vercel adds it to `.gitignore` on new projects; verify it's there.
+- **Refuse to deploy from a dirty tree by default.** Vercel will deploy whatever's in your working directory (not just committed code). Surface uncommitted changes as a yellow warning.
+- **Refuse to deploy if the workload is wrong for Vercel.** If you detect BullMQ/SSE/WebSocket usage, surface the warning + route to make-railway. See `references/vercel-vs-railway.md`.
+
+## Recovery paths
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `vercel: command not found` | CLI not installed | `npm install -g vercel` |
+| `Unauthorized` from `vercel whoami` | Not logged in | `vercel login` (browser-based) |
+| `vercel link` says "no projects found" | Auth scope wrong | `vercel switch` to the right team/org |
+| Build fails: "Cannot find module 'X'" | Dependency in `devDependencies`, Vercel skips by default | Move to `dependencies`, OR set `NPM_CONFIG_PRODUCTION=false` in env |
+| Build fails: "Function exceeds 50MB" | Large dep in serverless function bundle | See `references/function-size-limits.md` — usually Sharp/ffmpeg/native crypto |
+| Build SUCCESS but deployment URL returns 500 | Runtime error after build | Check Vercel dashboard → Functions → Logs |
+| `next.config.ts` `output: "standalone"` set | Vercel doesn't support standalone | Remove `output: "standalone"` — Vercel handles its own bundling |
+| Cron job timeout | Hobby tier cron has 10s limit | Upgrade plan, OR move cron to Railway |
+| Custom domain returns 404 | DNS not propagated, or alias not assigned | `vercel alias <preview-url> <domain>`; wait 60s for DNS |
+| Preview URL gates auth in prod-only logic | `process.env.VERCEL_ENV !== 'production'` not handled | Use `VERCEL_ENV` to differentiate prod/preview/dev in code |
+| `Failed to find Server Action` after deploy | `output: "standalone"` set, or framework override breaking action chunking | Remove overrides; let Vercel handle Next.js |
+
+## Customizing the recipe
+
+- **Non-Next frameworks (Astro, Remix, SvelteKit, Vue, Nuxt):** Vercel auto-detects all of these. Same Makefile structure works.
+- **Static-only sites (no functions):** Same Makefile; Vercel just doesn't generate functions.
+- **API-only project (no UI):** Vercel works but Railway is usually better — APIs benefit from long-running processes for connection pools, etc.
+- **Multiple environments:** Vercel handles `production`/`preview`/`development` natively. The Makefile only needs `make deploy` (prod) and `make preview` (per-commit URL).
+- **Skipping preview deploys per PR:** Set `git.disableDeploymentsForBranch` in `vercel.json` for branches you don't want auto-built.
+
+## Reference routing
+
+| File | Read when |
+|---|---|
+| `references/makefile-template.md` | Generating the Make targets — full template with placeholders. |
+| `references/find-or-create.md` | `vercel link`, `vercel projects ls`, naming conventions, when to create new vs reuse. |
+| `references/env-management.md` | `vercel env pull/add/rm`, env scoping (dev/preview/prod), encrypted secrets, parity with `.env.local`. |
+| `references/domains-and-aliases.md` | `vercel domains add`, `vercel alias`, DNS propagation, root vs www, redirect rules. |
+| `references/monorepo.md` | Setting Root Directory, Turborepo `vercel.json`, per-app projects vs monorepo project. |
+| `references/function-size-limits.md` | The 50MB compressed limit, common offenders, how to check, fixes. |
+| `references/vercel-config.md` | `vercel.json` schema for the cases auto-detection misses (rewrites, redirects, headers). |
+| `references/vercel-vs-railway.md` | Decision matrix; how to detect when a project's workloads make Vercel wrong. |
+| `references/cross-skill-handoffs.md` | When to route to make-local (dev), make-railway (alt prod / workers). |
+
+## Cross-skill handoffs
+
+- For local dev with the same project — **make-local**.
+- For workloads Vercel can't handle (workers, long SSE, large functions) — **make-railway**.
+- For Railway CLI questions — **use-railway**.
+
+## Guardrails
+
+- Never override Vercel's framework auto-detection unless you have a specific failure to fix.
+- Never set `output: "standalone"` in `next.config.*` for Vercel deploys — it's redundant and breaks Vercel's own bundling.
+- Never commit secrets to `.env.development` / `.env.preview` / `.env.production` — those are committed files. Use `vercel env add` for the actual values.
+- Never deploy a project with detectable BullMQ/long-running-SSE patterns to Vercel without explicitly warning the user. Show the make-railway decision pointer.
+- Never `--force` deploy without confirming it overwrites the current production.
+
+## Final checks
+
+Before declaring done:
+
+- [ ] `make deploy` completes end-to-end against a real Vercel project
+- [ ] Pre-flight refuses cleanly when `vercel` CLI is missing/unauthenticated/unlinked
+- [ ] Production URL responds 200 (or expected redirect)
+- [ ] `.vercel/` is in `.gitignore`
+- [ ] `vercel env pull .env.local` produces a working local env (not just empty file)
+- [ ] If monorepo: Vercel project root is set correctly (Settings or `vercel.json`)
+- [ ] No `output: "standalone"` in `next.config.*`
+- [ ] If long-running workloads detected: a clear warning + handoff to make-railway documented in the Makefile help

--- a/skills/make-vercel/skills/make-vercel/references/cross-skill-handoffs.md
+++ b/skills/make-vercel/skills/make-vercel/references/cross-skill-handoffs.md
@@ -1,0 +1,57 @@
+# Cross-skill handoffs
+
+## "I want a friendly local URL"
+
+Route to **`make-local`**. Tailscale Serve / portless / plain LAN bind.
+
+For `vercel dev` (Vercel's local-emulation server) — that's a different tool, not part of these skills. It runs the Vercel runtime locally; useful for testing edge functions before deploy. Not a substitute for `make local`.
+
+## "I have BullMQ workers / SSE / WebSocket — Vercel feels wrong"
+
+Route to **`make-railway`**. The decision matrix in `references/vercel-vs-railway.md` covers when. Short answer: anything with a long-running process, anything that consumes from a queue, anything that holds connection state.
+
+Hybrid: `make-vercel` for the web tier + `make-railway` for the worker tier. See the "split" pattern in `vercel-vs-railway.md`.
+
+## "How do I run a `vercel` CLI command I forgot?"
+
+No first-party `use-vercel` skill exists yet (as of this writing). Defer to:
+
+- `vercel --help` (built-in)
+- https://vercel.com/docs/cli (canonical)
+
+If a `use-vercel` skill is added later, route there for CLI questions and keep this skill focused on the Makefile workflow.
+
+## "I want CI/CD via GitHub Actions for Vercel"
+
+Vercel's Git integration handles this automatically — push to your linked Git provider, Vercel deploys. Per-PR previews + production from main. No GitHub Actions needed for the deploy.
+
+If you want pre-push checks (typecheck, lint, test) before Vercel sees the push, use the **`make-railway`** skill's git-hook installer (the hooks are deploy-target-agnostic).
+
+## "I want to deploy from CI to Vercel (skip the auto-deploy)"
+
+Disable Vercel's git auto-deploy in dashboard, then in your CI:
+
+```bash
+npm install -g vercel
+vercel deploy --prod --token=$VERCEL_TOKEN --yes
+```
+
+Use `VERCEL_TOKEN` from https://vercel.com/account/tokens. Same pattern as Railway's CI deploy.
+
+## "I want to migrate Vercel → Railway (or vice versa)"
+
+Out of scope. The destination is the same Make target shape; the source decommission is per-platform.
+
+Quick notes:
+- Vercel → Railway: lose preview deploys (build them yourself in CI), gain long-running processes
+- Railway → Vercel: lose Docker, lose workers (move to a separate Railway/Render instance), gain edge + free preview deploys
+
+## "Should I use Cloudflare Workers / Netlify / Render instead?"
+
+These skills don't cover those. Quick orientation:
+
+- **Cloudflare Workers** — like Vercel Edge Functions but Cloudflare's whole ecosystem. Good if you're already in Cloudflare-land (R2, KV, D1, Durable Objects).
+- **Netlify** — Vercel competitor. Mature, less Next.js-optimized. Pick if you have a strong Netlify reason; otherwise Vercel.
+- **Render** — Railway competitor. Different pricing model. Mostly equivalent feature set.
+
+For these, build a custom Makefile from scratch. The shape (pre-flight, deploy, verify, env management) is the same; the CLI commands differ.

--- a/skills/make-vercel/skills/make-vercel/references/domains-and-aliases.md
+++ b/skills/make-vercel/skills/make-vercel/references/domains-and-aliases.md
@@ -1,0 +1,145 @@
+# Domains and aliases on Vercel
+
+Two distinct concepts:
+
+- **Domains** — your owned domains (e.g., `acme.com`)
+- **Aliases** — pointers from a domain to a specific deployment
+
+## Adding a domain
+
+```bash
+vercel domains add acme.com
+```
+
+Vercel issues DNS instructions:
+
+```
+Configure your DNS:
+  Type: A
+  Name: @
+  Value: 76.76.21.21
+
+  Type: CNAME
+  Name: www
+  Value: cname.vercel-dns.com
+```
+
+Update your DNS provider; verify:
+
+```bash
+vercel domains inspect acme.com
+```
+
+Shows `Status: Verified` once DNS propagates (5min - 24h depending on TTL).
+
+## Assigning to production
+
+After domain is verified, link it to the project:
+
+```bash
+# Auto-aliases new production deploys to acme.com
+vercel domains add acme.com
+vercel alias acme.com my-project.vercel.app   # if not auto-assigned
+```
+
+Production deploys (`vercel --prod`) automatically alias to all domains assigned to the project. No manual aliasing per deploy.
+
+## Preview domain aliasing
+
+By default, preview deploys get unique URLs (`my-project-abc123.vercel.app`). To assign a stable preview URL (e.g., `staging.acme.com`):
+
+```bash
+# After a preview deploy
+PREVIEW=$(vercel deploy --yes 2>&1 | grep -oE 'https://[^ ]+\.vercel\.app' | tail -1)
+vercel alias $PREVIEW staging.acme.com
+```
+
+Or in CI for the staging branch:
+
+```yaml
+- run: |
+    PREVIEW=$(vercel deploy --yes --token=$VERCEL_TOKEN | tail -1)
+    vercel alias $PREVIEW staging.acme.com --token=$VERCEL_TOKEN
+```
+
+## Subdomain wildcards
+
+Vercel supports `*.acme.com` for multi-tenant setups:
+
+```bash
+vercel domains add "*.acme.com"
+```
+
+Each subdomain (e.g., `customer1.acme.com`) routes to your project; the app reads `req.headers.get('host')` to differentiate tenants.
+
+DNS:
+
+```
+Type: CNAME
+Name: *
+Value: cname.vercel-dns.com
+```
+
+## Removing
+
+```bash
+vercel domains rm acme.com
+# or remove just an alias
+vercel alias rm acme.com
+```
+
+## DNS providers
+
+- **Cloudflare:** set the records, then DISABLE Cloudflare's proxying for these (orange cloud → grey). Vercel needs direct DNS to issue cert.
+- **Route 53 / Cloudflare DNS / etc.:** Vercel works with all standard DNS providers. ALIAS records (Route 53 specific) work; CNAME at apex doesn't.
+- **Apex CNAME workaround:** Vercel offers `CNAME` flattening via their nameservers (`ns1.vercel-dns.com`, `ns2.vercel-dns.com`). Switch your domain to use Vercel as DNS.
+
+## SSL certificates
+
+Auto-issued via Let's Encrypt within minutes of DNS verification. Renewed automatically. No manual cert management.
+
+For wildcard certs, Vercel uses DNS-01 challenge — you may need to add a TXT record temporarily.
+
+## Custom 404s and redirects
+
+Use `vercel.json` for redirects:
+
+```json
+{
+  "redirects": [
+    { "source": "/old-page", "destination": "/new-page", "permanent": true },
+    { "source": "/blog/:slug", "destination": "/posts/:slug", "permanent": true }
+  ]
+}
+```
+
+For Next.js, prefer `next.config.ts` `async redirects()`. Same effect; lives with the app.
+
+## Inspecting
+
+```bash
+# Show all domains assigned to current project
+vercel domains ls
+
+# Inspect one
+vercel domains inspect acme.com
+
+# Show all aliases for the current project
+vercel alias ls
+```
+
+## Removing a wrong assignment
+
+If you accidentally aliased a preview to production:
+
+```bash
+# Unset
+vercel alias rm acme.com
+
+# Re-alias to production deploy
+vercel alias <prod-deployment-url> acme.com
+```
+
+## Don't aliases break the deploy URL?
+
+The unique `<project>-abc123.vercel.app` URL stays available alongside any aliases. So `acme.com` and `my-project-abc123.vercel.app` both point to the same deployment.

--- a/skills/make-vercel/skills/make-vercel/references/env-management.md
+++ b/skills/make-vercel/skills/make-vercel/references/env-management.md
@@ -1,0 +1,160 @@
+# Vercel env management
+
+Vercel scopes env vars to one of three environments: `development`, `preview`, `production`. The CLI manages each.
+
+## The three environments
+
+| Env | When applied | Typical use |
+|---|---|---|
+| `development` | `vercel dev` (local) and `vercel env pull` | Local dev, mirrors `.env.local` |
+| `preview` | All non-main branch deploys + per-PR previews | Staging-like; safe to break |
+| `production` | Deploys to the assigned production branch (usually `main`) | Real users; treat as immutable |
+
+A var can be set in 1, 2, or all 3 environments. They don't auto-cascade.
+
+## Pulling env to local
+
+```bash
+# Pull the development scope to .env.local
+vercel env pull .env.local
+
+# Pull production scope (DANGEROUS — production secrets to local file)
+vercel env pull .env.production --environment=production
+
+# Pull preview
+vercel env pull .env.preview --environment=preview
+```
+
+`.env.local` is in Vercel's default `.gitignore`. Verify after first pull:
+
+```bash
+git check-ignore .env.local && echo "✓ gitignored"
+```
+
+## Adding env vars
+
+```bash
+# Interactive prompt for value
+vercel env add API_KEY production
+# Enter value: sk-...
+
+# All three environments
+vercel env add API_KEY production preview development
+
+# From stdin (scriptable)
+echo "sk-..." | vercel env add API_KEY production
+```
+
+## Listing
+
+```bash
+# All envs, all scopes
+vercel env ls
+
+# Filter by environment
+vercel env ls production
+```
+
+Output shows the key + which environments it's set in. Values are masked.
+
+## Removing
+
+```bash
+vercel env rm API_KEY production
+# Confirms before removal
+```
+
+## Encrypted vs plain
+
+All Vercel env vars are encrypted at rest. The `--sensitive` flag (deprecated in favor of always-encrypted) ensured secrets don't appear in build logs. Modern Vercel always treats values as secrets.
+
+## Build-time vs runtime
+
+| Type | When read | Available in |
+|---|---|---|
+| Build-time | At `next build` | Server components, API routes (baked into bundle) |
+| Runtime | At request handling | Server components, API routes, edge functions |
+
+Next.js `process.env.X` is read at runtime by default. To inline at build (faster reads, but immutable post-deploy):
+
+```ts
+// next.config.ts
+const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_API_BASE: process.env.API_BASE,  // baked in
+  },
+};
+```
+
+Anything prefixed `NEXT_PUBLIC_` is exposed to client bundles — careful with secrets.
+
+## Vercel-managed env vars
+
+Vercel injects these automatically at deploy:
+
+| Var | Notes |
+|---|---|
+| `VERCEL` | `1` when running on Vercel |
+| `VERCEL_ENV` | `production` / `preview` / `development` |
+| `VERCEL_URL` | The deployment-specific URL (e.g., `my-app-abc123.vercel.app`) |
+| `VERCEL_BRANCH_URL` | The branch URL (`my-app-git-feature.vercel.app`) |
+| `VERCEL_GIT_COMMIT_SHA` | Short git SHA |
+| `VERCEL_REGION` | The execution region |
+
+Use `VERCEL_ENV !== 'production'` to differentiate prod from preview in code:
+
+```ts
+if (process.env.VERCEL_ENV === 'production') {
+  Sentry.init({ dsn: process.env.SENTRY_DSN });
+}
+```
+
+## Parity with `.env.local`
+
+Pattern: `vercel env pull` after major env changes:
+
+```makefile
+env-pull:
+	@vercel env pull .env.local --environment=development
+	@printf "✓ .env.local updated\n"
+```
+
+Run on first checkout, after onboarding new env vars, after secret rotations. Don't run constantly — pulls overwrite the file.
+
+## Secrets rotation
+
+```bash
+# 1. Rotate at the source (DB dashboard, OAuth provider)
+# 2. Update Vercel
+vercel env rm OLD_KEY production
+vercel env add NEW_KEY production
+# 3. Trigger redeploy (env changes don't auto-redeploy)
+vercel --prod --force
+```
+
+## Don't commit `.env.production`
+
+Vercel pulls write to local files. The convention:
+
+```gitignore
+.env.local
+.env.production
+.env.preview
+.env.*.local
+```
+
+Yes to `.env` (committed defaults), no to anything pulled or local-overridden.
+
+## Build-time env injection from Vercel
+
+For values that need to be in the build bundle (e.g., Sentry source-map upload tokens):
+
+1. Set in Vercel env (any environment)
+2. Reference in `next.config.ts` or build script
+3. They're available during `next build` because Vercel runs the build with all env vars injected
+
+This works for Sentry's `withSentryConfig({ authToken: process.env.SENTRY_AUTH_TOKEN, ... })` — token is read at build, source maps uploaded automatically.
+
+## Multi-tenant secrets
+
+If different tenants need different env values (rare in single-Vercel-project setups), you'd need separate Vercel projects per tenant. Within one project, env is shared per-environment.

--- a/skills/make-vercel/skills/make-vercel/references/find-or-create.md
+++ b/skills/make-vercel/skills/make-vercel/references/find-or-create.md
@@ -1,0 +1,130 @@
+# Find-or-create Vercel projects
+
+Vercel's `link` command is the find-or-create entrypoint. By default interactive; with flags, scriptable.
+
+## Listing existing projects
+
+```bash
+vercel projects ls
+# Project Name             Latest Production URL    Updated
+# my-blog                  my-blog-abc.vercel.app   2 days ago
+# acme-marketing           acme.com                 1 hour ago
+```
+
+Filter by name:
+
+```bash
+vercel projects ls | grep -iw "my-app"
+```
+
+## Linking to existing
+
+```bash
+# Interactive: shows a picker
+vercel link
+
+# Non-interactive: pick by exact project name
+vercel link --project my-existing-project --yes
+```
+
+After link, `.vercel/project.json` holds the IDs:
+
+```json
+{
+  "projectId": "prj_abc123...",
+  "orgId": "team_xyz789...",
+  "projectName": "my-existing-project"
+}
+```
+
+## Creating new
+
+`vercel link` will offer to create if no match. Or be explicit:
+
+```bash
+# Bare new-project init in current directory
+vercel link --yes
+# Picks defaults: project name = directory name, framework = auto-detected
+```
+
+For full control:
+
+```bash
+vercel link --project my-new-name --yes --confirm
+# Confirms creation if name doesn't exist
+```
+
+## Selecting team/org
+
+By default `vercel` operates in your personal account. For team projects:
+
+```bash
+vercel switch team-name        # changes scope for subsequent commands
+vercel link                    # links to a project under team-name
+```
+
+Or pass per-command:
+
+```bash
+vercel link --scope team-name --project my-app --yes
+```
+
+## Naming conventions
+
+- Lowercase, dash-separated: `acme-marketing`, `my-blog-v2`
+- Avoid environment in the name: `my-app` (not `my-app-prod`) — Vercel handles environments inside one project
+- For monorepos: prefix with the app: `acme-web`, `acme-admin`
+
+## When to NOT use the same project
+
+Multi-tenant deployments where you want separate analytics, separate domains, separate scaling: use separate Vercel projects. Same Git repo can link to multiple projects (each contributor's `.vercel/` points to a different one).
+
+## Detecting link state in the Makefile
+
+```sh
+_check-prereqs:
+	@[ -d .vercel ] || { \
+	  printf "project not linked  $(D)vercel link$(Z)\n"; exit 1; \
+	}
+```
+
+If `.vercel/` is missing, refuse to deploy. The user must `vercel link` first; don't auto-link from a recipe.
+
+## CI/CD: linking from a token
+
+For GitHub Actions / similar, you can't `vercel login` interactively. Use a project token:
+
+```bash
+# Generate a token: https://vercel.com/account/tokens
+export VERCEL_TOKEN=...
+
+# Link non-interactively
+vercel link --token=$VERCEL_TOKEN --yes --project my-app
+
+# Or skip linking and pass IDs directly
+vercel deploy --token=$VERCEL_TOKEN --yes --org-id $ORG_ID --project-id $PROJECT_ID
+```
+
+The IDs come from `.vercel/project.json` (after a one-time manual link from a dev's machine).
+
+## Renaming projects
+
+```bash
+vercel projects rename my-app new-name
+```
+
+Local `.vercel/project.json` will mismatch. Re-`vercel link --project new-name --yes` to fix.
+
+## Deletion
+
+```bash
+vercel projects rm my-app
+```
+
+Destructive. Never bake into a Makefile.
+
+## Workspaces vs personal projects
+
+Vercel supports two scopes: personal (free tier per-user) and team workspaces (Pro/Enterprise). The `--scope` flag toggles which one a CLI command operates against.
+
+For a team's first Vercel deployment of a project, the lead links once with `--scope team-name`. Other contributors do the same; their local `.vercel/project.json` will resolve to the same project.

--- a/skills/make-vercel/skills/make-vercel/references/function-size-limits.md
+++ b/skills/make-vercel/skills/make-vercel/references/function-size-limits.md
@@ -1,0 +1,131 @@
+# Function size limits
+
+Vercel serverless functions have a hard limit: **50MB compressed** (unzipped per region). Exceed it → deploy fails with `Function exceeds 50MB`.
+
+## Common offenders
+
+| Dependency | Compressed | Why |
+|---|---|---|
+| Sharp (image processing) | ~30MB | Native binaries per platform |
+| ffmpeg-static | ~50MB | Encodes to MP4/WebM |
+| @sentry/profiling-node | ~5MB | Native profiler |
+| canvas | ~30MB | Native renderer |
+| puppeteer (full) | ~170MB | Bundles Chromium |
+| playwright | ~250MB | Bundles browser drivers |
+
+A vanilla Next.js function with Prisma + Clerk is ~10-20MB. Add one heavy native dep and you're over.
+
+## Detecting
+
+Vercel's deploy log shows the function size:
+
+```
+λ /api/upload  10.5 MB
+λ /api/process 60.2 MB  ← FAIL
+```
+
+Or analyze locally:
+
+```bash
+# Build, then inspect
+npm run build
+du -sh .next/server/app/api/process/route.js .next/server/chunks/ | sort -h
+```
+
+`@vercel/analytics`'s "Function bundle size" check in CI also catches this.
+
+## Fixes (ordered by preference)
+
+### 1. Move the work to an external service
+
+The cleanest fix. Image processing, video encoding, large-model inference — these don't belong in serverless functions.
+
+- **Image processing:** Cloudinary, imgix, Vercel's built-in `next/image` (handles most cases)
+- **Video:** Mux, Cloudflare Stream
+- **Heavy compute:** offload to a Railway worker, AWS Lambda with bigger limits, or a dedicated service
+
+### 2. Use Edge runtime instead
+
+Edge functions have a different (smaller) bundle limit but no native code. If your function doesn't need native deps:
+
+```ts
+// app/api/process/route.ts
+export const runtime = 'edge';
+```
+
+Edge functions are smaller, faster cold-start, but limited (no Node APIs, no Prisma standard adapter).
+
+### 3. Externalize unused deps
+
+`serverExternalPackages` in `next.config.ts` keeps server-only deps out of the function bundle (they're loaded at runtime via `require()`):
+
+```ts
+serverExternalPackages: ['@prisma/client', 'sharp', 'pino']
+```
+
+This is the same fix as in the make-local skill's optimization references — applies to Vercel too.
+
+### 4. Tree-shake aggressively
+
+Some packages bundle their entire surface even when you import one symbol. Audit with `@next/bundle-analyzer`:
+
+```bash
+ANALYZE=true npm run build
+# opens a treemap of bundle contents
+```
+
+Look for large entries that don't match what you actually use → switch to subpath imports or smaller alternatives.
+
+### 5. Split the function
+
+If `/api/big-thing` does multiple things, split into multiple smaller functions:
+
+```
+/api/upload          (small — just receives the file)
+/api/process-video   (different function, different bundle)
+```
+
+Each has its own 50MB budget.
+
+## Edge runtime limits (different)
+
+| Constraint | Edge | Serverless (Node) |
+|---|---|---|
+| Bundle size | 1-4 MB | 50 MB |
+| Cold start | ~10ms | ~1s |
+| Available APIs | Web standard (fetch, crypto.subtle) | Full Node.js |
+| Native modules | ❌ | ✓ |
+| DB drivers | HTTP/REST only (e.g., Neon serverless driver) | Full Postgres/MySQL drivers |
+
+For high-volume read-heavy functions, Edge is great. For anything with Prisma + standard Postgres, use serverless.
+
+## Vercel Pro / Enterprise
+
+Pro doesn't lift the 50MB compressed limit — it's an architectural constraint of AWS Lambda (which Vercel uses under the hood).
+
+Enterprise can negotiate custom limits but it's rare to need it.
+
+## Alternative: deploy the heavy bit to Railway
+
+If you need ffmpeg/sharp/puppeteer-class workloads, move them to Railway:
+
+```ts
+// On Vercel:
+fetch('https://my-worker.railway.app/api/process', { method: 'POST', body: ... })
+```
+
+Vercel handles the request; Railway worker does the work. See `references/vercel-vs-railway.md`.
+
+## Pre-deploy guard
+
+Before `make deploy`, run a size check:
+
+```bash
+npm run build
+SIZE_MB=$(du -sk .next/server | awk '{print int($1/1024)}')
+if [ $SIZE_MB -gt 40 ]; then
+  echo "WARN: build is ${SIZE_MB}MB, approaching 50MB function limit"
+fi
+```
+
+40MB threshold = early warning; deploy proceeds. 50MB = hard fail at deploy time.

--- a/skills/make-vercel/skills/make-vercel/references/makefile-template.md
+++ b/skills/make-vercel/skills/make-vercel/references/makefile-template.md
@@ -1,0 +1,135 @@
+# Makefile template — copy and customize
+
+The Vercel-flavored equivalent of make-railway's deploy. GNU Make 3.81 compatible.
+
+## Placeholders
+
+| Placeholder | Default | Notes |
+|---|---|---|
+| `PROD_URL` | `https://<project>.vercel.app` | Custom domain or default vercel.app URL. |
+| `PROJECT_NAME` | from `package.json` | Used in banners. |
+
+## Full template
+
+```makefile
+SHELL := /bin/bash
+
+# ── Public URLs (post-deploy reachability check) ──────────────
+PROD_URL := https://app.example.com
+# Vercel-issued fallback: https://my-project.vercel.app
+
+# ── ANSI palette ──────────────────────────────────────────────
+B := \033[1m
+D := \033[2m
+G := \033[32m
+Y := \033[33m
+R := \033[31m
+C := \033[36m
+Z := \033[0m
+
+.PHONY: deploy preview verify env-pull env-add logs install-hooks _check-prereqs
+
+# ── make deploy (production) ──────────────────────────────────
+deploy: _check-prereqs
+	@sha=$$(git rev-parse --short HEAD); \
+	branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ -n "$$(git status --porcelain 2>/dev/null | head -1)" ]; then \
+	  printf "$(Y)WARN$(Z) deploying with uncommitted changes\n"; \
+	fi; \
+	tag="$$branch@$$sha"; \
+	printf "$(B)→ Vercel production deploy: $$tag$(Z)\n"; \
+	url=$$(vercel --prod --yes 2>&1 | tee /tmp/vercel-deploy.log | grep -oE 'https://[^ ]+\.vercel\.app' | tail -1); \
+	if [ -n "$$url" ]; then \
+	  printf "  $(G)✓$(Z) deployed to $$url\n"; \
+	else \
+	  printf "  $(R)✗ deploy failed — see /tmp/vercel-deploy.log$(Z)\n"; \
+	  exit 1; \
+	fi; \
+	printf "\n$(B)Live URL$(Z)\n"; \
+	printf "  $(G)→$(Z) $(PROD_URL)\n"; \
+	printf "\n$(D)HTTP check:  make verify$(Z)\n"
+
+# ── make preview (per-commit preview deploy) ──────────────────
+preview: _check-prereqs
+	@printf "$(B)→ Vercel preview deploy$(Z)\n"
+	@url=$$(vercel deploy --yes 2>&1 | tee /tmp/vercel-preview.log | grep -oE 'https://[^ ]+\.vercel\.app' | tail -1); \
+	if [ -n "$$url" ]; then \
+	  printf "  $(G)✓$(Z) preview at $$url\n"; \
+	  printf "$(D)Aliasing requires:  vercel alias $$url <your-preview-domain>$(Z)\n"; \
+	else \
+	  printf "  $(R)✗ preview failed$(Z)\n"; exit 1; \
+	fi
+
+# ── verification ──────────────────────────────────────────────
+verify:
+	@printf "$(D)→ HTTP probe$(Z)\n"
+	@code=$$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 12 $(PROD_URL)/ || echo "ERR"); \
+	case $$code in \
+	  2*|3*) printf "  $(G)$$code$(Z) $(PROD_URL)\n" ;; \
+	  *)     printf "  $(R)$$code$(Z) $(PROD_URL)\n" ;; \
+	esac
+
+# ── env management ────────────────────────────────────────────
+env-pull:
+	@printf "$(D)→ pulling Vercel env into .env.local$(Z)\n"
+	@vercel env pull .env.local --environment=development
+	@printf "$(G)✓ .env.local updated (development scope)$(Z)\n"
+
+env-add:
+	@printf "Add a key:  vercel env add KEY production\n"
+	@printf "Remove:     vercel env rm KEY production\n"
+	@printf "List:       vercel env ls\n"
+
+# ── observability ─────────────────────────────────────────────
+logs:
+	@vercel logs $(PROD_URL) --follow
+
+# ── git hooks installer (shared with make-railway) ────────────
+install-hooks:
+	@bash scripts/install-hooks.sh
+
+# ── pre-flight ────────────────────────────────────────────────
+_check-prereqs:
+	@command -v vercel >/dev/null 2>&1 || { \
+	  printf "$(R)vercel CLI not found$(Z)  $(D)npm install -g vercel$(Z)\n"; exit 1; }
+	@vercel whoami >/dev/null 2>&1 || { \
+	  printf "$(R)not logged into Vercel$(Z)  $(D)vercel login$(Z)\n"; exit 1; }
+	@[ -d .vercel ] || { \
+	  printf "$(R)project not linked$(Z)  $(D)vercel link$(Z)\n"; exit 1; }
+```
+
+## Notes on adapting
+
+- **No custom domain yet:** `PROD_URL` can be the auto-generated `<project>.vercel.app`. Update later when you assign a domain.
+- **Preview deploy URLs:** Vercel auto-assigns. The `make preview` target captures it from CLI output — if Vercel changes the format, update the regex.
+- **Multi-environment Make targets:** add `make deploy-staging` if you have a staging environment configured.
+- **`vercel deploy --target production`** vs `vercel --prod`: equivalent. The Makefile uses `--prod` because it's shorter.
+- **`--yes` flag:** non-interactive; auto-confirms prompts. Good for scripts. Drop for first-time deploy if you want to inspect the prompts.
+
+## Companion `vercel.json` (optional)
+
+Most Next.js projects don't need this. Add only when:
+
+```json
+{
+  "buildCommand": "cd apps/web && npm run build",
+  "outputDirectory": "apps/web/.next",
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "develop": false
+    }
+  },
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ]
+}
+```
+
+See `references/vercel-config.md` for the full schema.

--- a/skills/make-vercel/skills/make-vercel/references/monorepo.md
+++ b/skills/make-vercel/skills/make-vercel/references/monorepo.md
@@ -1,0 +1,151 @@
+# Vercel monorepo deploys
+
+Vercel supports monorepos via the **Root Directory** setting. The Vercel project lives at a subdirectory of the repo.
+
+## Setup
+
+Dashboard → Project Settings → General → Root Directory → `apps/web`
+
+Vercel then:
+- Runs `npm install` from the monorepo root
+- Builds in `apps/web/` (output: `apps/web/.next`)
+- Serves the result
+
+Alternative: set in `vercel.json` at the **monorepo root**:
+
+```json
+{
+  "buildCommand": "cd apps/web && npm run build",
+  "outputDirectory": "apps/web/.next",
+  "installCommand": "npm install",
+  "framework": "nextjs"
+}
+```
+
+The dashboard setting is preferred — it's clearer and lets each project pick a different root.
+
+## One project per app
+
+The cleanest pattern for monorepos:
+
+```
+my-monorepo/
+├── apps/
+│   ├── web/        ← Vercel project A (root: apps/web)
+│   ├── admin/      ← Vercel project B (root: apps/admin)
+│   └── docs/       ← Vercel project C (root: apps/docs)
+└── packages/
+    └── shared/     ← shared workspace, built per-app
+```
+
+Each app gets its own Vercel project, deploy URL, env, custom domain. Shared code lives in workspace packages.
+
+## Turborepo integration
+
+Vercel auto-detects Turborepo. Cache hits from Turbo's remote cache speed up builds dramatically:
+
+```bash
+# In CI / Vercel build env:
+export TURBO_TOKEN=...        # from https://vercel.com/account/tokens
+export TURBO_TEAM=acme        # your team slug
+```
+
+In `turbo.json`:
+
+```json
+{
+  "remoteCache": { "signature": true }
+}
+```
+
+Vercel's build picks this up automatically — no extra config in dashboard.
+
+## Per-PR preview deploys
+
+Vercel auto-creates preview deploys per branch + per PR. For monorepos, this triggers builds **for every project linked to the repo**, even if the changed files only affect one app.
+
+Limit to changed apps via `vercel.json`:
+
+```json
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "develop": false
+    }
+  }
+}
+```
+
+Or use Turborepo's "ignore step" — Vercel runs your `ignoreCommand` and skips the deploy if it returns 0:
+
+```json
+{
+  "ignoreCommand": "npx turbo-ignore"
+}
+```
+
+`turbo-ignore` checks if the current app's source changed since the last successful build. If not, returns 0 → Vercel skips the deploy. Saves preview minutes.
+
+## Workspaces (npm/yarn/pnpm)
+
+Vercel's `npm install` runs from the monorepo root, respecting workspaces. Nothing special to configure.
+
+For pnpm:
+
+```json
+// package.json at monorepo root
+{
+  "packageManager": "pnpm@9.0.0"
+}
+```
+
+Vercel auto-detects from `packageManager` field. Or add `corepack enable` to install command if needed.
+
+## Build cache scope
+
+Vercel caches per-project. Two projects from the same monorepo don't share cache — even if they install the same node_modules.
+
+Turborepo's remote cache *does* share — that's the whole point. Use it.
+
+## Env vars per app
+
+Each Vercel project has its own env. If `apps/web` and `apps/admin` need the same `DATABASE_URL`:
+
+```bash
+# Set on web
+vercel env add DATABASE_URL production --project apps-web
+
+# Set on admin separately
+vercel env add DATABASE_URL production --project apps-admin
+```
+
+Or use a shared .env in the workspace root and load via dotenv (less common in Vercel-deployed projects).
+
+## Next.js specific
+
+`apps/web/next.config.ts` works as expected. The `transpilePackages` field is useful for shared packages:
+
+```ts
+const nextConfig: NextConfig = {
+  transpilePackages: ['@acme/shared-ui'],
+};
+```
+
+Without it, `next build` will fail to compile workspace packages that ship TS source.
+
+## Common monorepo deploy failures
+
+| Symptom | Fix |
+|---|---|
+| `Module not found: Can't resolve '@acme/shared'` | Add `transpilePackages: ['@acme/shared']` to `next.config.ts` |
+| `npm ERR! ENOENT package.json` (when Vercel runs install at app dir) | Make sure Root Directory is set; install runs from monorepo root, not app dir |
+| Cache misses on every deploy | Verify Turborepo remote cache: `TURBO_TOKEN` + `TURBO_TEAM` set in Vercel env |
+| Preview deploys for every commit, even unrelated changes | Add `ignoreCommand: "npx turbo-ignore"` to `vercel.json` |
+| Build succeeds but routes 404 | `outputDirectory` mismatch — check it's `apps/web/.next` (not `.next`) |
+
+## Don't use a single Vercel project for multiple apps
+
+Vercel projects map 1:1 to deployment URLs. You can't have `acme.com` and `admin.acme.com` from the same project — that's two projects.
+
+Some teams work around this with subpath routing (`acme.com/admin/...`) and a single Next.js app that handles both. Cleaner for small projects; doesn't scale.

--- a/skills/make-vercel/skills/make-vercel/references/vercel-config.md
+++ b/skills/make-vercel/skills/make-vercel/references/vercel-config.md
@@ -1,0 +1,169 @@
+# vercel.json reference
+
+Most Next.js projects don't need this file — Vercel auto-detects everything. Add it for the cases auto-detection misses.
+
+## When to use
+
+| Need | `vercel.json` field |
+|---|---|
+| Custom build command | `buildCommand` |
+| Custom output directory | `outputDirectory` |
+| Override framework detection | `framework` |
+| Redirects | `redirects` (or `next.config.ts` if Next.js) |
+| Headers (CORS, security) | `headers` |
+| Rewrites (proxy routes) | `rewrites` |
+| Crons | `crons` |
+| Per-function memory/duration | `functions` |
+| Disable preview deploys per branch | `git.deploymentEnabled` |
+
+## Minimal example
+
+```json
+{
+  "framework": "nextjs"
+}
+```
+
+That's enough for Vercel to know the project type. Most cases need nothing more.
+
+## Common patterns
+
+### CORS headers for API routes
+
+```json
+{
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,POST,OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type,Authorization" }
+      ]
+    }
+  ]
+}
+```
+
+### Security headers (app-wide)
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
+  ]
+}
+```
+
+For Next.js, prefer `next.config.ts async headers()` — same result, lives with the app code.
+
+### Redirects
+
+```json
+{
+  "redirects": [
+    { "source": "/old", "destination": "/new", "permanent": true },
+    { "source": "/blog/:slug", "destination": "/posts/:slug", "permanent": true }
+  ]
+}
+```
+
+### Rewrites (proxy)
+
+```json
+{
+  "rewrites": [
+    { "source": "/api/external/:path*", "destination": "https://api.acme.com/:path*" }
+  ]
+}
+```
+
+The user sees `/api/external/foo`; Vercel proxies to `api.acme.com/foo`. CORS and TLS handled.
+
+### Per-function configuration
+
+```json
+{
+  "functions": {
+    "api/heavy.ts": {
+      "memory": 3008,
+      "maxDuration": 60
+    }
+  }
+}
+```
+
+`memory`: 128MB - 3008MB. Higher → more $.
+`maxDuration`: 10s (Hobby), 60s (Pro), 300s (Enterprise) for serverless. Edge: 25s max.
+
+### Vercel cron
+
+```json
+{
+  "crons": [
+    { "path": "/api/cron/cleanup", "schedule": "0 3 * * *" }
+  ]
+}
+```
+
+Schedule is standard cron (UTC). The path is hit via GET. Verify the request:
+
+```ts
+// app/api/cron/cleanup/route.ts
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  if (req.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  // ... do work
+  return NextResponse.json({ ok: true });
+}
+```
+
+`CRON_SECRET` is auto-set by Vercel; check it on every cron-invoked route.
+
+⚠️ Hobby tier: max 10s per cron + max 2 crons per project. For more, upgrade to Pro or use Railway Cron.
+
+### Disable preview deploys per branch
+
+```json
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "develop": false,
+      "feature/*": false
+    }
+  }
+}
+```
+
+Useful for monorepos where you only want main deploys, not every PR.
+
+## Schema validation
+
+Vercel CLI validates `vercel.json` on every deploy. Errors surface immediately:
+
+```bash
+vercel deploy --prebuilt
+# Error: Invalid header configuration in `vercel.json`: ...
+```
+
+The CLI's validation is comprehensive; trust the error messages.
+
+## Don't fight auto-detection
+
+If Vercel's auto-detected `framework`, `buildCommand`, `outputDirectory` are wrong, that's usually a project-shape issue (e.g., monorepo without Root Directory set). Fix the underlying issue first; reach for `vercel.json` overrides as last resort.
+
+## Per-environment vercel.json
+
+Not supported. `vercel.json` is global. Use `process.env.VERCEL_ENV` in code to differentiate per-env behavior.

--- a/skills/make-vercel/skills/make-vercel/references/vercel-vs-railway.md
+++ b/skills/make-vercel/skills/make-vercel/references/vercel-vs-railway.md
@@ -1,0 +1,113 @@
+# Vercel vs Railway — pick deliberately
+
+Both can host Next.js. Pick by the project's actual workload.
+
+## Quick decision
+
+| Workload | Vercel | Railway |
+|---|---|---|
+| Static + serverless Next.js | ✓✓ | ✓ |
+| Edge runtime / global distribution | ✓✓ | ✗ |
+| Per-PR preview deploys | ✓✓ (free, automatic) | ✓ (manual) |
+| Marketing / blog / docs | ✓✓ | ✓ |
+| BullMQ workers | ✗ | ✓✓ |
+| SSE > 5min | ✗ | ✓✓ |
+| WebSocket server | ✗ | ✓✓ |
+| Background queue consumers | ✗ | ✓✓ |
+| Long-running cron (>10s) | ✗ (Hobby) / ✓ (Pro+) | ✓✓ (free) |
+| Custom Docker | ✗ | ✓✓ |
+| Native deps > 50MB | ✗ | ✓✓ |
+| In-cluster Postgres / Redis | ✗ | ✓✓ (managed in same project) |
+| WebGPU / GPU compute | ✗ | partial |
+
+## The Vercel sweet spot
+
+- Static Next.js page → CDN edge (instant)
+- API route → serverless function (cold-start ~1s)
+- Per-PR preview → unique URL per PR (5min build → live)
+- Custom domain → Let's Encrypt cert (5min DNS)
+
+For these workloads, Vercel is unbeatable. Free tier handles real production traffic for many projects.
+
+## The Railway sweet spot
+
+- Anything that can't fit in a 5-min serverless invocation
+- Anything that needs warm in-memory state (DB connection pools, in-memory cache)
+- Anything that needs to *consume* (queues, streams, WebSocket connections)
+- Multi-service apps (web + worker + DB + Redis as one project)
+- Custom Dockerfiles for nontrivial build steps
+
+For these, Vercel will fight you at every turn. Railway is the right tool.
+
+## The "split" pattern
+
+A common production architecture: **Vercel for web, Railway for everything else**.
+
+```
+Vercel (web)
+├── Next.js app
+├── API routes that are quick (auth, simple CRUD)
+└── ↓ for slow/queued work, hits Railway
+
+Railway (workers + queue)
+├── BullMQ worker service
+├── BullMQ queue (Redis)
+├── Postgres (for queue durability)
+└── Cron service for scheduled jobs
+```
+
+Vercel's web service POSTs jobs to a Railway endpoint, which enqueues. Worker consumes. Done.
+
+Setup:
+
+1. Vercel project for the Next.js app
+2. Railway project with: web (lightweight API for queue ops), worker, redis, postgres
+3. Vercel env: `WORKER_URL=https://my-worker.railway.app`
+4. Web hits Worker URL to enqueue
+
+## Vercel hidden costs
+
+- **Function invocations** — generous free tier, but high-volume APIs add up
+- **Edge Functions** — separate quota; cheaper per invocation
+- **Bandwidth** — includes ~100GB/mo free; overages charged
+- **Build minutes** — 6,000 min/mo on Hobby; preview deploys eat this fast in busy repos
+- **Cron invocations** — 2 per project on Hobby
+
+Read the [pricing page](https://vercel.com/pricing) before committing.
+
+## Railway hidden costs
+
+- **Compute** — billed per CPU-second; idle services still cost
+- **Bandwidth** — egress to internet metered
+- **Storage** — DB volumes count toward limits
+- **No free tier for production** — Trial credits only ($5 then pay)
+
+For toy projects, Vercel's free tier wins. For production with workers, Railway's hourly billing is predictable.
+
+## Detection: when to flag the wrong choice
+
+If user is asking for `make-vercel` but their project has any of these patterns, recommend make-railway instead:
+
+```bash
+# Detector for "wrong-shape-for-Vercel" patterns
+grep -rE "BullMQ|new Worker\\(|@bullmq/|new Queue\\b|ioredis" src/ 2>/dev/null
+grep -rE "EventSource|res\\.write\\(|TransferEncoding" src/ 2>/dev/null    # SSE patterns
+grep -rE "WebSocket|ws://|wss://|new WebSocket\\(" src/ 2>/dev/null
+grep -rE "node-cron|@nestjs/schedule|setInterval.*60.*60" src/ 2>/dev/null  # in-process cron
+```
+
+If any of these match, surface a warning:
+
+```
+⚠ Detected long-running workload patterns (BullMQ/SSE/WebSocket).
+  Vercel functions are stateless and time-limited. Consider Railway instead:
+  → see make-railway skill
+```
+
+The user can override and proceed if they know what they're doing — but don't deploy quietly.
+
+## When users ask "is Vercel always right for Next.js?"
+
+No. Next.js is a framework; Vercel is a host with optimizations for it. The host is decided by workload, not framework.
+
+If the answer is "yes" 90% of the time for their project, Vercel's the call. If their backend has any of the patterns above, mixed deployment (Vercel + Railway) is usually right.


### PR DESCRIPTION
## Summary

Three new skills that together cover the local-dev → production-deploy workflow for Next.js and Node projects, encoded from the lived experience of shipping `zeo-radar-v2` (commits `974adcf` through `336bfec` on that repo).

### `make-local` — friendly URL for local dev

Three paths, each fails where the other two cover:

| Path | URL | When |
|---|---|---|
| portless (default) | `https://<name>.localhost` | Solo on this Mac, daily driver |
| Tailscale Serve | `https://<node>.ts.net` | Cross-device (phone, second laptop) |
| plain LAN bind | `http://<lan-ip>:PORT` | Phone-on-Wi-Fi when MagicDNS fails, headless CI |

Encodes the HSTS-preload trap (`*.ts.net` forces HTTPS in Chrome, which breaks Next.js middleware via EPROTO — full decision matrix in `references/hsts-preload-trap.md`), port-conflict detection (kill stale `node`/`next`/`turbopack`, refuse strangers), Clerk dev-bypass + soft-gate config, Next 16 `allowedDevOrigins` exact-match rule, Tailscale hostname rename procedure.

### `make-railway` — `make prod` for Railway

Pre-flight (`whoami` / `status` / `link`), parallel multi-service deploys with `railway up --detach -s name`, terminal-status polling, deploy message annotation (`branch@sha+dirty`).

Covers find-or-create services, web+worker shape from same image (`ZEO_ROLE`), Dockerfile vs Nixpacks decision, `RAILWAY_PRIVATE_DOMAIN` vs `DATABASE_PUBLIC_URL`, `process.env.PORT` + `0.0.0.0` binding rules, Prisma migration baselining, monorepo patterns, cron services.

Includes git-hook CI/CD without GitHub Actions (pre-commit / pre-push / post-merge installer with `.bak` backups). Cross-references `use-railway` for raw CLI questions.

### `make-vercel` — `make deploy` for Vercel

`vercel link` find-or-create, env scoping (development / preview / production), `vercel env pull` parity with `.env.local`, custom domains and aliases, Vercel-managed env vars.

The 50MB compressed function size limit + how to detect / mitigate. The decision matrix to **not** pick Vercel — BullMQ workers, SSE >5min, WebSocket, native deps. Detection patterns built into the SKILL.md so the skill flags wrong-shape projects before deploy.

## Cross-cutting

- Each SKILL.md has "How to think about this" / "Detection checks" / "Recovery paths" / "Customizing the recipe" sections
- All three cross-link via `references/cross-skill-handoffs.md`
- 10 / 13 / 9 reference files respectively, covering every obstacle hit during the zeo-radar build-out

## NAMING.md update

Added `make` to the canonical verb set:

> | `make` | Author Makefile targets / `make X` workflow scaffolding | `make-local`, `make-railway`, `make-vercel` |

Per the doc's own rule: *"If none of these fit, propose a new verb in a PR alongside the new skill."*

## README.md update

Three new rows in alphabetical position with `workflow` category.

## Validation

```
$ python3 scripts/validate-skills.py
Validated 47 skills

✅ All validations passed
```

- Frontmatter `name` matches dir for all three
- Descriptions ≤30 words, start with "Use skill if you are"
- Every reference file linked from SKILL.md
- No orphans, no junk files

## Test plan

- [x] `python3 scripts/validate-skills.py` passes
- [x] Frontmatter rules all met (name match, description start, ≤30 words)
- [x] Reference linkage clean (no orphans)
- [x] Skills load in Claude Code runtime (verified via available-skills list during authoring session)
- [ ] Trigger test: paste "I want a make local script for Next.js" — should fire make-local
- [ ] Trigger test: paste "deploy this to Railway with workers" — should fire make-railway
- [ ] Trigger test: paste "ship this Next.js to Vercel" — should fire make-vercel
- [ ] Trigger test: paste "build a React component" — should NOT fire any of these

## Why one PR for three skills

The trilogy cross-references itself: `make-local`'s SKILL.md routes deployment questions to `make-railway` / `make-vercel`; `make-railway`'s decision matrix references `make-vercel`. Splitting into three PRs would create dead cross-skill links until all three merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
