### PR TITLE
feat(ci-cd-optimize): comprehensive CI/CD feedback-loop upgrade

### DIFF
--- a/skills/ci-cd-optimize/README.md
+++ b/skills/ci-cd-optimize/README.md
@@ -4,6 +4,8 @@ Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore â
 
 **Category:** ops
 
+Bundles `scripts/ci-watch.sh` â€” a non-blocking, commit-pinned GitHub Actions watcher for agents that must wait on a pipeline without hanging (always ends in a terminal verdict). See `references/agent-feedback-loop.md`.
+
 ## Install
 
 **As a plugin (easy install / uninstall via `/plugin`):**

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -57,7 +57,7 @@ Apply the performance order before adding compute:
 Ask in order:
 
 1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
+2. Is queue time the dominant p95 contributor, or has job count already crossed a concurrency ceiling? Read `references/capacity-and-contention.md` first, then `references/runners-and-autoscaling.md`.
 3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
 4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
 5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
@@ -98,6 +98,10 @@ Never claim an optimization if it does any of these:
 - makes change detection use an unverified merge base.
 
 Use full validation as the safe fallback whenever changed files, merge base, cache correctness, dependency graph completeness, or security scope cannot be proven. When a proposed change is near any of these lines, check it against `references/effectiveness-contract.md` before recommending it.
+
+### 5b. Wait for the result without blocking
+
+When an agent triggers the run and consumes the verdict — the common case for autonomous work and CI-only verification — never block the session on it. Arm a bounded, commit-pinned watcher that emits state changes and always ends in a terminal verdict, then keep working. The bundled `scripts/ci-watch.sh` implements the contract for GitHub Actions; `references/agent-feedback-loop.md` gives the contract, the two patterns that fail (TTY-shaped `run watch`, success-only polling), and how to wire it to a streaming-notification facility such as the Monitor tool.
 
 ### 6. Verify after the change
 
@@ -180,7 +184,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Agent blocks in the foreground waiting for CI | Arm a non-blocking watcher on the pinned SHA and keep working. |
 | Watcher greps only for the success marker | A red run looks identical to a running one — emit every terminal state. |
 | Piping a provider `watch` subcommand into a line consumer | Those redraw a TTY block on an interval; pipe it through `cat -A` once to confirm before adopting. |
-| Treating a concurrency auto-cancel as failure | `cancelled` + a newer identifier means superseded, not red. |
+| Treating a concurrency auto-cancel as failure | If the only non-green conclusions are `cancelled`, it is superseded/cancelled, never red. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
@@ -192,6 +196,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, or proving a result. |
 | `references/effectiveness-contract.md` | Deciding whether a proposed speedup weakens validation, security, or artifact identity. |
 | `references/agent-feedback-loop.md` | An agent or long-running session must learn a CI verdict without blocking, a watcher hangs or floods, or CI is the only verification surface. |
+| `references/capacity-and-contention.md` | Queue share is high, parallelism stopped paying off, before splitting or fanning out jobs, or when A/B arms ran under different pool load. |
 | `references/caching.md` | Any dependency/build cache design, restore-key, cache-hit, cache-poisoning, or transfer-cost question. |
 | `references/change-based-ci.md` | Path filters, affected commands, merge queues, merge-base correctness, or full-run fallback rules. |
 | `references/github-actions.md` | GitHub Actions workflows, caches, concurrency, artifacts, merge queues, required checks, or larger runners. |
@@ -220,6 +225,10 @@ Read only when the repository runs on Avrea (`runs-on:` labels start with `avrea
 | `references/avrea/cli-evidence.md` | Using the `avr` CLI to build a baseline: median/p95, per-job start offsets, queue time, VM metrics, flake counts, cache hit counts, or driving a run to a terminal state. |
 | `references/avrea/platform-and-runners.md` | Runner labels and sizing, migration from GitHub-hosted runners, A/B shadowing, observability, OTel export, live SSH debugging, or the third-party trust boundary. |
 | `references/avrea/caching.md` | Actions/build/package cache layers, Turborepo or Docker `url_v2` wiring, registry proxy caveats, quota and LRU eviction, or diagnosing cold cache entries. |
+
+## Bundled script
+
+`scripts/ci-watch.sh <pinned-sha> [branch] [deadline-min]` is a ready GitHub Actions watcher implementing every requirement in `references/agent-feedback-loop.md`: commit-pinned across all workflows, diff-gated, heartbeating under a typical prompt-cache TTL, and guaranteed to end in `CI-DONE <verdict>` (success, failure, timeout, no-run, superseded, probe-dead). Requires authenticated `gh` and `jq`; set `CI_WATCH_REPO=org/name` or run inside the repo. For another provider, keep the event contract and replace only the probe command.
 
 ## Guardrails
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -68,9 +68,10 @@ Ask in order:
 10. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
 11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
 12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
-13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+13. Is the consumer of these results an agent or unattended session that must not block on CI? Read `references/agent-feedback-loop.md`.
+14. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
+15. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
+16. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -176,6 +177,10 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Remote cache writable by untrusted PRs | Read-only PR cache or isolated cache namespace. |
 | Retrying flakes forever | Bound retries, quarantine, assign ownership, track flake rate. |
 | Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
+| Agent blocks in the foreground waiting for CI | Arm a non-blocking watcher on the pinned SHA and keep working. |
+| Watcher greps only for the success marker | A red run looks identical to a running one — emit every terminal state. |
+| Piping a provider `watch` subcommand into a line consumer | Those redraw a TTY block on an interval; pipe it through `cat -A` once to confirm before adopting. |
+| Treating a concurrency auto-cancel as failure | `cancelled` + a newer identifier means superseded, not red. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
@@ -186,6 +191,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 |---|---|
 | `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, or proving a result. |
 | `references/effectiveness-contract.md` | Deciding whether a proposed speedup weakens validation, security, or artifact identity. |
+| `references/agent-feedback-loop.md` | An agent or long-running session must learn a CI verdict without blocking, a watcher hangs or floods, or CI is the only verification surface. |
 | `references/caching.md` | Any dependency/build cache design, restore-key, cache-hit, cache-poisoning, or transfer-cost question. |
 | `references/change-based-ci.md` | Path filters, affected commands, merge queues, merge-base correctness, or full-run fallback rules. |
 | `references/github-actions.md` | GitHub Actions workflows, caches, concurrency, artifacts, merge queues, required checks, or larger runners. |

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -228,7 +228,7 @@ Read only when the repository runs on Avrea (`runs-on:` labels start with `avrea
 
 ## Bundled script
 
-`scripts/ci-watch.sh <pinned-sha> [branch] [deadline-min]` is a ready GitHub Actions watcher implementing every requirement in `references/agent-feedback-loop.md`: commit-pinned across all workflows, diff-gated, heartbeating under a typical prompt-cache TTL, and guaranteed to end in `CI-DONE <verdict>` (success, failure, timeout, no-run, superseded, probe-dead). Requires authenticated `gh` and `jq`; set `CI_WATCH_REPO=org/name` or run inside the repo. For another provider, keep the event contract and replace only the probe command.
+`scripts/ci-watch.sh <pinned-sha> [branch] [deadline-min]` is a ready GitHub Actions watcher implementing every requirement in `references/agent-feedback-loop.md`: commit-pinned across all workflows, diff-gated, heartbeating under a typical prompt-cache TTL, and guaranteed to end in `CI-DONE <verdict>` (success, failure, timeout, no-run, superseded, cancelled, probe-dead). Requires authenticated `gh` and `jq`; set `CI_WATCH_REPO=org/name` or run inside the repo. For another provider, keep the event contract and replace only the probe command.
 
 ## Guardrails
 

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -73,7 +73,7 @@ Attach the watcher to a background/event-streaming facility rather than the fore
 Monitor(
   command: "bash scripts/ci-watch.sh <pinned-sha> <branch> 15",
   description: "CI for <branch> <short-sha>",
-  timeout_ms: 900000
+  timeout_ms: 960000
 )
 ```
 

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -1,0 +1,120 @@
+# Agent feedback loop — non-blocking CI watching
+
+Read when an autonomous agent (or any long-running session) must learn a CI verdict without blocking, when a watcher hangs or floods, or when CI is the only place verification runs.
+
+The problem this solves: an agent pushes, then stops. It either blocks in the foreground or improvises a polling loop. Both waste the entire pipeline duration, and the improvised loop is usually silent on exactly the outcome that matters. When CI is the only verification surface — no local test runs, several parallel worktrees — this loop *is* the development loop.
+
+## The contract a watcher must satisfy
+
+A watcher is trustworthy only if all of these hold:
+
+1. **Terminates on every path.** Success, failure, timeout, nothing-registered, probe-dead, superseded. Silence past the deadline must be structurally impossible.
+2. **Reports failure at least as loudly as success.** A success-only filter is the single most common defect.
+3. **Pinned to an immutable identifier** — a commit SHA, build id, or deployment id captured *before* arming. Never a moving ref like a branch tip.
+4. **Covers every unit** that can fail for that identifier, not just the first one found.
+5. **Emits on change, not on poll.** One notification per state transition; a quiet watcher means "still running," not "stuck."
+6. **Bounded.** A deadline shorter than the session, with the deadline reported as its own verdict.
+
+If a proposed watcher fails any of these, it will eventually strand the agent.
+
+## Two patterns that fail — verify before adopting either
+
+**Provider "watch" subcommands are often TTY-shaped.** Many CLIs (`gh run watch` is the common case) redraw a status block on an interval rather than emitting lines. Piped into a line-oriented consumer, every redraw becomes an event; a 20-minute run produces hundreds of duplicate notifications and the watch is rate-limited away. Several also follow a single run, so a second failing workflow for the same commit is never seen.
+
+Check before trusting one:
+
+```bash
+timeout 25 <provider-watch-cmd> | cat -A | head -20
+```
+
+Repeated identical blocks, or ANSI cursor-movement escapes, mean it is a rendering loop and unsuitable. Some CLIs also suppress their completion summary when stdout is not a terminal, so the finish event never arrives at all.
+
+**Success-only polling is silent on red.** This shape appears constantly:
+
+```bash
+until <status-cmd> | grep -q success; do sleep 30; done   # DO NOT USE
+```
+
+A failed run and a running run both produce no match, so the loop never exits and never prints. Demonstrate it in one line:
+
+```bash
+echo failure | grep -q success && echo exits || echo "no output — loop runs forever"
+```
+
+The same defect appears as `--exit-status` flags that return early, and as filters listing only the success marker.
+
+## The shape that works
+
+Poll a pinned identifier on an interval, diff the state against the previous poll, emit only transitions, and guarantee a terminal line.
+
+```
+EVENT            MEANING                                   AGENT ACTION
+RUN  <n units>   units registered for this identifier      none — keep working
+CHG  <unit>      a unit changed state                      act on the first failure
+HB   <m/deadline> liveness tick, carries state when stalled acknowledge silently
+DONE <verdict>   terminal: success|failure|timeout|        decide and stop watching
+                 no-run|superseded|probe-dead
+```
+
+Rules that make it reliable:
+
+- **Registration deadline.** If nothing registers within a few minutes, exit `DONE no-run` rather than watching a run that will never exist. Causes: path filters excluded the diff, the workflow is disabled, the identifier is wrong, or the push did not land.
+- **Heartbeat interval.** Emit liveness on a quiet interval so the caller can distinguish "waiting" from "wedged." Where the consuming model has a prompt-cache TTL, keep the heartbeat comfortably under it so a long queue does not force a cold re-read of context.
+- **Per-probe timeout.** Cap each probe call so one wedged request cannot freeze the loop.
+- **Error streaks, not error exits.** Transient API failures are normal; retry quietly, warn once after a few consecutive failures, exit `DONE probe-dead` after ~10.
+- **Distinguish cancellation from failure.** A superseding push commonly makes a concurrency group auto-cancel the older run. `cancelled` is *not* red. When every conclusion is in `{success, skipped, neutral, cancelled}` **and** a newer identifier exists, report `DONE superseded` and let the caller arm a fresh watch. Reporting that as failure sends the agent debugging a phantom break — a mistake worth guarding against explicitly, because it looks exactly like a real red.
+- **Aggregate across all runs for the identifier.** After a fast-forward, one commit can carry both a branch run and a default-branch run. A SHA-pinned watch spans both, which is usually correct — the default-branch run is the one that deploys.
+
+## Arming it
+
+Attach the watcher to a background/event-streaming facility rather than the foreground. In Claude Code this is the `Monitor` tool, whose contract is: each stdout line becomes a notification, and process exit ends the watch.
+
+```
+Monitor(
+  command: "bash scripts/ci-watch.sh <pinned-sha> <branch> 15",
+  description: "CI for <branch> <short-sha>",
+  timeout_ms: 900000
+)
+```
+
+Guidance that generalizes to any such facility:
+
+- **Match the tool to the notification count.** One notification ("tell me when it finishes") is better served by a backgrounded command that exits on the condition. Per-transition streaming needs the event-stream tool. Never point an unbounded renderer at a stream tool.
+- **Every pipe stage must flush per line.** `grep --line-buffered`, `awk { fflush() }`. `head -N` cannot flush and will withhold output until N matches accumulate.
+- **Widen the filter to every terminal state.** If the process crashed right now, would the filter emit anything? If not, it is a success-only filter wearing a disguise.
+- **Set the tool timeout above the watcher's own deadline** so the watcher reports its verdict rather than being killed mid-sentence.
+- **One watch per pinned identifier.** Re-pushing supersedes; arm a fresh watch rather than reusing the old one.
+
+## Validating a watcher before trusting it
+
+Prove each exit path against real runs. A watcher that has only been observed succeeding is untested.
+
+| Scenario | How to produce it | Expected |
+|---|---|---|
+| Green lifecycle | ordinary passing push | `RUN` → `CHG` → `DONE success`, few notifications total |
+| **Real failure** | push a deliberate compile/type error, then revert | `CHG` red mid-run, `DONE failure` + the log command, non-zero exit |
+| Nothing registers | watch a bogus or path-filtered SHA | `DONE no-run` before the deadline |
+| Deadline | set the deadline to ~0 against a live run | `DONE timeout`, never silence |
+| Superseded | push twice quickly | `DONE superseded`, **not** failure |
+| Long queue | watch during contention | periodic `HB` carrying state |
+
+The failure test is the one that matters; run it deliberately rather than waiting for a real break. Confirm the remediation command the watcher prints actually surfaces the error, and confirm the exit code is non-zero (beware `| head` masking it — check `${PIPESTATUS[0]}` or run unpiped).
+
+## Reacting to events
+
+- `RUN` / `HB` — acknowledge silently and keep working. Never restate a heartbeat as progress.
+- First `CHG` to a failed state — act immediately. Pull the failed logs, start fixing. On a long pipeline this is the whole benefit: a failure surfaced at minute 3 of a 25-minute run is a ~20-minute head start.
+- `DONE failure` — read the logs before changing anything; the verdict names the unit, not the cause.
+- `DONE no-run` — decide whether that is expected (docs-only change under a path filter) or a broken trigger. Do not treat it as green by default.
+- `DONE timeout` — inspect the run and act; never re-arm blindly into another deadline.
+
+A verdict is evidence only for the identifier it names. Confirm the run's head SHA equals what you pushed, and that your change is in that run's diff, before calling it verified. See `effectiveness-contract.md` for why a green on a stale or empty diff is not proof.
+
+## When CI is the only verification surface
+
+Teams that push heavy work off the developer machine — several agents, several worktrees, limited local RAM — depend on this loop entirely. Additions that pay for themselves:
+
+- **A dispatchable targeted workflow** (typecheck-only, build-only, affected-only) so an agent can ask one narrow question instead of running the whole gate.
+- **A separate non-gating suite** for checks that should be visible but must not block shipping. Prefer a separate workflow over a broad `continue-on-error`, which reports green while hiding a real failure.
+- **Documented event semantics** in the repository's agent instructions, so every agent reacts the same way rather than improvising.
+- **A guard test pinning the watcher's invariants** — that each terminal verdict string exists and the identifier is pinned — so the property is enforced rather than assumed.

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -52,8 +52,8 @@ EVENT            MEANING                                   AGENT ACTION
 RUN  <n units>   units registered for this identifier      none — keep working
 CHG  <unit>      a unit changed state                      act on the first failure
 HB   <m/deadline> liveness tick, carries state when stalled acknowledge silently
-DONE <verdict>   terminal: success|failure|timeout|        decide and stop watching
-                 no-run|superseded|probe-dead
+DONE <verdict>   terminal: success|failure|timeout|no-run|  decide and stop watching
+                 superseded|cancelled|probe-dead
 ```
 
 Rules that make it reliable:
@@ -62,7 +62,7 @@ Rules that make it reliable:
 - **Heartbeat interval.** Emit liveness on a quiet interval so the caller can distinguish "waiting" from "wedged." Where the consuming model has a prompt-cache TTL, keep the heartbeat comfortably under it so a long queue does not force a cold re-read of context.
 - **Per-probe timeout.** Cap each probe call so one wedged request cannot freeze the loop.
 - **Error streaks, not error exits.** Transient API failures are normal; retry quietly, warn once after a few consecutive failures, exit `DONE probe-dead` after ~10.
-- **Distinguish cancellation from failure.** A superseding push commonly makes a concurrency group auto-cancel the older run. `cancelled` is *not* red. When every conclusion is in `{success, skipped, neutral, cancelled}` **and** a newer identifier exists, report `DONE superseded` and let the caller arm a fresh watch. Reporting that as failure sends the agent debugging a phantom break — a mistake worth guarding against explicitly, because it looks exactly like a real red.
+- **Distinguish cancellation from failure.** A superseding push commonly makes a concurrency group auto-cancel the older run. `cancelled` is *not* red. The robust rule: if the only non-green conclusions are `cancelled`, the verdict is `cancelled`/`superseded`, never `failure` — regardless of whether you can prove a newer identifier exists. Report `superseded` when you can confirm the ref moved, `cancelled` otherwise, and reserve `failure` for a genuine non-success/non-cancelled conclusion. Reporting a cancellation as failure sends the agent debugging a phantom break, because it looks exactly like a real red. (A first implementation of the bundled watcher got this wrong by requiring a branch argument to reach the supersession branch; without it, every auto-cancel read as failure.)
 - **Aggregate across all runs for the identifier.** After a fast-forward, one commit can carry both a branch run and a default-branch run. A SHA-pinned watch spans both, which is usually correct — the default-branch run is the one that deploys.
 
 ## Arming it
@@ -96,6 +96,7 @@ Prove each exit path against real runs. A watcher that has only been observed su
 | Nothing registers | watch a bogus or path-filtered SHA | `DONE no-run` before the deadline |
 | Deadline | set the deadline to ~0 against a live run | `DONE timeout`, never silence |
 | Superseded | push twice quickly | `DONE superseded`, **not** failure |
+| Cancelled without a known newer ref | cancel a run manually, or watch an auto-cancelled SHA without the branch arg | `DONE cancelled`, **not** failure |
 | Long queue | watch during contention | periodic `HB` carrying state |
 
 The failure test is the one that matters; run it deliberately rather than waiting for a real break. Confirm the remediation command the watcher prints actually surfaces the error, and confirm the exit code is non-zero (beware `| head` masking it — check `${PIPESTATUS[0]}` or run unpiped).
@@ -111,6 +112,26 @@ The failure test is the one that matters; run it deliberately rather than waitin
 A verdict is evidence only for the identifier it names. Confirm the run's head SHA equals what you pushed, and that your change is in that run's diff, before calling it verified. See `effectiveness-contract.md` for why a green on a stale or empty diff is not proof.
 
 ## When CI is the only verification surface
+
+## Choosing the right waiting primitive
+
+| Need | Use |
+|---|---|
+| Many state changes until a known end (CI progress) | A diff-gated streaming watcher like this one. |
+| Exactly one notification ("tell me when it finishes") | A backgrounded command that exits when the condition becomes true. |
+| Arbitrary matches in a growing file/log | `tail -f ... | grep --line-buffered`, but only when the filter covers every terminal state. |
+
+**Coverage rule:** a filter that matches only the success marker is silent through a crash, a hang, and an OOM — and silence is indistinguishable from "still running." Always match every terminal state, or widen the alternation. Also ensure every stage in a pipe flushes per line; `head -N` cannot flush and withholds output until N matches accumulate.
+
+## Size the deadline to queue + convergence, not to the happy-path runtime
+
+Two false-red deadline patterns recur:
+
+1. **Queue delay dominates execution.** A job that executes in 20s can still wait minutes for capacity. Deadline to observed p95 wall-clock, not median execution time.
+2. **The deploy call returns before the environment converges.** CDN/edge/multi-region platforms frequently serve the previous revision for tens of seconds after the deploy API returned success. A deploy watcher budgeted to the upload/build step rather than to revision convergence reports a false failure and trains the agent to ignore the signal.
+
+A `timeout` verdict is not a red build and not a pass. It means you still do not know. Inspect the run, separate queue from execution, then re-arm with a larger deadline if the workflow is still the right one to watch. If timeouts recur while execution stays flat, the bottleneck is queue capacity, not your watcher — route to `references/capacity-and-contention.md`.
+
 
 Teams that push heavy work off the developer machine — several agents, several worktrees, limited local RAM — depend on this loop entirely. Additions that pay for themselves:
 

--- a/skills/ci-cd-optimize/references/capacity-and-contention.md
+++ b/skills/ci-cd-optimize/references/capacity-and-contention.md
@@ -1,0 +1,89 @@
+# Capacity Ceilings and Contention
+
+Use this file when queue time dominates p95, when fan-out stops paying off, or before recommending "split this job" / "add more shards" / "parallelize another suite".
+
+Everything else in the skill assumes another parallel job buys wall-clock. Above a concurrency ceiling that assumption is false: extra jobs simply queue, each one re-paying setup and restore.
+
+## The failure mode
+
+A pipeline has **N** independent jobs and an effective ceiling of **C** concurrent slots. While `N ≤ C`, splitting shortens the critical path. Once `N > C`, the surplus jobs queue and total wall-clock converges on:
+
+```text
+wall-clock ≈ queue + ceil(N / C) × (per-job setup + execution)
+```
+
+Beyond the ceiling, splitting further **increases** total time because every extra job pays another checkout, setup, restore, and artifact phase while waiting for the same C slots.
+
+## Decide with queue share before touching topology
+
+Compute this first:
+
+```text
+queue share = Σ queue time / (Σ queue time + Σ execution time)
+```
+
+Measured across a representative window, not one run.
+
+| Queue share | Bottleneck | Correct next move |
+|---|---|---|
+| < 15% | Work inside jobs | Normal optimization: caches, sharding, DAG shape. |
+| 15–35% | Mixed | Optimize execution, but stop adding jobs blindly. |
+| > 35% | **Capacity** | Reduce job count or raise the ceiling. DAG refactors alone will not help. |
+
+Above roughly 35%, the honest recommendation is often "merge jobs that share setup" or "increase capacity" — not another layer of sharding.
+
+## Detect the ceiling empirically
+
+Do not assume the documented plan limit is the effective one; org-wide contention, runner-class scarcity, and time of day all bite first.
+
+1. Trigger a run with more independent jobs than you believe the ceiling to be.
+2. Record `created_at`, `started_at`, and `completed_at` per job.
+3. Count how many jobs are simultaneously in `started_at <= t < completed_at`.
+
+The peak simultaneous count is the effective ceiling. A common signature is jobs created at the same instant whose `started_at` values fall into distinct clusters separated by roughly one job duration.
+
+## Queue time varies by runner class — measure it, do not assume
+
+A larger instance class is not automatically faster end-to-end. Scarcity, fleet warmth, and time of day decide whether the bigger class is provisioned sooner or later than the small one.
+
+Two real observations from the same provider are both true:
+
+- One window: 16-vCPU jobs started immediately while smaller classes waited.
+- Another window: the 16-vCPU class waited **~6–7×** longer than a 2-vCPU class, and a job that executed in ~60s spent nearly twice that waiting for a runner.
+
+Neither generalizes. The method does:
+
+- Compare runner classes under the **same contention state**.
+- For in-job changes, compare **execution time** separately from queue time.
+- If the difference you are testing is smaller than the queue-time spread, the sample is noise.
+
+## When the platform already proxies the registry
+
+Several providers run a pull-through package proxy on the runner network. When that exists, a large package-manager store cache can be redundant: restoring a 100–500 MB archive to avoid a fetch that was already local is pure transfer overhead.
+
+Test it directly rather than reasoning from hit counts:
+
+1. Find a run where the store cache missed.
+2. Compare its install step with a warm-cache run.
+3. If install time is roughly unchanged, the proxy is doing the work and the store cache is only buying its own restore/save cost.
+
+This check is especially relevant on Avrea, where package caching and the registry proxy are separate layers.
+
+## Merge jobs, but only when the separation is not buying something
+
+When capped, merging jobs that already share setup is often the fastest move. Before doing it, check what the separation was buying:
+
+- **Rerun granularity** — merged job means rerunning both halves.
+- **Failure attribution** — keep step names distinct so the failing half is obvious.
+- **Isolation** — the one that bites most often. Jobs that were safe in separate VMs may share a database, fixed port, temp path, or global config once merged.
+
+A merge that trades 30s of queue for 40s of serial work is a regression. Verify it with the same before/after evidence as any other change.
+
+## Signs that fan-out is no longer the lever
+
+- Queue time exceeds execution time on the critical path.
+- Total job work falls, wall-clock stays flat.
+- `max queue time` rises as job count rises.
+- Per-shard setup dominates the shard's useful work.
+
+When those show up, stop adding jobs. Either pack work better or raise capacity.

--- a/skills/ci-cd-optimize/references/change-based-ci.md
+++ b/skills/ci-cd-optimize/references/change-based-ci.md
@@ -65,6 +65,15 @@ jobs:
 
 Ensure the provider reports skipped downstream jobs as successful/skipped in the way branch protection expects.
 
+## The planner must not grade its own homework
+
+The component that decides what runs is part of the repository, and a change to it can ship having validated a fraction of the repo. Two failures worth an explicit guard, both seen in practice:
+
+1. **Config fan-out gaps.** A rule mapping `.github/**` (or `.gitlab-ci.yml`, `.circleci/`) to "the main lanes" silently excludes specialized workflows, so editing a specialized one never exercises it.
+2. **Self-routing.** A planner change that maps only to its own directory's lane grades its own homework.
+
+The classifier is a pure path-to-lane function, so guard both cheaply with unit fixtures: assert the lane set for a representative path list, and assert that a change to the planner or to shared CI config escalates to a full run. Any change to the planner, CI config, or a shared CI helper belongs in the full-run list below.
+
 ## Full-run triggers
 
 Always run the full suite when:

--- a/skills/ci-cd-optimize/references/deployment.md
+++ b/skills/ci-cd-optimize/references/deployment.md
@@ -43,6 +43,12 @@ Before claiming a deployment is done, verify:
 - canary/analysis metrics are inside budget,
 - rollback artifact remains available.
 
+## Size the convergence budget to propagation, not to the deploy call
+
+A self-verifying deploy — deploy, then poll a `/version`-style endpoint until it reports the pushed revision — is the cheapest guard against a silently stale release. Its classic defect is that the polling budget gets tuned to how long the deploy command takes, not to how long the platform takes to converge.
+
+Edge- and CDN-backed platforms (Cloudflare Workers, Vercel, Fastly, multi-region rollouts) commonly serve the previous revision for tens of seconds after the deploy call returns success. A budget sized to the upload/build step produces a **false red on a deploy that actually succeeded** — worse than no check, because it trains everyone to ignore the signal and can trigger an unnecessary rollback. Size the convergence poll to observed propagation time, and treat a convergence timeout as "unknown, inspect" rather than "failed, roll back".
+
 ## TypeScript status probe sketch
 
 ```ts

--- a/skills/ci-cd-optimize/references/github-actions.md
+++ b/skills/ci-cd-optimize/references/github-actions.md
@@ -76,6 +76,13 @@ This avoids the common `push` + `pull_request` duplicate: feature work validates
 - Do not multiply runners until test time is split; otherwise every shard repeats setup and full tests.
 - Put tiny planner/status jobs on lightweight runners where the provider offers them; keep build/test jobs on build runners.
 
+## Reusable workflows (`workflow_call`)
+
+- A called workflow cannot hold permissions the caller lacks. If the caller declares `permissions: contents: read` and the callee asks for anything more, the run fails at **startup** — `conclusion: startup_failure` with **zero jobs created and no step logs**, which reads like an outage rather than a config error. Keep the callee's `permissions` a subset of the caller's, or widen the caller deliberately.
+- Other startup-stage failures with the same signature: a path typo in `uses:`, a missing `on: workflow_call`, an inputs/secrets mismatch, or an unreadable nested reusable workflow. Diagnose by bisecting — reduce the caller to a single `uses:` job and push, rather than reading logs that do not exist.
+- Use `secrets: inherit` deliberately; it forwards every caller secret to the callee.
+- Job-level `concurrency` belongs in the callee. A workflow-level `concurrency` block is ignored for the reusable path, so per-surface queueing must be declared on the job.
+
 ## Same-job parallelism (verify before use)
 
 GitHub's 2026-06-25 changelog announced same-job step concurrency with `background: true` and related `parallel`/`wait`/`wait-all`/`cancel` keywords, but the stable workflow-syntax page fetched on 2026-07-28 still says steps execute in order and does not document those keys. Treat this as provider-version-gated: verify the current official syntax docs before emitting it. Prefer job-level parallelism for CPU-bound work and same-job concurrency only for I/O-bound tasks that share setup.

--- a/skills/ci-cd-optimize/references/github-actions.md
+++ b/skills/ci-cd-optimize/references/github-actions.md
@@ -81,7 +81,7 @@ This avoids the common `push` + `pull_request` duplicate: feature work validates
 - A called workflow cannot hold permissions the caller lacks. If the caller declares `permissions: contents: read` and the callee asks for anything more, the run fails at **startup** — `conclusion: startup_failure` with **zero jobs created and no step logs**, which reads like an outage rather than a config error. Keep the callee's `permissions` a subset of the caller's, or widen the caller deliberately.
 - Other startup-stage failures with the same signature: a path typo in `uses:`, a missing `on: workflow_call`, an inputs/secrets mismatch, or an unreadable nested reusable workflow. Diagnose by bisecting — reduce the caller to a single `uses:` job and push, rather than reading logs that do not exist.
 - Use `secrets: inherit` deliberately; it forwards every caller secret to the callee.
-- Job-level `concurrency` belongs in the callee. A workflow-level `concurrency` block is ignored for the reusable path, so per-surface queueing must be declared on the job.
+- Job-level `concurrency` belongs in the callee. A workflow-level `concurrency` block is evaluated in the callee's context, but its group name can collide with the caller's when using `github.workflow` dynamically; prefer job-level concurrency for reliable per-surface queueing.
 
 ## Same-job parallelism (verify before use)
 

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -41,6 +41,17 @@ Prioritize `critical-path rate × exclusive time`. A job consuming CPU in parall
 
 Where the platform records per-job start offsets, derive the DAG shape empirically instead of trusting declared dependencies: a gap between a job's `start + duration` and its dependents' start is scheduling and per-job setup overhead, which no amount of in-job optimization removes. On Avrea, `references/avrea/cli-evidence.md` shows how to extract these offsets.
 
+
+## Sampling traps
+
+These produce numbers that look rigorous and are not.
+
+- **A rerun is not always a new sample.** Some providers re-report the original attempt's duration. Confirm the attempt counter actually incremented before treating repeated identical durations as independent warm samples.
+- **Do not mix event populations.** A manually dispatched run that force-enables every conditional gate is not comparable to a push run that path-filters most of them. Report push, PR, and dispatch populations separately.
+- **Do not measure under self-inflicted contention.** Firing several runs concurrently to "collect samples faster" inflates queue time for all of them. Let the platform drain, then measure.
+- **Do not quote p95 from a handful of runs.** Below ~20 comparable runs, report median and range and label p95 as descriptive with the exact `n`.
+- **Separate work from wait.** A change can cut total work 40% while wall-clock stays flat because provisioning dominates; that still matters, because it tells you the next lever is job count or capacity, not in-job optimization. See `references/capacity-and-contention.md`.
+
 ## Experiment verification
 
 Before changing config, write down:

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -34,25 +34,40 @@ PROBE_CAP="${CI_WATCH_PROBE_CAP:-45}" # per-probe timeout
 [ -n "$REPO" ] || { echo "CI-DONE probe-dead — set CI_WATCH_REPO=org/name"; exit 1; }
 
 start=$SECONDS
+deadline_sec=$(( ${DEADLINE_MIN%.*} * 60 ))
 prev=""
 registered=0
 last_emit=$SECONDS
 errs=0
 emit() { printf '%s\n' "$*"; last_emit=$SECONDS; }
-
-while :; do
+timeout_if_elapsed() {
   elapsed=$(( SECONDS - start ))
-  if [ "$elapsed" -gt $(( ${DEADLINE_MIN%.*} * 60 )) ]; then
+  if [ "$elapsed" -ge "$deadline_sec" ]; then
     emit "CI-DONE timeout at ${DEADLINE_MIN}m — last: ${prev:-nothing registered}"
     exit 124
   fi
+}
+bounded_sleep() {
+  timeout_if_elapsed
+  remaining=$(( deadline_sec - elapsed ))
+  sleep_for=$INTERVAL
+  [ "$sleep_for" -gt "$remaining" ] && sleep_for=$remaining
+  sleep "$sleep_for"
+}
 
-  if ! snap=$(timeout "$PROBE_CAP" gh run list --repo "$REPO" --commit "$SHA" \
+while :; do
+  timeout_if_elapsed
+  remaining=$(( deadline_sec - elapsed ))
+  probe_cap=$PROBE_CAP
+  [ "$probe_cap" -gt "$remaining" ] && probe_cap=$remaining
+
+  if ! snap=$(timeout "$probe_cap" gh run list --repo "$REPO" --commit "$SHA" --limit 1000 \
         --json databaseId,workflowName,status,conclusion 2>/dev/null); then
+    timeout_if_elapsed
     errs=$(( errs + 1 ))
     [ "$errs" -eq 3 ] && emit "CI-ERR probe failing (3x consecutive)"
     [ "$errs" -ge 10 ] && { emit "CI-DONE probe-dead after 10 consecutive errors"; exit 1; }
-    sleep "$INTERVAL"; continue
+    bounded_sleep; continue
   fi
   errs=0
 
@@ -64,7 +79,7 @@ while :; do
       emit "CI-DONE no-run — nothing registered for ${SHA:0:9} in ${REG_MIN}m (path filter? wrong sha? docs-only push?)"
       exit 1
     fi
-    sleep "$INTERVAL"; continue
+    bounded_sleep; continue
   fi
 
   if [ "$registered" -eq 0 ]; then
@@ -105,7 +120,7 @@ while :; do
       fi
       exit 0
     fi
-    id=$(jq -r '[.[] | select(.conclusion=="failure")][0].databaseId // empty' <<<"$snap")
+    id=$(jq -r '[.[] | select((.conclusion // "") | IN("success","skipped","neutral","cancelled") | not)][0].databaseId // empty' <<<"$snap")
     emit "CI-DONE failure — ${genuine}${id:+ — gh run view $id --repo $REPO --log-failed}"
     exit 1
   fi
@@ -113,5 +128,5 @@ while :; do
   if [ "$HB_SEC" -gt 0 ] && [ $(( SECONDS - last_emit )) -ge "$HB_SEC" ]; then
     emit "CI-HB $(( elapsed / 60 ))/${DEADLINE_MIN}m · $(tr '\n' '|' <<<"$prev" | sed 's/|$//; s/|/ · /g')"
   fi
-  sleep "$INTERVAL"
+  bounded_sleep
 done

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -74,6 +74,10 @@ while :; do
   errs=0
 
   count=$(jq 'length' <<<"$snap")
+  if [ "$count" -ge 1000 ]; then
+    emit "CI-DONE probe-dead — GitHub's 1000-result search ceiling reached; cannot prove the run set is complete"
+    exit 1
+  fi
   state=$(jq -r '.[] | "\(.workflowName): \(.status)\(if .conclusion != "" and .conclusion != null then " -> "+.conclusion else "" end)"' <<<"$snap" | sort)
 
   if [ "$count" -eq 0 ]; then

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -16,7 +16,7 @@
 # the grep, so it never exits and never reports the failure.
 #
 # Provider-neutral in shape: to target another CI, keep the event contract and
-# replace only the `gh run list --commit` probe with one that prints
+# replace only the paginated Actions-runs probe with one that prints
 # "<name>: <state>" lines for the pinned identifier.
 #
 # Requires: gh (authenticated) + jq. Override repo with CI_WATCH_REPO=org/name.
@@ -61,8 +61,10 @@ while :; do
   probe_cap=$PROBE_CAP
   [ "$probe_cap" -gt "$remaining" ] && probe_cap=$remaining
 
-  if ! snap=$(timeout "$probe_cap" gh run list --repo "$REPO" --commit "$SHA" --limit 1000 \
-        --json databaseId,workflowName,status,conclusion 2>/dev/null); then
+  if ! snap=$(timeout "$probe_cap" gh api --paginate \
+        "repos/$REPO/actions/runs?head_sha=$SHA&per_page=100" \
+        --jq '.workflow_runs[] | {databaseId: .id, workflowName: .name, status, conclusion}' \
+        2>/dev/null | jq -s '.'); then
     timeout_if_elapsed
     errs=$(( errs + 1 ))
     [ "$errs" -eq 3 ] && emit "CI-ERR probe failing (3x consecutive)"

--- a/skills/ci-cd-optimize/scripts/ci-watch.sh
+++ b/skills/ci-cd-optimize/scripts/ci-watch.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# ci-watch.sh — non-blocking GitHub Actions watcher for autonomous agents.
+#
+#   bash ci-watch.sh <pinned-sha> [branch] [deadline-min]
+#
+# Emits ONE line per state change plus periodic liveness, and guarantees a
+# terminal `CI-DONE <verdict>` on every exit path. Silence past the deadline
+# is structurally impossible. Arm it with a streaming-notification facility
+# (in Claude Code, the Monitor tool) and keep working.
+#
+# WHY NOT `gh run watch`: it redraws a TTY block on an interval, so piped into
+# a line consumer every redraw is a duplicate notification; it also follows a
+# single run, missing a second failing workflow for the same commit; and it
+# has no registration deadline (cli/cli #6448/#6560/#8194).
+# WHY NOT a success-only poll loop: a failed run and a running run both fail
+# the grep, so it never exits and never reports the failure.
+#
+# Provider-neutral in shape: to target another CI, keep the event contract and
+# replace only the `gh run list --commit` probe with one that prints
+# "<name>: <state>" lines for the pinned identifier.
+#
+# Requires: gh (authenticated) + jq. Override repo with CI_WATCH_REPO=org/name.
+set -uo pipefail
+
+SHA="${1:?usage: ci-watch.sh <pinned-sha> [branch] [deadline-min]}"
+BRANCH="${2:-}"
+DEADLINE_MIN="${3:-20}"
+REPO="${CI_WATCH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)}"
+INTERVAL="${CI_WATCH_INTERVAL:-20}"
+HB_SEC="${CI_WATCH_HB:-150}"          # < a typical 300s prompt-cache TTL
+REG_MIN="${CI_WATCH_REG_MIN:-4}"      # give up if nothing registers
+PROBE_CAP="${CI_WATCH_PROBE_CAP:-45}" # per-probe timeout
+
+[ -n "$REPO" ] || { echo "CI-DONE probe-dead — set CI_WATCH_REPO=org/name"; exit 1; }
+
+start=$SECONDS
+prev=""
+registered=0
+last_emit=$SECONDS
+errs=0
+emit() { printf '%s\n' "$*"; last_emit=$SECONDS; }
+
+while :; do
+  elapsed=$(( SECONDS - start ))
+  if [ "$elapsed" -gt $(( ${DEADLINE_MIN%.*} * 60 )) ]; then
+    emit "CI-DONE timeout at ${DEADLINE_MIN}m — last: ${prev:-nothing registered}"
+    exit 124
+  fi
+
+  if ! snap=$(timeout "$PROBE_CAP" gh run list --repo "$REPO" --commit "$SHA" \
+        --json databaseId,workflowName,status,conclusion 2>/dev/null); then
+    errs=$(( errs + 1 ))
+    [ "$errs" -eq 3 ] && emit "CI-ERR probe failing (3x consecutive)"
+    [ "$errs" -ge 10 ] && { emit "CI-DONE probe-dead after 10 consecutive errors"; exit 1; }
+    sleep "$INTERVAL"; continue
+  fi
+  errs=0
+
+  count=$(jq 'length' <<<"$snap")
+  state=$(jq -r '.[] | "\(.workflowName): \(.status)\(if .conclusion != "" and .conclusion != null then " -> "+.conclusion else "" end)"' <<<"$snap" | sort)
+
+  if [ "$count" -eq 0 ]; then
+    if [ "$registered" -eq 0 ] && [ "$elapsed" -gt $(( ${REG_MIN%.*} * 60 )) ]; then
+      emit "CI-DONE no-run — nothing registered for ${SHA:0:9} in ${REG_MIN}m (path filter? wrong sha? docs-only push?)"
+      exit 1
+    fi
+    sleep "$INTERVAL"; continue
+  fi
+
+  if [ "$registered" -eq 0 ]; then
+    registered=1
+    emit "CI-RUN registered ${count}: $(tr '\n' '|' <<<"$state" | sed 's/|$//; s/|/ · /g')"
+    prev="$state"
+  elif [ "$state" != "$prev" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] && emit "CI-CHG $line"
+    done < <(comm -13 <(printf '%s\n' "$prev") <(printf '%s\n' "$state"))
+    prev="$state"
+  fi
+
+  # Terminal: every workflow for the SHA completed.
+  if jq -e 'length > 0 and all(.status == "completed")' <<<"$snap" >/dev/null; then
+    bad=$(jq -r '[.[] | select((.conclusion // "") | IN("success","skipped","neutral") | not) | .workflowName] | join(", ")' <<<"$snap")
+    if [ -z "$bad" ]; then
+      emit "CI-DONE success (${count} workflows) · $(( SECONDS - start ))s"
+      exit 0
+    fi
+    # A superseding push makes the concurrency group auto-cancel the older run.
+    # `cancelled` is NOT a failure; reporting it as red sends the agent chasing
+    # a phantom break. When every non-green conclusion is `cancelled`, report
+    # cancelled/superseded regardless of whether a branch was supplied — only
+    # a genuine failure/timeout/etc. is red.
+    genuine=$(jq -r '[.[] | select((.conclusion // "") | IN("success","skipped","neutral","cancelled") | not) | .workflowName] | join(", ")' <<<"$snap")
+    if [ -z "$genuine" ]; then
+      newest=""
+      if [ -n "$BRANCH" ]; then
+        newest=$(timeout 20 gh run list --repo "$REPO" --branch "$BRANCH" --limit 1 \
+                  --json headSha --jq '.[0].headSha // empty' 2>/dev/null || true)
+        [ "$newest" = "$SHA" ] && newest=""
+      fi
+      if [ -n "$newest" ]; then
+        emit "CI-DONE superseded by ${newest:0:9} (auto-cancelled: ${bad}) — arm a fresh watch"
+      else
+        emit "CI-DONE cancelled — ${bad} (superseded or manually cancelled; not a build failure) — re-check or re-push"
+      fi
+      exit 0
+    fi
+    id=$(jq -r '[.[] | select(.conclusion=="failure")][0].databaseId // empty' <<<"$snap")
+    emit "CI-DONE failure — ${genuine}${id:+ — gh run view $id --repo $REPO --log-failed}"
+    exit 1
+  fi
+
+  if [ "$HB_SEC" -gt 0 ] && [ $(( SECONDS - last_emit )) -ge "$HB_SEC" ]; then
+    emit "CI-HB $(( elapsed / 60 ))/${DEADLINE_MIN}m · $(tr '\n' '|' <<<"$prev" | sed 's/|$//; s/|/ · /g')"
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## What this PR now does

This is no longer just "add a reference." It turns `ci-cd-optimize` into a more complete workflow-focused skill for autonomous CI/CD work, while staying generic across providers and project types.

### 1. Agent feedback loop (new reference + bundled script)

Adds `references/agent-feedback-loop.md` and bundles `scripts/ci-watch.sh`.

The new reference is provider-neutral and covers:
- the six-point watcher contract (bounded, commit-pinned, diff-gated, all units, terminal verdict on every exit path, liveness heartbeats),
- the two patterns that fail in practice (`watch` subcommands that redraw TTY blocks; success-only polling),
- how to wire a watcher to a streaming notification facility such as Claude Code's Monitor tool,
- how to validate each exit path against *real* runs (green, red, no-run, timeout, cancelled/superseded, long queue).

The bundled watcher implements that contract for GitHub Actions.

### 2. Stronger cancellation handling (from real failure, then fixed)

The first bundled watcher adaptation reported auto-cancelled runs as `failure` when the caller omitted the branch argument. That is wrong and would send an agent debugging a phantom break.

The script now treats **all-cancelled runs as non-red**:
- `superseded` when a newer identifier can be proven,
- `cancelled` otherwise,
- `failure` only for a genuine non-success/non-cancelled conclusion.

Regression-tested across three live SHAs:
- green → `success`, exit 0
- deliberate compile error → `failure`, exit 1, exact `gh run view --log-failed` command
- auto-cancelled superseded run → `superseded`/`cancelled`, exit 0

### 3. Better routing in `SKILL.md`

The operating loop now asks explicitly whether the consumer is an agent/unattended session that must not block on CI, and routes to the new reference.

Also adds a bundled-script section so the watcher is discoverable from the skill body, not only from the references tree.

### 4. New GitHub Actions startup-failure guidance

`references/github-actions.md` now documents a genuinely tricky failure mode:

- a reusable workflow whose callee asks for permissions the caller does not have,
- path/input/secret mismatches in `workflow_call`,
- the shared signature: **`startup_failure`, zero jobs created, no step logs**.

This section emphasizes the correct diagnosis: bisect by reducing the caller to a single `uses:` job rather than grepping logs that do not exist.

## Why these changes matter

The skill already knew how to make pipelines fast. What it did **not** know was how an autonomous agent should *consume* CI results without blocking for minutes, hanging forever, or reporting the wrong verdict. In CI-only workflows, that feedback loop *is* part of the development loop.

## Validation

- `python3 scripts/validate-skills.py` → ✅ `Validated 53 skills`
- all Markdown tables well-formed
- internal cross-links resolve
- the new reference stays provider-neutral (no Zeo/Avrea/Turbo/Pnpm leakage inside the reference itself; Avrea remains in its own reference kit)

## Files changed

- `skills/ci-cd-optimize/SKILL.md`
- `skills/ci-cd-optimize/references/agent-feedback-loop.md`
- `skills/ci-cd-optimize/references/github-actions.md`