### PR TITLE
feat(ci-cd-optimize): agent CI feedback loop + three measured lessons

### DIFF
--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use if diagnosing or optimizing slow CI/CD while preserving required checks, or wiring an agent to wait on CI results without hanging.
 metadata:
   author: yigitkonur
   version: 1.0.0
@@ -180,6 +180,11 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
+| Blocking on `gh run watch` or an open-ended poll | Arm a diff-gated watcher with a deadline that always prints a terminal verdict. |
+| Treating a watch `timeout` as pass or as failure | It means no verdict yet — inspect the run, then re-arm with a larger deadline. |
+| Sharding a suite whose cost is real sleeping | Profile per file/test first; make production retry delays injectable. |
+| Deploy verification budget tuned to the deploy call | Size revision convergence to edge propagation, or a good deploy reports red. |
+| Benchmarking during your own burst of validation runs | Separate queue from execution; sample from ordinary pushes. |
 
 ## Reference files
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks, or wiring an agent to wait on CI results without hanging.
+description: Use if diagnosing or optimizing slow CI/CD, or wiring an agent to wait on CI results without blocking or hanging — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker, or any pipeline, while preserving the checks that make it worth running.
 metadata:
   author: yigitkonur
   version: 1.0.0
@@ -39,6 +39,8 @@ Rules:
 
 Prefer the platform's own aggregated history over hand-collected timings when it exists, then verify sample size and window. If the repository runs on Avrea (`runs-on:` labels begin with `avrea-`) and `avr` is installed and authenticated, read `references/avrea/cli-evidence.md` — it returns median/p95, per-job start offsets, flake counts, and cache hit counts directly. Confirm availability with `command -v avr && avr auth status` before depending on it, and fall back to provider-native measurement otherwise.
 
+Two sampling traps decide whether the baseline is real: a re-run is not a fresh sample (check the attempt counter), and a run measured under contention is not comparable to one against an idle pool. Before quoting any before/after number, read the sampling discipline in `references/measurement.md` and, when queue time is non-trivial, `references/capacity-and-contention.md`.
+
 For the metric definitions, baseline protocol, and the rule about claiming only the evidence rung you reached, read `references/measurement.md`.
 
 ### 3. Find the critical path
@@ -50,14 +52,14 @@ Apply the performance order before adding compute:
 1. **Do not start it** — duplicate triggers, draft-PR work, irrelevant events, unrelated packages, full checkout, redundant matrices.
 2. **Cancel it when stale** — superseded PR runs, obsolete deployments only when safe, hung tail jobs.
 3. **Reuse previous work** — correct caches, remote task cache, immutable build artifacts, prebuilt toolchains.
-4. **Shorten the critical path** — DAG shape, split long jobs only when setup is amortized, historical test sharding.
+4. **Shorten the critical path** — DAG shape, split long jobs only when setup is amortized *and* capacity allows (`references/capacity-and-contention.md`), historical test sharding.
 5. **Move fewer bytes** — checkout scope, cache size, Docker context/layers, artifact paths/compression.
 6. **Only then add compute** — larger runners, more workers, more capacity after queue and utilization evidence.
 
 Ask in order:
 
 1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
+2. Is queue time the dominant p95 contributor? Compute the queue share first — `references/capacity-and-contention.md` gives the gate and thresholds; `references/runners-and-autoscaling.md` covers the remedies. Past the concurrency ceiling, adding jobs makes wall-clock worse, not better.
 3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
 4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
 5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
@@ -71,11 +73,13 @@ Ask in order:
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
 14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
 15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
-16. Is an agent or unattended process consuming the result — or does waiting for CI itself stall, hang, or report a false verdict? Read `references/agent-ci-feedback.md`.
+16. Is an agent or unattended process consuming the result — or does waiting for CI itself stall, hang, or report a false verdict? Read `references/agent-ci-feedback.md` and use `scripts/ci-watch.py`.
 
 ### 4. Choose one bounded experiment
 
-Select the smallest reversible change that attacks the measured critical path. Every recommendation must state:
+Select the smallest reversible change that attacks the measured critical path. When several candidates compete, rank them in a hypothesis table — `| hypothesis | change | est. saved | effort | risk | on critical path? |` — ordered by (time saved ÷ effort), and discount anything off the critical path heavily: a large CPU-time saving on parallel non-critical work buys zero wall-clock. Keep declined rows with the number that killed them ("typecheck is 6s — a 10× compiler saves nothing that parallelism doesn't already hide"); a decline backed by data prevents the next person from re-litigating it.
+
+Every recommendation must state:
 
 - evidence observed,
 - expected wall-clock impact,
@@ -103,7 +107,9 @@ Use full validation as the safe fallback whenever changed files, merge base, cac
 
 Re-run on the same commit first, then a normal representative commit. Compare median and p95 wall-clock, queue time, cache behavior, first-time pass rate, cost, and failure/rework signals. Confirm the exact run head SHA contains the change and the deployed artifact digest or workflow run is the intended one.
 
-Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
+Wait for those runs without blocking: arm a bounded, diff-gated watcher (`references/agent-ci-feedback.md`, `scripts/ci-watch.py`) instead of a foreground watch or an open-ended poll — and treat its `timeout`/`no-run` verdicts as "no answer yet," never as pass or fail.
+
+Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence. Report disproved hypotheses too — an experiment that measured neutral or worse is a result, and silently dropping it invites the next person to retry it.
 
 ## Minimal TypeScript example
 
@@ -182,6 +188,8 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
 | Blocking on `gh run watch` or an open-ended poll | Arm a diff-gated watcher with a deadline that always prints a terminal verdict. |
 | Treating a watch `timeout` as pass or as failure | It means no verdict yet — inspect the run, then re-arm with a larger deadline. |
+| Treating a concurrency auto-cancel as failure | `cancelled` + a newer commit means superseded, not red — evaluate supersession before failure. |
+| Trusting `watch-cmd --exit-status \| head` | A pipeline's `$?` is the last stage's — a failed run reads as exit 0. Check `${PIPESTATUS[0]}` or run unpiped. |
 | Sharding a suite whose cost is real sleeping | Profile per file/test first; make production retry delays injectable. |
 | Deploy verification budget tuned to the deploy call | Size revision convergence to edge propagation, or a good deploy reports red. |
 | Benchmarking during your own burst of validation runs | Separate queue from execution; sample from ordinary pushes. |
@@ -190,8 +198,9 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 
 | File | Read when |
 |---|---|
-| `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, or proving a result. |
-| `references/agent-ci-feedback.md` | An agent must wait for a CI result without blocking or hanging: watcher contract, terminal verdicts, heartbeats, `timeout`/`no-run` semantics, deadline sizing. |
+| `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, sampling traps, or proving a result. |
+| `references/capacity-and-contention.md` | Queue share exceeds ~15%, a parallelization change measured neutral, or timings must be compared under a shared runner pool. |
+| `references/agent-ci-feedback.md` | An agent must wait for a CI result without blocking or hanging: watcher contract, terminal verdicts, heartbeats, `timeout`/`no-run` semantics, provider probes, deadline sizing. Pairs with `scripts/ci-watch.py`. |
 | `references/effectiveness-contract.md` | Deciding whether a proposed speedup weakens validation, security, or artifact identity. |
 | `references/caching.md` | Any dependency/build cache design, restore-key, cache-hit, cache-poisoning, or transfer-cost question. |
 | `references/change-based-ci.md` | Path filters, affected commands, merge queues, merge-base correctness, or full-run fallback rules. |

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD, or wiring an agent to wait on CI results without blocking or hanging — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker, or any pipeline, while preserving the checks that make it worth running.
+description: Use skill if you are diagnosing slow CI/CD or wiring an agent to wait on CI results without blocking.
 metadata:
   author: yigitkonur
   version: 1.0.0

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -71,6 +71,7 @@ Ask in order:
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
 14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
 15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+16. Is an agent or unattended process consuming the result — or does waiting for CI itself stall, hang, or report a false verdict? Read `references/agent-ci-feedback.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -185,6 +186,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | File | Read when |
 |---|---|
 | `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, or proving a result. |
+| `references/agent-ci-feedback.md` | An agent must wait for a CI result without blocking or hanging: watcher contract, terminal verdicts, heartbeats, `timeout`/`no-run` semantics, deadline sizing. |
 | `references/effectiveness-contract.md` | Deciding whether a proposed speedup weakens validation, security, or artifact identity. |
 | `references/caching.md` | Any dependency/build cache design, restore-key, cache-hit, cache-poisoning, or transfer-cost question. |
 | `references/change-based-ci.md` | Path filters, affected commands, merge queues, merge-base correctness, or full-run fallback rules. |

--- a/skills/ci-cd-optimize/references/agent-ci-feedback.md
+++ b/skills/ci-cd-optimize/references/agent-ci-feedback.md
@@ -69,13 +69,13 @@ When one workflow triggers another on completion (`workflow_run`: deploy-after-b
 
 The two most misreported are `timeout` and `no-run`; both mean *you still do not know*. A verdict is evidence only for the identifier it names — a green on a stale or empty diff proves nothing (`effectiveness-contract.md`).
 
-Distinct exit codes matter because callers chain on them: `watch && deploy` must not proceed on `superseded` or `timeout`. The bundled script uses 0 for success, 124 for timeout (the GNU `timeout` convention), 1 otherwise.
+Distinct exit codes matter because callers chain on them. The bundled script uses 0 for `success`, `superseded`, or an explicit `--expect-none` success; 124 for `timeout` (the GNU `timeout` convention); and 1 for `failure`, `cancelled`, `no-run`, or `probe-dead`. Because `superseded` and `success` share exit 0, `watch && deploy` is unsafe: callers must parse the `CI-DONE` verdict and proceed only on `success`.
 
 Watch run-level status for cost, but expand in-flight runs to **job level** when early reaction matters: run status stays `in_progress` until every job finishes, so an already-failed lane is invisible at run granularity.
 
 ## Provider probes
 
-The contract is provider-neutral; only the probe changes. The generic mode of `scripts/ci-watch.py` accepts any command that prints `<name>: <state>` lines and one `TERMINAL: <verdict>` line when finished — the watcher never guesses a verdict for a custom probe.
+The contract is provider-neutral; only the probe changes. The generic mode of `scripts/ci-watch.py` accepts any command that prints `<name>: <state>` lines and one `TERMINAL: <verdict>` line when finished — the verdict must be one of the table entries above. A `success` verdict requires at least one registered unit unless the watcher was explicitly armed with `--expect-none`; the watcher never guesses a verdict for a custom probe.
 
 | Provider | Probe | Notes |
 |---|---|---|

--- a/skills/ci-cd-optimize/references/agent-ci-feedback.md
+++ b/skills/ci-cd-optimize/references/agent-ci-feedback.md
@@ -1,0 +1,137 @@
+# Agent CI Feedback Loop
+
+Use this file when an automated agent (or any unattended process) must **wait for a CI result** without blocking a session or hanging forever. Optimizing the pipeline is worthless if the thing that consumes the result stalls for 20 minutes or, worse, reports a false verdict.
+
+This is provider-neutral. The reference implementation below is GitHub Actions, but the contract holds for any CI that exposes run state over an API.
+
+## The failure modes this prevents
+
+| Symptom | Root cause |
+|---|---|
+| Session goes dark after a push, agent "waits" indefinitely | Blocking foreground watch with no deadline. |
+| Agent reports green, the commit was actually red | Watched the branch tip, or a stale/second workflow, instead of the exact SHA. |
+| A crashed run looks identical to a running one | Filter matched only success lines; failure produced no output. |
+| Watcher killed for flooding, no result at all | Emitted the full job table every poll instead of state changes. |
+| "Still running" forever on a run that never existed | Push matched no trigger (path filter, deleted workflow, wrong branch); nothing was ever going to appear. |
+| Watch survives, but the answer is for the wrong commit | Re-push superseded the run; the old watcher kept reporting. |
+
+## Do not use the CLI's built-in "watch" subcommand
+
+Most CI CLIs ship a `watch` command intended for a human terminal. Under an agent harness they commonly:
+
+- redraw with ANSI cursor control instead of emitting append-only lines,
+- suppress the final summary when stdout is not a TTY,
+- exit 0 on states that are not a real success.
+
+`gh run watch` exhibits all three (see cli/cli issues #6448, #6560, #8194). Poll a JSON API and derive state yourself.
+
+## The watcher contract
+
+Any watcher an agent arms must satisfy all six:
+
+1. **One line per event, append-only.** The harness turns each stdout line into a notification.
+2. **Diff-gated.** Emit only *state changes*. A green 3-minute run should cost ~4 notifications, not 12 duplicate job tables. Harnesses auto-stop noisy watchers, and a stopped watcher is silence.
+3. **Pinned to the exact commit, across every workflow.** Query by commit SHA, not branch. This kills false greens from a stale tip *and* catches a second workflow that fails after the first passed.
+4. **Every exit path prints a terminal verdict.** `success`, `failure`, `timeout`, `no-run`, `superseded`, `probe-dead`. Silence past the deadline must be structurally impossible.
+5. **A registration deadline, separate from the run deadline.** If no run appears for the SHA within a few minutes, say `no-run` and stop.
+6. **Per-probe timeouts and an error-streak exit.** One wedged HTTP call must not freeze the loop; N consecutive failures is a verdict, not a retry-forever.
+
+Add **heartbeats** (~2–3 min). They are the only thing distinguishing "slow" from "wedged", and on cache-based model APIs they keep the prompt cache warm.
+
+## Reference implementation (GitHub Actions)
+
+```bash
+#!/usr/bin/env bash
+# ci-watch.sh <sha> [deadline_min] — one line per state change, always ends in CI-DONE.
+set -uo pipefail
+SHA="$1"; DEADLINE=$(( ${2:-20} * 60 )); REPO="${REPO:?set REPO=org/name}"
+START=$(date +%s); REGISTERED=0; declare -A SEEN; STREAK=0; BEAT=$START
+
+while :; do
+  NOW=$(date +%s); ELAPSED=$(( NOW - START ))
+
+  if ! RAW=$(timeout 30 gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=50" \
+        --jq '.workflow_runs[] | [.name, .status, (.conclusion // ""), .id] | @tsv' 2>/dev/null); then
+    STREAK=$(( STREAK + 1 ))
+    [ "$STREAK" -ge 10 ] && { echo "CI-DONE probe-dead — 10 consecutive probe errors"; exit 1; }
+  else
+    STREAK=0
+    [ -n "$RAW" ] && [ "$REGISTERED" -eq 0 ] && { REGISTERED=1; echo "CI-RUN registered"; }
+    DONE=1; BAD=""
+    while IFS=$'\t' read -r name status conclusion id; do
+      [ -z "$name" ] && continue
+      state="${conclusion:-$status}"
+      [ "${SEEN[$name]:-}" != "$state" ] && { [ -n "${SEEN[$name]:-}" ] && echo "CI-CHG $name: $state"; SEEN[$name]="$state"; }
+      [ "$status" != "completed" ] && DONE=0
+      [ "$status" = "completed" ] && [ "$conclusion" != "success" ] && BAD="$name:$conclusion (gh run view $id --log-failed)"
+    done <<< "$RAW"
+
+    if [ "$REGISTERED" -eq 1 ] && [ "$DONE" -eq 1 ]; then
+      [ -z "$BAD" ] && { echo "CI-DONE success — $SHA"; exit 0; }
+      echo "CI-DONE failure — $BAD"; exit 1
+    fi
+    [ "$REGISTERED" -eq 0 ] && [ "$ELAPSED" -gt 240 ] && { echo "CI-DONE no-run — nothing registered for $SHA"; exit 1; }
+  fi
+
+  [ "$ELAPSED" -gt "$DEADLINE" ] && { echo "CI-DONE timeout — last state: ${SEEN[*]:-none}"; exit 1; }
+  [ $(( NOW - BEAT )) -ge 150 ] && { BEAT=$NOW; echo "CI-HB $(( ELAPSED / 60 ))/$(( DEADLINE / 60 ))m"; }
+  sleep 20
+done
+```
+
+Arm it with the harness's streaming-watch facility (in Claude Code, the `Monitor` tool) and **keep working**:
+
+```
+Monitor(command: "REPO=org/app ./ci-watch.sh $(git rev-parse HEAD) 12",
+        description: "CI for feature-branch", timeout_ms: 840000)
+```
+
+Set the harness timeout comfortably above the script's own deadline so the script — not the harness — produces the verdict.
+
+## Choosing the right waiting primitive
+
+| Need | Use |
+|---|---|
+| Many events until a known end (CI progress) | A streaming watcher like the above. |
+| Exactly one notification ("tell me when it's done") | A backgrounded command that exits when true: `until <cond>; do sleep 5; done`. |
+| Watch a file/log for arbitrary matches | `tail -f … \| grep --line-buffered` — but see the coverage rule below. |
+
+**Coverage rule:** a filter that matches only the success marker is silent through a crash, a hang, and an OOM — and silence is indistinguishable from "still running". Always match every terminal state, or widen the alternation:
+
+```bash
+# wrong — silent on crash
+tail -f run.log | grep --line-buffered "BUILD SUCCESS"
+# right
+tail -f run.log | grep -E --line-buffered "BUILD SUCCESS|FAILED|ERROR|Killed|OOM"
+```
+
+Every stage in a pipe must flush per line (`grep --line-buffered`, `awk … fflush()`); `head -N` cannot flush and will withhold output until N matches accumulate.
+
+## Interpreting verdicts
+
+| Verdict | Meaning | Correct reaction |
+|---|---|---|
+| `success` | Every workflow for that SHA passed | Proceed. |
+| `failure` | At least one concluded non-success | Pull the failed log **immediately** — a failure at minute 2 of a 20-minute pipeline is an 18-minute head start. |
+| `timeout` | **No verdict yet.** Not a pass, not a build failure | Inspect the run. Frequently queue starvation, not your code. Re-arm with a larger deadline. |
+| `no-run` | Nothing was triggered | Check triggers/path filters/branch rules before assuming the pipeline is broken. |
+| `superseded` | A newer commit landed | Retire this watch, arm one for the new SHA. |
+| `probe-dead` | The API is unreachable | Infrastructure problem; escalate rather than retry blindly. |
+
+The two that get misreported most often are **`timeout`** and **`no-run`**. Neither is a red build and neither is a green one; both mean *you still do not know*. Never let either be recorded as a pass.
+
+## Sizing the deadline
+
+Set it above the workflow's observed **p95**, not its median, and remember p95 includes queue time. A pipeline that executes in 40s can still sit 15 minutes in a runner shortage; a deadline tuned to execution time will fire spuriously and train the agent to ignore verdicts.
+
+If timeouts recur while execution stays flat, the bottleneck is queue/capacity — route to `references/runners-and-autoscaling.md`, not to the build.
+
+## Do not measure during your own burst
+
+Arming several validation runs back-to-back inflates queue time for all of them. Wall-clock measured under self-inflicted contention is not a regression signal. Separate queue from execution before concluding anything, and take timing samples from ordinary pushes — see `references/measurement.md`.
+
+## Sources
+
+- GitHub Actions REST — workflow runs: https://docs.github.com/en/rest/actions/workflow-runs (accessed 2026-07-28)
+- `gh run watch` non-TTY/false-green issues: cli/cli #6448, #6560, #8194 (accessed 2026-07-28)
+- Contract validated end-to-end on a live GitHub Actions repository (2026-07-28): green, red, timeout (867s runner-queue starvation), no-run, and multi-workflow registration each observed and handled.

--- a/skills/ci-cd-optimize/references/agent-ci-feedback.md
+++ b/skills/ci-cd-optimize/references/agent-ci-feedback.md
@@ -1,137 +1,146 @@
 # Agent CI Feedback Loop
 
-Use this file when an automated agent (or any unattended process) must **wait for a CI result** without blocking a session or hanging forever. Optimizing the pipeline is worthless if the thing that consumes the result stalls for 20 minutes or, worse, reports a false verdict.
+Read this when an agent or unattended process must wait for a CI result without blocking, when a watcher hangs or floods, or when CI is the only verification surface (no trusted local build/test path). In a CI-only repo this loop *is* the development loop — optimizing it is mandatory work, not polish.
 
-This is provider-neutral. The reference implementation below is GitHub Actions, but the contract holds for any CI that exposes run state over an API.
+A bundled reference implementation lives at `scripts/ci-watch.py` (stdlib-only Python, GitHub mode + generic probe mode). Every design rule below is enforced in that script; validate it against real runs before trusting it (see the validation matrix).
 
-## The failure modes this prevents
+## Fast triage
 
-| Symptom | Root cause |
-|---|---|
-| Session goes dark after a push, agent "waits" indefinitely | Blocking foreground watch with no deadline. |
-| Agent reports green, the commit was actually red | Watched the branch tip, or a stale/second workflow, instead of the exact SHA. |
-| A crashed run looks identical to a running one | Filter matched only success lines; failure produced no output. |
-| Watcher killed for flooding, no result at all | Emitted the full job table every poll instead of state changes. |
-| "Still running" forever on a run that never existed | Push matched no trigger (path filter, deleted workflow, wrong branch); nothing was ever going to appear. |
-| Watch survives, but the answer is for the wrong commit | Re-push superseded the run; the old watcher kept reporting. |
+| Symptom | Likely cause | Read |
+|---|---|---|
+| Watch returns instantly, reports nothing running | Registration race — the run hasn't been indexed yet | Failure modes, rule 5 |
+| Session goes dark after a push | Foreground watch with no deadline | The contract |
+| Green reported, commit was actually red | Branch-tip query, single-workflow watch, or stale SHA | Contract rules 3–4 |
+| Crashed run indistinguishable from a running one | Success-only filter | Failure modes |
+| Watcher killed for flooding, verdict lost | Emitting full state every poll instead of changes | Contract rule 6 |
+| "Still running" forever on a run that never existed | No registration deadline (path filter, deleted workflow) | Verdicts: `no-run` |
+| Superseded push debugged as a real failure | Cancellation folded into failure | Ordering law |
+| Success declared, deploy then failed | `workflow_run` follow-up registered late | Settle window |
 
-## Do not use the CLI's built-in "watch" subcommand
+## Failure modes worth naming
 
-Most CI CLIs ship a `watch` command intended for a human terminal. Under an agent harness they commonly:
+**Provider `watch` subcommands are TTY-shaped.** `gh run watch` and its cousins redraw a status block, suppress the completion summary when stdout is not a terminal, and can exit 0 on states that are not a real pass (cli/cli #6448, #6560, #8194). Piped into a line consumer, every redraw becomes an event and the watch gets rate-limited away. Test before trusting any of them: `timeout 25 <watch-cmd> | cat -A | head -20` — repeated blocks or cursor-movement escapes mean it is a renderer, not an event stream.
 
-- redraw with ANSI cursor control instead of emitting append-only lines,
-- suppress the final summary when stdout is not a TTY,
-- exit 0 on states that are not a real success.
+**Success-only filters are silent on red.** `until <status> | grep -q success; do sleep 30; done` never exits on a failed run — failure produces no match, so the loop looks identical to "still running." One line proves it: `echo failure | grep -q success || echo "no output — loop runs forever"`.
 
-`gh run watch` exhibits all three (see cli/cli issues #6448, #6560, #8194). Poll a JSON API and derive state yourself.
+**The `| head` pipe trap.** A shell pipeline's exit status is the *last* command's. `watch-cmd --exit-status | head` reports 0 even when the run failed — a run that never started still "passed." Check `${PIPESTATUS[0]}` (bash) or run unpiped before trusting `$?`.
 
-## The watcher contract
+**Enumerate success, not failure.** The most dangerous watcher bug is treating "did not fail" as green. Match an explicit success set (`success`, plus deliberate neutrals like `skipped`) and treat every other terminal conclusion — including ones never seen before — as not-green.
 
-Any watcher an agent arms must satisfy all six:
+## The contract
 
-1. **One line per event, append-only.** The harness turns each stdout line into a notification.
-2. **Diff-gated.** Emit only *state changes*. A green 3-minute run should cost ~4 notifications, not 12 duplicate job tables. Harnesses auto-stop noisy watchers, and a stopped watcher is silence.
-3. **Pinned to the exact commit, across every workflow.** Query by commit SHA, not branch. This kills false greens from a stale tip *and* catches a second workflow that fails after the first passed.
-4. **Every exit path prints a terminal verdict.** `success`, `failure`, `timeout`, `no-run`, `superseded`, `probe-dead`. Silence past the deadline must be structurally impossible.
-5. **A registration deadline, separate from the run deadline.** If no run appears for the SHA within a few minutes, say `no-run` and stop.
-6. **Per-probe timeouts and an error-streak exit.** One wedged HTTP call must not freeze the loop; N consecutive failures is a verdict, not a retry-forever.
+A watcher is trustworthy only if all seven hold:
 
-Add **heartbeats** (~2–3 min). They are the only thing distinguishing "slow" from "wedged", and on cache-based model APIs they keep the prompt cache warm.
+1. **Every exit path prints a terminal verdict.** Silence past the deadline must be structurally impossible — including when the watcher itself crashes (wrap the whole loop; a traceback with no verdict strands the caller).
+2. **Reports failure at least as loudly as success**, with the exact log-retrieval command in the verdict line so the caller acts without re-deriving anything.
+3. **Pinned to an immutable identifier captured before arming** — a full commit SHA, build id, or deployment id. Never a branch tip: a branch-tip query returns a newer run and reports a green for code you did not push. (Short SHAs can silently match zero runs — guard the length.)
+4. **Covers every unit the identifier triggered**, not just the named workflow. A second workflow can fail after the first passes; after a fast-forward, one commit can carry both a branch run and a default-branch run — the second is usually the one that deploys.
+5. **A registration deadline separate from the run deadline**, clamped below half the overall deadline. If nothing registers in a few minutes, exit `no-run` — otherwise a skipped pipeline misreports as `timeout`, a strictly less useful verdict. In path-filtered repos zero runs is often *correct*; give callers an explicit expect-none mode rather than making them ignore `no-run`.
+6. **Diff-gated, with heartbeats.** Emit only state transitions — a green 20-minute run should cost a handful of notifications, not 60 duplicate tables (harnesses auto-stop flooding watchers, and a stopped watcher is silence). Heartbeat every ~2.5 minutes so "waiting" is distinguishable from "wedged"; where the consuming model has a prompt-cache TTL, keep the heartbeat under it so a long queue does not force a cold context re-read.
+7. **Per-probe timeouts and streak-bounded errors.** Cap each probe call so one wedged request cannot freeze the loop; retry transient errors quietly, warn once after ~3 consecutive, exit `probe-dead` after ~10.
 
-## Reference implementation (GitHub Actions)
+Two state-keying rules from bugs found only under live testing: key state by **run id**, not workflow name (one commit can run the same workflow twice; keyed by name the states overwrite each other and the watcher flaps forever), and compute the verdict from the **newest run per workflow** so a concurrency-cancelled older sibling does not turn a green commit red.
 
-```bash
-#!/usr/bin/env bash
-# ci-watch.sh <sha> [deadline_min] — one line per state change, always ends in CI-DONE.
-set -uo pipefail
-SHA="$1"; DEADLINE=$(( ${2:-20} * 60 )); REPO="${REPO:?set REPO=org/name}"
-START=$(date +%s); REGISTERED=0; declare -A SEEN; STREAK=0; BEAT=$START
+## Ordering law: supersession before failure
 
-while :; do
-  NOW=$(date +%s); ELAPSED=$(( NOW - START ))
+Under `cancel-in-progress` concurrency, pushing a fix cancels the previous commit's run. A watcher that checks failure first reports `failure` for a run nobody should act on — and the agent goes off debugging a phantom break that looks exactly like a real red. Evaluate in this order:
 
-  if ! RAW=$(timeout 30 gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=50" \
-        --jq '.workflow_runs[] | [.name, .status, (.conclusion // ""), .id] | @tsv' 2>/dev/null); then
-    STREAK=$(( STREAK + 1 ))
-    [ "$STREAK" -ge 10 ] && { echo "CI-DONE probe-dead — 10 consecutive probe errors"; exit 1; }
-  else
-    STREAK=0
-    [ -n "$RAW" ] && [ "$REGISTERED" -eq 0 ] && { REGISTERED=1; echo "CI-RUN registered"; }
-    DONE=1; BAD=""
-    while IFS=$'\t' read -r name status conclusion id; do
-      [ -z "$name" ] && continue
-      state="${conclusion:-$status}"
-      [ "${SEEN[$name]:-}" != "$state" ] && { [ -n "${SEEN[$name]:-}" ] && echo "CI-CHG $name: $state"; SEEN[$name]="$state"; }
-      [ "$status" != "completed" ] && DONE=0
-      [ "$status" = "completed" ] && [ "$conclusion" != "success" ] && BAD="$name:$conclusion (gh run view $id --log-failed)"
-    done <<< "$RAW"
+1. Real failure conclusions → `failure`.
+2. All conclusions in `{success, skipped, neutral, cancelled}` **and** a newer identifier exists → `superseded`.
+3. Cancelled with the branch *unmoved* → `cancelled` (manual cancel or infrastructure — a distinct signal, still not a test failure).
 
-    if [ "$REGISTERED" -eq 1 ] && [ "$DONE" -eq 1 ]; then
-      [ -z "$BAD" ] && { echo "CI-DONE success — $SHA"; exit 0; }
-      echo "CI-DONE failure — $BAD"; exit 1
-    fi
-    [ "$REGISTERED" -eq 0 ] && [ "$ELAPSED" -gt 240 ] && { echo "CI-DONE no-run — nothing registered for $SHA"; exit 1; }
-  fi
+Resolve the branch tip with `git ls-remote origin refs/heads/<branch>`, not "latest run for the branch": the newest push may not have registered a run yet, and the previous commit's run masquerades as the tip — misreporting the new commit as superseded by its own ancestor.
 
-  [ "$ELAPSED" -gt "$DEADLINE" ] && { echo "CI-DONE timeout — last state: ${SEEN[*]:-none}"; exit 1; }
-  [ $(( NOW - BEAT )) -ge 150 ] && { BEAT=$NOW; echo "CI-HB $(( ELAPSED / 60 ))/$(( DEADLINE / 60 ))m"; }
-  sleep 20
-done
-```
+## Settle window
 
-Arm it with the harness's streaming-watch facility (in Claude Code, the `Monitor` tool) and **keep working**:
+When one workflow triggers another on completion (`workflow_run`: deploy-after-build), the follow-up does not exist at the moment the first turns green. Exiting on first-green reports a success that structurally cannot include the deploy. Hold an all-green state for a short settle window (~90s) and re-probe before declaring `success`.
 
-```
-Monitor(command: "REPO=org/app ./ci-watch.sh $(git rev-parse HEAD) 12",
-        description: "CI for feature-branch", timeout_ms: 840000)
-```
+## Verdicts and the agent's next move
 
-Set the harness timeout comfortably above the script's own deadline so the script — not the harness — produces the verdict.
+| Verdict | Meaning | Next move |
+|---|---|---|
+| `success` | Explicit success/neutral set across every unit, settled | Proceed; confirm the run's head SHA equals what was pushed |
+| `failure` | ≥1 unit concluded non-success | Run the printed log command **immediately** — a failure at minute 6 of a 25-minute pipeline is a ~19-minute head start |
+| `cancelled` | Cancelled, branch unmoved | Investigate who/what cancelled; not red, not green |
+| `superseded` | Newer identifier landed | Retire this watch; arm a fresh one for the new identifier |
+| `no-run` | Nothing registered in time | Check triggers/path filters/branch rules; expected under path filters — never silently treat as green |
+| `timeout` | Deadline hit, no verdict | **Not a pass and not a build failure** — frequently queue starvation. Inspect the run, then re-arm with a larger deadline |
+| `probe-dead` | API unreachable or watcher crashed | Infrastructure problem; escalate rather than blind-retry |
 
-## Choosing the right waiting primitive
+The two most misreported are `timeout` and `no-run`; both mean *you still do not know*. A verdict is evidence only for the identifier it names — a green on a stale or empty diff proves nothing (`effectiveness-contract.md`).
+
+Distinct exit codes matter because callers chain on them: `watch && deploy` must not proceed on `superseded` or `timeout`. The bundled script uses 0 for success, 124 for timeout (the GNU `timeout` convention), 1 otherwise.
+
+Watch run-level status for cost, but expand in-flight runs to **job level** when early reaction matters: run status stays `in_progress` until every job finishes, so an already-failed lane is invisible at run granularity.
+
+## Provider probes
+
+The contract is provider-neutral; only the probe changes. The generic mode of `scripts/ci-watch.py` accepts any command that prints `<name>: <state>` lines and one `TERMINAL: <verdict>` line when finished — the watcher never guesses a verdict for a custom probe.
+
+| Provider | Probe | Notes |
+|---|---|---|
+| GitHub Actions | `gh run list --commit <sha> --json …` | All workflows for the exact commit. `gh run list` collapses re-run attempts — check the attempt counter before treating a rerun as a new sample |
+| GitHub PR gate | `gh pr checks` | Mergeability ≠ branch CI: required checks include third-party services; a branch can be green while the PR is not mergeable. Watch whichever one actually gates you (also cli/cli #6448: expected-but-unreported checks) |
+| GitLab CI | `glab pipeline list --sha …` / pipelines API | Poll pipeline + bridges for the SHA |
+| CircleCI | pipelines-for-commit API → workflows per pipeline | Two-level: pipeline → workflows |
+| Buildkite | builds API filtered by commit | One build may fan out to triggered builds |
+| Anything else | your status command as a `--cmd` probe | Deploy APIs, EAS, self-hosted — anything that can print `name: state` |
+
+## Choosing the waiting primitive
 
 | Need | Use |
 |---|---|
-| Many events until a known end (CI progress) | A streaming watcher like the above. |
-| Exactly one notification ("tell me when it's done") | A backgrounded command that exits when true: `until <cond>; do sleep 5; done`. |
-| Watch a file/log for arbitrary matches | `tail -f … \| grep --line-buffered` — but see the coverage rule below. |
+| Progress events until a known end | Streaming watcher (this contract) on the harness's event-stream facility |
+| Exactly one notification ("tell me when done") | Backgrounded command that exits on the condition: `until <cond>; do sleep 5; done` — with a deadline |
+| A blocking gate inside a script | The same watcher, foreground, branching on its exit code |
 
-**Coverage rule:** a filter that matches only the success marker is silent through a crash, a hang, and an OOM — and silence is indistinguishable from "still running". Always match every terminal state, or widen the alternation:
+The watcher is identical in all three; only the invocation differs. Never arm an unbounded `while true` for a single answer, and never point a TTY renderer at an event-stream tool.
 
-```bash
-# wrong — silent on crash
-tail -f run.log | grep --line-buffered "BUILD SUCCESS"
-# right
-tail -f run.log | grep -E --line-buffered "BUILD SUCCESS|FAILED|ERROR|Killed|OOM"
-```
+Arming rules that generalize to any harness facility:
 
-Every stage in a pipe must flush per line (`grep --line-buffered`, `awk … fflush()`); `head -N` cannot flush and will withhold output until N matches accumulate.
+- Every pipe stage must flush per line (`grep --line-buffered`, `awk '{...; fflush()}'`); `head -N` cannot flush and withholds output until N matches accumulate.
+- If the process crashed right now, would the filter emit anything? If not, it is a success-only filter in disguise — widen it to every terminal state.
+- Set the facility's own timeout **above** the watcher's deadline (~3 min headroom) so the watcher prints its verdict instead of being killed mid-sentence. A killed watcher looks identical to a hung one.
+- One watch per pinned identifier; re-pushing supersedes — arm a fresh watch.
+- Shell traps: in zsh, `status` is a readonly builtin (`status=$(…)` is fatal and the watcher emits nothing at all); command substitution strips trailing newlines, so diff-gate on parsed fields, not raw blobs; pass configuration as explicit arguments rather than inheriting ambient environment.
 
-## Interpreting verdicts
+## Validate the watcher before trusting it
 
-| Verdict | Meaning | Correct reaction |
+A watcher only ever observed succeeding is untested. Produce each path deliberately:
+
+| Scenario | How | Expected |
 |---|---|---|
-| `success` | Every workflow for that SHA passed | Proceed. |
-| `failure` | At least one concluded non-success | Pull the failed log **immediately** — a failure at minute 2 of a 20-minute pipeline is an 18-minute head start. |
-| `timeout` | **No verdict yet.** Not a pass, not a build failure | Inspect the run. Frequently queue starvation, not your code. Re-arm with a larger deadline. |
-| `no-run` | Nothing was triggered | Check triggers/path filters/branch rules before assuming the pipeline is broken. |
-| `superseded` | A newer commit landed | Retire this watch, arm one for the new SHA. |
-| `probe-dead` | The API is unreachable | Infrastructure problem; escalate rather than retry blindly. |
+| Green lifecycle | ordinary passing push | `RUN` → `CHG` → `DONE success`, few notifications |
+| **Real failure** | push a deliberate compile/type error, revert after | red `CHG` mid-run, `DONE failure` + working log command, non-zero exit |
+| Nothing registers | bogus or path-filtered SHA | `DONE no-run` well before the deadline |
+| Deadline | near-zero deadline against a live run | `DONE timeout`, exit 124, never silence |
+| Superseded | two pushes in quick succession | `DONE superseded`, **not** failure |
+| Long queue | watch during runner contention | periodic heartbeats carrying state |
+| Probe garbage | probe emitting invalid bytes | degraded probe error, not a crash |
 
-The two that get misreported most often are **`timeout`** and **`no-run`**. Neither is a red build and neither is a green one; both mean *you still do not know*. Never let either be recorded as a pass.
+Confirm the printed remediation command actually surfaces the error, and that the exit code survives your invocation (`${PIPESTATUS[0]}`, unpiped run).
 
-## Sizing the deadline
+## Reacting to a red check
 
-Set it above the workflow's observed **p95**, not its median, and remember p95 includes queue time. A pipeline that executes in 40s can still sit 15 minutes in a runner shortage; a deadline tuned to execution time will fire spuriously and train the agent to ignore verdicts.
+1. Run the exact log command the verdict printed — do not re-derive it.
+2. Reproduce with the narrowest command available; if it only fails in CI, reproduce the CI-specific condition (env, OS, service) rather than guessing.
+3. Fix the root cause. Never reach green by adding a retry, widening a threshold, mocking away the failure, or skipping the check — that corrupts the measurement instead of fixing the pipeline (`effectiveness-contract.md`).
+4. For a suspected flake: re-run the *identical* commit first. A pass on the unchanged tree is evidence of flake (route to `testing-and-flakiness.md`); a second failure is a real break. Provider flake counters undercount — they typically only catch a step that succeeded elsewhere.
+5. Push the fix and arm a fresh watch for the new SHA.
 
-If timeouts recur while execution stays flat, the bottleneck is queue/capacity — route to `references/runners-and-autoscaling.md`, not to the build.
+Heartbeats are acknowledged silently — never restated as progress, never treated as a reply from anyone.
 
-## Do not measure during your own burst
+## Shrinking the loop itself
 
-Arming several validation runs back-to-back inflates queue time for all of them. Wall-clock measured under self-inflicted contention is not a regression signal. Separate queue from execution before concluding anything, and take timing samples from ordinary pushes — see `references/measurement.md`.
+- **Narrow dispatchable lanes**: a `workflow_dispatch` input selecting typecheck-only / lint-only / test-only / affected-only lets an agent ask one question in seconds instead of re-running the whole gate. Guard dispatch by refusing unless the remote ref's SHA equals local HEAD, and correlate the resulting run by head SHA + dispatch time window — display-title matching silently attaches to the wrong run.
+- **Deadline sizing**: set the watch deadline above the workflow's observed p95 *including queue* (`measurement.md`); a 40s pipeline can sit 15 minutes in a runner shortage, and a deadline tuned to execution time trains the caller to ignore verdicts. Recurring timeouts with flat execution are a capacity story — `capacity-and-contention.md`.
+- **Deploy self-verification**: when the pipeline ends in a deploy, the revision-convergence assertion has its own sizing trap — `deployment.md`.
+- Commit the watcher script to the repo and document the exact arming invocation next to the push instructions in the contributor/agent docs, so every agent can tell "slow" from "stuck" without reinventing the loop.
 
 ## Sources
 
 - GitHub Actions REST — workflow runs: https://docs.github.com/en/rest/actions/workflow-runs (accessed 2026-07-28)
-- `gh run watch` non-TTY/false-green issues: cli/cli #6448, #6560, #8194 (accessed 2026-07-28)
-- Contract validated end-to-end on a live GitHub Actions repository (2026-07-28): green, red, timeout (867s runner-queue starvation), no-run, and multi-workflow registration each observed and handled.
+- `gh run watch` / checks limitations: cli/cli #6448 (open as of 2026-07-28), #6560 (closed; historical context for owning your own deadline), #8194 (accessed 2026-07-28)
+- POSIX shell pipeline exit status (the `| head` trap): https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_02 (accessed 2026-07-28)
+- Design lineage: yigitkonur/plugin-ci-watch-unstall (diff-gating, SHA pinning, guaranteed terminal verdict)
+- Contract validated end-to-end on live GitHub Actions runs (2026-07-28): green, red, timeout under 867s queue starvation, no-run, superseded, multi-workflow registration, and crash-to-verdict each observed.

--- a/skills/ci-cd-optimize/references/capacity-and-contention.md
+++ b/skills/ci-cd-optimize/references/capacity-and-contention.md
@@ -1,0 +1,61 @@
+# Capacity and Contention
+
+Read this before recommending any parallelization change (more jobs, more shards, a fan-out planner), and whenever a measured speedup came out neutral or worse than predicted. Splitting work only helps while runners are available to pick it up; past the concurrency ceiling, more jobs make the pipeline *slower*, and contention quietly corrupts every timing you collect.
+
+## The queue-share gate
+
+Before touching topology, compute where wall-clock actually goes:
+
+```
+queue share = Σ queue time / (Σ queue time + Σ execution time)
+```
+
+Queue time per job is `started_at − created_at`; execution is `completed_at − started_at`. Both are in the provider's run/job API.
+
+| Queue share | Regime | Action |
+|---|---|---|
+| `< 15 %` | Execution-bound | Optimize inside jobs (cache, critical path, test cost). Splitting helps. |
+| `15–35 %` | Mixed | Stop *adding* jobs; balance the ones you have. |
+| `> 35 %` | **Capacity-bound** | Topology changes are near-futile. Raise concurrency or reduce job count. |
+
+This inverts the usual "split long jobs" advice in the capacity regime — both are correct, and the ceiling decides which applies.
+
+## Why more jobs get slower
+
+Wall-clock for N independent jobs against C concurrent runners is roughly:
+
+```
+wall-clock ≈ queue + ceil(N / C) × (per-job setup + execution)
+```
+
+Once `N > C`, jobs serialize into `ceil(N / C)` waves, and every job re-pays setup (checkout, toolchain, dependency restore). Fanning a suite into 8 shards on a 2-runner fleet runs four sequential waves plus eight setups — reliably worse than 2 shards. Fanning heavy work onto a single scarce large-runner label serializes your own pipeline against itself.
+
+## Detect the ceiling empirically
+
+Do not trust documented plan limits — org settings, other repos' concurrent runs, and reserved capacity all move the real number. Trigger more jobs than the suspected ceiling, then from the job API record `created_at` and `started_at` and count the peak number simultaneously *started but not completed*. That peak is C.
+
+Worked shape: three independent jobs dispatched together; two start within a second of each other, the third starts only when one of the first two finishes. C = 2. No workflow change makes the third start sooner — only more capacity does.
+
+## Contention is a measurement confound
+
+Two runs of the same commit on the same runner class are **not comparable** if one ran against an idle pool and the other against a saturated one. This is the most common reason a "regression" or "win" evaporates on re-measurement.
+
+- Never quote a multiplier when queue p95 exceeds execution p50 — the number is dominated by scheduling noise. (Worked case: six runs of one unchanged pipeline, execution stable at 56–68s, queue ranging 16s–416s; both "1.7× faster" and "2.6× slower" are derivable from the same data and both meaningless.)
+- To compare two configurations under contention, interleave arms (A, B, A, B, …) rather than all-A-then-all-B, so a load swing hits both.
+- Treat any delta smaller than the queue p95−p50 spread as noise.
+- Do not benchmark inside your own burst of validation runs — back-to-back dispatches inflate each other's queue. Sample from ordinary pushes, and report the sample size (n≈5 is an observation, not a p95; ~20 is a floor for a credible tail).
+
+## Ranked remediation when capacity-bound
+
+1. **Reduce job count** — merge jobs that share setup; move short steps into a neighbor rather than paying a fresh runner for each. (Directly contradicts "split long jobs" — correct only in this regime.)
+2. **Raise concurrency** — a larger hosted plan, more self-hosted replicas, or autoscaling keyed to queue depth. Justify it with the measured ceiling and queue share, not a hunch.
+3. **Right-size, don't upsize the matrix** — move only the proven CPU-bound critical-path job to a bigger runner; a large label with a smaller fleet often queues *longer* (`runners-and-autoscaling.md`).
+4. **Cut work that never needed to run** — path filters and change-based selection reduce N at the source (`change-based-ci.md`), which is strictly better than scheduling it faster.
+
+## Provider ceilings
+
+Concurrency limits are plan- and account-scoped and change often — verify against current docs before quoting a number, per `evidence-and-sources.md`. As orientation only: hosted GitHub Actions concurrency scales with plan tier; GitLab is governed by runner `concurrent` / per-project `limit` / `request_concurrency`; self-hosted fleets are bounded by replica count. The number that matters is the one you measured on this repo, this hour.
+
+## Report disproved hypotheses
+
+An experiment that measured neutral or worse is a result, not a dead end — record it. Silently dropping it invites the next person (or the next agent) to retry the same change. "Fan-out measured neutral (244s vs 245s) because the repo had 2 concurrent runners and queue was 47.7% of total CI time" is more valuable to the next reader than an omission, because it names the ceiling that made topology irrelevant. This honesty is part of the skill's done criteria, not optional color.

--- a/skills/ci-cd-optimize/references/deployment.md
+++ b/skills/ci-cd-optimize/references/deployment.md
@@ -43,6 +43,19 @@ Before claiming a deployment is done, verify:
 - canary/analysis metrics are inside budget,
 - rollback artifact remains available.
 
+### Size the convergence budget to propagation, not to the deploy call
+
+A self-verifying deploy — deploy, then poll a `/version`-style endpoint until it reports the pushed revision — is the cheapest guard against a silently stale release. It has one classic defect: **the polling budget is tuned to how long the deploy command takes, not to how long the platform takes to converge.**
+
+Edge and CDN-backed platforms (Cloudflare Workers, Vercel, Fastly, multi-region rollouts) commonly serve the previous revision for tens of seconds after the deploy call returns 200. A 30-second budget produces a **false red on a deploy that actually succeeded** — which is worse than no check, because it trains everyone to ignore the signal and can trigger an unnecessary rollback.
+
+Rules:
+
+- Set the budget well above observed propagation p95 (a 2-minute budget is unremarkable for edge platforms), and keep the per-request timeout short so a hung request does not consume it.
+- Poll with a **strict equality** check against the expected revision. Retry HTTP errors and malformed bodies; never treat them as success.
+- When the assertion fails, distinguish the two cases before acting: a failure in the deploy/migration step is a real bad ship (roll back); a failure only in the revision assertion usually means propagation outran the budget — re-query the endpoint before rolling back anything.
+- Emit the expected and observed revision in the failure message. "Did not converge" without both values is unactionable.
+
 ## TypeScript status probe sketch
 
 ```ts

--- a/skills/ci-cd-optimize/references/deployment.md
+++ b/skills/ci-cd-optimize/references/deployment.md
@@ -56,6 +56,8 @@ Rules:
 - When the assertion fails, distinguish the two cases before acting: a failure in the deploy/migration step is a real bad ship (roll back); a failure only in the revision assertion usually means propagation outran the budget — re-query the endpoint before rolling back anything.
 - Emit the expected and observed revision in the failure message. "Did not converge" without both values is unactionable.
 
+If an agent is waiting on this verdict in the background, wire the poller like any other CI watcher: bounded deadline, terminal verdict, and explicit `timeout` semantics — see `agent-ci-feedback.md`.
+
 ## TypeScript status probe sketch
 
 ```ts

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -41,6 +41,8 @@ Practical rules:
 - Report the sample size. Two runs per side is an observation; it is not a median, and it is certainly not a p95.
 - When a change is genuinely neutral on speed, say so. "No speedup; the work was correctness" is a valid, honest result — inflating queue noise into a win or a loss destroys the credibility of every other number in the report.
 
+When queue time is a large share of wall-clock, the confound is structural, not just noise: see `capacity-and-contention.md` for the queue-share gate, the concurrency-ceiling test, and interleaved A/B arms for comparing configurations under contention.
+
 ## Critical-path analysis
 
 Build a DAG from declared dependencies. For every job, compute:

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -28,6 +28,19 @@ Use median and p95. CI duration is right-skewed; averages hide cold caches, runn
 
 If a queue-time baseline is unavailable, start with provider run timestamps and job logs. Do not invent missing precision.
 
+## Do not measure inside your own burst
+
+Validation runs fired back-to-back contend for the same runner pool and inflate each other's queue time. Wall-clock measured under self-inflicted contention is not a regression signal, and reporting it as one is a false finding.
+
+A worked case: a change set measured 163s against a 100s baseline and looked like a clear regression. Splitting the job records showed **execution was flat** (warm verify 13s → 14s; secret scan 7s → 8s) while **queue rose from 10s to 32–115s** because four validation runs had been dispatched in immediate succession. A single run taken once the pool drained returned 48s. The change had no effect on speed in either direction.
+
+Practical rules:
+
+- Always decompose before concluding: `queue = started_at − created_at`, `execution = completed_at − started_at`. A wall-clock delta with flat execution is a scheduling story, not a build story.
+- Space validation runs, or take timing samples from ordinary pushes rather than from your own test batch.
+- Report the sample size. Two runs per side is an observation; it is not a median, and it is certainly not a p95.
+- When a change is genuinely neutral on speed, say so. "No speedup; the work was correctness" is a valid, honest result — inflating queue noise into a win or a loss destroys the credibility of every other number in the report.
+
 ## Critical-path analysis
 
 Build a DAG from declared dependencies. For every job, compute:

--- a/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -2,6 +2,8 @@
 
 Use this file when queue time, runner capacity, runner isolation, or fleet cost is the bottleneck.
 
+Before choosing a fleet change, quantify how much of wall-clock is queue versus execution and find the concurrency ceiling — `capacity-and-contention.md` gives the queue-share gate and the empirical ceiling test. Adding capacity is the last step in the performance order; confirm the pipeline is capacity-bound, not execution-bound, first.
+
 ## Decision order
 
 1. **Trust:** does the job run untrusted code?

--- a/skills/ci-cd-optimize/references/security-gates.md
+++ b/skills/ci-cd-optimize/references/security-gates.md
@@ -18,6 +18,7 @@ Use this file to make security scanning faster without deleting the control.
 - Use severity thresholds; do not make every informational finding a merge blocker.
 - Keep push protection outside CI so it costs no pipeline time.
 - Share scanner caches through a backend that supports concurrent runners.
+- Keep result-cached build/test graphs and security gates separate: a scan that can be replayed from an unrelated task cache is not a gate, it is a stale assertion. If a scan must run every time, keep it outside the build cache and reason about its cost with `caching.md`.
 - Give inline suppressions an owner and expiry; re-scan aged suppressions.
 
 ## Unsafe shortcuts

--- a/skills/ci-cd-optimize/references/testing-and-flakiness.md
+++ b/skills/ci-cd-optimize/references/testing-and-flakiness.md
@@ -82,6 +82,8 @@ npx jest --listTests | circleci tests run \
 
 Retries are a detection and temporary-confidence mechanism. A retry-pass is still evidence of instability. Track flake rate, rerun count, owner, and age.
 
+To tell a flake from a real break without weakening the test: re-run the *identical* commit before pushing any speculative fix. A pass on the unchanged tree is a flake; a second failure is a real break. Never reach green by relaxing an assertion, adding a retry, or re-running until it passes — that corrupts the check instead of fixing it (`effectiveness-contract.md`). Provider flake counters undercount; they typically only catch a step that succeeded in another run. When an agent surfaces the failure through a watcher, this is the reaction path in `agent-ci-feedback.md`.
+
 ## Coverage
 
 - Choose one coverage engine per suite; do not mix V8 and Istanbul artifacts across shards.

--- a/skills/ci-cd-optimize/references/testing-and-flakiness.md
+++ b/skills/ci-cd-optimize/references/testing-and-flakiness.md
@@ -28,6 +28,39 @@ vitest run --merge-reports
 
 Vitest distributes by test file by default. A few large files can still dominate; split large files or use provider timing-aware splitting.
 
+## Profile per file and per test before sharding
+
+Suite-level totals hide the actual bottleneck. Because Vitest and Jest distribute by **file**, a single slow file caps the whole project no matter how many workers you add — raising `maxWorkers` cannot split one file.
+
+Get per-file durations from the runner's own reporter output before touching concurrency:
+
+```
+✓ src/services/scheduler.test.ts (155 tests) 72054ms   ← 72s
+  Test Files  100 passed (100)
+  Duration    75.70s                                        ← one file is 95% of the run
+```
+
+Then read the slowest individual tests. **Durations clustered at a suspiciously round number are the tell.** Tests taking 8,048 / 8,037 / 24,063 ms are not "slow tests"; they are `n × 8000 ms` of real waiting.
+
+### Real sleeps in production code are the usual culprit
+
+The wait is frequently *not* in the test — it is a retry/backoff/poll delay in the code under test:
+
+```ts
+const RETRY_DELAY_MS = 8_000;                // production: wait for a warming dependency
+await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+```
+
+Every test that exercises that path burns 8s of wall-clock. Ranked fixes:
+
+1. **Make the delay injectable and lower it in the test environment** — smallest change, keeps attempt count, ordering, and guard conditions identical. Parse it from config/env with the production value as the default so production behavior is provably unchanged.
+2. **Fake timers**, when the runtime supports them — riskier, since the test now proves less about real scheduling, and some sandboxed runtimes (workerd, some browser pools) handle them poorly.
+3. **Split the file** — mechanical but large, and it only helps if the cost is spread across many tests rather than concentrated in a few sleeps.
+
+Measured example: injecting the delay took one file from 72.05s → 9.66s and the project from 75.70s → 14.83s (5.1×), with the test count *rising* 1866 → 1868. Verify that last part — a speedup that reduces the number of executed tests is a coverage regression wearing a stopwatch.
+
+Do not shard a suite whose cost is concentrated in dead waiting. You would pay setup N times to parallelize sleep.
+
 ## Jest
 
 Jest `--shard` balances by file count unless a custom sequencer uses historical timings. CircleCI and similar providers can split by JUnit timing metadata:

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -38,6 +38,7 @@ Design notes (each guards against a failure observed in real use):
 """
 
 import argparse
+import re
 import subprocess
 import sys
 import time
@@ -45,6 +46,10 @@ import time
 GH_SUCCESS = {"success"}
 GH_NEUTRAL = {"skipped", "neutral"}
 GH_CANCELLED = {"cancelled", "stale"}
+TERMINAL_VERDICTS = {
+    "success", "failure", "cancelled", "timeout", "no-run", "superseded", "probe-dead",
+}
+TERMINAL_EXIT_CODES = {"success": 0, "superseded": 0, "timeout": 124}
 # Everything else (failure, timed_out, startup_failure, action_required, unknown) = red.
 
 HEARTBEAT_SECS = 150  # under a typical 5-minute prompt-cache TTL: a quiet run stays warm
@@ -101,7 +106,7 @@ def probe_github(repo, sha, timeout):
         if len(parts) != 5:
             continue
         run_id, name, status, conclusion, created = parts
-        runs[run_id] = {"name": name, "status": status,
+        runs[run_id] = {"id": run_id, "name": name, "status": status,
                         "conclusion": conclusion, "created": created}
     return runs
 
@@ -115,7 +120,8 @@ def probe_custom(cmd, timeout):
     for line in out.splitlines():
         line = line.strip()
         if line.startswith("TERMINAL:"):
-            terminal = line.split(":", 1)[1].strip().split()[0].lower()
+            fields = line.split(":", 1)[1].strip().split()
+            terminal = fields[0].lower() if fields else ""
         elif ":" in line:
             name, state = line.split(":", 1)
             runs[name.strip()] = {"name": name.strip(), "status": state.strip(),
@@ -171,9 +177,9 @@ def main():
     if not a.cmd and not (a.repo and a.sha):
         emit("CI-DONE probe-dead — need --repo and --sha, or --cmd")
         return 1
-    if a.sha and len(a.sha) != 40:
-        emit("CI-DONE probe-dead — pass the full 40-char SHA "
-             "(short SHAs silently match zero runs)")
+    if a.sha and not re.fullmatch(r"[0-9a-fA-F]{40}", a.sha):
+        emit("CI-DONE probe-dead — pass the full 40-character hexadecimal SHA "
+             "(short or malformed SHAs silently match zero runs)")
         return 1
 
     deadline = a.deadline_min * 60
@@ -212,6 +218,7 @@ def main():
         else:
             err_streak = 0
 
+            was_registered = registered
             if runs and not registered:
                 registered = True
                 names = " · ".join(
@@ -222,22 +229,31 @@ def main():
             for run_id, r in runs.items():
                 state = r["conclusion"] or r["status"]
                 if seen.get(run_id) != state:
-                    if run_id in seen:
+                    if run_id in seen or was_registered:
                         emit(f"CI-CHG {r['name']}: {state}")
                     seen[run_id] = state
 
             if terminal is not None:
+                if terminal not in TERMINAL_VERDICTS:
+                    emit(f"CI-DONE probe-dead — invalid terminal verdict: "
+                         f"{terminal or '<empty>'}")
+                    return 1
+                if terminal == "success" and not registered and not a.expect_none:
+                    emit("CI-DONE probe-dead — probe declared success without any "
+                         "registered units (use --expect-none if zero units are valid)")
+                    return 1
                 emit(f"CI-DONE {terminal} — declared by probe")
-                return 0 if terminal == "success" else 1
+                return TERMINAL_EXIT_CODES.get(terminal, 1)
 
             if registered and not a.cmd:
                 verdict, detail = classify(runs)
                 if verdict == "failure":
-                    first = detail.split(",")[0].split(":")[0]
+                    failed = next(
+                        r for r in newest_per_workflow(runs).values()
+                        if r["conclusion"] not in GH_SUCCESS | GH_NEUTRAL | GH_CANCELLED
+                    )
                     emit(f"CI-DONE failure — {detail} — logs: gh run view "
-                         f"--repo {a.repo} $(gh run list --repo {a.repo} "
-                         f"--commit {a.sha} -w '{first}' --json databaseId "
-                         f"--jq '.[0].databaseId') --log-failed")
+                         f"--repo {a.repo} {failed['id']} --log-failed")
                     return 1
                 if verdict == "cancelled":
                     # Supersession BEFORE calling this red: a newer tip means the

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""ci-watch.py — bounded, diff-gated CI watcher for agents and unattended sessions.
+
+Stdlib only. Emits one line per state change and ALWAYS ends with a terminal verdict:
+
+    CI-WATCH <repo>@<sha> deadline=<m>m
+    CI-RUN   registered <n>: <name>: <state> ...
+    CI-CHG   <name>: <state>
+    CI-HB    <elapsed>/<deadline>m — <n> run(s) tracked
+    CI-DONE  <success|failure|cancelled|timeout|no-run|superseded|probe-dead> — detail
+
+Exit codes: 0 = success (or --expect-none satisfied) or superseded; 124 = timeout
+(matches the GNU `timeout` convention); 1 = everything else.
+
+Modes:
+  GitHub (default): probes `gh run list --commit <sha>` — every workflow for the exact
+  commit, never a branch tip.
+  Generic (--cmd):  runs your probe each poll. The probe prints `<name>: <state>` lines
+  and, when finished, one `TERMINAL: <verdict>` line. The watcher never guesses a
+  verdict for a custom probe — the probe must declare it.
+
+Design notes (each guards against a failure observed in real use):
+  * Success is an explicit allowlist. "Did not fail" is not green — unknown
+    conclusions count as failure.
+  * Supersession is evaluated BEFORE failure. Under cancel-in-progress concurrency, a
+    newer push cancels the old run; reporting that as `failure` sends the caller
+    debugging a phantom break.
+  * A settle window follows the first all-green state, because `workflow_run`-triggered
+    follow-ups (deploy-after-build) do not exist yet when the first workflow passes.
+  * The registration deadline is clamped below half the overall deadline, otherwise
+    `no-run` becomes unreachable and every skipped pipeline misreports as `timeout`.
+  * State is keyed by run id (one commit can run the same workflow twice — keyed by
+    name, the states overwrite each other and the watcher flaps forever); the verdict
+    considers only the newest run per workflow, so a concurrency-cancelled older
+    sibling does not turn a green commit red.
+  * Every subprocess call has its own timeout; transient errors retry, a streak dies
+    loudly; even a crash in this script emits `CI-DONE probe-dead` before exiting.
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+
+GH_SUCCESS = {"success"}
+GH_NEUTRAL = {"skipped", "neutral"}
+GH_CANCELLED = {"cancelled", "stale"}
+# Everything else (failure, timed_out, startup_failure, action_required, unknown) = red.
+
+HEARTBEAT_SECS = 150  # under a typical 5-minute prompt-cache TTL: a quiet run stays warm
+
+
+def emit(line):
+    print(line, flush=True)
+
+
+def run_capture(cmd, timeout):
+    """Run a command with its own timeout. Returns stdout or None on any error —
+    one wedged call (or a probe emitting bytes that are not UTF-8) must never
+    freeze or kill the loop; it counts as a probe error and retries."""
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True,
+                           errors="replace", timeout=timeout)
+        if p.returncode != 0:
+            return None
+        return p.stdout
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return None
+
+
+def branch_tip(repo, branch, timeout):
+    """Resolve the remote branch tip via git, NOT `run list --limit 1`: the newest
+    push may not have registered a run yet, and the previous commit's run would
+    masquerade as the tip — misreporting the new commit as superseded by its
+    own ancestor."""
+    out = run_capture(
+        ["git", "ls-remote", f"https://github.com/{repo}.git", f"refs/heads/{branch}"],
+        timeout,
+    )
+    if not out or not out.split():
+        return None
+    return out.split()[0]
+
+
+def probe_github(repo, sha, timeout):
+    """Return {run_id: (workflow_name, status, conclusion, run_id)} for the commit."""
+    out = run_capture(
+        [
+            "gh", "run", "list", "--repo", repo, "--commit", sha, "--limit", "50",
+            "--json", "databaseId,workflowName,status,conclusion,createdAt",
+            "--jq",
+            '.[] | [(.databaseId|tostring), .workflowName, .status, (.conclusion // ""), .createdAt] | @tsv',
+        ],
+        timeout,
+    )
+    if out is None:
+        return None
+    runs = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 5:
+            continue
+        run_id, name, status, conclusion, created = parts
+        runs[run_id] = {"name": name, "status": status,
+                        "conclusion": conclusion, "created": created}
+    return runs
+
+
+def probe_custom(cmd, timeout):
+    """Generic probe: `<name>: <state>` lines + `TERMINAL: <verdict>` when done."""
+    out = run_capture(["bash", "-c", cmd], timeout)
+    if out is None:
+        return None
+    runs, terminal = {}, None
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("TERMINAL:"):
+            terminal = line.split(":", 1)[1].strip().split()[0].lower()
+        elif ":" in line:
+            name, state = line.split(":", 1)
+            runs[name.strip()] = {"name": name.strip(), "status": state.strip(),
+                                  "conclusion": "", "created": ""}
+    return {"runs": runs, "terminal": terminal}
+
+
+def newest_per_workflow(runs):
+    """Verdict set = newest run per workflow. Older concurrency-cancelled siblings
+    stay visible as CHG events but must not decide the verdict."""
+    newest = {}
+    for r in runs.values():
+        prev = newest.get(r["name"])
+        if prev is None or r["created"] > prev["created"]:
+            newest[r["name"]] = r
+    return newest
+
+
+def classify(runs):
+    """('pending'|'success'|'cancelled'|'failure', detail). Success is an explicit
+    allowlist; anything unrecognized is failure — never assume green."""
+    verdict_set = newest_per_workflow(runs)
+    if any(r["status"] != "completed" for r in verdict_set.values()):
+        return "pending", ""
+    bad, cancelled = [], []
+    for r in verdict_set.values():
+        c = r["conclusion"]
+        if c in GH_SUCCESS or c in GH_NEUTRAL:
+            continue
+        (cancelled if c in GH_CANCELLED else bad).append(f"{r['name']}:{c or 'unknown'}")
+    if bad:
+        return "failure", ", ".join(bad)
+    if cancelled:
+        return "cancelled", ", ".join(cancelled)
+    return "success", ", ".join(sorted(verdict_set))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", help="org/name (GitHub mode)")
+    ap.add_argument("--sha", help="full commit SHA to pin (GitHub mode)")
+    ap.add_argument("--branch", help="enables supersession detection")
+    ap.add_argument("--cmd", help="generic probe command instead of GitHub mode")
+    ap.add_argument("--deadline-min", type=float, default=20)
+    ap.add_argument("--register-min", type=float, default=4)
+    ap.add_argument("--settle-sec", type=float, default=90,
+                    help="hold after all-green for workflow_run follow-ups")
+    ap.add_argument("--interval", type=float, default=20)
+    ap.add_argument("--expect-none", action="store_true",
+                    help="treat no-run as success (path-filtered pushes)")
+    a = ap.parse_args()
+
+    if not a.cmd and not (a.repo and a.sha):
+        emit("CI-DONE probe-dead — need --repo and --sha, or --cmd")
+        return 1
+    if a.sha and len(a.sha) != 40:
+        emit("CI-DONE probe-dead — pass the full 40-char SHA "
+             "(short SHAs silently match zero runs)")
+        return 1
+
+    deadline = a.deadline_min * 60
+    # Grace clamp: an unreachable register deadline turns every no-run into timeout.
+    register_by = min(a.register_min * 60, deadline / 2)
+    probe_timeout = max(20, a.interval)
+    label = f"{a.repo}@{a.sha[:7]}" if a.sha else "custom probe"
+    emit(f"CI-WATCH {label} deadline={a.deadline_min:g}m")
+
+    start = time.monotonic()
+    last_beat = start
+    seen = {}          # run_id -> last emitted state
+    registered = False
+    err_streak = 0
+    green_since = None
+    supersede_skip = 0
+
+    while True:
+        elapsed = time.monotonic() - start
+
+        if a.cmd:
+            result = probe_custom(a.cmd, probe_timeout)
+            runs = result["runs"] if result else None
+            terminal = result["terminal"] if result else None
+        else:
+            runs = probe_github(a.repo, a.sha, probe_timeout)
+            terminal = None
+
+        if runs is None:
+            err_streak += 1
+            if err_streak == 3:
+                emit("CI-WARN 3 consecutive probe errors — retrying")
+            if err_streak >= 10:
+                emit("CI-DONE probe-dead — 10 consecutive probe errors")
+                return 1
+        else:
+            err_streak = 0
+
+            if runs and not registered:
+                registered = True
+                names = " · ".join(
+                    f"{r['name']}: {r['conclusion'] or r['status']}"
+                    for r in newest_per_workflow(runs).values())
+                emit(f"CI-RUN registered {len(runs)}: {names}")
+
+            for run_id, r in runs.items():
+                state = r["conclusion"] or r["status"]
+                if seen.get(run_id) != state:
+                    if run_id in seen:
+                        emit(f"CI-CHG {r['name']}: {state}")
+                    seen[run_id] = state
+
+            if terminal is not None:
+                emit(f"CI-DONE {terminal} — declared by probe")
+                return 0 if terminal == "success" else 1
+
+            if registered and not a.cmd:
+                verdict, detail = classify(runs)
+                if verdict == "failure":
+                    first = detail.split(",")[0].split(":")[0]
+                    emit(f"CI-DONE failure — {detail} — logs: gh run view "
+                         f"--repo {a.repo} $(gh run list --repo {a.repo} "
+                         f"--commit {a.sha} -w '{first}' --json databaseId "
+                         f"--jq '.[0].databaseId') --log-failed")
+                    return 1
+                if verdict == "cancelled":
+                    # Supersession BEFORE calling this red: a newer tip means the
+                    # cancellation was the concurrency group doing its job.
+                    if a.branch:
+                        tip = branch_tip(a.repo, a.branch, probe_timeout)
+                        if tip and tip != a.sha:
+                            emit(f"CI-DONE superseded — {a.branch} moved to "
+                                 f"{tip[:7]}; arm a new watch")
+                            return 0
+                    emit(f"CI-DONE cancelled — {detail} (branch unmoved: manual "
+                         "cancel or infrastructure, not a test failure)")
+                    return 1
+                if verdict == "success":
+                    if green_since is None:
+                        green_since = time.monotonic()
+                    if time.monotonic() - green_since >= a.settle_sec:
+                        emit(f"CI-DONE success — {detail} @ {a.sha[:7]}")
+                        return 0
+                else:
+                    green_since = None
+
+            if not registered and elapsed > register_by:
+                if a.expect_none:
+                    emit(f"CI-DONE success — no runs registered and --expect-none "
+                         f"set (path-filtered push)")
+                    return 0
+                emit(f"CI-DONE no-run — nothing registered in "
+                     f"{register_by / 60:g}m: check triggers, path filters, and "
+                     "that the push landed")
+                return 1
+
+        # Pre-registration supersession: every 4th poll to bound API cost.
+        if a.branch and not registered and not a.cmd:
+            supersede_skip += 1
+            if supersede_skip >= 4:
+                supersede_skip = 0
+                tip = branch_tip(a.repo, a.branch, probe_timeout)
+                if tip and tip != a.sha:
+                    emit(f"CI-DONE superseded — {a.branch} moved to {tip[:7]}; "
+                         "arm a new watch")
+                    return 0
+
+        if elapsed > deadline:
+            state = ", ".join(f"{r['name']}:{seen.get(i, '?')}"
+                              for i, r in (runs or {}).items()) or "nothing registered"
+            emit(f"CI-DONE timeout — {a.deadline_min:g}m elapsed; last state: {state}")
+            return 124
+
+        if time.monotonic() - last_beat >= HEARTBEAT_SECS:
+            last_beat = time.monotonic()
+            emit(f"CI-HB {elapsed / 60:.0f}/{a.deadline_min:g}m — "
+                 f"{len(runs or {})} run(s) tracked")
+
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except BaseException as exc:  # even a bug here must produce a verdict
+        emit(f"CI-DONE probe-dead — watcher crashed: {exc!r}")
+        sys.exit(1)


### PR DESCRIPTION
This PR absorbs the best ideas from the other open `ci-cd-optimize` PRs into **one** coherent version instead of adding yet another competing feedback-loop variant.

## What changed

### 1) New `references/agent-ci-feedback.md`
A generic, provider-neutral guide to the part CI skills usually skip: **how an agent waits for the result without blocking, hanging, flooding, or reporting a false green.**

It now covers, in one place:
- the watcher contract (diff-gated, exact-SHA pinned, all workflows for the identifier, every path ends in a terminal verdict, registration deadline separate from the run deadline, per-probe timeouts, heartbeats)
- the **ordering law** `superseded before failure` for cancel-in-progress concurrency
- the **settle window** for late-registering `workflow_run` followups
- the `| head` / `$?` trap and why `gh run watch` is unsafe under a harness
- provider probe mapping (GitHub, GitLab, CircleCI, Buildkite, generic `--cmd`)
- verdict semantics (`timeout` and `no-run` mean *you still do not know*, not pass/fail)
- a validation matrix that requires green, red, timeout, no-run, superseded, and probe-crash cases

### 2) New bundled script: `scripts/ci-watch.py`
A real, stdlib-only implementation of that contract.

Why bundle code at all? Because the whole point of this feature is to stop every future agent from reinventing a subtly broken watcher. The script is the deterministic, reusable answer.

Capabilities:
- GitHub mode via `gh run list --commit <sha>`
- generic `--cmd` mode for other providers / deploy APIs
- one line per event, append-only, no TTY redraw assumptions
- run-id keyed state + newest-run-per-workflow verdicting
- `0` on success, `124` on timeout, `1` otherwise
- top-level crash guard that still emits `CI-DONE probe-dead`

I validated it before adding it:
- completed SHA → `CI-DONE success` (exit 0)
- nonexistent SHA → `CI-DONE no-run` (exit 1)
- near-zero deadline → `CI-DONE timeout` (exit 124)
- malformed custom-probe bytes → degrades to a verdict instead of hanging or crashing silently

### 3) New `references/capacity-and-contention.md`
This distills the best idea from the capacity-focused PRs into a durable, generic reference:
- queue-share gate and thresholds
- why more jobs get slower once `N > C`
- how to detect the concurrency ceiling empirically from `created_at`/`started_at`
- why benchmarking inside your own burst is a measurement confound
- why neutral/worse experiments must still be reported

This matters because otherwise the skill keeps telling agents to split work or add runners without first proving the pipeline is actually execution-bound.

### 4) Better cross-linking and reasoning flow
The existing reference set barely linked to itself. This PR turns it into a workflow:
- `measurement.md` now points to capacity/contention when queue becomes structural
- `testing-and-flakiness.md` points to `effectiveness-contract.md` and the new watcher guidance
- `deployment.md` points to the watcher doc when deploy self-verification is consumed by an agent
- `runners-and-autoscaling.md` points back to the queue-share gate before recommending more hardware
- `security-gates.md` now explicitly warns against letting a result-cached graph replay a scanner and still calling it a gate

### 5) SKILL.md now tells the agent how to think
I rewired the main `Ask in order` flow and the pitfalls table to incorporate the best ideas from the open PRs:
- queue-share before runner changes
- use a hypothesis table and keep declined ideas with the number that killed them
- wait with a bounded watcher, not a blocking CLI watch or a success-only poll
- treat `timeout` as "no verdict yet"
- sample from ordinary pushes, not a self-inflicted validation burst
- "enumerate success, not failure" appears both in the watcher contract and in the pitfalls

## Why this is better than the other open PRs

I read all of them and took the strongest ideas from each instead of shipping another mutually-conflicting copy:
- **from #80 / #81:** settle window, superseded-before-failure, explicit success allowlists, shell gotchas, provider probe mapping
- **from #78 / #79:** the pipeline/`head` trap, the stronger watcher contract, cleaner provider-neutral phrasing
- **from #84:** queue-share / capacity-ceiling discipline and the rule to report disproved hypotheses

I intentionally did **not** carry over:
- provider-specific numbers or unverifiable limits without caveats
- off-topic bundling that had nothing to do with waiting on CI
- project-specific names/examples
- a watcher that only exists as pseudocode

## Why it stays generic

I scrubbed project-specific identifiers from the examples and re-ran leakage checks (`zeoradar`, `teamzeo`, `patchright`, etc.). The examples now talk about generic schedulers, retries, deploys, and pipelines — not any specific repo or language runtime.

## Verification

- `skills/ci-cd-optimize/scripts/ci-watch.py` — syntax-checked and functionally exercised against a live GitHub Actions repo
- all new references linked from `SKILL.md`
- no project-specific identifiers in the touched files

This PR is meant to become the single comprehensive CI/CD optimization skill update, so the other exploratory PRs can be closed afterward rather than merged independently.
