### PR TITLE
🙈 chore: ignore .claude/ project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ to-delete/
 # Session artifacts from AI coding tools.
 .continues-handoff.md
 *.claude-session*
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ to-delete/
 # Session artifacts from AI coding tools.
 .continues-handoff.md
 *.claude-session*
-.claude/
+/.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore` so the local Claude Code project config directory (`.claude/settings.local.json`, hooks, etc.) is never accidentally committed.

## Why now

`.claude/` keeps appearing as untracked in `git status` after every Claude Code session. The repo already gitignores other AI session artifacts (`.continues-handoff.md`, `*.claude-session*`) — this is the missing sibling pattern.

## The 1 item

| File | Change | Rationale |
|---|---|---|
| `.gitignore` | +1 line: `.claude/` | Per-machine config, never repo-shared. |

## Files touched

`.gitignore` only — 1 line added.

## Verification

- [x] `git status` no longer shows `.claude/` as untracked after this lands.
- [x] No skill content touched; `python3 scripts/validate-skills.py` still passes (44 skills unchanged on this branch).

## Risks / Open items

None. If a future workflow needs to commit something under `.claude/` deliberately, force-add with `git add -f`.

## Follow-ups

Independent of, and complementary to, PR #63 (build-kernel-ts-sdk skill). No ordering dependency between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `/.claude/` to `.gitignore` to prevent committing local Claude Code project files. Anchored to the repo root to avoid matching nested `.claude/` dirs; aligns with existing `*.claude-session*` and `.continues-handoff.md` ignores.

<sup>Written for commit 319248f8f5171ad84f739fcc95a1356df213dc1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

