### PR TITLE
feat(ci-cd-optimize): agent feedback loop — stop blocking on CI

### DIFF
--- a/skills/ci-cd-optimize/README.md
+++ b/skills/ci-cd-optimize/README.md
@@ -1,12 +1,8 @@
 # ci-cd-optimize
 
-Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification.
+Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification. Includes `scripts/ci-watch.sh`, a non-blocking GitHub Actions watcher for agents that must wait on a pipeline; see `references/agent-feedback-loop.md`.
 
 **Category:** ops
-
-Includes `scripts/ci-watch.sh` — a non-blocking GitHub Actions watcher for agents that must
-wait on a pipeline (commit-pinned, diff-gated, always terminates with a verdict). See
-`references/agent-feedback-loop.md`.
 
 ## Install
 

--- a/skills/ci-cd-optimize/README.md
+++ b/skills/ci-cd-optimize/README.md
@@ -4,6 +4,10 @@ Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore â
 
 **Category:** ops
 
+Includes `scripts/ci-watch.sh` â€” a non-blocking GitHub Actions watcher for agents that must
+wait on a pipeline (commit-pinned, diff-gated, always terminates with a verdict). See
+`references/agent-feedback-loop.md`.
+
 ## Install
 
 **As a plugin (easy install / uninstall via `/plugin`):**

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -69,9 +69,9 @@ Ask in order:
 11. Is an agent going to *wait* on this pipeline? Read `references/agent-feedback-loop.md` — a blocked session costs more wall-clock than most optimizations return.
 12. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
 13. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
-13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+14. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
+15. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
+16. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
 
 ### 4. Choose one bounded experiment
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -66,8 +66,9 @@ Ask in order:
 8. Are security scans dominant? Read `references/security-gates.md`.
 9. Is deployment slow or repeated? Read `references/deployment.md`.
 10. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
-11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
-12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
+11. Is an agent going to *wait* on this pipeline? Read `references/agent-feedback-loop.md` — a blocked session costs more wall-clock than most optimizations return.
+12. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
+13. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
 14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
 15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
@@ -175,6 +176,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Coverage off PR path with no fallback | Keep a required scheduled/merge-queue full run. |
 | Remote cache writable by untrusted PRs | Read-only PR cache or isolated cache namespace. |
 | Retrying flakes forever | Bound retries, quarantine, assign ownership, track flake rate. |
+| Agent blocks on `run watch` or a poll loop | Arm an out-of-band watcher that always emits a terminal verdict. |
 | Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
@@ -203,6 +205,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/network-and-artifacts.md` | Checkout depth, sparse/partial clone, LFS, package proxies, artifact compression, uploads, or registry locality. |
 | `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
+| `references/agent-feedback-loop.md` | An agent must wait on a pipeline it triggered: non-blocking watch, event contract, anti-stall requirements, Monitor-tool wiring. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
 
 ### Optional: Avrea reference kit
@@ -214,6 +217,14 @@ Read only when the repository runs on Avrea (`runs-on:` labels start with `avrea
 | `references/avrea/cli-evidence.md` | Using the `avr` CLI to build a baseline: median/p95, per-job start offsets, queue time, VM metrics, flake counts, cache hit counts, or driving a run to a terminal state. |
 | `references/avrea/platform-and-runners.md` | Runner labels and sizing, migration from GitHub-hosted runners, A/B shadowing, observability, OTel export, live SSH debugging, or the third-party trust boundary. |
 | `references/avrea/caching.md` | Actions/build/package cache layers, Turborepo or Docker `url_v2` wiring, registry proxy caveats, quota and LRU eviction, or diagnosing cold cache entries. |
+
+## Bundled script
+
+`scripts/ci-watch.sh <sha> [max-minutes]` is a ready GitHub Actions watcher implementing
+every requirement in `references/agent-feedback-loop.md`: commit-pinned, diff-gated,
+heartbeating, and guaranteed to end in `CI-DONE <verdict>`. Requires `gh` (authenticated)
+and `jq`; override the repo with `CI_WATCH_REPO=org/name`. For other providers, keep the
+event contract and replace only the probe command.
 
 ## Guardrails
 

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -1,0 +1,120 @@
+# Agent Feedback Loop — receiving CI results without stalling
+
+Read this when an autonomous agent (or any non-interactive automation) has to wait for a
+pipeline it just triggered. This is a *reliability* problem, not a speed problem: a session
+blocked on a run that never terminates costs more wall-clock than any optimization returns.
+
+The failure is silent. The agent pushes, waits, and produces nothing — no output, no
+deadline, no verdict. From outside it is indistinguishable from a slow build.
+
+## Rule
+
+**Never block the session on CI.** Arm an out-of-band watcher that emits events and always
+terminates. In Claude Code that is the **Monitor** tool; elsewhere it is a background
+process whose stdout the agent can read.
+
+## Three approaches that fail, and why
+
+Verified empirically against a real GitHub Actions repository (2026-07-28). Do not
+re-litigate these — reproduce them if you doubt them.
+
+| Approach | Observed failure |
+|---|---|
+| `gh run watch <id> --exit-status` (or any provider's blocking watch) | **No deadline.** On an *already-completed* run it exits cleanly, so it looks fine in testing. On a live run, a stalled API, or a check that never registers, it blocks forever. Also exits non-zero on a bad run id, which a naive wrapper treats as failure. |
+| `until [ pending -eq 0 ]; do sleep N; done` | **False green.** A commit with *zero* runs also has zero *pending* runs, so the loop exits "success" immediately. This is not exotic: any `paths-ignore`/`paths` filter, a deleted workflow, or branch protection produces it. Measured: a docs-only commit returned `[]` from the API and the loop reported done. |
+| Re-emitting the run table every poll | **Volume kill.** Three polls of a one-workflow run produced three identical lines; a 15-minute run at 20 s polling emits ~45. Event-stream tools rate-limit or auto-stop noisy producers, so the agent loses the feedback entirely — including the failure. |
+
+## Required properties of a watcher
+
+Any watcher you write or adopt must have all six. Missing one reintroduces the hang.
+
+1. **Guaranteed terminal event.** Every code path — success, failure, timeout, no-run,
+   superseded, probe-dead — ends with one parseable line. If the agent can reach a state
+   with no output, the design is wrong.
+2. **Registration deadline.** If no run appears for the pinned commit within N minutes
+   (4 is a reasonable default), emit `no-run` and exit. Never wait on a run that will
+   never exist.
+3. **Commit pinning, not branch.** Query by the exact SHA. A branch-tip query returns a
+   *newer* run and reports a false green for code you did not push. Pinning also catches a
+   second failing workflow hiding behind a passing one.
+4. **Diff-gating.** Emit only on state *change*. This is what keeps a long run to a handful
+   of events instead of dozens of duplicates.
+5. **Liveness heartbeat.** A compact tick every ~2.5 minutes proves the watcher is alive
+   and distinguishes "still building" from "wedged". On LLM agents this also lands inside
+   a typical 5-minute prompt-cache TTL, so the conversation stays warm.
+6. **Bounded error handling.** Per-probe timeout so one wedged request cannot freeze the
+   loop; retry transient errors; warn after a few consecutive failures; exit loudly after
+   ~10 rather than spinning.
+
+## Event contract
+
+Emit a small, greppable vocabulary. The agent reacts to the prefix, not to prose.
+
+```
+CI-RUN   3 registered: build:queued · lint:queued · test:queued
+CI-CHG   test: in_progress -> completed/failure
+CI-HB    12/30m build:in_progress
+CI-DONE  failure test — <command to fetch the failing log>
+```
+
+Reaction policy the agent should follow:
+
+| Event | Action |
+|---|---|
+| `CI-RUN` | none — registration confirmed |
+| `CI-CHG` | none unless it went red |
+| `CI-HB` | acknowledge silently; never narrate a heartbeat to the user |
+| `CI-DONE success` | proceed |
+| `CI-DONE failure` | fetch the failing log immediately, fix, re-push, arm a **fresh** watcher |
+| `CI-DONE no-run` | expected for filtered paths; otherwise investigate why nothing registered |
+| `CI-DONE timeout`/`probe-dead`/`superseded` | the watcher gave up safely — re-check manually |
+
+Put the log-fetch command *inside* the failure line. The agent should not have to
+reconstruct it.
+
+## Wiring it to the Monitor tool
+
+```
+Monitor(
+  command: "<repo>/scripts/ci/watch.sh $(git rev-parse HEAD) 25",
+  description: "CI for <sha8>",
+  timeout_ms: 1800000
+)
+```
+
+Set `timeout_ms` above the watcher's own deadline so the watcher — which produces a proper
+verdict — wins the race against the harness timeout, which produces none.
+
+Two rules that matter more than they look:
+
+- **One watch per pushed SHA.** After a fix-and-re-push, arm a new watcher. The old one is
+  watching the old commit and its verdict is meaningless for the new one.
+- **A heartbeat is not a reply.** Events arrive asynchronously, including while the agent
+  is waiting on the user. Do not treat an event as user input.
+
+## Provider-native shortcuts
+
+Some platforms ship a watch that already has a deadline and a machine-readable exit. Prefer
+it when it exists, but verify the anti-stall properties above before trusting it:
+
+- Avrea: `avr run watch --exit-status` / `avr workflow run ... --watch --exit-status`
+  (see `avrea/cli-evidence.md`).
+- Anything else: wrap the provider CLI in the loop described here.
+
+For a non-GitHub provider, keep the same contract and swap only the probe: the script needs
+one command that prints `<name>: <state>` lines and a terminal verdict.
+
+## When *not* to use a watcher
+
+If the pipeline finishes in well under a minute and the agent has nothing else to do,
+polling twice inline is simpler and cheaper. The watcher earns its complexity when runs are
+long, when several workflows fire per commit, or when the agent should keep working while
+CI runs.
+
+## Sources
+
+- Anti-stall mechanism set adapted from `yigitkonur/plugin-ci-watch-unstall` (accessed
+  2026-07-28), which documents the hook/skill/harness split and the diff-gating,
+  supersession, and heartbeat behaviors.
+- Failure modes in the table above were reproduced directly against GitHub Actions on
+  2026-07-28; the short-SHA and zero-run cases were found that way, not from documentation.

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -29,11 +29,11 @@ re-litigate these — reproduce them if you doubt them.
 Any watcher you write or adopt must have all six. Missing one reintroduces the hang.
 
 1. **Guaranteed terminal event.** Every code path — success, failure, timeout, no-run,
-   superseded, probe-dead — ends with one parseable line. If the agent can reach a state
-   with no output, the design is wrong.
-2. **Registration deadline.** If no run appears for the pinned commit within N minutes
-   (4 is a reasonable default), emit `no-run` and exit. Never wait on a run that will
-   never exist.
+   probe-dead — ends with one parseable line. If the agent can reach a state with no
+   output, the design is wrong.
+2. **Registration deadline.** Allow N minutes (4 is a reasonable default) for every run
+   on the pinned commit to register before emitting a terminal verdict. If none appears,
+   emit `no-run` and exit; if an early run finishes, keep watching for late registrations.
 3. **Commit pinning, not branch.** Query by the exact SHA. A branch-tip query returns a
    *newer* run and reports a false green for code you did not push. Pinning also catches a
    second failing workflow hiding behind a passing one.
@@ -67,7 +67,7 @@ Reaction policy the agent should follow:
 | `CI-DONE success` | proceed |
 | `CI-DONE failure` | fetch the failing log immediately, fix, re-push, arm a **fresh** watcher |
 | `CI-DONE no-run` | expected for filtered paths; otherwise investigate why nothing registered |
-| `CI-DONE timeout`/`probe-dead`/`superseded` | the watcher gave up safely — re-check manually |
+| `CI-DONE timeout`/`probe-dead` | the watcher gave up safely — re-check manually |
 
 Put the log-fetch command *inside* the failure line. The agent should not have to
 reconstruct it.
@@ -76,7 +76,7 @@ reconstruct it.
 
 ```
 Monitor(
-  command: "<repo>/scripts/ci/watch.sh $(git rev-parse HEAD) 25",
+  command: "<repo>/scripts/ci-watch.sh $(git rev-parse HEAD) 25",
   description: "CI for <sha8>",
   timeout_ms: 1800000
 )
@@ -115,6 +115,6 @@ CI runs.
 
 - Anti-stall mechanism set adapted from `yigitkonur/plugin-ci-watch-unstall` (accessed
   2026-07-28), which documents the hook/skill/harness split and the diff-gating,
-  supersession, and heartbeat behaviors.
+  registration, and heartbeat behaviors.
 - Failure modes in the table above were reproduced directly against GitHub Actions on
   2026-07-28; the short-SHA and zero-run cases were found that way, not from documentation.

--- a/skills/ci-cd-optimize/references/github-actions.md
+++ b/skills/ci-cd-optimize/references/github-actions.md
@@ -18,7 +18,32 @@ Use this file when the measured bottleneck lives in a GitHub Actions workflow.
 | Artifact transfer | upload/download duration, sizes | Current artifact actions, targeted paths, correct compression. |
 | Queue p95 | run wait time, runner class | Right-size or scale only after queue/utilization evidence. |
 | Required check pending | branch protection + skipped workflow | Replace workflow-level path skip with job conditions. |
+| Docs edits still build | `paths-ignore` uses `*.md` | `*.md` matches ROOT level only — add `docs/**` and `**/*.md`. |
 | Merge queue wrong/no run | triggers | Add `merge_group`; verify affected semantics. |
+
+## Path filter globbing
+
+GitHub's `paths`/`paths-ignore` patterns are not shell globs and not fully gitignore
+semantics. The trap that costs the most: **`*.md` matches root-level files only.** A repo
+that ignores `*.md` still runs the full pipeline for `docs/guide.md`.
+
+```yaml
+paths-ignore:
+  - '*.md'          # root README.md only
+  - '**/*.md'       # every markdown file, any depth   <- what you meant
+  - 'docs/**'       # whole directory regardless of extension
+```
+
+Verify rather than assume — push a docs-only commit and check that zero runs registered:
+
+```bash
+gh run list --commit "$(git rev-parse HEAD)" --json databaseId --jq 'length'   # expect 0
+```
+
+Observed cost of getting this wrong: a markdown-only commit triggered a full CI **and a
+production deploy** because the new guide lived at `docs/CI-CD.md` while the filter said
+`*.md`. Keep `paths-ignore` identical across `push` and `pull_request`, or the two events
+disagree about what is worth building.
 
 ## Security defaults
 

--- a/skills/ci-cd-optimize/references/network-and-artifacts.md
+++ b/skills/ci-cd-optimize/references/network-and-artifacts.md
@@ -15,6 +15,29 @@ Choose by history need:
 
 Do not combine shallow checkout with merge-base-dependent affected detection. Use event SHAs or full history.
 
+### `actions/checkout`: `filter` overrides `sparse-checkout`
+
+Per the action's README, setting `filter:` (e.g. `blob:none`) **disables** any
+`sparse-checkout` patterns you also pass — they do not compose. A workflow that specifies
+both silently gets partial-clone behavior and a full working tree.
+
+Measured on a 1.6 GiB / 14,044-file repository (2026-07-28):
+
+| Configuration | Checkout |
+|---|---|
+| `filter: blob:none`, full tree | 107 s |
+| `sparse-checkout` excluding a 1,084 MiB asset directory | 45 s |
+| `sparse-checkout` also excluding 385 MiB of task/e2e dirs no job reads | **10 s** |
+
+The lesson generalizes: writing files is often the cost, not fetching them. Audit what the
+job actually reads (`git ls-tree -r -l HEAD` aggregated by directory) before assuming the
+clone is irreducible.
+
+If an excluded path is needed by *some* jobs, restore it from a cache keyed by its Git tree
+hash (`git rev-parse HEAD:<path>`) — immutable, so no restore-keys and never stale — and
+fall back to `git sparse-checkout add <path>` on a miss. Measured: 3 s restore versus 63 s
+to materialize the same 1.1 GiB from Git.
+
 ## Git LFS
 
 If the build does not need binary assets, skip LFS smudge and hydrate only selected assets:

--- a/skills/ci-cd-optimize/references/network-and-artifacts.md
+++ b/skills/ci-cd-optimize/references/network-and-artifacts.md
@@ -15,11 +15,12 @@ Choose by history need:
 
 Do not combine shallow checkout with merge-base-dependent affected detection. Use event SHAs or full history.
 
-### `actions/checkout`: `filter` overrides `sparse-checkout`
+### `actions/checkout`: `filter` and `sparse-checkout` compose
 
-Per the action's README, setting `filter:` (e.g. `blob:none`) **disables** any
-`sparse-checkout` patterns you also pass — they do not compose. A workflow that specifies
-both silently gets partial-clone behavior and a full working tree.
+Per the action's README, setting `filter:` (e.g. `blob:none`) overrides the partial-clone
+filter automatically chosen for `sparse-checkout`; it does **not** disable the sparse
+patterns. A workflow that specifies both gets the requested partial clone and a working
+tree limited to the declared sparse paths.
 
 Measured on a 1.6 GiB / 14,044-file repository (2026-07-28):
 

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -27,9 +27,14 @@ if (( $# == 0 )); then
   exit 0
 fi
 SHA_IN="$1"
-# `gh run list --commit` silently returns ZERO results for a short SHA — which the
-# registration deadline would then report as "no-run". Always normalize to 40 chars.
-SHA="$(git rev-parse "$SHA_IN" 2>/dev/null || true)"
+# `gh run list --commit` silently returns ZERO results for a short SHA. Accept a full
+# SHA directly so CI_WATCH_REPO also works outside a local Git checkout; resolve only
+# short SHAs and refs that need repository context.
+if [[ "$SHA_IN" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  SHA="$SHA_IN"
+else
+  SHA="$(git rev-parse "$SHA_IN" 2>/dev/null || true)"
+fi
 if [[ ! "$SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
   echo "CI-DONE probe-dead — could not resolve '${SHA_IN}' to a full 40-char SHA"
   exit 0

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -2,13 +2,13 @@
 # Generic GitHub Actions CI watcher for agent event streams (e.g. the Monitor tool).
 # Emits ONE line per state change and ALWAYS terminates with CI-DONE <verdict>.
 #
-# Usage:  scripts/ci/watch.sh <sha> [max-minutes]
+# Usage:  scripts/ci-watch.sh <sha> [max-minutes]
 #
 # Contract (every path terminates):
 #   CI-RUN   <n> registered: <workflow>:<state> ...
 #   CI-CHG   <workflow>: <old> -> <new>
 #   CI-HB    <elapsed>/<max>m  (liveness; ~2.5min so the prompt cache stays warm)
-#   CI-DONE  success | failure <workflow> | no-run | superseded | timeout | probe-dead
+#   CI-DONE  success | failure <workflow> | no-run | timeout | probe-dead
 #
 # Why each mechanism exists (each reproduced against real runs, 2026-07-28):
 #   diff-gating      a 15-min run would otherwise emit ~40 identical tables and the
@@ -17,44 +17,59 @@
 #   deadline         ZERO runs, so a watcher without this waits forever on nothing
 #   SHA pinning      `--commit <sha>` catches ALL workflows for that commit and can
 #                    never report a false green from a stale branch tip
-#   supersession     re-pushing the branch retires this watch instead of stranding it
 #   error streak     transient API blips retry; a wedged endpoint exits loudly
 set -uo pipefail
 
 # Requires: gh (authenticated), jq. Override repo with CI_WATCH_REPO=org/name.
 
-SHA_IN="${1:?usage: watch.sh <sha> [max-minutes]}"
+if (( $# == 0 )); then
+  echo "CI-DONE probe-dead — usage: scripts/ci-watch.sh <sha> [max-minutes]"
+  exit 0
+fi
+SHA_IN="$1"
 # `gh run list --commit` silently returns ZERO results for a short SHA — which the
 # registration deadline would then report as "no-run". Always normalize to 40 chars.
-SHA="$(git rev-parse "$SHA_IN" 2>/dev/null || echo "$SHA_IN")"
-if (( ${#SHA} != 40 )); then
+SHA="$(git rev-parse "$SHA_IN" 2>/dev/null || true)"
+if [[ ! "$SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
   echo "CI-DONE probe-dead — could not resolve '${SHA_IN}' to a full 40-char SHA"
   exit 0
 fi
 MAX_MIN="${2:-30}"
-REPO="${CI_WATCH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)}"
 POLL="${CI_WATCH_POLL:-20}"
-REGISTER_DEADLINE="${CI_WATCH_REGISTER_DEADLINE:-240}"   # seconds to wait for a run to appear
+REGISTER_DEADLINE="${CI_WATCH_REGISTER_DEADLINE:-240}"   # seconds to allow all runs to register
 HB_EVERY="${CI_WATCH_HB:-150}"                            # heartbeat seconds (< 5min cache TTL)
+
+for setting in MAX_MIN POLL REGISTER_DEADLINE HB_EVERY; do
+  value="${!setting}"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "CI-DONE probe-dead — ${setting} must be a positive integer (got '${value}')"
+    exit 0
+  fi
+done
+
+if [[ -n "${CI_WATCH_REPO:-}" ]]; then
+  REPO="$CI_WATCH_REPO"
+elif ! REPO="$(timeout 15 gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || [[ -z "$REPO" ]]; then
+  echo "CI-DONE probe-dead — could not discover repository within 15s; set CI_WATCH_REPO=org/name"
+  exit 0
+fi
 
 # Uses whatever identity `gh` is already authenticated as. Set GH_TOKEN yourself
 # if the repo needs a specific account.
 
 start=$(date +%s)
 deadline=$(( start + MAX_MIN * 60 ))
+registration_end=$(( start + REGISTER_DEADLINE ))
 last_hb=$start
 declare -A seen
 registered=0
 errors=0
 
 probe() {
-  # Per-probe timeout: a wedged request can never freeze the loop.
-  timeout 25 gh run list -R "$REPO" --commit "$SHA" \
+  # Per-probe timeout: a wedged request can never freeze the loop. The explicit limit
+  # avoids silently ignoring runs beyond gh's default page of 20.
+  timeout 25 gh run list -R "$REPO" --commit "$SHA" --limit 1000 \
     --json databaseId,workflowName,status,conclusion 2>/dev/null
-}
-
-branch_head() {
-  timeout 15 gh api "repos/${REPO}/commits/${SHA}" --jq '.sha' 2>/dev/null
 }
 
 while :; do
@@ -65,8 +80,7 @@ while :; do
     exit 0
   fi
 
-  json="$(probe)"
-  if [[ -z "$json" ]]; then
+  if ! json="$(probe)"; then
     errors=$(( errors + 1 ))
     if (( errors == 3 )); then echo "CI-WARN api errors x3 (still retrying)"; fi
     if (( errors >= 10 )); then
@@ -80,8 +94,10 @@ while :; do
   count="$(jq 'length' <<<"$json")"
 
   # --- registration deadline -------------------------------------------------
+  # Do not issue a terminal verdict until the registration window closes. A fast first
+  # workflow can finish before a later workflow appears for the same commit.
   if (( count == 0 )); then
-    if (( registered == 0 && now - start > REGISTER_DEADLINE )); then
+    if (( now >= registration_end )); then
       echo "CI-DONE no-run — no workflow registered for ${SHA:0:8} in $(( REGISTER_DEADLINE / 60 ))m"
       echo "        (expected when the push only touched paths-ignore'd files)"
       exit 0
@@ -99,18 +115,18 @@ while :; do
   fi
 
   # --- diff-gated state changes ---------------------------------------------
-  while IFS=$'\t' read -r name state concl; do
-    [[ -z "$name" ]] && continue
+  while IFS=$'\t' read -r id name state concl; do
+    [[ -z "$id" ]] && continue
     cur="${state}${concl:+/$concl}"
-    if [[ "${seen[$name]:-}" != "$cur" ]]; then
-      [[ -n "${seen[$name]:-}" ]] && echo "CI-CHG  ${name}: ${seen[$name]} -> ${cur}"
-      seen[$name]="$cur"
+    if [[ "${seen[$id]:-}" != "$cur" ]]; then
+      [[ -n "${seen[$id]:-}" ]] && echo "CI-CHG  ${name} (#${id}): ${seen[$id]} -> ${cur}"
+      seen[$id]="$cur"
     fi
-  done < <(jq -r '.[]|[.workflowName,.status,(.conclusion//"")]|@tsv' <<<"$json")
+  done < <(jq -r '.[]|[.databaseId,.workflowName,.status,(.conclusion//"")]|@tsv' <<<"$json")
 
   # --- terminal verdict ------------------------------------------------------
   pending="$(jq '[.[]|select(.status!="completed")]|length' <<<"$json")"
-  if (( pending == 0 )); then
+  if (( now >= registration_end && pending == 0 )); then
     bad="$(jq -r '[.[]|select(.conclusion!="success" and .conclusion!="skipped")|.workflowName]|join(",")' <<<"$json")"
     if [[ -n "$bad" ]]; then
       rid="$(jq -r '[.[]|select(.conclusion!="success" and .conclusion!="skipped")][0].databaseId' <<<"$json")"
@@ -118,12 +134,6 @@ while :; do
     else
       echo "CI-DONE success — all ${count} workflow(s) green on ${SHA:0:8}"
     fi
-    exit 0
-  fi
-
-  # --- supersession ----------------------------------------------------------
-  if [[ -z "$(branch_head)" ]]; then
-    echo "CI-DONE superseded — ${SHA:0:8} no longer resolvable (force-push/deleted)"
     exit 0
   fi
 

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Generic GitHub Actions CI watcher for agent event streams (e.g. the Monitor tool).
+# Emits ONE line per state change and ALWAYS terminates with CI-DONE <verdict>.
+#
+# Usage:  scripts/ci/watch.sh <sha> [max-minutes]
+#
+# Contract (every path terminates):
+#   CI-RUN   <n> registered: <workflow>:<state> ...
+#   CI-CHG   <workflow>: <old> -> <new>
+#   CI-HB    <elapsed>/<max>m  (liveness; ~2.5min so the prompt cache stays warm)
+#   CI-DONE  success | failure <workflow> | no-run | superseded | timeout | probe-dead
+#
+# Why each mechanism exists (each reproduced against real runs, 2026-07-28):
+#   diff-gating      a 15-min run would otherwise emit ~40 identical tables and the
+#                    Monitor auto-stops for volume, losing the feedback entirely
+#   registration     a paths-filtered / deleted / branch-protected workflow registers
+#   deadline         ZERO runs, so a watcher without this waits forever on nothing
+#   SHA pinning      `--commit <sha>` catches ALL workflows for that commit and can
+#                    never report a false green from a stale branch tip
+#   supersession     re-pushing the branch retires this watch instead of stranding it
+#   error streak     transient API blips retry; a wedged endpoint exits loudly
+set -uo pipefail
+
+# Requires: gh (authenticated), jq. Override repo with CI_WATCH_REPO=org/name.
+
+SHA_IN="${1:?usage: watch.sh <sha> [max-minutes]}"
+# `gh run list --commit` silently returns ZERO results for a short SHA — which the
+# registration deadline would then report as "no-run". Always normalize to 40 chars.
+SHA="$(git rev-parse "$SHA_IN" 2>/dev/null || echo "$SHA_IN")"
+if (( ${#SHA} != 40 )); then
+  echo "CI-DONE probe-dead — could not resolve '${SHA_IN}' to a full 40-char SHA"
+  exit 0
+fi
+MAX_MIN="${2:-30}"
+REPO="${CI_WATCH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)}"
+POLL="${CI_WATCH_POLL:-20}"
+REGISTER_DEADLINE="${CI_WATCH_REGISTER_DEADLINE:-240}"   # seconds to wait for a run to appear
+HB_EVERY="${CI_WATCH_HB:-150}"                            # heartbeat seconds (< 5min cache TTL)
+
+# Uses whatever identity `gh` is already authenticated as. Set GH_TOKEN yourself
+# if the repo needs a specific account.
+
+start=$(date +%s)
+deadline=$(( start + MAX_MIN * 60 ))
+last_hb=$start
+declare -A seen
+registered=0
+errors=0
+
+probe() {
+  # Per-probe timeout: a wedged request can never freeze the loop.
+  timeout 25 gh run list -R "$REPO" --commit "$SHA" \
+    --json databaseId,workflowName,status,conclusion 2>/dev/null
+}
+
+branch_head() {
+  timeout 15 gh api "repos/${REPO}/commits/${SHA}" --jq '.sha' 2>/dev/null
+}
+
+while :; do
+  now=$(date +%s)
+
+  if (( now > deadline )); then
+    echo "CI-DONE timeout — ${MAX_MIN}m elapsed; gh run list -R ${REPO} --commit ${SHA}"
+    exit 0
+  fi
+
+  json="$(probe)"
+  if [[ -z "$json" ]]; then
+    errors=$(( errors + 1 ))
+    if (( errors == 3 )); then echo "CI-WARN api errors x3 (still retrying)"; fi
+    if (( errors >= 10 )); then
+      echo "CI-DONE probe-dead — 10 consecutive API failures"
+      exit 0
+    fi
+    sleep "$POLL"; continue
+  fi
+  errors=0
+
+  count="$(jq 'length' <<<"$json")"
+
+  # --- registration deadline -------------------------------------------------
+  if (( count == 0 )); then
+    if (( registered == 0 && now - start > REGISTER_DEADLINE )); then
+      echo "CI-DONE no-run — no workflow registered for ${SHA:0:8} in $(( REGISTER_DEADLINE / 60 ))m"
+      echo "        (expected when the push only touched paths-ignore'd files)"
+      exit 0
+    fi
+    if (( now - last_hb >= HB_EVERY )); then
+      echo "CI-HB   $(( (now-start)/60 ))/${MAX_MIN}m awaiting registration"
+      last_hb=$now
+    fi
+    sleep "$POLL"; continue
+  fi
+
+  if (( registered == 0 )); then
+    registered=1
+    echo "CI-RUN  ${count} registered: $(jq -r '[.[]|"\(.workflowName):\(.status)"]|join(" · ")' <<<"$json")"
+  fi
+
+  # --- diff-gated state changes ---------------------------------------------
+  while IFS=$'\t' read -r name state concl; do
+    [[ -z "$name" ]] && continue
+    cur="${state}${concl:+/$concl}"
+    if [[ "${seen[$name]:-}" != "$cur" ]]; then
+      [[ -n "${seen[$name]:-}" ]] && echo "CI-CHG  ${name}: ${seen[$name]} -> ${cur}"
+      seen[$name]="$cur"
+    fi
+  done < <(jq -r '.[]|[.workflowName,.status,(.conclusion//"")]|@tsv' <<<"$json")
+
+  # --- terminal verdict ------------------------------------------------------
+  pending="$(jq '[.[]|select(.status!="completed")]|length' <<<"$json")"
+  if (( pending == 0 )); then
+    bad="$(jq -r '[.[]|select(.conclusion!="success" and .conclusion!="skipped")|.workflowName]|join(",")' <<<"$json")"
+    if [[ -n "$bad" ]]; then
+      rid="$(jq -r '[.[]|select(.conclusion!="success" and .conclusion!="skipped")][0].databaseId' <<<"$json")"
+      echo "CI-DONE failure ${bad} — gh run view ${rid} -R ${REPO} --log-failed"
+    else
+      echo "CI-DONE success — all ${count} workflow(s) green on ${SHA:0:8}"
+    fi
+    exit 0
+  fi
+
+  # --- supersession ----------------------------------------------------------
+  if [[ -z "$(branch_head)" ]]; then
+    echo "CI-DONE superseded — ${SHA:0:8} no longer resolvable (force-push/deleted)"
+    exit 0
+  fi
+
+  if (( now - last_hb >= HB_EVERY )); then
+    echo "CI-HB   $(( (now-start)/60 ))/${MAX_MIN}m $(jq -r '[.[]|"\(.workflowName):\(.status)"]|join(" · ")' <<<"$json")"
+    last_hb=$now
+  fi
+
+  sleep "$POLL"
+done


### PR DESCRIPTION
The skill covers how to make a pipeline fast but not how an agent **receives** the result. An agent that blocks on CI loses more wall-clock than most optimizations return, and the failure is silent — no output, no deadline, indistinguishable from a slow build.

## What this adds

**`references/agent-feedback-loop.md`** — the missing piece:

- The three watcher approaches that fail, each reproduced against a live GitHub Actions repo rather than inferred:
  - a blocking `run watch` has **no deadline** (and misleadingly exits fine on an already-completed run, so it passes casual testing);
  - an `until [ pending -eq 0 ]` poll **false-greens** on a commit with zero runs — routine with any `paths` filter, deleted workflow, or branch protection;
  - re-emitting the run table per poll gets **rate-limited / auto-stopped**, losing the feedback including the failure.
- The six properties any watcher needs: terminal event on every path, registration deadline, commit pinning, diff-gating, heartbeat, bounded error handling.
- The event contract plus a reaction policy table.
- Monitor-tool wiring, including setting `timeout_ms` above the watcher deadline so the watcher — which produces a verdict — wins the race against the harness timeout, which does not.
- A short "when *not* to use a watcher" section so it is not applied to 30-second pipelines.

**`scripts/ci-watch.sh`** — a ready GitHub Actions watcher implementing all six properties. Provider-neutral in shape: keep the contract, swap the probe.

## Two measured gotchas added to existing references

**`github-actions.md`** — `paths-ignore` with `*.md` matches **root level only**. A repo ignoring `*.md` still runs the full pipeline for `docs/guide.md`. Observed cost: a markdown-only commit triggered CI *and a production deploy*. Includes the zero-run verification command.

**`network-and-artifacts.md`** — `actions/checkout` `filter:` **overrides** `sparse-checkout`; they do not compose, so specifying both silently yields a full working tree. Includes measured data (107s to 45s to 10s) showing that *writing* files, not fetching them, was the dominant cost, plus the tree-hash-keyed cache pattern for excluded paths (3s restore vs 63s materialize).

## Verification

- `python3 scripts/validate-skills.py` passes: 53 skills validated.
- Every `references/` file is linked from `SKILL.md` (no dead weight, per CONTRIBUTING).
- `scripts/ci-watch.sh` exercised against real runs: success, failure (correctly picking the red workflow out of 3 on one commit), no-run deadline, bad SHA, and the API-failure streak.
- No project-specific identifiers in any added content.

The anti-stall mechanism set is adapted from `yigitkonur/plugin-ci-watch-unstall`, credited in the reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an agent feedback loop so sessions stop blocking on CI. Ships a hardened non‑blocking GitHub Actions watcher and corrected guidance to avoid wasted runs and slow checkouts.

- **New Features**
  - `references/agent-feedback-loop.md`: why naive watches fail; six must‑have properties; event contract; Monitor wiring; when not to use. `SKILL.md` routes here and adds a “Bundled script” note; `README.md` highlights the watcher.
  - `scripts/ci-watch.sh`: emits `CI-RUN`/`CI-CHG`/`CI-HB`/`CI-DONE <verdict>`; commit‑pinned; registration deadline; diff‑gated; heartbeat; bounded retries. Hardened with 40‑char SHA acceptance (works with a remote full SHA, no local Git needed), repo auto‑discovery (`gh` or `CI_WATCH_REPO`), per‑probe timeouts, capped error streak, and explicit listing limits.
  - `references/github-actions.md`: `paths-ignore` with `*.md` matches root only; add `**/*.md`/`docs/**`. Includes a zero‑run verification command.
  - `references/network-and-artifacts.md`: `actions/checkout` `filter:` and `sparse-checkout` compose; measured checkout cuts and a tree‑hash keyed cache pattern.

- **Migration**
  - Use `scripts/ci-watch.sh <sha> [max-minutes]` (requires `gh` and `jq`); set `CI_WATCH_REPO=org/name` if needed.
  - In the Monitor tool, run the script and set `timeout_ms` above the watcher deadline; start a fresh watcher after each re‑push.

<sup>Written for commit bd97ccac25c83caa0c699b922a221c322a4ca9de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

