### PR TITLE
Add run-aligned-delivery skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "yk-everything",
       "source": "./",
-      "description": "The whole pack — all 41 skills plus the internet-researcher agents. Heaviest context cost; prefer a themed bundle or single skill.",
+      "description": "The whole pack — all 42 skills plus the internet-researcher agents. Heaviest context cost; prefer a themed bundle or single skill.",
       "version": "1.0.8",
       "category": "bundle",
       "strict": false,
@@ -197,6 +197,20 @@
       "skills": [
         "./skills/build-skill",
         "./skills/audit-skill-by-derailment"
+      ]
+    },
+    {
+      "name": "yk-delivery",
+      "source": "./",
+      "description": "Aligned delivery — scored multi-round question alignment, a filename-state spec corpus, and waved parallel subagent orchestration for a large or ambiguous initiative.",
+      "version": "1.0.8",
+      "category": "bundle",
+      "tags": [
+        "delivery"
+      ],
+      "strict": false,
+      "skills": [
+        "./skills/run-aligned-delivery"
       ]
     },
     {
@@ -516,6 +530,17 @@
       "strict": false,
       "skills": [
         "./skills/run-agent-browser"
+      ]
+    },
+    {
+      "name": "run-aligned-delivery",
+      "source": "./",
+      "description": "Use skill if you are driving a large, ambiguous initiative (modernize, rewrite, migrate, greenfield, or a multi-component bug hunt) and want scored multi-round question alignment before orchestrating parallel execution.",
+      "version": "1.0.8",
+      "category": "delivery",
+      "strict": false,
+      "skills": [
+        "./skills/run-aligned-delivery"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skills-by-yigitkonur
 
-skills for ai coding agents — one pack, **41 skills** + the internet-researcher agents. review, research, ui/ux audit, mcp & framework builders, browser/device automation, config files, publish. install what you need, skip the rest. no monolith.
+skills for ai coding agents — one pack, **42 skills** + the internet-researcher agents. review, research, ui/ux audit, mcp & framework builders, browser/device automation, config files, publish. install what you need, skip the rest. no monolith.
 
 > used to be two repos (a main pack + a `-secondary` b-side). they're one now. the old secondary repo is gone — everything lives here.
 
@@ -61,7 +61,7 @@ themed groups for one-shot installs. every skill also installs on its own — se
 
 | bundle | what's in it | install |
 |---|---|---|
-| **yk-everything** | all 41 skills + researcher agents | `/plugin install yk-everything@yigitkonur` |
+| **yk-everything** | all 42 skills + researcher agents | `/plugin install yk-everything@yigitkonur` |
 | **yk-researchers** | internet-researcher agents only, no skills | `/plugin install yk-researchers@yigitkonur` |
 | **yk-review** | review, codex-review-loop, codex adversarial loop, completion audit, runtime debug | `/plugin install yk-review@yigitkonur` |
 | **yk-frontend** | url→next.js, ui/ux/laws-of-ux audits | `/plugin install yk-frontend@yigitkonur` |
@@ -72,6 +72,7 @@ themed groups for one-shot installs. every skill also installs on its own — se
 | **yk-config** | agents/claude/review files, drift audit, makefiles | `/plugin install yk-config@yigitkonur` |
 | **yk-ops** | railway, coolify-cloud deploy, repo-cleanup, npm publish | `/plugin install yk-ops@yigitkonur` |
 | **yk-skills** | build-skill, derailment stress-test | `/plugin install yk-skills@yigitkonur` |
+| **yk-delivery** | scored alignment, spec corpus, waved orchestration for big initiatives | `/plugin install yk-delivery@yigitkonur` |
 
 ---
 
@@ -194,6 +195,16 @@ build and harden skills themselves.
 - **[audit-skill-by-derailment](skills/audit-skill-by-derailment/)** — stress-test an existing skill.md by running a fresh subagent on a real task and editing the skill where the trace shows friction.
 
 `/plugin install yk-skills@yigitkonur`
+
+---
+
+## 🧭 aligned delivery
+
+drive a large, ambiguous initiative front-to-back: scored question alignment, then a spec corpus, then waved subagent orchestration.
+
+- **[run-aligned-delivery](skills/run-aligned-delivery/)** — scored multi-round question alignment, then a filename-state spec corpus, then waved subagent orchestration — for a large or ambiguous initiative.
+
+`/plugin install yk-delivery@yigitkonur`
 
 ---
 

--- a/scripts/gen-marketplace.py
+++ b/scripts/gen-marketplace.py
@@ -118,6 +118,11 @@ GROUPS = {
         "Skill authoring — research-driven skill creation and derailment stress-testing of existing SKILL.md files.",
         ["build-skill", "audit-skill-by-derailment"],
     ),
+    "yk-delivery": (
+        "delivery",
+        "Aligned delivery — scored multi-round question alignment, a filename-state spec corpus, and waved parallel subagent orchestration for a large or ambiguous initiative.",
+        ["run-aligned-delivery"],
+    ),
 }
 
 # Bundles that also ship the internet-researcher subagents from subagents/claude/.

--- a/skills/run-aligned-delivery/INSTALL.md
+++ b/skills/run-aligned-delivery/INSTALL.md
@@ -1,0 +1,26 @@
+# run-aligned-delivery
+
+Driving a large, ambiguous initiative (modernize, rewrite, migrate, greenfield, or a multi-component bug hunt) through scored multi-round question alignment and waved parallel subagent orchestration.
+
+**Category:** delivery
+
+## Install
+
+**As a plugin (easy install / uninstall via `/plugin`):**
+
+```
+/plugin marketplace add yigitkonur/skills-by-yigitkonur
+/plugin install run-aligned-delivery@yigitkonur
+```
+
+**Or with the `skills` CLI — this skill only:**
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur/skills/run-aligned-delivery
+```
+
+**Or the full pack:**
+
+```bash
+npx -y skills add -y -g yigitkonur/skills-by-yigitkonur
+```

--- a/skills/run-aligned-delivery/SKILL.md
+++ b/skills/run-aligned-delivery/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: run-aligned-delivery
+description: Use skill if you are driving a large, ambiguous initiative (modernize, rewrite, migrate, greenfield, or a multi-component bug hunt) and want scored multi-round question alignment before orchestrating parallel execution.
+---
+
+# Run Aligned Delivery
+
+Drive a large, ambiguous initiative the way a great architect runs a project:
+**front-load every decision that is genuinely the human's to make** (so execution
+can be autonomous), **turn the answers into a living spec corpus**, then
+**orchestrate parallel agents in disciplined waves**. The signature is
+collaboration, not interrogation — you surface the real forks, scored and with
+their catch, the human chooses, then you build hard.
+
+One skill, three phases. Run them in order; loop back when an answer changes the picture.
+
+## When to use / not use
+
+**Use** when the work is big AND at least one of: ambiguous (many valid
+interpretations), high-stakes (modernization, rewrite, migration, data/auth), or
+multi-component (spans subsystems). Examples: "modernize this stack", "rewrite X
+in Y", "port this service", "migrate N call sites", "build this platform from
+scratch", "this gnarly bug spans three services".
+
+**Do NOT use** for small, clear, single-file or single-function work — just
+implement it, or have one short design conversation first. If you can name the
+destination and the diff in one sentence, you do not need this skill. For chasing
+a single reproducible runtime bug, use a dedicated debugging methodology, not this.
+
+## Core principle
+
+> **The brief is the lever.** Time spent surfacing the right forks — and scoring
+> the options so the human chooses well — buys autonomous, high-quality execution
+> later. Cheap-to-check unknowns you resolve yourself; user-only unknowns you ask, well.
+
+## The loop
+
+```dot
+digraph rad {
+  "Frame + self-discover" [shape=box];
+  "User-only unknowns remain?" [shape=diamond];
+  "ALIGN: scored AskUserQuestion rounds" [shape=box];
+  "Answer pivots the design?" [shape=diamond];
+  "SPEC: living corpus (filename=state)" [shape=box];
+  "ORCHESTRATE: waves + verify/commit barriers" [shape=box];
+  "Wave verified?" [shape=diamond];
+  "Reconcile / next wave or report" [shape=doublecircle];
+
+  "Frame + self-discover" -> "User-only unknowns remain?";
+  "User-only unknowns remain?" -> "ALIGN: scored AskUserQuestion rounds" [label="yes"];
+  "User-only unknowns remain?" -> "SPEC: living corpus (filename=state)" [label="no"];
+  "ALIGN: scored AskUserQuestion rounds" -> "Answer pivots the design?";
+  "Answer pivots the design?" -> "Frame + self-discover" [label="yes: re-frame, research"];
+  "Answer pivots the design?" -> "SPEC: living corpus (filename=state)" [label="no: locked"];
+  "SPEC: living corpus (filename=state)" -> "ORCHESTRATE: waves + verify/commit barriers";
+  "ORCHESTRATE: waves + verify/commit barriers" -> "Wave verified?";
+  "Wave verified?" -> "ORCHESTRATE: waves + verify/commit barriers" [label="next wave"];
+  "Wave verified?" -> "Reconcile / next wave or report" [label="done/blocked"];
+}
+```
+
+---
+
+## Phase 0 — Frame and self-discover (before asking anything)
+
+You do not get to ask the human a question you could have answered yourself.
+
+1. **State your framing + assumptions out loud**, and invite correction: "Here's
+   how I read this; here's what I'm assuming — correct me or I proceed." Surfacing
+   a wrong assumption now is cheaper than building on it.
+2. **Scan for contradictions first.** Mutually exclusive goals ("offline-first" +
+   "always-current"), unacknowledged trade-offs ("simple" + "handles every edge
+   case"). Reconcile these *before* any detailed question — disambiguating the
+   wrong foundation is wasted effort.
+3. **Do the homework an agent can do:** read the code, run searches/researchers,
+   map the subsystems. If a question is answerable from the repo, the docs, or a
+   quick research pass, answer it — don't spend a question on it.
+4. **Decompose if it's really several initiatives.** If the ask is N independent
+   subsystems, say so and sequence them; this skill drives one coherent initiative
+   at a time.
+
+What's left — the genuine **user-only unknowns** (a preference, a risk tolerance, a
+credential/constraint, an irreversible or outward-facing call) — is what Phase 1 asks.
+
+## Phase 1 — ALIGN: scored, multi-round questioning (the heart)
+
+Use your environment's structured multi-choice question tool (e.g. `AskUserQuestion`)
+to surface the real forks. This is NOT one polite clarifying question; it is
+**repeated batches of carefully designed, scored, categorized questions** that
+converge the design.
+
+The full method (scoring rubric, recommendation-first, the "what's the catch",
+categorization, batching, adaptation) is in
+[`references/question-design.md`](references/question-design.md) — read it before
+your first round. The essentials:
+
+- **Recommendation first, scored options.** Each option carries a `/100` score and a
+  one-line trade-off; lead with the recommended option marked "(Recommended)". The
+  human should choose in seconds and see why.
+- **Name the catch.** Every option states its downside/risk, not just its upside.
+  The score is honest, not a sales pitch.
+- **Categorize** the decision space (runtime, data, security, deploy, testing,
+  sequencing, …) so the human sees the shape — up to ~20 categories for a big
+  initiative.
+- **Batch** within the tool's per-card limits (`AskUserQuestion`: up to 4
+  questions/card, up to 4 options each — surface the top-scored options; "Other"
+  covers the rest). Group a card by theme.
+- **Adaptation budget: up to ~10 rounds** (ceiling, not a target — many initiatives
+  need fewer). Treat 10 as the default adaptation budget: re-plan the remaining
+  questions after each batch based on the answers.
+- **Adaptive re-planning is mandatory.** When an answer changes the architecture (a
+  pivot), loop back to Phase 0 — re-frame, research the new constraint, re-score the
+  *downstream* questions before continuing. A locked early answer can invalidate a
+  later question; don't ask it stale.
+- **Ask only user-only unknowns.** If you can decide it from evidence or a sensible
+  default, decide it, state it, and move on (note auto-decided low-stakes items
+  rather than spending a card on them).
+
+**Gate:** the decisions are locked — every load-bearing fork has an answer. Do not
+start the spec corpus or write code before this gate. Carry the answers verbatim
+into Phase 2.
+
+## Phase 2 — SPEC: a living corpus where the filename is the state
+
+Convert the locked decisions into a navigable spec corpus that another agent (or a
+future you) can execute with zero prior context — and that doubles as the project's
+to-do board.
+
+**Filename-prefix-as-state** (the distinctive convention — lighter than
+status-fields-in-content; scannable with `ls`; transitioned with `git mv`):
+
+| Prefix | Meaning |
+|---|---|
+| `00_`, `01_`, … | Stable spine: the decision log, architecture, data model, contracts. Not state-tracked. |
+| `TODO_` | Specced, not started. |
+| `WIP_` | In progress. |
+| `DONE_` | Implemented **and** verified. |
+| `BLOCKED_` | Needs an operator resource or an unresolved decision (say why at the top). |
+
+Build, at minimum:
+- **`00_DECISIONS_LOCKED.md`** — every Phase-1 answer, grouped by category, each
+  with the chosen option + why. This is the contract the orchestration obeys.
+- A short **architecture / data-model / interface-contract spine** (the
+  cross-cutting shapes every later agent must honor).
+- **One spec per unit of work** (per component / per provider / per migration site),
+  each: pointing at the **source-of-truth code as ground truth** (the existing or
+  legacy implementation to reproduce — link exact paths), restating the applicable
+  locked decisions, listing the contract + edge cases + a porting/build checklist.
+
+Rules: keep each spec a *living to-do* (rename the prefix as state changes);
+reference, don't duplicate; persistent files are your working memory and survive
+context compaction (re-read them after a compaction). Don't pad to a file count — a
+navigable corpus, not dozens of thin files.
+
+**Gate:** the corpus is sufficient for a zero-context agent and every spec links
+real ground-truth. Confirm sufficiency before orchestrating.
+
+## Phase 3 — ORCHESTRATE: dependency-ordered waves with verify-and-commit barriers
+
+Drive execution with parallel subagents — deterministically if your environment has
+a workflow primitive (e.g. the `Workflow` tool; otherwise parallel subagent/Task
+dispatch). Treat the spec corpus as the source of truth and yourself as the
+conductor who never writes the code.
+
+Hard-won discipline (this is where naive parallelism fails):
+
+- **Waves, not a free-for-all.** Each wave contains only **file-disjoint, genuinely
+  independent** units. Put a **barrier** between waves where the next depends on the
+  prior. Order waves by dependency (foundation → shared utils → leaf units → integration).
+- **Cap concurrency to respect rate limits.** Keep each parallel wave at or under the
+  agreed concurrency (e.g. ≤5); sequence the rest. Queue accordingly.
+- **Pin the model** for every agent when the human asks for a specific tier.
+- **Verify-and-commit at each barrier, with a single agent, alone.** A lone verifier
+  runs the gate (typecheck + tests), fixes drift, and commits the wave — so no two
+  agents ever race the git index or the lockfile. Build agents do NOT commit and do
+  NOT run installs concurrently; one scaffold/verify agent owns installs and commits.
+- **Mission-grade prompts.** Each subagent starts at zero context: give it role,
+  dense context, the exact spec file as its blueprint, hard constraints, a
+  binary/specific/verifiable definition-of-done, evidence-based verification, a
+  failure protocol, and a handback format. Set ceilings (upper bounds with a release
+  valve), never floors. Define the destination; leave the path open.
+- **Reconcile after every wave** — agents make systematic errors. Read the handback,
+  re-run the full gate yourself, spot-check; a subagent's "done" is a claim, not
+  verification.
+- **Flag what you cannot verify.** If a step needs an operator resource (a live
+  credential, a proxy, production access), reach the highest rung you can
+  (static/unit/integration) and hand off the genuinely-unverifiable slice with the
+  exact command to run.
+
+As units land verified, `git mv` their specs `WIP_`/`TODO_` → `DONE_`. The corpus
+stays the live board.
+
+---
+
+## Decision rules
+
+- If you can answer a question from the code, docs, or a quick research pass,
+  **decide it** — don't spend a question card. Ask only user-only unknowns.
+- If two stated goals contradict, **resolve the contradiction before** any technical question.
+- If an answer pivots the architecture, **stop and re-frame + re-research** before
+  continuing the question rounds — don't ask downstream questions against a stale design.
+- If a wave's units share files or state, they are **not** the same wave — serialize
+  or re-cut the boundaries.
+- If you cannot make a verification claim with fresh evidence, **don't make it** —
+  say which rung you reached.
+- If the initiative is actually several initiatives, **decompose and sequence**; run
+  this loop on one at a time.
+- Prefer the smallest corpus and the fewest agents that do the job. Reject machinery
+  that doesn't improve the outcome.
+
+## What to show the user (output contract)
+
+1. Your framing + assumptions + any contradictions found (Phase 0).
+2. The scored question rounds (Phase 1) — recommendation-first, options scored with their catch.
+3. A short summary of locked decisions, then the spec corpus location + the filename-state convention (Phase 2).
+4. The wave plan (what runs in parallel, concurrency cap, barriers) before launching, then per-wave verified results (Phase 3).
+5. Honest status: what's verified, what's `BLOCKED_`/operator-gated, what's next.
+
+## Guardrails
+
+- Do not write code, scaffold, or dispatch build agents before the Phase-1 decisions
+  are locked and (for non-trivial work) a spec exists.
+- Do not ask the human a question you could answer yourself; do not present an option
+  without its score and its catch.
+- Do not let a parallel wave exceed the agreed concurrency, share files across agents,
+  or let build agents commit concurrently.
+- Do not claim a wave is done without re-running the gate yourself.
+- Do not pad the spec corpus with thin files or invent a deadline/timeline the work didn't specify.
+
+## Reference routing
+
+| File | Read when |
+|---|---|
+| [`references/question-design.md`](references/question-design.md) | Designing the Phase-1 question rounds — the scoring rubric, recommendation-first/catch format, categorization, batching within tool limits, the ~10-round adaptation budget, and when to ask vs decide. |

--- a/skills/run-aligned-delivery/references/question-design.md
+++ b/skills/run-aligned-delivery/references/question-design.md
@@ -1,0 +1,114 @@
+# Question design — the scored, multi-round alignment method
+
+This is the Phase-1 playbook for `run-aligned-delivery`. The goal: surface every
+fork that is genuinely the human's to decide, present each so well that they
+choose correctly in seconds, and converge a large design across a handful of
+rounds. Use your environment's structured multi-choice question tool (e.g.
+`AskUserQuestion`).
+
+## What earns a question (ask vs decide)
+
+Ask the human ONLY for **user-only unknowns**:
+- a preference with no objectively-right answer (tone, naming scheme, which of two sound architectures),
+- a risk/effort tolerance (purity vs speed; big-bang vs incremental),
+- a constraint only they hold (budget, a credential, a deadline, a vendor mandate),
+- an irreversible or outward-facing call (data migration, a public contract, a deploy).
+
+Decide everything else yourself and state it: anything answerable from the code,
+the docs, a quick research pass, or a sensible convention. For low-stakes
+auto-decisions, name them in passing ("I'm defaulting X to Y — say the word to
+change") rather than spending a question card. **A question the agent could have
+answered is a wasted question.**
+
+## The option scoring rubric
+
+Every option in every question carries a **score out of 100** and a one-line
+trade-off, and the **recommended option comes first**, labeled "(Recommended)".
+
+Score each option against (weight to the situation):
+- **Fit** — how well it meets the actual goal/requirements.
+- **Risk / blast radius** — how badly it bites if wrong; reversibility.
+- **Cost** — effort, money, latency, operational burden.
+- **Maintainability / longevity** — does it age well; lock-in.
+
+Then **name the catch**: every option states its downside, not just its upside.
+A score with no catch is a sales pitch — the human can't trust it. Example option
+description: *"Score 84/100. Fastest path, matches the existing toolchain; but
+loses per-account isolation — mitigate with strict module boundaries."*
+
+If you genuinely recommend one option, make it first and say "(Recommended)". If
+it's a real toss-up, say so and score them close — don't fake a winner.
+
+## Categorize the decision space
+
+For a large initiative, group the forks into categories so the human sees the
+shape and you don't miss a dimension. Typical categories: runtime/toolchain,
+architecture/topology, data/storage, security/secrets, observability, testing,
+deploy/CI, repo/migration mechanics, API/contract, per-component specifics,
+sequencing/priorities. Up to ~20 categories for a sprawling initiative — fewer is
+fine. Announce the categories up front so the human knows the map.
+
+## Batching within tool limits
+
+`AskUserQuestion` (and most structured-choice tools) cap a card at **4 questions,
+4 options each**. Work with that, don't fight it:
+- **Group each card by theme** (one category, or closely related forks).
+- Surface the **top-scored options** (≤4); "Other" lets the human write in anything
+  you didn't list — so a fork with more than 4 viable options still works (list the
+  best 4, scored).
+- Keep an internal tally of the categories so successive cards cover the space
+  without repeats.
+- A 12-char header per question, a clear question ending in "?", scores + catch in
+  each option description, recommendation first.
+
+## The adaptation budget: up to ~10 rounds
+
+Treat **~10 rounds as the default adaptation budget** — a ceiling, not a target.
+Small initiatives converge in 2-3 rounds; a sprawling modernization may genuinely
+use ten-plus. The number signals "I've budgeted for depth; I'll stop when the
+design is locked, not when I hit a count."
+
+**Adaptation is the point, not the count.** After each batch:
+1. Record the answers as locked decisions.
+2. **Re-plan the remaining questions** against them. An answer often makes a
+   queued question obsolete, or splits one into two, or changes its options' scores.
+3. If an answer **pivots the architecture** (e.g. "actually, put it all on platform
+   X"), STOP the question flow, return to Phase 0: re-frame, run researchers on the
+   new constraint to get current ground truth, and **re-score the downstream
+   questions** before resuming. Never ask a question whose options were computed
+   against the old design.
+
+This adaptive re-planning — questions that bend to prior answers and to fresh
+research — is what makes the rounds feel like collaboration instead of a form.
+
+## Sequencing the rounds
+
+Front-load the **load-bearing, hardest-to-reverse** decisions (runtime, core
+architecture, the data model, the migration strategy) — they unblock or reshape
+the most downstream questions. Defer cosmetic and easily-reversible choices to
+later rounds (or auto-decide them). When a single answer would invalidate many
+queued questions, ask it first.
+
+## When research belongs mid-questioning
+
+If a fork depends on current external truth (a platform's capabilities, a library's
+state, a vendor limit) and you can't answer it from training, **run researchers
+before** presenting that card — so the options and scores reflect reality, not a
+guess. It's legitimate to pause the rounds, research, then return with corrected,
+re-scored options. Cite what you found when you present them.
+
+## Anti-patterns
+
+- Asking what you could discover (wasted question; erodes trust).
+- Options without scores or without their catch (the human can't choose well).
+- A "recommended" option that isn't actually best (dishonest scoring).
+- Asking 20 questions in one undifferentiated dump with no categories.
+- Ignoring an answer that pivoted the design and continuing with stale downstream
+  questions.
+- Padding to hit a round count, or stopping before the load-bearing forks are locked.
+
+## Exit
+
+The phase is done when **every load-bearing fork has a locked answer** — not when
+you hit a round number. Summarize the locked decisions and carry them verbatim into
+the spec corpus (Phase 2). Then, and only then, build.


### PR DESCRIPTION
New `run-` workflow skill for large/ambiguous initiatives (modernize, rewrite, migrate, greenfield, multi-component bug hunt). Three phases: ALIGN — scored, categorized, recommendation-first AskUserQuestion rounds (every option scored with its catch; ~10-round adaptation budget; re-plan on pivots; ask only user-only unknowns). SPEC — a living corpus where the filename prefix is the state (TODO_/WIP_/DONE_/BLOCKED_, via git mv), referencing source-of-truth code. ORCHESTRATE — dependency-ordered waves of parallel subagents, capped concurrency, model pin, verify-and-commit barriers (one lone verifier per wave so no git/lockfile races). Naming: run- per the 12-verb registry (plan-tradeoff was pulled, so the alignment soul lives inside this run- workflow). Flat layout + INSTALL.md + README row under the Run section (alphabetical) + count bump. One routed reference (question-design.md). validate-skills.py green (23 skills); SKILL.md 234 lines (<500); agent-agnostic, no foreign sibling-skill names.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/skills-by-yigitkonur/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `run-aligned-delivery` workflow skill for large or ambiguous initiatives with scored alignment, a filename-state spec corpus, and dependency-ordered orchestration. Registers the skill in the marketplace, adds the `yk-delivery` bundle, and updates docs and counts to 42.

- **New Features**
  - `run-aligned-delivery` — three phases:
    - ALIGN — scored multi-round questions via `AskUserQuestion` (recommendation-first; adapt up to ~10 rounds).
    - SPEC — filename-state corpus (`TODO_`/`WIP_`/`DONE_`/`BLOCKED_`, plus `00_` spine) referencing source-of-truth code.
    - ORCHESTRATE — dependency-ordered waves, capped concurrency, model pinning, single-agent verify-and-commit barriers.
  - Docs: added `references/question-design.md` and `INSTALL.md`.
  - README: new aligned-delivery section and bundle row; skill count updated to 42.
  - Marketplace: added `run-aligned-delivery` entry and `yk-delivery` bundle; updated `yk-everything` description to 42. Registered `yk-delivery` in `scripts/gen-marketplace.py`.

<sup>Written for commit 514a492087ff882696552054b1547b3231c521c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

