### PR TITLE
feat(ci-cd-optimize): add agent feedback loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -556,7 +556,7 @@
     {
       "name": "ci-cd-optimize",
       "source": "./",
-      "description": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+      "description": "Use skill if you are diagnosing or optimizing slow CI/CD, runner queues, cache misses, build/test/deploy latency, or an agent has pushed and needs non-stalling CI feedback while preserving required checks.",
       "version": "1.0.36",
       "category": "ops",
       "strict": false,

--- a/plugins/ci-cd-optimize/.codex-plugin/plugin.json
+++ b/plugins/ci-cd-optimize/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci-cd-optimize",
   "version": "1.0.36",
-  "description": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+  "description": "Use skill if you are diagnosing or optimizing slow CI/CD, runner queues, cache misses, build/test/deploy latency, or an agent has pushed and needs non-stalling CI feedback while preserving required checks.",
   "author": {
     "name": "Yigit Konur",
     "url": "https://github.com/yigitkonur"
@@ -17,7 +17,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "ci-cd-optimize",
-    "shortDescription": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+    "shortDescription": "Use skill if you are diagnosing or optimizing slow CI/CD, runner queues, cache misses, build/test/deploy latency, or an agent has pushed and needs non-stalling CI feedback while preserving required checks.",
     "longDescription": "Install only the ci-cd-optimize workflow from Yigit Konur's curated skills pack.",
     "developerName": "Yigit Konur",
     "category": "Productivity",

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
@@ -69,8 +69,9 @@ Ask in order:
 11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
 12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+14. Is an agent pushing and then waiting on CI — or has a session gone silent after a push? Read `references/agent-feedback-loop.md`.
+15. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
+16. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -101,6 +102,10 @@ Use full validation as the safe fallback whenever changed files, merge base, cac
 ### 6. Verify after the change
 
 Re-run on the same commit first, then a normal representative commit. Compare median and p95 wall-clock, queue time, cache behavior, first-time pass rate, cost, and failure/rework signals. Confirm the exact run head SHA contains the change and the deployed artifact digest or workflow run is the intended one.
+
+Do not wait for those runs in the foreground. Arm a bounded watcher so a red check surfaces the moment it happens instead of at the deadline — `references/agent-feedback-loop.md`, or `scripts/ci-watch.py` directly. Expect to keep working between its events.
+
+Making CI automatic surfaces defects that a manual, hand-dispatched pipeline hid — environment leakage between jobs, assertions that drifted from the contract they check, and pre-existing flakes. Treat each as a real finding: root-cause it and verify red-first. Reaching green by adding a retry, widening a threshold, or skipping the check corrupts the measurement instead of fixing the pipeline (`references/effectiveness-contract.md`).
 
 Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
 
@@ -177,6 +182,11 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Retrying flakes forever | Bound retries, quarantine, assign ownership, track flake rate. |
 | Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
+| Agent blocks on a foreground `run watch` | Arm a bounded watcher that emits per state change and always prints a terminal verdict (`references/agent-feedback-loop.md`). |
+| Watcher greps only for the success marker | Silence then looks identical to "still running". Match failure signatures too. |
+| Caching a store the platform already proxies | Measure install cold vs warm; a 0-hit cache costs quota and returns nothing. |
+| Sizing a runner by intuition | Read VM CPU/memory/load for the job; a lane bounded by a single-threaded step gains nothing from more cores. |
+| Trusting a green from the branch tip | Pin the pushed SHA; confirm the run's head commit is the commit you pushed. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
 
@@ -204,6 +214,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
+| `references/agent-feedback-loop.md` | An agent must push and then act on the result: arming a non-stalling watcher, the event/verdict contract, reacting to a red check, or a session that went silent after a push. |
+
+### Bundled script
+
+| Script | Purpose |
+|---|---|
+| `scripts/ci-watch.py` | Stdlib-only watcher. Emits one line per state change for a pinned commit and always terminates with `CI-DONE success\|failure\|timeout\|no-run\|probe-dead\|superseded`. Built-in GitHub Actions probe (`--sha`, `--repo`); any other provider via `--cmd` printing `<name>: <state>` lines. See `references/agent-feedback-loop.md`. |
 
 ### Optional: Avrea reference kit
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use skill if you are diagnosing or optimizing slow CI/CD, runner queues, cache misses, build/test/deploy latency, or an agent has pushed and needs non-stalling CI feedback while preserving required checks.
 metadata:
   author: yigitkonur
   version: 1.0.0
@@ -57,21 +57,22 @@ Apply the performance order before adding compute:
 Ask in order:
 
 1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
-3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
-4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
-5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
-6. Are tests dominant? Read `references/testing-and-flakiness.md` and `references/integration-environments.md`.
-7. Is Docker/OCI work dominant? Read `references/containers.md`.
-8. Are security scans dominant? Read `references/security-gates.md`.
-9. Is deployment slow or repeated? Read `references/deployment.md`.
-10. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
-11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
-12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
-13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is an agent pushing and then waiting on CI — or has a session gone silent after a push? Read `references/agent-feedback-loop.md`.
-15. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-16. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+2. Is an agent pushing and then waiting on CI — or has a session gone silent after a push? Read `references/agent-feedback-loop.md` first; the feedback loop itself may be the bottleneck.
+3. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
+4. Do the queue numbers suggest a capacity ceiling rather than uniformly slow work? Read `references/capacity-and-contention.md`.
+5. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
+6. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
+7. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
+8. Are tests dominant? Read `references/testing-and-flakiness.md` and `references/integration-environments.md`.
+9. Is Docker/OCI work dominant? Read `references/containers.md`.
+10. Are security scans dominant? Read `references/security-gates.md`.
+11. Is deployment slow or repeated? Read `references/deployment.md`.
+12. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
+13. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
+14. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
+15. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md`, `references/avrea/caching.md`, and `references/avrea/cli-evidence.md`.
+16. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
+17. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -105,7 +106,11 @@ Re-run on the same commit first, then a normal representative commit. Compare me
 
 Do not wait for those runs in the foreground. Arm a bounded watcher so a red check surfaces the moment it happens instead of at the deadline — `references/agent-feedback-loop.md`, or `scripts/ci-watch.py` directly. Expect to keep working between its events.
 
+Before trusting a watcher, verify it like any other piece of CI infrastructure: make it produce `success`, `failure`, `no-run`, `timeout`, `probe-dead`, and (when relevant) `superseded` on purpose. A watcher only observed succeeding is untested.
+
 Making CI automatic surfaces defects that a manual, hand-dispatched pipeline hid — environment leakage between jobs, assertions that drifted from the contract they check, and pre-existing flakes. Treat each as a real finding: root-cause it and verify red-first. Reaching green by adding a retry, widening a threshold, or skipping the check corrupts the measurement instead of fixing the pipeline (`references/effectiveness-contract.md`).
+
+If an experiment comes back neutral or worse, report that. A disproved hypothesis is still evidence, and hiding it guarantees the next person retries the same losing move.
 
 Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
 
@@ -183,10 +188,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Agent blocks on a foreground `run watch` | Arm a bounded watcher that emits per state change and always prints a terminal verdict (`references/agent-feedback-loop.md`). |
-| Watcher greps only for the success marker | Silence then looks identical to "still running". Match failure signatures too. |
+| Trusting `$?` after piping a watcher into `head`/`tail` | Pipeline status comes from the last command; capture the watcher's real exit code directly. |
+| Watching the branch tip instead of the pushed SHA | Pin the commit; a green on the tip can be another commit entirely. |
+| Watcher greps only for the success marker | Silence then looks identical to "still running". Match failure and timeout states too. |
 | Caching a store the platform already proxies | Measure install cold vs warm; a 0-hit cache costs quota and returns nothing. |
 | Sizing a runner by intuition | Read VM CPU/memory/load for the job; a lane bounded by a single-threaded step gains nothing from more cores. |
 | Trusting a green from the branch tip | Pin the pushed SHA; confirm the run's head commit is the commit you pushed. |
+| Queue dominates but the DAG keeps growing | Read `references/capacity-and-contention.md`; above a capacity ceiling, extra jobs repay setup and can make the wall-clock worse. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
 
@@ -215,12 +223,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
 | `references/agent-feedback-loop.md` | An agent must push and then act on the result: arming a non-stalling watcher, the event/verdict contract, reacting to a red check, or a session that went silent after a push. |
+| `references/capacity-and-contention.md` | Queue share, concurrency ceilings, when more jobs make the wall-clock worse, and when the remediation ladder inverts from "split" to "merge". |
 
 ### Bundled script
 
 | Script | Purpose |
 |---|---|
-| `scripts/ci-watch.py` | Stdlib-only watcher. Emits one line per state change for a pinned commit and always terminates with `CI-DONE success\|failure\|timeout\|no-run\|probe-dead\|superseded`. Built-in GitHub Actions probe (`--sha`, `--repo`); any other provider via `--cmd` printing `<name>: <state>` lines. See `references/agent-feedback-loop.md`. |
+| `scripts/ci-watch.py` | Stdlib-only watcher. Emits one line per state change for a pinned commit and always terminates with `CI-DONE success\|failure\|cancelled\|timeout\|no-run\|probe-dead\|superseded`. Built-in GitHub probe (`--sha`, `--repo`); any other provider via `--cmd` printing `<name>: <state>` lines. See `references/agent-feedback-loop.md`. |
 
 ### Optional: Avrea reference kit
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
@@ -106,7 +106,7 @@ Re-run on the same commit first, then a normal representative commit. Compare me
 
 Do not wait for those runs in the foreground. Arm a bounded watcher so a red check surfaces the moment it happens instead of at the deadline — `references/agent-feedback-loop.md`, or `scripts/ci-watch.py` directly. Expect to keep working between its events.
 
-Before trusting a watcher, verify it like any other piece of CI infrastructure: make it produce `success`, `failure`, `no-run`, `timeout`, `probe-dead`, and (when relevant) `superseded` on purpose. A watcher only observed succeeding is untested.
+Before trusting a watcher, verify it like any other piece of CI infrastructure: make it produce `success`, `failure`, `cancelled`, `no-run`, `timeout`, `probe-dead`, and (when relevant) `superseded` on purpose. A watcher only observed succeeding is untested.
 
 Making CI automatic surfaces defects that a manual, hand-dispatched pipeline hid — environment leakage between jobs, assertions that drifted from the contract they check, and pre-existing flakes. Treat each as a real finding: root-cause it and verify red-first. Reaching green by adding a retry, widening a threshold, or skipping the check corrupts the measurement instead of fixing the pipeline (`references/effectiveness-contract.md`).
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -137,7 +137,7 @@ Check the real process exit code after each, not the exit of a pipeline you pipe
 
 ## Reacting to a red check
 
-1. Run the exact log command the failure verdict printed. Do not re-derive it.
+1. In built-in GitHub mode, run the exact log command the failure verdict printed. Do not re-derive it. A custom `--cmd` probe cannot supply a provider-specific log command through the `<name>: <state>` contract, so use that provider's CLI or API to fetch logs for the printed failing job name at the pinned `$SHA`.
 2. Reproduce with the narrowest local command. If the failure is CI-only, reproduce the CI condition — job-wide environment variables, a clean checkout, a different working directory, absent secrets.
 3. Fix the cause. Never add a retry, widen a threshold, mock the failure away, or `skip` to reach green; the check measures reality.
 4. Verify red-first: confirm the test fails without the fix and passes with it.

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -1,166 +1,165 @@
-# Agent feedback loop — waiting for CI without stalling
+# Agent feedback loop
 
-Read when an agent must push and then act on the result: choosing how to wait,
-arming a watcher, reacting to a red check, or debugging a session that went
-silent after a push.
+Use this file when an agent must push and then act on the result: choosing how to wait, arming a watcher, reacting to a red check, or debugging a session that went silent after a push.
 
-This is provider-neutral. The probe command changes per provider; the contract
-does not.
+This file is provider-neutral. The probe command changes per provider; the contract does not.
 
 ## The problem
 
-An agent pushes, then blocks. The usual attempts all fail in ways that look
-like "CI is just slow":
+After an agent pushes, it still needs the answer. The usual waits fail in ways that look like "CI is just slow":
 
 | Attempt | Failure mode |
 |---|---|
-| `gh run watch` (or equivalent) in the foreground | Emits TTY redraw frames, not lines, when stdout is not a terminal; suppresses its completion summary for the same reason; has no deadline of its own. |
-| `sleep N` polling loop | Burns turns, re-prints the same table, and produces no event when the run *crashes* — a dead run and a slow run look identical. |
-| A watcher that greps only for success | Silence on failure. The agent waits out the full timeout for a run that died in minute two. |
-| No deadline | A run that never registers — path filter excluded it, workflow disabled, wrong branch — waits forever for something that will never exist. |
+| Foreground `run watch` command | Re-renders a TTY-oriented table instead of clean line events when stdout is not a terminal; often suppresses its completion summary for the same reason; usually has no deadline of its own. |
+| Hand-rolled `while true; do sleep N; …; done` | Burns context, re-prints the same table, and often emits nothing on failure — a crash and a slow run look identical. |
+| Success-only filter | Silence on red. The agent waits out the full timeout for a run that died in minute two. |
+| No registration deadline | A path-filtered or disabled workflow is watched forever even though no run can ever exist. |
 
-The cost is asymmetric: a failure detected at minute 2 of a 25-minute pipeline
-gives back 23 minutes of agent time; the same failure detected at the timeout
-gives back nothing.
+The payoff for solving this is immediate: a failure detected at minute 2 of a 25-minute pipeline gives back 23 minutes of agent time.
 
-## The contract a watcher must satisfy
+## The watcher contract
 
-1. **Terminate, always.** Every path ends in an explicit verdict line. Silence
-   past the deadline must be structurally impossible, not merely unlikely.
-2. **Emit on state change only.** Diff-gate the output. A 25-minute green run
-   should cost a handful of events, not fifty identical job tables. Watchers
-   that flood get rate-limited or killed, which reintroduces the stall.
-3. **Cover failure, not just success.** If the process crashed right now, the
-   filter must emit something. Widen the match rather than narrow it.
-4. **Pin the commit, not the branch.** Query by the SHA you pushed. "Latest run
-   on the branch" can be someone else's commit, or your own previous one — a
-   classic false green.
-5. **Watch every workflow that commit triggered**, not just the one you care
-   about. A second workflow can fail while the first goes green.
-6. **Heartbeat.** A periodic liveness tick proves the watcher is alive and, on
-   agents with a prompt cache, keeps that cache warm so waiting stays cheap.
-   Roughly every 2–3 minutes is a reasonable default.
-7. **Bound the probe itself.** Give each API call its own timeout; a wedged
-   request must not freeze the loop. Retry transient errors, but exit loudly on
-   a sustained streak.
+A watcher is verification infrastructure. Hold it to the same standard as any other gate.
+
+1. **Terminate, always.** Every path ends in an explicit terminal line. Silence past the deadline must be structurally impossible.
+2. **Emit on change, not on poll.** A 25-minute green run should cost a handful of notifications, not fifty duplicate job tables.
+3. **Cover failure at least as loudly as success.** Ask: if this process crashed right now, would the watcher emit anything? If not, it is broken.
+4. **Pin the commit, not the branch.** Query by the SHA you pushed. A green run on the branch tip can be another commit — a classic false green.
+5. **Watch every workflow that commit triggered.** A second workflow can fail while the first passes. Completion-triggered follow-up workflows need a settle window before declaring success.
+6. **Heartbeat.** Emit a liveness tick every ~2–3 minutes so a quiet watch still proves it is alive.
+7. **Bound each probe call.** A single wedged API request must not freeze the whole watch.
 
 ## Event vocabulary
 
-A small, stable set of prefixes lets the agent react without parsing prose:
+Use stable, machine-readable prefixes:
 
+```text
+CI-RUN    registered 3: build: queued · lint: queued · test: queued
+CI-CHG    test: in_progress -> failure
+CI-HB     12/20m
+CI-SETTLE all green — holding 90s for completion-triggered follow-ups
+CI-WARN   probe failing (3x) — still retrying
+CI-DONE   failure — test — <command that prints the failing log>
 ```
-CI-RUN   registered 3: build: queued · lint: queued · test: queued
-CI-CHG   test: in_progress -> failure
-CI-HB    12/30m
-CI-WARN  probe failing (3x) — still retrying
-CI-DONE  failure — test — <command that prints the failing log>
-```
 
-Terminal verdicts worth distinguishing, because each implies a different next
-action:
+Terminal verdicts worth distinguishing:
 
-| Verdict | Meaning | Reaction |
+| Verdict | Meaning | Default reaction |
 |---|---|---|
 | `success` | every workflow green on that SHA | proceed |
 | `failure` | at least one red | fetch the failing log immediately |
-| `cancelled` | ended `cancelled`/`skipped`/`stale`/`neutral` | **not green** — usually a concurrency cancel or a filtered job; decide whether the commit was ever validated |
-| `timeout` | deadline hit with work outstanding | read the run; decide to wait or cancel |
-| `no-run` | nothing ever registered | check triggers, path filters, enabled state |
-| `probe-dead` | the API was unreachable repeatedly | check auth/network |
-| `superseded` | the branch moved on | this verdict is moot; arm a watch on the new SHA |
+| `cancelled` | terminal but not green (`cancelled`, `skipped`, `stale`, `neutral`) | do not treat as success; decide whether the commit was actually validated |
+| `timeout` | deadline hit with work outstanding | read the run; decide whether to keep waiting |
+| `no-run` | nothing ever registered | check triggers, path filters, and enabled state |
+| `probe-dead` | the provider probe failed repeatedly | check auth/network/tooling |
+| `superseded` | the branch moved past the watched SHA | arm a fresh watch on the new SHA |
 
-`no-run` and `superseded` are the two that hand-rolled loops almost always
-miss, and they are the two that waste the most wall-clock.
+`timeout` and `no-run` are the two most-misreported outcomes: neither is red, neither is green, both mean you still do not know.
 
-**Enumerate success, not failure.** The most dangerous bug in a watcher is
-treating "did not fail" as green. A run that ends `cancelled`, `skipped`,
-`stale`, or `neutral` is terminal but *not* validated — and `cancel-in-progress`
-concurrency, which this skill recommends elsewhere, manufactures exactly that
-state. Match an explicit success set and treat every other terminal conclusion,
-including ones you have never seen, as not-green.
+Enumerate **success**, not failure. A watcher that treats "did not fail" as green will eventually call `cancelled`, `skipped`, or an unknown terminal state a pass.
+
+## Watch-shape selection
+
+Pick the wait shape by how many notifications you need:
+
+| Need | Shape |
+|---|---|
+| One final answer only | background task with an internal `until` loop or equivalent |
+| One line per state change until a known end | Monitor tool + diff-gated watcher |
+| Raw logs for diagnosis | do **not** watch the raw log stream; pull logs once after a red verdict |
+
+Never arm an unbounded `while true` or `tail -f` for a single answer. It stays armed long after the event and can only end by timeout.
 
 ## Reference implementation shape
 
-Stdlib only, no dependencies. The loop:
+Bundle an executable watcher in the skill so agents do not rewrite a poll loop every time. The bundled implementation here is [`scripts/ci-watch.py`](../scripts/ci-watch.py).
 
-```
-poll(sha) -> list of {id, workflow, status, conclusion}
-  on error:      streak++; warn once at 3; exit `probe-dead` at 10
+A minimal control loop:
+
+```text
+poll(commit) -> list of {id, workflow, state}
+  on error:      retry silently, warn on a streak, then exit probe-dead
   on first data: emit CI-RUN once
   per item:      emit CI-CHG only when state differs from last seen
-  all terminal:  emit CI-DONE success|failure (+ the log command) and exit
+  all terminal:  emit CI-DONE success|failure|cancelled and exit
   branch moved:  emit CI-DONE superseded and exit
   no data yet and past registration deadline: emit CI-DONE no-run and exit
   past overall deadline: emit CI-DONE timeout and exit
   else: heartbeat if due, sleep interval
 ```
 
-Two deadlines matter and they are different: a short **registration** deadline
-(a few minutes — did any run appear at all?) and a longer **overall** deadline
-(the pipeline's p95 plus headroom).
+Provider probes differ only in the `poll(commit)` step:
 
-Provider probes differ only in the poll step:
-
-| Provider | Poll |
+| Provider | Probe |
 |---|---|
 | GitHub Actions | `gh run list --commit <sha> --json databaseId,workflowName,status,conclusion` |
-| GitLab CI | pipelines API filtered by `sha` |
+| GitLab CI | pipelines API filtered by revision |
 | Buildkite | builds API filtered by commit |
-| CircleCI | pipeline → workflow status by revision |
-| Anything else | any command printing `<name>: <state>` lines and a terminal marker |
+| CircleCI | pipeline → workflow state by revision |
+| Anything else | any command printing `<name>: <state>` lines |
 
-## Wiring it to a streaming-notification tool
+### Hard requirements for the implementation
 
-Agent harnesses that expose a background monitor (each stdout line becomes a
-notification) are the right host for this. Rules that matter in practice:
+- Key state by **run id** (or an equivalent stable identifier), not workflow name. One commit can carry multiple runs of the same workflow.
+- Collapse retries/attempts correctly **per provider**. Some APIs already do; some do not. Verify it.
+- If expanding GitHub runs to job level for faster failure notice, expand only **active** runs so the extra API cost is bounded.
+- Keep only the newest run per workflow **and event** when deciding the final verdict. A dispatch-only rerun and the original push run are different validation surfaces.
+- Require the run set to be stable across two polls (or hold a settle window) before calling success. A fast workflow can finish before a slower sibling is even created.
+- For completion-triggered follow-ups (`workflow_run`, deploy-after-build, etc.), hold a grace period after all-green and re-probe before declaring success.
+- Keep the registration deadline below the overall deadline. If they cross, `no-run` becomes unreachable and every skipped pipeline misreports as `timeout`.
+- Distinguish exit codes. `watch && deploy` must not ship on `failure`, `cancelled`, `timeout`, or `superseded`.
 
-- **Every pipe stage must flush per line**, or matches sit in a buffer unseen:
-  `grep --line-buffered`, `awk { ...; fflush() }`. `head -N` cannot flush at
-  all — it delivers nothing until N matches accumulate.
-- **Prefer one bounded process over an unbounded tail.** `tail -f`, `while
-  true`, and `inotifywait -m` never exit on their own, so the watch stays armed
-  long after the event fired.
-- **`tail -f log | grep -m1 …` does not fix that.** If the log goes quiet after
-  the match, `tail` never receives SIGPIPE and the pipeline hangs.
-- **Arm the watch in the same turn as the push**, then keep working. Do not add
-  a `sleep` loop beside an armed watcher; the events come to you.
-- **One watch per pushed SHA.** A re-push supersedes the old watch; retire it
-  and arm a fresh one.
-- **A heartbeat is not a result.** Acknowledge it silently; never report it as
-  progress or treat it as a user message.
+## Wiring to a streaming monitor
 
-### Shell gotchas that produce silent watchers
+A monitor tool that turns each stdout line into a notification is the best host for this pattern. Use it when you need feedback while still working.
 
-- In `zsh`, `status` is a readonly builtin variable — `status=$(...)` is a fatal
-  error inside the watcher, which then emits nothing at all. Name it anything
-  else.
-- Command substitution strips trailing newlines; compare parsed fields, not raw
-  blobs, when diff-gating.
-- A watcher that inherits the harness's environment can pick up variables that
-  change CI behavior. Prefer explicit arguments over ambient state.
+Rules:
+- Arm the watch in the same turn as the push.
+- One watch per pushed SHA. Re-push ⇒ old watch retires, arm a fresh one.
+- Every pipe stage must flush per line (`grep --line-buffered`, `awk { fflush() }`). `head -N` cannot flush; it withholds output until N matches accumulate.
+- Keep the monitor timeout **above** the watcher's own deadline so the script can emit its own `timeout` verdict instead of being killed silently.
+- A heartbeat is not a result. Acknowledge it silently; never treat it as user input.
+
+## Verifying the watcher itself
+
+Do not trust a watcher that has only been observed succeeding. Rehearse it like any other piece of verification infrastructure.
+
+Run each of these deliberately:
+
+1. **Known green** — a historical SHA where every workflow succeeded.
+2. **Known red** — a historical SHA with a real failing run.
+3. **No-run** — a SHA that will never register, or a path-filtered push declared with `--expect-none`.
+4. **Timeout** — a probe that reports a running state forever under a tiny deadline.
+5. **Probe-dead** — a broken or unauthenticated provider CLI.
+6. **Superseded** — arm on one SHA, then move the branch tip.
+
+Check the real process exit code after each, not the exit of a pipeline you piped it through. `watch | tail` or `watch | head` can hide the watcher's own status behind the last command's `$?`.
 
 ## Reacting to a red check
 
-1. Run the exact log command the verdict printed. Do not re-derive it.
-2. Reproduce with the narrowest local command. If the failure is CI-only,
-   reproduce the *CI condition* — job-wide environment variables, a clean
-   checkout, a different working directory, absent secrets.
-3. Fix the cause. Never add a retry, widen a threshold, mock the failure away,
-   or `skip` to reach green; the check measures reality.
+1. Run the exact log command the failure verdict printed. Do not re-derive it.
+2. Reproduce with the narrowest local command. If the failure is CI-only, reproduce the CI condition — job-wide environment variables, a clean checkout, a different working directory, absent secrets.
+3. Fix the cause. Never add a retry, widen a threshold, mock the failure away, or `skip` to reach green; the check measures reality.
 4. Verify red-first: confirm the test fails without the fix and passes with it.
-   A fix you never saw fail is a fix you cannot vouch for.
 5. Push and arm a fresh watch on the new SHA.
 
-## Failure-only diagnostics
+## Common traps
 
-Upload the diagnostic bundle on failure only, with short retention and exact
-paths — logs, screenshots, server output. A successful run does not need them,
-and uploading a whole workspace turns every green run into a transfer cost.
-Never include generated credentials or a provisioning directory in the bundle.
+- `gh run watch` (or equivalent) piped into another command: the pipe can hide the real exit code, and the watcher often emits table redraws instead of line events.
+- Looking only for a success marker: silence then looks identical to "still running".
+- Using `run list --branch --limit 1` as a branch-tip check: the newest **run** can lag the newest **commit**, so a fresh push is falsely reported as superseded by its own ancestor.
+- Reusing a large static monitor timeout for every provider: the deadline should be tied to measured p95 plus headroom.
+- Assuming a watcher bug is harmless because the CI itself is correct. A false green in the watcher is the exact defect class this file exists to prevent.
 
-## Why this is worth the file
+## Related references
 
-The measurable win is not a faster pipeline; it is the agent noticing. A team
-that adopts automatic CI without a reliable feedback loop trades a slow local
-loop for a silent remote one, and the first red check that goes unnoticed for
-twenty minutes erases the migration's entire gain.
+- `references/measurement.md` — queue versus execution, sample size, and evidence rungs
+- `references/github-actions.md` — trigger duplication, concurrency, required checks, and when a PR gate differs from a branch gate
+- `references/testing-and-flakiness.md` — deciding whether a red check is a real regression or a flake
+- `references/effectiveness-contract.md` — why retries and weakened assertions are not valid fixes for a red pipeline
+
+## Sources
+
+- GitHub CLI watch source (`watchRun`, TTY-gated output paths): https://github.com/cli/cli/blob/trunk/pkg/cmd/run/watch/watch.go (accessed 2026-07-28)
+- GitHub CLI iostreams TTY detection: https://github.com/cli/cli/blob/trunk/pkg/iostreams/iostreams.go (accessed 2026-07-28)
+- POSIX shell pipeline exit status: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_02 (accessed 2026-07-28)

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -1,0 +1,166 @@
+# Agent feedback loop — waiting for CI without stalling
+
+Read when an agent must push and then act on the result: choosing how to wait,
+arming a watcher, reacting to a red check, or debugging a session that went
+silent after a push.
+
+This is provider-neutral. The probe command changes per provider; the contract
+does not.
+
+## The problem
+
+An agent pushes, then blocks. The usual attempts all fail in ways that look
+like "CI is just slow":
+
+| Attempt | Failure mode |
+|---|---|
+| `gh run watch` (or equivalent) in the foreground | Emits TTY redraw frames, not lines, when stdout is not a terminal; suppresses its completion summary for the same reason; has no deadline of its own. |
+| `sleep N` polling loop | Burns turns, re-prints the same table, and produces no event when the run *crashes* — a dead run and a slow run look identical. |
+| A watcher that greps only for success | Silence on failure. The agent waits out the full timeout for a run that died in minute two. |
+| No deadline | A run that never registers — path filter excluded it, workflow disabled, wrong branch — waits forever for something that will never exist. |
+
+The cost is asymmetric: a failure detected at minute 2 of a 25-minute pipeline
+gives back 23 minutes of agent time; the same failure detected at the timeout
+gives back nothing.
+
+## The contract a watcher must satisfy
+
+1. **Terminate, always.** Every path ends in an explicit verdict line. Silence
+   past the deadline must be structurally impossible, not merely unlikely.
+2. **Emit on state change only.** Diff-gate the output. A 25-minute green run
+   should cost a handful of events, not fifty identical job tables. Watchers
+   that flood get rate-limited or killed, which reintroduces the stall.
+3. **Cover failure, not just success.** If the process crashed right now, the
+   filter must emit something. Widen the match rather than narrow it.
+4. **Pin the commit, not the branch.** Query by the SHA you pushed. "Latest run
+   on the branch" can be someone else's commit, or your own previous one — a
+   classic false green.
+5. **Watch every workflow that commit triggered**, not just the one you care
+   about. A second workflow can fail while the first goes green.
+6. **Heartbeat.** A periodic liveness tick proves the watcher is alive and, on
+   agents with a prompt cache, keeps that cache warm so waiting stays cheap.
+   Roughly every 2–3 minutes is a reasonable default.
+7. **Bound the probe itself.** Give each API call its own timeout; a wedged
+   request must not freeze the loop. Retry transient errors, but exit loudly on
+   a sustained streak.
+
+## Event vocabulary
+
+A small, stable set of prefixes lets the agent react without parsing prose:
+
+```
+CI-RUN   registered 3: build: queued · lint: queued · test: queued
+CI-CHG   test: in_progress -> failure
+CI-HB    12/30m
+CI-WARN  probe failing (3x) — still retrying
+CI-DONE  failure — test — <command that prints the failing log>
+```
+
+Terminal verdicts worth distinguishing, because each implies a different next
+action:
+
+| Verdict | Meaning | Reaction |
+|---|---|---|
+| `success` | every workflow green on that SHA | proceed |
+| `failure` | at least one red | fetch the failing log immediately |
+| `cancelled` | ended `cancelled`/`skipped`/`stale`/`neutral` | **not green** — usually a concurrency cancel or a filtered job; decide whether the commit was ever validated |
+| `timeout` | deadline hit with work outstanding | read the run; decide to wait or cancel |
+| `no-run` | nothing ever registered | check triggers, path filters, enabled state |
+| `probe-dead` | the API was unreachable repeatedly | check auth/network |
+| `superseded` | the branch moved on | this verdict is moot; arm a watch on the new SHA |
+
+`no-run` and `superseded` are the two that hand-rolled loops almost always
+miss, and they are the two that waste the most wall-clock.
+
+**Enumerate success, not failure.** The most dangerous bug in a watcher is
+treating "did not fail" as green. A run that ends `cancelled`, `skipped`,
+`stale`, or `neutral` is terminal but *not* validated — and `cancel-in-progress`
+concurrency, which this skill recommends elsewhere, manufactures exactly that
+state. Match an explicit success set and treat every other terminal conclusion,
+including ones you have never seen, as not-green.
+
+## Reference implementation shape
+
+Stdlib only, no dependencies. The loop:
+
+```
+poll(sha) -> list of {id, workflow, status, conclusion}
+  on error:      streak++; warn once at 3; exit `probe-dead` at 10
+  on first data: emit CI-RUN once
+  per item:      emit CI-CHG only when state differs from last seen
+  all terminal:  emit CI-DONE success|failure (+ the log command) and exit
+  branch moved:  emit CI-DONE superseded and exit
+  no data yet and past registration deadline: emit CI-DONE no-run and exit
+  past overall deadline: emit CI-DONE timeout and exit
+  else: heartbeat if due, sleep interval
+```
+
+Two deadlines matter and they are different: a short **registration** deadline
+(a few minutes — did any run appear at all?) and a longer **overall** deadline
+(the pipeline's p95 plus headroom).
+
+Provider probes differ only in the poll step:
+
+| Provider | Poll |
+|---|---|
+| GitHub Actions | `gh run list --commit <sha> --json databaseId,workflowName,status,conclusion` |
+| GitLab CI | pipelines API filtered by `sha` |
+| Buildkite | builds API filtered by commit |
+| CircleCI | pipeline → workflow status by revision |
+| Anything else | any command printing `<name>: <state>` lines and a terminal marker |
+
+## Wiring it to a streaming-notification tool
+
+Agent harnesses that expose a background monitor (each stdout line becomes a
+notification) are the right host for this. Rules that matter in practice:
+
+- **Every pipe stage must flush per line**, or matches sit in a buffer unseen:
+  `grep --line-buffered`, `awk { ...; fflush() }`. `head -N` cannot flush at
+  all — it delivers nothing until N matches accumulate.
+- **Prefer one bounded process over an unbounded tail.** `tail -f`, `while
+  true`, and `inotifywait -m` never exit on their own, so the watch stays armed
+  long after the event fired.
+- **`tail -f log | grep -m1 …` does not fix that.** If the log goes quiet after
+  the match, `tail` never receives SIGPIPE and the pipeline hangs.
+- **Arm the watch in the same turn as the push**, then keep working. Do not add
+  a `sleep` loop beside an armed watcher; the events come to you.
+- **One watch per pushed SHA.** A re-push supersedes the old watch; retire it
+  and arm a fresh one.
+- **A heartbeat is not a result.** Acknowledge it silently; never report it as
+  progress or treat it as a user message.
+
+### Shell gotchas that produce silent watchers
+
+- In `zsh`, `status` is a readonly builtin variable — `status=$(...)` is a fatal
+  error inside the watcher, which then emits nothing at all. Name it anything
+  else.
+- Command substitution strips trailing newlines; compare parsed fields, not raw
+  blobs, when diff-gating.
+- A watcher that inherits the harness's environment can pick up variables that
+  change CI behavior. Prefer explicit arguments over ambient state.
+
+## Reacting to a red check
+
+1. Run the exact log command the verdict printed. Do not re-derive it.
+2. Reproduce with the narrowest local command. If the failure is CI-only,
+   reproduce the *CI condition* — job-wide environment variables, a clean
+   checkout, a different working directory, absent secrets.
+3. Fix the cause. Never add a retry, widen a threshold, mock the failure away,
+   or `skip` to reach green; the check measures reality.
+4. Verify red-first: confirm the test fails without the fix and passes with it.
+   A fix you never saw fail is a fix you cannot vouch for.
+5. Push and arm a fresh watch on the new SHA.
+
+## Failure-only diagnostics
+
+Upload the diagnostic bundle on failure only, with short retention and exact
+paths — logs, screenshots, server output. A successful run does not need them,
+and uploading a whole workspace turns every green run into a transfer cost.
+Never include generated credentials or a provisioning directory in the bundle.
+
+## Why this is worth the file
+
+The measurable win is not a faster pipeline; it is the agent noticing. A team
+that adopts automatic CI without a reliable feedback loop trades a slow local
+loop for a silent remote one, and the first red check that goes unnoticed for
+twenty minutes erases the migration's entire gain.

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/avrea/caching.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/avrea/caching.md
@@ -79,6 +79,23 @@ avr cache list --repo org/app -L 200 --json key,cache_type,size_bytes,hit_count,
 
 Zero hits can also mean the key changes on every run. Check whether the key includes something volatile before deleting anything.
 
+### The package proxy can make a store cache redundant
+
+The Actions store cache and the package proxy solve the same problem for
+dependency installs, and on Avrea the proxy alone is often enough. Measure the
+install step cold and warm before keeping the store cache:
+
+| Observation | Reading |
+|---|---|
+| install is equally fast cold and warm | the proxy is doing the work; the store cache adds bytes, not speed |
+| install is materially slower cold | the store cache is earning its quota |
+
+Measured on a real repository (2026-07-28): a pnpm install took 3.3 s on a cold
+runner and 2.5 s warm, while the 300 MB store entry recorded 0 hits and the
+save step cost ~0 s. Removing `cache: pnpm` freed 1.2 % of the 25 GiB quota and
+cost nothing in wall-clock. The correct default on Avrea is to start without a
+package-store cache and add one only if cold installs measurably hurt.
+
 ## Diagnosing and changing caches
 
 ```bash

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/avrea/platform-and-runners.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/avrea/platform-and-runners.md
@@ -41,7 +41,36 @@ Larger runners are the last resort in the performance order, and the measured A/
 2. Confirm it is CPU- or memory-bound via `avr job metrics`.
 3. Confirm the workload is actually parallel — a single-threaded `tsc` or a serial test runner gains nothing from 32 vCPU and costs proportionally more.
 
-ARM is generally cheaper per vCPU, but only choose it when the toolchain and any native dependencies are known to build on ARM64; a cross-architecture surprise costs more than the savings. macOS runners exist in two sizes only, so Swift/Xcode pipelines have limited headroom — see `references/swift-xcode.md` for what to optimize instead.
+### Downsizing is the more common finding
+
+"Start large, then step down" sounds prudent but silently overpays, because the
+step-down half rarely gets measured. `avr job metrics` makes over-provisioning
+obvious: read CPU average against peak, and peak memory against the size's
+allocation.
+
+Measured on a real repository (2026-07-28), the same gate on two sizes:
+
+| | 16 vCPU / 64 GB | 8 vCPU / 32 GB |
+|---|---|---|
+| Gate duration | 159 s | 158 s and 160 s |
+| CPU | avg 58–59 %, peak 98 % | avg 74 %, peak 99 % |
+| Peak memory | 7.4–7.8 GB | 4.0 GB |
+| Rate | $0.032/min | $0.016/min |
+
+The gate was bounded by a test runner that does not scale past a few workers,
+so the extra 8 cores idled and memory was ~8× over-provisioned at the larger
+size. Halving the runner cost nothing in wall-clock and halved the bill. Treat
+"peak memory far below allocation, CPU average well under 100 %, wall-clock flat
+across sizes" as the signature of a job that should shrink.
+
+ARM pricing is provider-specific and must be checked rather than assumed: on
+Avrea's published pricing (checked 2026-07-28) Linux ARM costs about 3× the x64
+rate per vCPU ($0.006 vs $0.002 per vCPU-minute) and caps at 16 vCPU, so ARM is
+a performance choice there, not a cost saving. Choose it only when the toolchain
+and native dependencies are known to build on ARM64, and re-check the rate table
+before relying on it. macOS runners exist in two sizes only, so Swift/Xcode
+pipelines have limited headroom — see `references/swift-xcode.md` for what to
+optimize instead.
 
 ## Observability
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/capacity-and-contention.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/capacity-and-contention.md
@@ -1,0 +1,115 @@
+# Capacity and contention
+
+Use this file when queue time is a large share of wall-clock, when adding more jobs failed to reduce latency, or when the same workflow is fast one hour and much slower the next with identical code.
+
+## The inversion
+
+Most CI advice says split work and add parallelism. That is correct **below** the capacity ceiling. Above it, the advice inverts:
+
+```text
+wall-clock ≈ queue + ceil(total_parallel_jobs / effective_capacity)
+              × (per-job setup + execution)
+```
+
+Treat that as a heuristic, not an exact formula. The point is structural: once the queue is dominant, extra jobs repay setup while waiting for scarce slots, so the DAG looks more parallel and finishes no faster.
+
+## Queue-share gate
+
+Measure over a window, not one run:
+
+```text
+queue share = Σ queue / (Σ queue + Σ execution)
+```
+
+Interpret it conservatively:
+
+| Queue share | Meaning | Default move |
+|---|---|---|
+| <15% | queue is noise | optimize execution first |
+| 15–35% | queue is material | stop adding jobs until setup and critical-path work are justified |
+| >35% | capacity is the bottleneck | topology changes are near-futile; fix contention or capacity first |
+
+This number is easy to lie with. Sum per-job queue only across **comparable jobs in the same stage**. A `needs`-gated DAG pays queue once per stage; blindly summing every queued job overstates the problem.
+
+## Detect the effective ceiling empirically
+
+Do not trust the advertised concurrency limit. Org-wide contention, runner-class scarcity, and workflow-level caps usually bite first.
+
+Method:
+
+1. Trigger more independent jobs than you think the pool can run.
+2. Record `created_at` and `started_at` per job.
+3. Count the largest number of jobs that were started but not yet completed at the same time.
+4. Compare it with the runner class and workflow topology.
+
+Signature of a ceiling:
+- `started_at` values arrive in clusters rather than smoothly.
+- Later jobs wait roughly one earlier-job duration before starting.
+- Queue p95 jumps while execution stays flat.
+
+If a 25-second job waits 120 seconds for a slot, adding one more stage or fan-out cell makes the whole workflow slower even if the job itself is tiny.
+
+## Contention is a measurement confound
+
+Two runs of the same commit on the same runner class are **not** comparable if one ran against an idle pool and the other against a saturated one.
+
+Rules:
+- Compare execution separately from queue.
+- Interleave experiment arms (`A, B, A, B`) rather than running all `A` then all `B`.
+- Treat any delta smaller than `queue p95 - queue p50` as suspicious until proven otherwise.
+- When execution is flat and queue moved, report that as a scheduling story, not a build story.
+
+## The inversion ladder
+
+When the ceiling is the bottleneck, fix in this order:
+
+1. **Merge jobs that share setup.** A single checkout/install on one runner is often cheaper than N queue waits plus N setups.
+2. **Shrink per-job setup.** The queue forces you to repay setup `ceil(N/C)` times, so checkout and install inflation hurts twice.
+3. **Stop starting irrelevant work.** Path routing, affected selection, draft gating, and duplicate-trigger removal matter more than micro-optimizing a test command.
+4. **Raise capacity.** Add or upsize only after you know queue is the bottleneck and the job is on the critical path.
+5. **Only then reshape the DAG.** Splitting long jobs further is correct only once the queue no longer dominates.
+
+This directly contradicts the usual "split long jobs" advice. Both are correct in their own regime; the ceiling decides which one applies.
+
+## Pricing a queue hop
+
+Every extra job pays a queue hop, VM boot, checkout, and toolchain setup. Before adding a planner job, aggregate-status job, or another matrix axis, price the hop:
+
+```text
+extra critical-path cost = queue_p50_or_p95 + setup_p50
+```
+
+If the proposed new job does 10 seconds of useful work but the hop costs 35 seconds, that job is a regression unless it removes a larger amount of downstream work.
+
+## Distinguish critical-path value from total work
+
+A repository can spend many compute-minutes in parallel and still be fast. A repository can also spend little compute and still feel slow because the critical path is queue-dominated.
+
+Optimize in this order:
+1. jobs with high critical-path rate,
+2. jobs with large exclusive time,
+3. only then total compute.
+
+A dramatic reduction in parallel non-critical work can produce zero wall-clock improvement.
+
+## What to report
+
+Do not headline "2× faster" when half the difference is queue noise. Report two numbers:
+
+- execution change on the bottlenecked job or stage,
+- queue share (or queue p50/p95) that constrained the result.
+
+An experiment that measured neutral or worse is still a result. Record it. Silently dropping a disproved idea guarantees the next person retries it.
+
+## Related references
+
+- `references/measurement.md` — how to separate queue, setup, execution, and critical path
+- `references/runners-and-autoscaling.md` — how to choose hosted/self-hosted/ephemeral capacity once queue is proven dominant
+- `references/change-based-ci.md` — ways to stop launching irrelevant work
+- `references/network-and-artifacts.md` — shrinking per-job setup when a queue hop is unavoidable
+
+## Sources
+
+- GitHub Actions limits: https://docs.github.com/actions/reference/limits (accessed 2026-07-28)
+- GitLab Runner advanced configuration (`concurrent`, per-runner `limit`, `request_concurrency`): https://docs.gitlab.com/runner/configuration/advanced-configuration/ (accessed 2026-07-28)
+- OpenTelemetry CI/CD semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/ (accessed 2026-07-28)

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import subprocess
@@ -461,10 +462,10 @@ def main() -> int:
                    help="skip job-level expansion of in-flight GitHub runs")
     a = p.parse_args()
 
-    if a.interval <= 0:
-        p.error("--interval must be greater than zero")
-    if a.heartbeat_min <= 0:
-        p.error("--heartbeat-min must be greater than zero")
+    if not math.isfinite(a.interval) or a.interval <= 0:
+        p.error("--interval must be a finite value greater than zero")
+    if not math.isfinite(a.heartbeat_min) or a.heartbeat_min <= 0:
+        p.error("--heartbeat-min must be a finite value greater than zero")
     # `gh run list --commit` silently returns ZERO rows for a short SHA, which
     # the registration deadline would then misreport as no-run. Fail fast.
     if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""ci-watch.py — emit one line per CI state change for a pushed commit, then exit.
+
+Provider-neutral watcher for agent harnesses. Built for a background monitor
+where each stdout line becomes one notification. The process ALWAYS terminates
+with an explicit `CI-DONE <verdict>` line — including on crashes and missing
+tooling — so silence past the deadline is structurally impossible.
+
+Why not a foreground `run watch`: under an agent harness it re-renders the whole
+job table each interval rather than emitting lines, gates its completion summary
+behind an interactive stdout check, and carries no deadline — so a run that never
+registers (path filter, disabled workflow) or an API outage hangs the session.
+
+Event vocabulary (one line each, diff-gated — only CHANGES emit):
+  CI-RUN   registered <n>: <name>: <state> · ...
+  CI-CHG   <name>: <state> -> <state>
+  CI-HB    <elapsed>/<deadline>m           liveness; keeps a prompt cache warm
+  CI-WARN  <detail>                        non-terminal problem, still retrying
+  CI-DONE  success|failure|cancelled|timeout|no-run|probe-dead|superseded — <detail>
+
+Exit code is 0 only for `success` and `superseded`.
+
+GitHub Actions (built in — needs authenticated `gh`, run from inside the repo
+when `--repo` is omitted):
+  ci-watch.py --sha "$(git rev-parse HEAD)" [--repo owner/name] [--branch main]
+
+Any other provider — supply a probe printing one `<name>: <state>` line per job.
+`$SHA` is exported to the probe's environment (not string-substituted):
+  ci-watch.py --sha "$(git rev-parse HEAD)" \
+      --cmd 'curl -sS "$API/pipelines?sha=$SHA" | jq -r ".[]|\\"\\(.name): \\(.status)\\""'
+
+`--branch` is opt-in: supplying it retires the watch when that branch moves past
+the pinned SHA. Omit it on feature branches, or the first poll self-retires.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+# GitHub Actions conclusions. Anything not in SUCCESS is not green — listing the
+# bad states explicitly (rather than treating "not failure" as success) is what
+# keeps a cancelled or skipped run from being reported as a false green.
+GH_SUCCESS = {"success"}
+GH_FAILURE = {"failure", "timed_out", "startup_failure", "action_required"}
+GH_CANCELLED = {"cancelled", "skipped", "stale", "neutral"}
+
+# Custom-probe state vocabulary. Exact matches on a normalised token, not
+# substrings: substring matching reports "not_failed" as a failure and never
+# terminates on "skipped".
+CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "fixed"}
+CUSTOM_FAILURE = {"failed", "failure", "failing_final", "error", "errored", "broken", "red"}
+CUSTOM_CANCELLED = {"cancelled", "canceled", "skipped", "manual", "blocked",
+                    "not_run", "neutral", "stale", "timed_out", "timeout"}
+
+
+def emit(line: str) -> None:
+    """One event per line, flushed immediately: the monitor reads stdout live."""
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def run_capture(args: list[str] | str, timeout: int, shell: bool = False,
+                env: dict[str, str] | None = None) -> subprocess.CompletedProcess | None:
+    """Every probe call is individually bounded; a missing binary is not fatal here."""
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=timeout,
+                              check=False, shell=shell, env=env)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def gh_json(args: list[str], timeout: int) -> object | None:
+    out = run_capture(args, timeout)
+    if out is None or out.returncode != 0:
+        return None
+    try:
+        return json.loads(out.stdout or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def head_sha(repo: str | None, branch: str, timeout: int = 30) -> str | None:
+    # NOT an f-string: gh expands the literal {owner}/{repo} placeholder from the
+    # git remote of the current directory. Do not "fix" the braces.
+    prefix = f"repos/{repo}" if repo else "repos/{owner}/{repo}"
+    out = run_capture(["gh", "api", f"{prefix}/commits/{branch}", "--jq", ".sha"], timeout)
+    if out is None or out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def classify_gh(conclusion: str | None, status: str) -> tuple[bool, str]:
+    """(terminal, bucket) where bucket is success|failure|cancelled|running."""
+    if status != "completed":
+        return False, "running"
+    if conclusion in GH_SUCCESS:
+        return True, "success"
+    if conclusion in GH_CANCELLED:
+        return True, "cancelled"
+    # Unknown conclusions are treated as failure: never assume green.
+    return True, "failure"
+
+
+def classify_custom(state: str) -> tuple[bool, str]:
+    token = state.strip().lower().replace("-", "_").replace(" ", "_")
+    if token in CUSTOM_SUCCESS:
+        return True, "success"
+    if token in CUSTOM_FAILURE:
+        return True, "failure"
+    if token in CUSTOM_CANCELLED:
+        return True, "cancelled"
+    return False, "running"
+
+
+def poll_gh(repo: str | None, sha: str, timeout: int) -> list[dict] | None:
+    """All runs for the pinned SHA — never 'latest', which can be another commit."""
+    args = ["gh", "run", "list", "--commit", sha, "--limit", "100",
+            "--json", "databaseId,workflowName,status,conclusion"]
+    if repo:
+        args += ["--repo", repo]
+    data = gh_json(args, timeout)
+    if not isinstance(data, list):
+        return None
+    rows = []
+    for r in data:
+        terminal, bucket = classify_gh(r.get("conclusion"), r.get("status", ""))
+        rows.append({"key": str(r["databaseId"]), "name": r["workflowName"],
+                     "state": r.get("conclusion") or r.get("status", ""),
+                     "terminal": terminal, "bucket": bucket})
+    return rows
+
+
+def poll_custom(cmd: str, sha: str, timeout: int) -> list[dict] | None:
+    """Probe contract: print one `<name>: <state>` line per job, nothing else."""
+    env = {**os.environ, "SHA": sha}
+    out = run_capture(cmd, timeout, shell=True, env=env)
+    if out is None or out.returncode != 0:
+        return None
+    rows: list[dict] = []
+    for line in out.stdout.splitlines():
+        if ":" not in line:
+            continue
+        # rpartition: job names legitimately contain ':' (GitLab `test:unit`).
+        name, _, state = line.rpartition(":")
+        name, state = name.strip(), state.strip()
+        if not name or not state:
+            continue
+        terminal, bucket = classify_custom(state)
+        rows.append({"key": name, "name": name, "state": state.lower(),
+                     "terminal": terminal, "bucket": bucket})
+    return rows
+
+
+def watch(a: argparse.Namespace) -> int:
+    started = time.monotonic()
+    deadline = started + a.deadline_min * 60
+    register_by = started + a.register_min * 60
+    next_beat = started + a.heartbeat_min * 60
+
+    seen: dict[str, str] = {}
+    registered = False
+    err_streak = 0
+    warned_at = 0
+    last_keys: frozenset[str] | None = None
+    polls_since_check = 0
+
+    while True:
+        runs = (poll_custom(a.cmd, a.sha, 45) if a.cmd
+                else poll_gh(a.repo, a.sha, 45))
+
+        if runs is None:
+            err_streak += 1
+            if err_streak >= 3 and err_streak != warned_at and err_streak % 3 == 0:
+                emit(f"CI-WARN probe failing ({err_streak}x) — still retrying")
+                warned_at = err_streak
+            if err_streak >= 10:
+                emit("CI-DONE probe-dead — 10 consecutive probe failures")
+                return 1
+        else:
+            err_streak = 0
+            if runs and not registered:
+                registered = True
+                emit(f"CI-RUN  registered {len(runs)}: "
+                     + " · ".join(f"{r['name']}: {r['state']}" for r in runs))
+
+            for r in runs:
+                if seen.get(r["key"]) != r["state"]:
+                    if r["key"] in seen:
+                        emit(f"CI-CHG  {r['name']}: {seen[r['key']]} -> {r['state']}")
+                    seen[r["key"]] = r["state"]
+
+            keys = frozenset(r["key"] for r in runs)
+            stable = last_keys == keys
+            last_keys = keys
+
+            # Do not call success while workflows may still be registering: a fast
+            # job can finish before a slower sibling is even created.
+            settled = stable or time.monotonic() > register_by
+            if registered and runs and settled and all(r["terminal"] for r in runs):
+                failed = [r for r in runs if r["bucket"] == "failure"]
+                stopped = [r for r in runs if r["bucket"] == "cancelled"]
+                if failed:
+                    hint = ""
+                    if not a.cmd:
+                        flag = f" --repo {a.repo}" if a.repo else ""
+                        hint = " — " + "; ".join(
+                            f"gh run view {r['key']}{flag} --log-failed" for r in failed[:3])
+                    emit(f"CI-DONE failure — {', '.join(r['name'] for r in failed)}{hint}")
+                    return 1
+                if stopped:
+                    emit("CI-DONE cancelled — "
+                         + ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
+                         + " — not a green result")
+                    return 1
+                emit(f"CI-DONE success — {len(runs)} workflow(s) green on {a.sha[:9]}")
+                return 0
+
+            # Opt-in supersession; polled sparsely to avoid doubling API calls.
+            polls_since_check += 1
+            if registered and a.branch and not a.cmd and polls_since_check >= 4:
+                polls_since_check = 0
+                tip = head_sha(a.repo, a.branch)
+                if tip and tip != a.sha:
+                    emit(f"CI-DONE superseded — {a.branch} moved to {tip[:9]}")
+                    return 0
+
+        now = time.monotonic()   # re-sampled: the probe above can take ~45s
+        if not registered and now > register_by:
+            emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} in "
+                 f"{a.register_min:g}m (path filter? workflow disabled? wrong branch?)")
+            return 1
+        if now > deadline:
+            pending = sum(1 for k in seen if k not in
+                          {r["key"] for r in (runs or []) if r["terminal"]})
+            emit(f"CI-DONE timeout — {a.deadline_min:g}m elapsed, {pending} still running")
+            return 1
+        if now >= next_beat:
+            emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
+            next_beat = now + a.heartbeat_min * 60
+
+        time.sleep(a.interval)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--sha", required=True, help="full commit SHA that was pushed")
+    p.add_argument("--repo", help="owner/name (GitHub mode; inferred from cwd if omitted)")
+    p.add_argument("--branch", default="",
+                   help="opt-in: retire the watch when this branch moves past --sha")
+    p.add_argument("--cmd", help="probe printing '<name>: <state>' lines; $SHA is in its env")
+    p.add_argument("--deadline-min", type=float, default=30.0)
+    p.add_argument("--interval", type=float, default=15.0)
+    p.add_argument("--heartbeat-min", type=float, default=2.5)
+    p.add_argument("--register-min", type=float, default=4.0)
+    a = p.parse_args()
+    try:
+        return watch(a)
+    except KeyboardInterrupt:
+        emit("CI-DONE timeout — interrupted")
+        return 1
+    except BaseException as exc:  # noqa: BLE001 — a crash must still emit a verdict
+        emit(f"CI-DONE probe-dead — {type(exc).__name__}: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -241,6 +241,7 @@ def watch(a: argparse.Namespace) -> int:
 
     seen: dict[str, str] = {}
     registered = False
+    successful_empty_probe = False
     err_streak = 0
     warned_at = 0
     last_keys: frozenset[str] | None = None
@@ -251,13 +252,16 @@ def watch(a: argparse.Namespace) -> int:
     while True:
         now = time.monotonic()
         if not registered and now >= register_by:
-            if a.expect_none:
+            if a.expect_none and successful_empty_probe:
                 emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
                      "expected (declared path-filtered)")
                 return 0
+            detail = ("probe never returned a successful empty snapshot"
+                      if a.expect_none else
+                      "path filter? workflow disabled? wrong branch? short SHA?")
             return done("no-run",
                         f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
-                        "(path filter? workflow disabled? wrong branch? short SHA?)")
+                        f"({detail})")
         if now >= deadline:
             pending = sum(1 for k, v in seen.items()
                           if "/" not in k and not classify_custom(v)[0]
@@ -275,11 +279,16 @@ def watch(a: argparse.Namespace) -> int:
                 warned_at = err_streak
             if err_streak >= 10:
                 return done("probe-dead", "10 consecutive probe failures")
-        elif not runs and registered:
-            # A transient empty result after registration is a blip, never a
-            # verdict: `all([])` is True, and treating it as "all terminal and
-            # nothing failed" manufactures a success out of an outage.
-            green_since = None
+        elif not runs:
+            # An empty list is a successful provider response, not another probe
+            # failure. Before registration it proves --expect-none observed the
+            # provider; after registration it remains a transient blip, never a
+            # verdict (`all([])` would otherwise manufacture a success).
+            err_streak = 0
+            if registered:
+                green_since = None
+            else:
+                successful_empty_probe = True
         else:
             err_streak = 0
             if runs and not registered:
@@ -305,9 +314,9 @@ def watch(a: argparse.Namespace) -> int:
                                              max(0.1, min(30.0, remaining))):
                             jk = j["key"]
                             if seen.get(jk) != j["state"] and j["state"]:
-                                if jk in seen:
-                                    emit(f"CI-CHG  {r['name']}/{j['name']}: "
-                                         f"{seen[jk]} -> {j['state']}")
+                                previous = seen.get(jk, "unknown")
+                                emit(f"CI-CHG  {r['name']}/{j['name']}: "
+                                     f"{previous} -> {j['state']}")
                                 seen[jk] = j["state"]
 
             keys = frozenset(r["key"] for r in runs)
@@ -408,13 +417,16 @@ def watch(a: argparse.Namespace) -> int:
 
         now = time.monotonic()   # re-sampled: the probes above can take ~45s
         if not registered and now > register_by:
-            if a.expect_none:
+            if a.expect_none and successful_empty_probe:
                 emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
                      "expected (declared path-filtered)")
                 return 0
+            detail = ("probe never returned a successful empty snapshot"
+                      if a.expect_none else
+                      "path filter? workflow disabled? wrong branch? short SHA?")
             return done("no-run",
                         f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
-                        "(path filter? workflow disabled? wrong branch? short SHA?)")
+                        f"({detail})")
         if now > deadline:
             pending = sum(1 for k, v in seen.items()
                           if "/" not in k and not classify_custom(v)[0]
@@ -449,6 +461,10 @@ def main() -> int:
                    help="skip job-level expansion of in-flight GitHub runs")
     a = p.parse_args()
 
+    if a.interval <= 0:
+        p.error("--interval must be greater than zero")
+    if a.heartbeat_min <= 0:
+        p.error("--heartbeat-min must be greater than zero")
     # `gh run list --commit` silently returns ZERO rows for a short SHA, which
     # the registration deadline would then misreport as no-run. Fail fast.
     if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -352,22 +352,27 @@ def watch(a: argparse.Namespace) -> int:
                     return done("cancelled", names + " — not a green result "
                                 "(pass --branch to distinguish supersession)")
                 if a.settle_sec > 0:
-                    now = time.monotonic()
+                    settle_now = time.monotonic()
                     if green_since is None:
-                        green_since = now
+                        green_since = settle_now
                         if not settle_announced:
                             emit(f"CI-SETTLE all green — holding {a.settle_sec:g}s "
                                  "for completion-triggered follow-ups")
                             settle_announced = True
-                    if now >= deadline:
+                    if settle_now >= deadline:
                         return done("timeout",
                                     f"{a.deadline_min:g}m elapsed while waiting to settle")
-                    if now - green_since < a.settle_sec:
-                        if now >= next_beat:
-                            emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
-                            next_beat = now + a.heartbeat_min * 60
+                    if settle_now - green_since < a.settle_sec:
+                        if settle_now >= next_beat:
+                            emit(f"CI-HB   {int((settle_now - started) / 60)}/"
+                                 f"{a.deadline_min:g}m")
+                            next_beat = settle_now + a.heartbeat_min * 60
                         wake_at = min(deadline, next_beat, green_since + a.settle_sec)
-                        time.sleep(max(0, min(a.interval, wake_at - now)))
+                        sleep_now = time.monotonic()
+                        if sleep_now >= deadline:
+                            return done("timeout",
+                                        f"{a.deadline_min:g}m elapsed while waiting to settle")
+                        time.sleep(max(0, min(a.interval, wake_at - sleep_now)))
                         continue
                 if a.branch and not a.cmd:
                     remaining = deadline - time.monotonic()

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -12,47 +12,68 @@ behind an interactive stdout check, and carries no deadline — so a run that ne
 registers (path filter, disabled workflow) or an API outage hangs the session.
 
 Event vocabulary (one line each, diff-gated — only CHANGES emit):
-  CI-RUN   registered <n>: <name>: <state> · ...
-  CI-CHG   <name>: <state> -> <state>
-  CI-HB    <elapsed>/<deadline>m           liveness; keeps a prompt cache warm
-  CI-WARN  <detail>                        non-terminal problem, still retrying
-  CI-DONE  success|failure|cancelled|timeout|no-run|probe-dead|superseded — <detail>
+  CI-RUN    registered <n>: <name>: <state> · ...
+  CI-CHG    <name>: <state> -> <state>          run-level, and job-level for
+                                                in-flight runs (react to the
+                                                first red job, not the verdict)
+  CI-HB     <elapsed>/<deadline>m               liveness tick
+  CI-SETTLE all green — holding <n>s for completion-triggered follow-ups
+  CI-WARN   <detail>                            non-terminal problem, still retrying
+  CI-DONE   success|failure|cancelled|timeout|no-run|probe-dead|superseded — <detail>
 
-Exit code is 0 only for `success` and `superseded`.
+Exit code encodes the verdict so `ci-watch.py … && deploy` is safe:
+  0 success (and no-run under --expect-none)
+  1 failure, cancelled
+  2 timeout, no-run, probe-dead      — indeterminate: you still do not know
+  3 superseded                       — the pinned SHA never reached a verdict
+Collapsing these to 0 (a tempting shortcut) makes `watch && deploy` ship a red
+build; treating 2 as red hides that the answer is "unknown", not "no".
 
-GitHub Actions (built in — needs authenticated `gh`, run from inside the repo
-when `--repo` is omitted):
+GitHub Actions (built in — needs authenticated `gh`; pass --repo when the
+session cwd is not the target repo, e.g. another worktree):
   ci-watch.py --sha "$(git rev-parse HEAD)" [--repo owner/name] [--branch main]
 
 Any other provider — supply a probe printing one `<name>: <state>` line per job.
-`$SHA` is exported to the probe's environment (not string-substituted):
+`$SHA` is exported to the probe's environment (never string-substituted into the
+command, which would be a quoting/injection hazard):
   ci-watch.py --sha "$(git rev-parse HEAD)" \
       --cmd 'curl -sS "$API/pipelines?sha=$SHA" | jq -r ".[]|\\"\\(.name): \\(.status)\\""'
 
-`--branch` is opt-in: supplying it retires the watch when that branch moves past
-the pinned SHA. Omit it on feature branches, or the first poll self-retires.
+Flags for specific pipeline shapes:
+  --settle-sec N   hold an all-green result N seconds and re-probe before
+                   declaring success. Use when one workflow triggers another on
+                   completion (deploy after build): the follow-up does not exist
+                   yet at the moment the first turns green.
+  --expect-none    a path-filtered push may legitimately trigger nothing; make
+                   "zero runs registered" an asserted expectation (exit 0)
+                   instead of an ambiguous no-run (exit 2).
+  --no-jobs        skip per-run job expansion in GitHub mode (halves API calls
+                   on busy commits; you lose early job-level failure events).
 """
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 
-# GitHub Actions conclusions. Anything not in SUCCESS is not green — listing the
-# bad states explicitly (rather than treating "not failure" as success) is what
-# keeps a cancelled or skipped run from being reported as a false green.
+EXIT = {"success": 0, "failure": 1, "cancelled": 1,
+        "timeout": 2, "no-run": 2, "probe-dead": 2, "superseded": 3}
+
+# GitHub Actions conclusions. Anything not in SUCCESS is not green — enumerating
+# success (rather than treating "not failure" as green) is what keeps a
+# cancelled or skipped run from being reported as a false green.
 GH_SUCCESS = {"success"}
-GH_FAILURE = {"failure", "timed_out", "startup_failure", "action_required"}
 GH_CANCELLED = {"cancelled", "skipped", "stale", "neutral"}
 
 # Custom-probe state vocabulary. Exact matches on a normalised token, not
 # substrings: substring matching reports "not_failed" as a failure and never
 # terminates on "skipped".
 CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "fixed"}
-CUSTOM_FAILURE = {"failed", "failure", "failing_final", "error", "errored", "broken", "red"}
+CUSTOM_FAILURE = {"failed", "failure", "error", "errored", "broken", "red"}
 CUSTOM_CANCELLED = {"cancelled", "canceled", "skipped", "manual", "blocked",
                     "not_run", "neutral", "stale", "timed_out", "timeout"}
 
@@ -63,12 +84,19 @@ def emit(line: str) -> None:
     sys.stdout.flush()
 
 
+def done(verdict: str, detail: str) -> int:
+    emit(f"CI-DONE {verdict} — {detail}")
+    return EXIT[verdict]
+
+
 def run_capture(args: list[str] | str, timeout: int, shell: bool = False,
                 env: dict[str, str] | None = None) -> subprocess.CompletedProcess | None:
-    """Every probe call is individually bounded; a missing binary is not fatal here."""
+    """Every probe call is individually bounded; a wedged request must not
+    freeze the loop, and a missing binary is handled by the caller."""
     try:
         return subprocess.run(args, capture_output=True, text=True, timeout=timeout,
-                              check=False, shell=shell, env=env)
+                              check=False, shell=shell, env=env,
+                              stdin=subprocess.DEVNULL)
     except (subprocess.TimeoutExpired, OSError):
         return None
 
@@ -84,8 +112,11 @@ def gh_json(args: list[str], timeout: int) -> object | None:
 
 
 def head_sha(repo: str | None, branch: str, timeout: int = 30) -> str | None:
-    # NOT an f-string: gh expands the literal {owner}/{repo} placeholder from the
-    # git remote of the current directory. Do not "fix" the braces.
+    """Branch tip from the API — NOT `run list --branch --limit 1`, whose newest
+    RUN can lag the newest COMMIT and report a push superseded by its own
+    ancestor."""
+    # NOT an f-string: gh expands the literal {owner}/{repo} placeholder from
+    # the git remote of the current directory. Do not "fix" the braces.
     prefix = f"repos/{repo}" if repo else "repos/{owner}/{repo}"
     out = run_capture(["gh", "api", f"{prefix}/commits/{branch}", "--jq", ".sha"], timeout)
     if out is None or out.returncode != 0:
@@ -117,9 +148,14 @@ def classify_custom(state: str) -> tuple[bool, str]:
 
 
 def poll_gh(repo: str | None, sha: str, timeout: int) -> list[dict] | None:
-    """All runs for the pinned SHA — never 'latest', which can be another commit."""
+    """All runs for the pinned SHA — never 'latest', which can be another commit.
+
+    `gh run list` returns one row per run id already reflecting the latest
+    attempt (verified against gh 2.x); providers whose listing returns one row
+    per ATTEMPT need the highest attempt kept per id or the watcher oscillates.
+    """
     args = ["gh", "run", "list", "--commit", sha, "--limit", "100",
-            "--json", "databaseId,workflowName,status,conclusion"]
+            "--json", "databaseId,workflowName,event,status,conclusion"]
     if repo:
         args += ["--repo", repo]
     data = gh_json(args, timeout)
@@ -129,9 +165,51 @@ def poll_gh(repo: str | None, sha: str, timeout: int) -> list[dict] | None:
     for r in data:
         terminal, bucket = classify_gh(r.get("conclusion"), r.get("status", ""))
         rows.append({"key": str(r["databaseId"]), "name": r["workflowName"],
+                     "group": (r["workflowName"], r.get("event", "")),
                      "state": r.get("conclusion") or r.get("status", ""),
                      "terminal": terminal, "bucket": bucket})
     return rows
+
+
+def poll_gh_jobs(repo: str | None, run_key: str, timeout: int) -> list[dict]:
+    """Jobs of one in-flight run. A run's status stays in_progress until every
+    job finishes, so run-level polling cannot surface the first red job — this
+    expansion is what makes 'react to the first failure' possible. Bounded to
+    active runs so the extra API call does not multiply on finished work."""
+    args = ["gh", "run", "view", run_key, "--json", "jobs"]
+    if repo:
+        args += ["--repo", repo]
+    data = gh_json(args, timeout)
+    if not isinstance(data, dict):
+        return []
+    rows = []
+    for j in data.get("jobs", []):
+        state = j.get("conclusion") or j.get("status") or ""
+        rows.append({"key": f"{run_key}/{j.get('name', '?')}",
+                     "name": j.get("name", "?"), "state": state})
+    return rows
+
+
+def newest_per_workflow(runs: list[dict]) -> list[dict]:
+    """One commit can carry several runs of the same workflow (a rerun, or a
+    concurrency-cancelled attempt beside its replacement). The newest run per
+    (workflow, trigger event) decides the verdict; otherwise a cancelled
+    sibling turns a green commit red. Grouping includes the EVENT because a
+    workflow_dispatch rerun is a different validation surface than the push
+    run it sits beside — a dispatch that skips a deploy job must not forgive
+    the push run whose deploy job failed. GitHub run ids are monotonic, so
+    max(id) is the newest within a group."""
+    by_group: dict[tuple, dict] = {}
+    for r in runs:
+        group = r.get("group", (r["name"],))
+        prev = by_group.get(group)
+        if prev is None or _key_order(r["key"]) > _key_order(prev["key"]):
+            by_group[group] = r
+    return list(by_group.values())
+
+
+def _key_order(key: str):
+    return (0, int(key)) if key.isdigit() else (1, key)
 
 
 def poll_custom(cmd: str, sha: str, timeout: int) -> list[dict] | None:
@@ -166,7 +244,9 @@ def watch(a: argparse.Namespace) -> int:
     err_streak = 0
     warned_at = 0
     last_keys: frozenset[str] | None = None
-    polls_since_check = 0
+    green_since: float | None = None
+    settle_announced = False
+    polls_since_branch_check = 0
 
     while True:
         runs = (poll_custom(a.cmd, a.sha, 45) if a.cmd
@@ -178,8 +258,12 @@ def watch(a: argparse.Namespace) -> int:
                 emit(f"CI-WARN probe failing ({err_streak}x) — still retrying")
                 warned_at = err_streak
             if err_streak >= 10:
-                emit("CI-DONE probe-dead — 10 consecutive probe failures")
-                return 1
+                return done("probe-dead", "10 consecutive probe failures")
+        elif not runs and registered:
+            # A transient empty result after registration is a blip, never a
+            # verdict: `all([])` is True, and treating it as "all terminal and
+            # nothing failed" manufactures a success out of an outage.
+            green_since = None
         else:
             err_streak = 0
             if runs and not registered:
@@ -193,51 +277,97 @@ def watch(a: argparse.Namespace) -> int:
                         emit(f"CI-CHG  {r['name']}: {seen[r['key']]} -> {r['state']}")
                     seen[r["key"]] = r["state"]
 
+            # Job-level expansion for in-flight runs only (GitHub mode): the
+            # first red job surfaces minutes before the run's own conclusion.
+            if not a.cmd and not a.no_jobs:
+                for r in runs:
+                    if not r["terminal"]:
+                        for j in poll_gh_jobs(a.repo, r["key"], 30):
+                            jk = j["key"]
+                            if seen.get(jk) != j["state"] and j["state"]:
+                                if jk in seen:
+                                    emit(f"CI-CHG  {r['name']}/{j['name']}: "
+                                         f"{seen[jk]} -> {j['state']}")
+                                seen[jk] = j["state"]
+
             keys = frozenset(r["key"] for r in runs)
             stable = last_keys == keys
             last_keys = keys
 
-            # Do not call success while workflows may still be registering: a fast
-            # job can finish before a slower sibling is even created.
+            # The verdict comes from the newest run per workflow, and only once
+            # the run SET has been stable across two polls (or registration has
+            # closed): a fast workflow can finish before a slower sibling is
+            # even created, and success-on-first-green would miss the sibling.
+            decisive = newest_per_workflow(runs) if not a.cmd else runs
             settled = stable or time.monotonic() > register_by
-            if registered and runs and settled and all(r["terminal"] for r in runs):
-                failed = [r for r in runs if r["bucket"] == "failure"]
-                stopped = [r for r in runs if r["bucket"] == "cancelled"]
+            if registered and decisive and settled and all(r["terminal"] for r in decisive):
+                failed = [r for r in decisive if r["bucket"] == "failure"]
+                stopped = [r for r in decisive if r["bucket"] == "cancelled"]
                 if failed:
+                    # Failure outranks supersession: a completed red answers
+                    # "did this SHA pass" regardless of where the branch went.
                     hint = ""
                     if not a.cmd:
                         flag = f" --repo {a.repo}" if a.repo else ""
                         hint = " — " + "; ".join(
                             f"gh run view {r['key']}{flag} --log-failed" for r in failed[:3])
-                    emit(f"CI-DONE failure — {', '.join(r['name'] for r in failed)}{hint}")
-                    return 1
+                    return done("failure", ", ".join(r["name"] for r in failed) + hint)
                 if stopped:
-                    emit("CI-DONE cancelled — "
-                         + ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
-                         + " — not a green result")
-                    return 1
-                emit(f"CI-DONE success — {len(runs)} workflow(s) green on {a.sha[:9]}")
-                return 0
+                    # Cancelled is ambiguous: under cancel-in-progress
+                    # concurrency, a newer push cancels this SHA's runs. Check
+                    # the branch tip to tell auto-supersession from a manual or
+                    # infrastructure cancel.
+                    names = ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
+                    if a.branch and not a.cmd:
+                        tip = head_sha(a.repo, a.branch)
+                        if tip and tip != a.sha:
+                            return done("superseded",
+                                        f"runs cancelled and {a.branch} moved to "
+                                        f"{tip[:9]} — no verdict for {a.sha[:9]}")
+                        return done("cancelled", names + " on an unmoved branch "
+                                    "— not green, not superseded")
+                    return done("cancelled", names + " — not a green result "
+                                "(pass --branch to distinguish supersession)")
+                if a.settle_sec > 0:
+                    now = time.monotonic()
+                    if green_since is None:
+                        green_since = now
+                        if not settle_announced:
+                            emit(f"CI-SETTLE all green — holding {a.settle_sec:g}s "
+                                 "for completion-triggered follow-ups")
+                            settle_announced = True
+                    if now - green_since < a.settle_sec:
+                        time.sleep(a.interval)
+                        continue
+                return done("success",
+                            f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
+            green_since = None
 
-            # Opt-in supersession; polled sparsely to avoid doubling API calls.
-            polls_since_check += 1
-            if registered and a.branch and not a.cmd and polls_since_check >= 4:
-                polls_since_check = 0
+            # Mid-flight supersession (opt-in, sparse — the branch probe would
+            # otherwise double API traffic). A moved branch retires a watch that
+            # has no verdict yet; a finished verdict above always wins.
+            polls_since_branch_check += 1
+            if registered and a.branch and not a.cmd and polls_since_branch_check >= 4:
+                polls_since_branch_check = 0
                 tip = head_sha(a.repo, a.branch)
                 if tip and tip != a.sha:
-                    emit(f"CI-DONE superseded — {a.branch} moved to {tip[:9]}")
-                    return 0
+                    return done("superseded", f"{a.branch} moved to {tip[:9]}")
 
-        now = time.monotonic()   # re-sampled: the probe above can take ~45s
+        now = time.monotonic()   # re-sampled: the probes above can take ~45s
         if not registered and now > register_by:
-            emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} in "
-                 f"{a.register_min:g}m (path filter? workflow disabled? wrong branch?)")
-            return 1
+            if a.expect_none:
+                emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
+                     "expected (declared path-filtered)")
+                return 0
+            return done("no-run",
+                        f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
+                        "(path filter? workflow disabled? wrong branch? short SHA?)")
         if now > deadline:
-            pending = sum(1 for k in seen if k not in
-                          {r["key"] for r in (runs or []) if r["terminal"]})
-            emit(f"CI-DONE timeout — {a.deadline_min:g}m elapsed, {pending} still running")
-            return 1
+            pending = sum(1 for k, v in seen.items()
+                          if "/" not in k and not classify_custom(v)[0]
+                          and v not in ("completed",))
+            return done("timeout",
+                        f"{a.deadline_min:g}m elapsed, ~{pending} still running")
         if now >= next_beat:
             emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
             next_beat = now + a.heartbeat_min * 60
@@ -247,8 +377,9 @@ def watch(a: argparse.Namespace) -> int:
 
 def main() -> int:
     p = argparse.ArgumentParser()
-    p.add_argument("--sha", required=True, help="full commit SHA that was pushed")
-    p.add_argument("--repo", help="owner/name (GitHub mode; inferred from cwd if omitted)")
+    p.add_argument("--sha", required=True, help="full 40-char commit SHA that was pushed")
+    p.add_argument("--repo", help="owner/name (GitHub mode; inferred from cwd if omitted "
+                                  "— pass it explicitly when running from another worktree)")
     p.add_argument("--branch", default="",
                    help="opt-in: retire the watch when this branch moves past --sha")
     p.add_argument("--cmd", help="probe printing '<name>: <state>' lines; $SHA is in its env")
@@ -256,15 +387,32 @@ def main() -> int:
     p.add_argument("--interval", type=float, default=15.0)
     p.add_argument("--heartbeat-min", type=float, default=2.5)
     p.add_argument("--register-min", type=float, default=4.0)
+    p.add_argument("--settle-sec", type=float, default=0.0,
+                   help="hold all-green N seconds for completion-triggered follow-ups")
+    p.add_argument("--expect-none", action="store_true",
+                   help="zero registered runs is the expected outcome (exit 0)")
+    p.add_argument("--no-jobs", action="store_true",
+                   help="skip job-level expansion of in-flight GitHub runs")
     a = p.parse_args()
+
+    # `gh run list --commit` silently returns ZERO rows for a short SHA, which
+    # the registration deadline would then misreport as no-run. Fail fast.
+    if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):
+        p.error("--sha must be the full 40-character lowercase SHA in GitHub mode "
+                "(use \"$(git rev-parse HEAD)\")")
+    # If the registration cutoff meets or exceeds the deadline, no-run becomes
+    # unreachable and every skipped pipeline misreports as timeout.
+    if a.register_min * 2 > a.deadline_min:
+        a.register_min = a.deadline_min / 2
+        emit(f"CI-WARN register window clamped to {a.register_min:g}m "
+             f"(half of the {a.deadline_min:g}m deadline)")
+
     try:
         return watch(a)
     except KeyboardInterrupt:
-        emit("CI-DONE timeout — interrupted")
-        return 1
+        return done("timeout", "interrupted")
     except BaseException as exc:  # noqa: BLE001 — a crash must still emit a verdict
-        emit(f"CI-DONE probe-dead — {type(exc).__name__}: {exc}")
-        return 1
+        return done("probe-dead", f"{type(exc).__name__}: {exc}")
 
 
 if __name__ == "__main__":

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -73,7 +73,7 @@ GH_CANCELLED = {"cancelled", "skipped", "stale", "neutral"}
 # substrings: substring matching reports "not_failed" as a failure and never
 # terminates on "skipped".
 CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "fixed"}
-CUSTOM_FAILURE = {"failed", "failure", "error", "errored", "broken", "red"}
+CUSTOM_FAILURE = {"failed", "failure", "failing_final", "error", "errored", "broken", "red"}
 CUSTOM_CANCELLED = {"cancelled", "canceled", "skipped", "manual", "blocked",
                     "not_run", "neutral", "stale", "timed_out", "timeout"}
 
@@ -249,8 +249,24 @@ def watch(a: argparse.Namespace) -> int:
     polls_since_branch_check = 0
 
     while True:
-        runs = (poll_custom(a.cmd, a.sha, 45) if a.cmd
-                else poll_gh(a.repo, a.sha, 45))
+        now = time.monotonic()
+        if not registered and now >= register_by:
+            if a.expect_none:
+                emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
+                     "expected (declared path-filtered)")
+                return 0
+            return done("no-run",
+                        f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
+                        "(path filter? workflow disabled? wrong branch? short SHA?)")
+        if now >= deadline:
+            pending = sum(1 for k, v in seen.items()
+                          if "/" not in k and not classify_custom(v)[0]
+                          and v not in ("completed",))
+            return done("timeout",
+                        f"{a.deadline_min:g}m elapsed, ~{pending} still running")
+        probe_timeout = max(0.1, min(45.0, deadline - now))
+        runs = (poll_custom(a.cmd, a.sha, probe_timeout) if a.cmd
+                else poll_gh(a.repo, a.sha, probe_timeout))
 
         if runs is None:
             err_streak += 1
@@ -282,7 +298,11 @@ def watch(a: argparse.Namespace) -> int:
             if not a.cmd and not a.no_jobs:
                 for r in runs:
                     if not r["terminal"]:
-                        for j in poll_gh_jobs(a.repo, r["key"], 30):
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        for j in poll_gh_jobs(a.repo, r["key"],
+                                             max(0.1, min(30.0, remaining))):
                             jk = j["key"]
                             if seen.get(jk) != j["state"] and j["state"]:
                                 if jk in seen:
@@ -319,7 +339,10 @@ def watch(a: argparse.Namespace) -> int:
                     # infrastructure cancel.
                     names = ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
                     if a.branch and not a.cmd:
-                        tip = head_sha(a.repo, a.branch)
+                        remaining = deadline - time.monotonic()
+                        tip = (head_sha(a.repo, a.branch,
+                                        max(0.1, min(30.0, remaining)))
+                               if remaining > 0 else None)
                         if tip and tip != a.sha:
                             return done("superseded",
                                         f"runs cancelled and {a.branch} moved to "
@@ -336,11 +359,33 @@ def watch(a: argparse.Namespace) -> int:
                             emit(f"CI-SETTLE all green — holding {a.settle_sec:g}s "
                                  "for completion-triggered follow-ups")
                             settle_announced = True
+                    if now >= deadline:
+                        return done("timeout",
+                                    f"{a.deadline_min:g}m elapsed while waiting to settle")
                     if now - green_since < a.settle_sec:
-                        time.sleep(a.interval)
+                        if now >= next_beat:
+                            emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
+                            next_beat = now + a.heartbeat_min * 60
+                        wake_at = min(deadline, next_beat, green_since + a.settle_sec)
+                        time.sleep(max(0, min(a.interval, wake_at - now)))
                         continue
-                return done("success",
-                            f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
+                if a.branch and not a.cmd:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return done("timeout",
+                                    f"{a.deadline_min:g}m elapsed before branch verification")
+                    tip = head_sha(a.repo, a.branch,
+                                   max(0.1, min(30.0, remaining)))
+                    if tip is None:
+                        emit("CI-WARN branch tip check failed — withholding green verdict")
+                    elif tip != a.sha:
+                        return done("superseded", f"{a.branch} moved to {tip[:9]}")
+                    else:
+                        return done("success",
+                                    f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
+                else:
+                    return done("success",
+                                f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
             green_since = None
 
             # Mid-flight supersession (opt-in, sparse — the branch probe would
@@ -349,7 +394,10 @@ def watch(a: argparse.Namespace) -> int:
             polls_since_branch_check += 1
             if registered and a.branch and not a.cmd and polls_since_branch_check >= 4:
                 polls_since_branch_check = 0
-                tip = head_sha(a.repo, a.branch)
+                remaining = deadline - time.monotonic()
+                tip = (head_sha(a.repo, a.branch,
+                                max(0.1, min(30.0, remaining)))
+                       if remaining > 0 else None)
                 if tip and tip != a.sha:
                     return done("superseded", f"{a.branch} moved to {tip[:9]}")
 
@@ -372,7 +420,8 @@ def watch(a: argparse.Namespace) -> int:
             emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
             next_beat = now + a.heartbeat_min * 60
 
-        time.sleep(a.interval)
+        wake_at = min(deadline, next_beat, register_by if not registered else deadline)
+        time.sleep(max(0, min(a.interval, wake_at - time.monotonic())))
 
 
 def main() -> int:
@@ -400,12 +449,12 @@ def main() -> int:
     if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):
         p.error("--sha must be the full 40-character lowercase SHA in GitHub mode "
                 "(use \"$(git rev-parse HEAD)\")")
-    # If the registration cutoff meets or exceeds the deadline, no-run becomes
+    # If the registration cutoff exceeds the deadline, no-run becomes
     # unreachable and every skipped pipeline misreports as timeout.
-    if a.register_min * 2 > a.deadline_min:
-        a.register_min = a.deadline_min / 2
+    if a.register_min > a.deadline_min:
+        a.register_min = a.deadline_min
         emit(f"CI-WARN register window clamped to {a.register_min:g}m "
-             f"(half of the {a.deadline_min:g}m deadline)")
+             f"(the {a.deadline_min:g}m deadline)")
 
     try:
         return watch(a)

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -69,8 +69,9 @@ Ask in order:
 11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
 12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+14. Is an agent pushing and then waiting on CI — or has a session gone silent after a push? Read `references/agent-feedback-loop.md`.
+15. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
+16. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -101,6 +102,10 @@ Use full validation as the safe fallback whenever changed files, merge base, cac
 ### 6. Verify after the change
 
 Re-run on the same commit first, then a normal representative commit. Compare median and p95 wall-clock, queue time, cache behavior, first-time pass rate, cost, and failure/rework signals. Confirm the exact run head SHA contains the change and the deployed artifact digest or workflow run is the intended one.
+
+Do not wait for those runs in the foreground. Arm a bounded watcher so a red check surfaces the moment it happens instead of at the deadline — `references/agent-feedback-loop.md`, or `scripts/ci-watch.py` directly. Expect to keep working between its events.
+
+Making CI automatic surfaces defects that a manual, hand-dispatched pipeline hid — environment leakage between jobs, assertions that drifted from the contract they check, and pre-existing flakes. Treat each as a real finding: root-cause it and verify red-first. Reaching green by adding a retry, widening a threshold, or skipping the check corrupts the measurement instead of fixing the pipeline (`references/effectiveness-contract.md`).
 
 Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
 
@@ -177,6 +182,11 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Retrying flakes forever | Bound retries, quarantine, assign ownership, track flake rate. |
 | Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
+| Agent blocks on a foreground `run watch` | Arm a bounded watcher that emits per state change and always prints a terminal verdict (`references/agent-feedback-loop.md`). |
+| Watcher greps only for the success marker | Silence then looks identical to "still running". Match failure signatures too. |
+| Caching a store the platform already proxies | Measure install cold vs warm; a 0-hit cache costs quota and returns nothing. |
+| Sizing a runner by intuition | Read VM CPU/memory/load for the job; a lane bounded by a single-threaded step gains nothing from more cores. |
+| Trusting a green from the branch tip | Pin the pushed SHA; confirm the run's head commit is the commit you pushed. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
 
@@ -204,6 +214,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
+| `references/agent-feedback-loop.md` | An agent must push and then act on the result: arming a non-stalling watcher, the event/verdict contract, reacting to a red check, or a session that went silent after a push. |
+
+### Bundled script
+
+| Script | Purpose |
+|---|---|
+| `scripts/ci-watch.py` | Stdlib-only watcher. Emits one line per state change for a pinned commit and always terminates with `CI-DONE success\|failure\|timeout\|no-run\|probe-dead\|superseded`. Built-in GitHub Actions probe (`--sha`, `--repo`); any other provider via `--cmd` printing `<name>: <state>` lines. See `references/agent-feedback-loop.md`. |
 
 ### Optional: Avrea reference kit
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use skill if you are diagnosing or optimizing slow CI/CD, runner queues, cache misses, build/test/deploy latency, or an agent has pushed and needs non-stalling CI feedback while preserving required checks.
 metadata:
   author: yigitkonur
   version: 1.0.0
@@ -57,21 +57,22 @@ Apply the performance order before adding compute:
 Ask in order:
 
 1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
-3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
-4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
-5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
-6. Are tests dominant? Read `references/testing-and-flakiness.md` and `references/integration-environments.md`.
-7. Is Docker/OCI work dominant? Read `references/containers.md`.
-8. Are security scans dominant? Read `references/security-gates.md`.
-9. Is deployment slow or repeated? Read `references/deployment.md`.
-10. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
-11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
-12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
-13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is an agent pushing and then waiting on CI — or has a session gone silent after a push? Read `references/agent-feedback-loop.md`.
-15. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-16. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+2. Is an agent pushing and then waiting on CI — or has a session gone silent after a push? Read `references/agent-feedback-loop.md` first; the feedback loop itself may be the bottleneck.
+3. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
+4. Do the queue numbers suggest a capacity ceiling rather than uniformly slow work? Read `references/capacity-and-contention.md`.
+5. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
+6. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
+7. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
+8. Are tests dominant? Read `references/testing-and-flakiness.md` and `references/integration-environments.md`.
+9. Is Docker/OCI work dominant? Read `references/containers.md`.
+10. Are security scans dominant? Read `references/security-gates.md`.
+11. Is deployment slow or repeated? Read `references/deployment.md`.
+12. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
+13. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
+14. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
+15. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md`, `references/avrea/caching.md`, and `references/avrea/cli-evidence.md`.
+16. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
+17. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -105,7 +106,11 @@ Re-run on the same commit first, then a normal representative commit. Compare me
 
 Do not wait for those runs in the foreground. Arm a bounded watcher so a red check surfaces the moment it happens instead of at the deadline — `references/agent-feedback-loop.md`, or `scripts/ci-watch.py` directly. Expect to keep working between its events.
 
+Before trusting a watcher, verify it like any other piece of CI infrastructure: make it produce `success`, `failure`, `no-run`, `timeout`, `probe-dead`, and (when relevant) `superseded` on purpose. A watcher only observed succeeding is untested.
+
 Making CI automatic surfaces defects that a manual, hand-dispatched pipeline hid — environment leakage between jobs, assertions that drifted from the contract they check, and pre-existing flakes. Treat each as a real finding: root-cause it and verify red-first. Reaching green by adding a retry, widening a threshold, or skipping the check corrupts the measurement instead of fixing the pipeline (`references/effectiveness-contract.md`).
+
+If an experiment comes back neutral or worse, report that. A disproved hypothesis is still evidence, and hiding it guarantees the next person retries the same losing move.
 
 Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
 
@@ -183,10 +188,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Agent blocks on a foreground `run watch` | Arm a bounded watcher that emits per state change and always prints a terminal verdict (`references/agent-feedback-loop.md`). |
-| Watcher greps only for the success marker | Silence then looks identical to "still running". Match failure signatures too. |
+| Trusting `$?` after piping a watcher into `head`/`tail` | Pipeline status comes from the last command; capture the watcher's real exit code directly. |
+| Watching the branch tip instead of the pushed SHA | Pin the commit; a green on the tip can be another commit entirely. |
+| Watcher greps only for the success marker | Silence then looks identical to "still running". Match failure and timeout states too. |
 | Caching a store the platform already proxies | Measure install cold vs warm; a 0-hit cache costs quota and returns nothing. |
 | Sizing a runner by intuition | Read VM CPU/memory/load for the job; a lane bounded by a single-threaded step gains nothing from more cores. |
 | Trusting a green from the branch tip | Pin the pushed SHA; confirm the run's head commit is the commit you pushed. |
+| Queue dominates but the DAG keeps growing | Read `references/capacity-and-contention.md`; above a capacity ceiling, extra jobs repay setup and can make the wall-clock worse. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
 
@@ -215,12 +223,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
 | `references/agent-feedback-loop.md` | An agent must push and then act on the result: arming a non-stalling watcher, the event/verdict contract, reacting to a red check, or a session that went silent after a push. |
+| `references/capacity-and-contention.md` | Queue share, concurrency ceilings, when more jobs make the wall-clock worse, and when the remediation ladder inverts from "split" to "merge". |
 
 ### Bundled script
 
 | Script | Purpose |
 |---|---|
-| `scripts/ci-watch.py` | Stdlib-only watcher. Emits one line per state change for a pinned commit and always terminates with `CI-DONE success\|failure\|timeout\|no-run\|probe-dead\|superseded`. Built-in GitHub Actions probe (`--sha`, `--repo`); any other provider via `--cmd` printing `<name>: <state>` lines. See `references/agent-feedback-loop.md`. |
+| `scripts/ci-watch.py` | Stdlib-only watcher. Emits one line per state change for a pinned commit and always terminates with `CI-DONE success\|failure\|cancelled\|timeout\|no-run\|probe-dead\|superseded`. Built-in GitHub probe (`--sha`, `--repo`); any other provider via `--cmd` printing `<name>: <state>` lines. See `references/agent-feedback-loop.md`. |
 
 ### Optional: Avrea reference kit
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -106,7 +106,7 @@ Re-run on the same commit first, then a normal representative commit. Compare me
 
 Do not wait for those runs in the foreground. Arm a bounded watcher so a red check surfaces the moment it happens instead of at the deadline — `references/agent-feedback-loop.md`, or `scripts/ci-watch.py` directly. Expect to keep working between its events.
 
-Before trusting a watcher, verify it like any other piece of CI infrastructure: make it produce `success`, `failure`, `no-run`, `timeout`, `probe-dead`, and (when relevant) `superseded` on purpose. A watcher only observed succeeding is untested.
+Before trusting a watcher, verify it like any other piece of CI infrastructure: make it produce `success`, `failure`, `cancelled`, `no-run`, `timeout`, `probe-dead`, and (when relevant) `superseded` on purpose. A watcher only observed succeeding is untested.
 
 Making CI automatic surfaces defects that a manual, hand-dispatched pipeline hid — environment leakage between jobs, assertions that drifted from the contract they check, and pre-existing flakes. Treat each as a real finding: root-cause it and verify red-first. Reaching green by adding a retry, widening a threshold, or skipping the check corrupts the measurement instead of fixing the pipeline (`references/effectiveness-contract.md`).
 

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -137,7 +137,7 @@ Check the real process exit code after each, not the exit of a pipeline you pipe
 
 ## Reacting to a red check
 
-1. Run the exact log command the failure verdict printed. Do not re-derive it.
+1. In built-in GitHub mode, run the exact log command the failure verdict printed. Do not re-derive it. A custom `--cmd` probe cannot supply a provider-specific log command through the `<name>: <state>` contract, so use that provider's CLI or API to fetch logs for the printed failing job name at the pinned `$SHA`.
 2. Reproduce with the narrowest local command. If the failure is CI-only, reproduce the CI condition — job-wide environment variables, a clean checkout, a different working directory, absent secrets.
 3. Fix the cause. Never add a retry, widen a threshold, mock the failure away, or `skip` to reach green; the check measures reality.
 4. Verify red-first: confirm the test fails without the fix and passes with it.

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -1,166 +1,165 @@
-# Agent feedback loop — waiting for CI without stalling
+# Agent feedback loop
 
-Read when an agent must push and then act on the result: choosing how to wait,
-arming a watcher, reacting to a red check, or debugging a session that went
-silent after a push.
+Use this file when an agent must push and then act on the result: choosing how to wait, arming a watcher, reacting to a red check, or debugging a session that went silent after a push.
 
-This is provider-neutral. The probe command changes per provider; the contract
-does not.
+This file is provider-neutral. The probe command changes per provider; the contract does not.
 
 ## The problem
 
-An agent pushes, then blocks. The usual attempts all fail in ways that look
-like "CI is just slow":
+After an agent pushes, it still needs the answer. The usual waits fail in ways that look like "CI is just slow":
 
 | Attempt | Failure mode |
 |---|---|
-| `gh run watch` (or equivalent) in the foreground | Emits TTY redraw frames, not lines, when stdout is not a terminal; suppresses its completion summary for the same reason; has no deadline of its own. |
-| `sleep N` polling loop | Burns turns, re-prints the same table, and produces no event when the run *crashes* — a dead run and a slow run look identical. |
-| A watcher that greps only for success | Silence on failure. The agent waits out the full timeout for a run that died in minute two. |
-| No deadline | A run that never registers — path filter excluded it, workflow disabled, wrong branch — waits forever for something that will never exist. |
+| Foreground `run watch` command | Re-renders a TTY-oriented table instead of clean line events when stdout is not a terminal; often suppresses its completion summary for the same reason; usually has no deadline of its own. |
+| Hand-rolled `while true; do sleep N; …; done` | Burns context, re-prints the same table, and often emits nothing on failure — a crash and a slow run look identical. |
+| Success-only filter | Silence on red. The agent waits out the full timeout for a run that died in minute two. |
+| No registration deadline | A path-filtered or disabled workflow is watched forever even though no run can ever exist. |
 
-The cost is asymmetric: a failure detected at minute 2 of a 25-minute pipeline
-gives back 23 minutes of agent time; the same failure detected at the timeout
-gives back nothing.
+The payoff for solving this is immediate: a failure detected at minute 2 of a 25-minute pipeline gives back 23 minutes of agent time.
 
-## The contract a watcher must satisfy
+## The watcher contract
 
-1. **Terminate, always.** Every path ends in an explicit verdict line. Silence
-   past the deadline must be structurally impossible, not merely unlikely.
-2. **Emit on state change only.** Diff-gate the output. A 25-minute green run
-   should cost a handful of events, not fifty identical job tables. Watchers
-   that flood get rate-limited or killed, which reintroduces the stall.
-3. **Cover failure, not just success.** If the process crashed right now, the
-   filter must emit something. Widen the match rather than narrow it.
-4. **Pin the commit, not the branch.** Query by the SHA you pushed. "Latest run
-   on the branch" can be someone else's commit, or your own previous one — a
-   classic false green.
-5. **Watch every workflow that commit triggered**, not just the one you care
-   about. A second workflow can fail while the first goes green.
-6. **Heartbeat.** A periodic liveness tick proves the watcher is alive and, on
-   agents with a prompt cache, keeps that cache warm so waiting stays cheap.
-   Roughly every 2–3 minutes is a reasonable default.
-7. **Bound the probe itself.** Give each API call its own timeout; a wedged
-   request must not freeze the loop. Retry transient errors, but exit loudly on
-   a sustained streak.
+A watcher is verification infrastructure. Hold it to the same standard as any other gate.
+
+1. **Terminate, always.** Every path ends in an explicit terminal line. Silence past the deadline must be structurally impossible.
+2. **Emit on change, not on poll.** A 25-minute green run should cost a handful of notifications, not fifty duplicate job tables.
+3. **Cover failure at least as loudly as success.** Ask: if this process crashed right now, would the watcher emit anything? If not, it is broken.
+4. **Pin the commit, not the branch.** Query by the SHA you pushed. A green run on the branch tip can be another commit — a classic false green.
+5. **Watch every workflow that commit triggered.** A second workflow can fail while the first passes. Completion-triggered follow-up workflows need a settle window before declaring success.
+6. **Heartbeat.** Emit a liveness tick every ~2–3 minutes so a quiet watch still proves it is alive.
+7. **Bound each probe call.** A single wedged API request must not freeze the whole watch.
 
 ## Event vocabulary
 
-A small, stable set of prefixes lets the agent react without parsing prose:
+Use stable, machine-readable prefixes:
 
+```text
+CI-RUN    registered 3: build: queued · lint: queued · test: queued
+CI-CHG    test: in_progress -> failure
+CI-HB     12/20m
+CI-SETTLE all green — holding 90s for completion-triggered follow-ups
+CI-WARN   probe failing (3x) — still retrying
+CI-DONE   failure — test — <command that prints the failing log>
 ```
-CI-RUN   registered 3: build: queued · lint: queued · test: queued
-CI-CHG   test: in_progress -> failure
-CI-HB    12/30m
-CI-WARN  probe failing (3x) — still retrying
-CI-DONE  failure — test — <command that prints the failing log>
-```
 
-Terminal verdicts worth distinguishing, because each implies a different next
-action:
+Terminal verdicts worth distinguishing:
 
-| Verdict | Meaning | Reaction |
+| Verdict | Meaning | Default reaction |
 |---|---|---|
 | `success` | every workflow green on that SHA | proceed |
 | `failure` | at least one red | fetch the failing log immediately |
-| `cancelled` | ended `cancelled`/`skipped`/`stale`/`neutral` | **not green** — usually a concurrency cancel or a filtered job; decide whether the commit was ever validated |
-| `timeout` | deadline hit with work outstanding | read the run; decide to wait or cancel |
-| `no-run` | nothing ever registered | check triggers, path filters, enabled state |
-| `probe-dead` | the API was unreachable repeatedly | check auth/network |
-| `superseded` | the branch moved on | this verdict is moot; arm a watch on the new SHA |
+| `cancelled` | terminal but not green (`cancelled`, `skipped`, `stale`, `neutral`) | do not treat as success; decide whether the commit was actually validated |
+| `timeout` | deadline hit with work outstanding | read the run; decide whether to keep waiting |
+| `no-run` | nothing ever registered | check triggers, path filters, and enabled state |
+| `probe-dead` | the provider probe failed repeatedly | check auth/network/tooling |
+| `superseded` | the branch moved past the watched SHA | arm a fresh watch on the new SHA |
 
-`no-run` and `superseded` are the two that hand-rolled loops almost always
-miss, and they are the two that waste the most wall-clock.
+`timeout` and `no-run` are the two most-misreported outcomes: neither is red, neither is green, both mean you still do not know.
 
-**Enumerate success, not failure.** The most dangerous bug in a watcher is
-treating "did not fail" as green. A run that ends `cancelled`, `skipped`,
-`stale`, or `neutral` is terminal but *not* validated — and `cancel-in-progress`
-concurrency, which this skill recommends elsewhere, manufactures exactly that
-state. Match an explicit success set and treat every other terminal conclusion,
-including ones you have never seen, as not-green.
+Enumerate **success**, not failure. A watcher that treats "did not fail" as green will eventually call `cancelled`, `skipped`, or an unknown terminal state a pass.
+
+## Watch-shape selection
+
+Pick the wait shape by how many notifications you need:
+
+| Need | Shape |
+|---|---|
+| One final answer only | background task with an internal `until` loop or equivalent |
+| One line per state change until a known end | Monitor tool + diff-gated watcher |
+| Raw logs for diagnosis | do **not** watch the raw log stream; pull logs once after a red verdict |
+
+Never arm an unbounded `while true` or `tail -f` for a single answer. It stays armed long after the event and can only end by timeout.
 
 ## Reference implementation shape
 
-Stdlib only, no dependencies. The loop:
+Bundle an executable watcher in the skill so agents do not rewrite a poll loop every time. The bundled implementation here is [`scripts/ci-watch.py`](../scripts/ci-watch.py).
 
-```
-poll(sha) -> list of {id, workflow, status, conclusion}
-  on error:      streak++; warn once at 3; exit `probe-dead` at 10
+A minimal control loop:
+
+```text
+poll(commit) -> list of {id, workflow, state}
+  on error:      retry silently, warn on a streak, then exit probe-dead
   on first data: emit CI-RUN once
   per item:      emit CI-CHG only when state differs from last seen
-  all terminal:  emit CI-DONE success|failure (+ the log command) and exit
+  all terminal:  emit CI-DONE success|failure|cancelled and exit
   branch moved:  emit CI-DONE superseded and exit
   no data yet and past registration deadline: emit CI-DONE no-run and exit
   past overall deadline: emit CI-DONE timeout and exit
   else: heartbeat if due, sleep interval
 ```
 
-Two deadlines matter and they are different: a short **registration** deadline
-(a few minutes — did any run appear at all?) and a longer **overall** deadline
-(the pipeline's p95 plus headroom).
+Provider probes differ only in the `poll(commit)` step:
 
-Provider probes differ only in the poll step:
-
-| Provider | Poll |
+| Provider | Probe |
 |---|---|
 | GitHub Actions | `gh run list --commit <sha> --json databaseId,workflowName,status,conclusion` |
-| GitLab CI | pipelines API filtered by `sha` |
+| GitLab CI | pipelines API filtered by revision |
 | Buildkite | builds API filtered by commit |
-| CircleCI | pipeline → workflow status by revision |
-| Anything else | any command printing `<name>: <state>` lines and a terminal marker |
+| CircleCI | pipeline → workflow state by revision |
+| Anything else | any command printing `<name>: <state>` lines |
 
-## Wiring it to a streaming-notification tool
+### Hard requirements for the implementation
 
-Agent harnesses that expose a background monitor (each stdout line becomes a
-notification) are the right host for this. Rules that matter in practice:
+- Key state by **run id** (or an equivalent stable identifier), not workflow name. One commit can carry multiple runs of the same workflow.
+- Collapse retries/attempts correctly **per provider**. Some APIs already do; some do not. Verify it.
+- If expanding GitHub runs to job level for faster failure notice, expand only **active** runs so the extra API cost is bounded.
+- Keep only the newest run per workflow **and event** when deciding the final verdict. A dispatch-only rerun and the original push run are different validation surfaces.
+- Require the run set to be stable across two polls (or hold a settle window) before calling success. A fast workflow can finish before a slower sibling is even created.
+- For completion-triggered follow-ups (`workflow_run`, deploy-after-build, etc.), hold a grace period after all-green and re-probe before declaring success.
+- Keep the registration deadline below the overall deadline. If they cross, `no-run` becomes unreachable and every skipped pipeline misreports as `timeout`.
+- Distinguish exit codes. `watch && deploy` must not ship on `failure`, `cancelled`, `timeout`, or `superseded`.
 
-- **Every pipe stage must flush per line**, or matches sit in a buffer unseen:
-  `grep --line-buffered`, `awk { ...; fflush() }`. `head -N` cannot flush at
-  all — it delivers nothing until N matches accumulate.
-- **Prefer one bounded process over an unbounded tail.** `tail -f`, `while
-  true`, and `inotifywait -m` never exit on their own, so the watch stays armed
-  long after the event fired.
-- **`tail -f log | grep -m1 …` does not fix that.** If the log goes quiet after
-  the match, `tail` never receives SIGPIPE and the pipeline hangs.
-- **Arm the watch in the same turn as the push**, then keep working. Do not add
-  a `sleep` loop beside an armed watcher; the events come to you.
-- **One watch per pushed SHA.** A re-push supersedes the old watch; retire it
-  and arm a fresh one.
-- **A heartbeat is not a result.** Acknowledge it silently; never report it as
-  progress or treat it as a user message.
+## Wiring to a streaming monitor
 
-### Shell gotchas that produce silent watchers
+A monitor tool that turns each stdout line into a notification is the best host for this pattern. Use it when you need feedback while still working.
 
-- In `zsh`, `status` is a readonly builtin variable — `status=$(...)` is a fatal
-  error inside the watcher, which then emits nothing at all. Name it anything
-  else.
-- Command substitution strips trailing newlines; compare parsed fields, not raw
-  blobs, when diff-gating.
-- A watcher that inherits the harness's environment can pick up variables that
-  change CI behavior. Prefer explicit arguments over ambient state.
+Rules:
+- Arm the watch in the same turn as the push.
+- One watch per pushed SHA. Re-push ⇒ old watch retires, arm a fresh one.
+- Every pipe stage must flush per line (`grep --line-buffered`, `awk { fflush() }`). `head -N` cannot flush; it withholds output until N matches accumulate.
+- Keep the monitor timeout **above** the watcher's own deadline so the script can emit its own `timeout` verdict instead of being killed silently.
+- A heartbeat is not a result. Acknowledge it silently; never treat it as user input.
+
+## Verifying the watcher itself
+
+Do not trust a watcher that has only been observed succeeding. Rehearse it like any other piece of verification infrastructure.
+
+Run each of these deliberately:
+
+1. **Known green** — a historical SHA where every workflow succeeded.
+2. **Known red** — a historical SHA with a real failing run.
+3. **No-run** — a SHA that will never register, or a path-filtered push declared with `--expect-none`.
+4. **Timeout** — a probe that reports a running state forever under a tiny deadline.
+5. **Probe-dead** — a broken or unauthenticated provider CLI.
+6. **Superseded** — arm on one SHA, then move the branch tip.
+
+Check the real process exit code after each, not the exit of a pipeline you piped it through. `watch | tail` or `watch | head` can hide the watcher's own status behind the last command's `$?`.
 
 ## Reacting to a red check
 
-1. Run the exact log command the verdict printed. Do not re-derive it.
-2. Reproduce with the narrowest local command. If the failure is CI-only,
-   reproduce the *CI condition* — job-wide environment variables, a clean
-   checkout, a different working directory, absent secrets.
-3. Fix the cause. Never add a retry, widen a threshold, mock the failure away,
-   or `skip` to reach green; the check measures reality.
+1. Run the exact log command the failure verdict printed. Do not re-derive it.
+2. Reproduce with the narrowest local command. If the failure is CI-only, reproduce the CI condition — job-wide environment variables, a clean checkout, a different working directory, absent secrets.
+3. Fix the cause. Never add a retry, widen a threshold, mock the failure away, or `skip` to reach green; the check measures reality.
 4. Verify red-first: confirm the test fails without the fix and passes with it.
-   A fix you never saw fail is a fix you cannot vouch for.
 5. Push and arm a fresh watch on the new SHA.
 
-## Failure-only diagnostics
+## Common traps
 
-Upload the diagnostic bundle on failure only, with short retention and exact
-paths — logs, screenshots, server output. A successful run does not need them,
-and uploading a whole workspace turns every green run into a transfer cost.
-Never include generated credentials or a provisioning directory in the bundle.
+- `gh run watch` (or equivalent) piped into another command: the pipe can hide the real exit code, and the watcher often emits table redraws instead of line events.
+- Looking only for a success marker: silence then looks identical to "still running".
+- Using `run list --branch --limit 1` as a branch-tip check: the newest **run** can lag the newest **commit**, so a fresh push is falsely reported as superseded by its own ancestor.
+- Reusing a large static monitor timeout for every provider: the deadline should be tied to measured p95 plus headroom.
+- Assuming a watcher bug is harmless because the CI itself is correct. A false green in the watcher is the exact defect class this file exists to prevent.
 
-## Why this is worth the file
+## Related references
 
-The measurable win is not a faster pipeline; it is the agent noticing. A team
-that adopts automatic CI without a reliable feedback loop trades a slow local
-loop for a silent remote one, and the first red check that goes unnoticed for
-twenty minutes erases the migration's entire gain.
+- `references/measurement.md` — queue versus execution, sample size, and evidence rungs
+- `references/github-actions.md` — trigger duplication, concurrency, required checks, and when a PR gate differs from a branch gate
+- `references/testing-and-flakiness.md` — deciding whether a red check is a real regression or a flake
+- `references/effectiveness-contract.md` — why retries and weakened assertions are not valid fixes for a red pipeline
+
+## Sources
+
+- GitHub CLI watch source (`watchRun`, TTY-gated output paths): https://github.com/cli/cli/blob/trunk/pkg/cmd/run/watch/watch.go (accessed 2026-07-28)
+- GitHub CLI iostreams TTY detection: https://github.com/cli/cli/blob/trunk/pkg/iostreams/iostreams.go (accessed 2026-07-28)
+- POSIX shell pipeline exit status: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_02 (accessed 2026-07-28)

--- a/skills/ci-cd-optimize/references/agent-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/agent-feedback-loop.md
@@ -1,0 +1,166 @@
+# Agent feedback loop — waiting for CI without stalling
+
+Read when an agent must push and then act on the result: choosing how to wait,
+arming a watcher, reacting to a red check, or debugging a session that went
+silent after a push.
+
+This is provider-neutral. The probe command changes per provider; the contract
+does not.
+
+## The problem
+
+An agent pushes, then blocks. The usual attempts all fail in ways that look
+like "CI is just slow":
+
+| Attempt | Failure mode |
+|---|---|
+| `gh run watch` (or equivalent) in the foreground | Emits TTY redraw frames, not lines, when stdout is not a terminal; suppresses its completion summary for the same reason; has no deadline of its own. |
+| `sleep N` polling loop | Burns turns, re-prints the same table, and produces no event when the run *crashes* — a dead run and a slow run look identical. |
+| A watcher that greps only for success | Silence on failure. The agent waits out the full timeout for a run that died in minute two. |
+| No deadline | A run that never registers — path filter excluded it, workflow disabled, wrong branch — waits forever for something that will never exist. |
+
+The cost is asymmetric: a failure detected at minute 2 of a 25-minute pipeline
+gives back 23 minutes of agent time; the same failure detected at the timeout
+gives back nothing.
+
+## The contract a watcher must satisfy
+
+1. **Terminate, always.** Every path ends in an explicit verdict line. Silence
+   past the deadline must be structurally impossible, not merely unlikely.
+2. **Emit on state change only.** Diff-gate the output. A 25-minute green run
+   should cost a handful of events, not fifty identical job tables. Watchers
+   that flood get rate-limited or killed, which reintroduces the stall.
+3. **Cover failure, not just success.** If the process crashed right now, the
+   filter must emit something. Widen the match rather than narrow it.
+4. **Pin the commit, not the branch.** Query by the SHA you pushed. "Latest run
+   on the branch" can be someone else's commit, or your own previous one — a
+   classic false green.
+5. **Watch every workflow that commit triggered**, not just the one you care
+   about. A second workflow can fail while the first goes green.
+6. **Heartbeat.** A periodic liveness tick proves the watcher is alive and, on
+   agents with a prompt cache, keeps that cache warm so waiting stays cheap.
+   Roughly every 2–3 minutes is a reasonable default.
+7. **Bound the probe itself.** Give each API call its own timeout; a wedged
+   request must not freeze the loop. Retry transient errors, but exit loudly on
+   a sustained streak.
+
+## Event vocabulary
+
+A small, stable set of prefixes lets the agent react without parsing prose:
+
+```
+CI-RUN   registered 3: build: queued · lint: queued · test: queued
+CI-CHG   test: in_progress -> failure
+CI-HB    12/30m
+CI-WARN  probe failing (3x) — still retrying
+CI-DONE  failure — test — <command that prints the failing log>
+```
+
+Terminal verdicts worth distinguishing, because each implies a different next
+action:
+
+| Verdict | Meaning | Reaction |
+|---|---|---|
+| `success` | every workflow green on that SHA | proceed |
+| `failure` | at least one red | fetch the failing log immediately |
+| `cancelled` | ended `cancelled`/`skipped`/`stale`/`neutral` | **not green** — usually a concurrency cancel or a filtered job; decide whether the commit was ever validated |
+| `timeout` | deadline hit with work outstanding | read the run; decide to wait or cancel |
+| `no-run` | nothing ever registered | check triggers, path filters, enabled state |
+| `probe-dead` | the API was unreachable repeatedly | check auth/network |
+| `superseded` | the branch moved on | this verdict is moot; arm a watch on the new SHA |
+
+`no-run` and `superseded` are the two that hand-rolled loops almost always
+miss, and they are the two that waste the most wall-clock.
+
+**Enumerate success, not failure.** The most dangerous bug in a watcher is
+treating "did not fail" as green. A run that ends `cancelled`, `skipped`,
+`stale`, or `neutral` is terminal but *not* validated — and `cancel-in-progress`
+concurrency, which this skill recommends elsewhere, manufactures exactly that
+state. Match an explicit success set and treat every other terminal conclusion,
+including ones you have never seen, as not-green.
+
+## Reference implementation shape
+
+Stdlib only, no dependencies. The loop:
+
+```
+poll(sha) -> list of {id, workflow, status, conclusion}
+  on error:      streak++; warn once at 3; exit `probe-dead` at 10
+  on first data: emit CI-RUN once
+  per item:      emit CI-CHG only when state differs from last seen
+  all terminal:  emit CI-DONE success|failure (+ the log command) and exit
+  branch moved:  emit CI-DONE superseded and exit
+  no data yet and past registration deadline: emit CI-DONE no-run and exit
+  past overall deadline: emit CI-DONE timeout and exit
+  else: heartbeat if due, sleep interval
+```
+
+Two deadlines matter and they are different: a short **registration** deadline
+(a few minutes — did any run appear at all?) and a longer **overall** deadline
+(the pipeline's p95 plus headroom).
+
+Provider probes differ only in the poll step:
+
+| Provider | Poll |
+|---|---|
+| GitHub Actions | `gh run list --commit <sha> --json databaseId,workflowName,status,conclusion` |
+| GitLab CI | pipelines API filtered by `sha` |
+| Buildkite | builds API filtered by commit |
+| CircleCI | pipeline → workflow status by revision |
+| Anything else | any command printing `<name>: <state>` lines and a terminal marker |
+
+## Wiring it to a streaming-notification tool
+
+Agent harnesses that expose a background monitor (each stdout line becomes a
+notification) are the right host for this. Rules that matter in practice:
+
+- **Every pipe stage must flush per line**, or matches sit in a buffer unseen:
+  `grep --line-buffered`, `awk { ...; fflush() }`. `head -N` cannot flush at
+  all — it delivers nothing until N matches accumulate.
+- **Prefer one bounded process over an unbounded tail.** `tail -f`, `while
+  true`, and `inotifywait -m` never exit on their own, so the watch stays armed
+  long after the event fired.
+- **`tail -f log | grep -m1 …` does not fix that.** If the log goes quiet after
+  the match, `tail` never receives SIGPIPE and the pipeline hangs.
+- **Arm the watch in the same turn as the push**, then keep working. Do not add
+  a `sleep` loop beside an armed watcher; the events come to you.
+- **One watch per pushed SHA.** A re-push supersedes the old watch; retire it
+  and arm a fresh one.
+- **A heartbeat is not a result.** Acknowledge it silently; never report it as
+  progress or treat it as a user message.
+
+### Shell gotchas that produce silent watchers
+
+- In `zsh`, `status` is a readonly builtin variable — `status=$(...)` is a fatal
+  error inside the watcher, which then emits nothing at all. Name it anything
+  else.
+- Command substitution strips trailing newlines; compare parsed fields, not raw
+  blobs, when diff-gating.
+- A watcher that inherits the harness's environment can pick up variables that
+  change CI behavior. Prefer explicit arguments over ambient state.
+
+## Reacting to a red check
+
+1. Run the exact log command the verdict printed. Do not re-derive it.
+2. Reproduce with the narrowest local command. If the failure is CI-only,
+   reproduce the *CI condition* — job-wide environment variables, a clean
+   checkout, a different working directory, absent secrets.
+3. Fix the cause. Never add a retry, widen a threshold, mock the failure away,
+   or `skip` to reach green; the check measures reality.
+4. Verify red-first: confirm the test fails without the fix and passes with it.
+   A fix you never saw fail is a fix you cannot vouch for.
+5. Push and arm a fresh watch on the new SHA.
+
+## Failure-only diagnostics
+
+Upload the diagnostic bundle on failure only, with short retention and exact
+paths — logs, screenshots, server output. A successful run does not need them,
+and uploading a whole workspace turns every green run into a transfer cost.
+Never include generated credentials or a provisioning directory in the bundle.
+
+## Why this is worth the file
+
+The measurable win is not a faster pipeline; it is the agent noticing. A team
+that adopts automatic CI without a reliable feedback loop trades a slow local
+loop for a silent remote one, and the first red check that goes unnoticed for
+twenty minutes erases the migration's entire gain.

--- a/skills/ci-cd-optimize/references/avrea/caching.md
+++ b/skills/ci-cd-optimize/references/avrea/caching.md
@@ -79,6 +79,23 @@ avr cache list --repo org/app -L 200 --json key,cache_type,size_bytes,hit_count,
 
 Zero hits can also mean the key changes on every run. Check whether the key includes something volatile before deleting anything.
 
+### The package proxy can make a store cache redundant
+
+The Actions store cache and the package proxy solve the same problem for
+dependency installs, and on Avrea the proxy alone is often enough. Measure the
+install step cold and warm before keeping the store cache:
+
+| Observation | Reading |
+|---|---|
+| install is equally fast cold and warm | the proxy is doing the work; the store cache adds bytes, not speed |
+| install is materially slower cold | the store cache is earning its quota |
+
+Measured on a real repository (2026-07-28): a pnpm install took 3.3 s on a cold
+runner and 2.5 s warm, while the 300 MB store entry recorded 0 hits and the
+save step cost ~0 s. Removing `cache: pnpm` freed 1.2 % of the 25 GiB quota and
+cost nothing in wall-clock. The correct default on Avrea is to start without a
+package-store cache and add one only if cold installs measurably hurt.
+
 ## Diagnosing and changing caches
 
 ```bash

--- a/skills/ci-cd-optimize/references/avrea/platform-and-runners.md
+++ b/skills/ci-cd-optimize/references/avrea/platform-and-runners.md
@@ -41,7 +41,36 @@ Larger runners are the last resort in the performance order, and the measured A/
 2. Confirm it is CPU- or memory-bound via `avr job metrics`.
 3. Confirm the workload is actually parallel — a single-threaded `tsc` or a serial test runner gains nothing from 32 vCPU and costs proportionally more.
 
-ARM is generally cheaper per vCPU, but only choose it when the toolchain and any native dependencies are known to build on ARM64; a cross-architecture surprise costs more than the savings. macOS runners exist in two sizes only, so Swift/Xcode pipelines have limited headroom — see `references/swift-xcode.md` for what to optimize instead.
+### Downsizing is the more common finding
+
+"Start large, then step down" sounds prudent but silently overpays, because the
+step-down half rarely gets measured. `avr job metrics` makes over-provisioning
+obvious: read CPU average against peak, and peak memory against the size's
+allocation.
+
+Measured on a real repository (2026-07-28), the same gate on two sizes:
+
+| | 16 vCPU / 64 GB | 8 vCPU / 32 GB |
+|---|---|---|
+| Gate duration | 159 s | 158 s and 160 s |
+| CPU | avg 58–59 %, peak 98 % | avg 74 %, peak 99 % |
+| Peak memory | 7.4–7.8 GB | 4.0 GB |
+| Rate | $0.032/min | $0.016/min |
+
+The gate was bounded by a test runner that does not scale past a few workers,
+so the extra 8 cores idled and memory was ~8× over-provisioned at the larger
+size. Halving the runner cost nothing in wall-clock and halved the bill. Treat
+"peak memory far below allocation, CPU average well under 100 %, wall-clock flat
+across sizes" as the signature of a job that should shrink.
+
+ARM pricing is provider-specific and must be checked rather than assumed: on
+Avrea's published pricing (checked 2026-07-28) Linux ARM costs about 3× the x64
+rate per vCPU ($0.006 vs $0.002 per vCPU-minute) and caps at 16 vCPU, so ARM is
+a performance choice there, not a cost saving. Choose it only when the toolchain
+and native dependencies are known to build on ARM64, and re-check the rate table
+before relying on it. macOS runners exist in two sizes only, so Swift/Xcode
+pipelines have limited headroom — see `references/swift-xcode.md` for what to
+optimize instead.
 
 ## Observability
 

--- a/skills/ci-cd-optimize/references/capacity-and-contention.md
+++ b/skills/ci-cd-optimize/references/capacity-and-contention.md
@@ -1,0 +1,115 @@
+# Capacity and contention
+
+Use this file when queue time is a large share of wall-clock, when adding more jobs failed to reduce latency, or when the same workflow is fast one hour and much slower the next with identical code.
+
+## The inversion
+
+Most CI advice says split work and add parallelism. That is correct **below** the capacity ceiling. Above it, the advice inverts:
+
+```text
+wall-clock ≈ queue + ceil(total_parallel_jobs / effective_capacity)
+              × (per-job setup + execution)
+```
+
+Treat that as a heuristic, not an exact formula. The point is structural: once the queue is dominant, extra jobs repay setup while waiting for scarce slots, so the DAG looks more parallel and finishes no faster.
+
+## Queue-share gate
+
+Measure over a window, not one run:
+
+```text
+queue share = Σ queue / (Σ queue + Σ execution)
+```
+
+Interpret it conservatively:
+
+| Queue share | Meaning | Default move |
+|---|---|---|
+| <15% | queue is noise | optimize execution first |
+| 15–35% | queue is material | stop adding jobs until setup and critical-path work are justified |
+| >35% | capacity is the bottleneck | topology changes are near-futile; fix contention or capacity first |
+
+This number is easy to lie with. Sum per-job queue only across **comparable jobs in the same stage**. A `needs`-gated DAG pays queue once per stage; blindly summing every queued job overstates the problem.
+
+## Detect the effective ceiling empirically
+
+Do not trust the advertised concurrency limit. Org-wide contention, runner-class scarcity, and workflow-level caps usually bite first.
+
+Method:
+
+1. Trigger more independent jobs than you think the pool can run.
+2. Record `created_at` and `started_at` per job.
+3. Count the largest number of jobs that were started but not yet completed at the same time.
+4. Compare it with the runner class and workflow topology.
+
+Signature of a ceiling:
+- `started_at` values arrive in clusters rather than smoothly.
+- Later jobs wait roughly one earlier-job duration before starting.
+- Queue p95 jumps while execution stays flat.
+
+If a 25-second job waits 120 seconds for a slot, adding one more stage or fan-out cell makes the whole workflow slower even if the job itself is tiny.
+
+## Contention is a measurement confound
+
+Two runs of the same commit on the same runner class are **not** comparable if one ran against an idle pool and the other against a saturated one.
+
+Rules:
+- Compare execution separately from queue.
+- Interleave experiment arms (`A, B, A, B`) rather than running all `A` then all `B`.
+- Treat any delta smaller than `queue p95 - queue p50` as suspicious until proven otherwise.
+- When execution is flat and queue moved, report that as a scheduling story, not a build story.
+
+## The inversion ladder
+
+When the ceiling is the bottleneck, fix in this order:
+
+1. **Merge jobs that share setup.** A single checkout/install on one runner is often cheaper than N queue waits plus N setups.
+2. **Shrink per-job setup.** The queue forces you to repay setup `ceil(N/C)` times, so checkout and install inflation hurts twice.
+3. **Stop starting irrelevant work.** Path routing, affected selection, draft gating, and duplicate-trigger removal matter more than micro-optimizing a test command.
+4. **Raise capacity.** Add or upsize only after you know queue is the bottleneck and the job is on the critical path.
+5. **Only then reshape the DAG.** Splitting long jobs further is correct only once the queue no longer dominates.
+
+This directly contradicts the usual "split long jobs" advice. Both are correct in their own regime; the ceiling decides which one applies.
+
+## Pricing a queue hop
+
+Every extra job pays a queue hop, VM boot, checkout, and toolchain setup. Before adding a planner job, aggregate-status job, or another matrix axis, price the hop:
+
+```text
+extra critical-path cost = queue_p50_or_p95 + setup_p50
+```
+
+If the proposed new job does 10 seconds of useful work but the hop costs 35 seconds, that job is a regression unless it removes a larger amount of downstream work.
+
+## Distinguish critical-path value from total work
+
+A repository can spend many compute-minutes in parallel and still be fast. A repository can also spend little compute and still feel slow because the critical path is queue-dominated.
+
+Optimize in this order:
+1. jobs with high critical-path rate,
+2. jobs with large exclusive time,
+3. only then total compute.
+
+A dramatic reduction in parallel non-critical work can produce zero wall-clock improvement.
+
+## What to report
+
+Do not headline "2× faster" when half the difference is queue noise. Report two numbers:
+
+- execution change on the bottlenecked job or stage,
+- queue share (or queue p50/p95) that constrained the result.
+
+An experiment that measured neutral or worse is still a result. Record it. Silently dropping a disproved idea guarantees the next person retries it.
+
+## Related references
+
+- `references/measurement.md` — how to separate queue, setup, execution, and critical path
+- `references/runners-and-autoscaling.md` — how to choose hosted/self-hosted/ephemeral capacity once queue is proven dominant
+- `references/change-based-ci.md` — ways to stop launching irrelevant work
+- `references/network-and-artifacts.md` — shrinking per-job setup when a queue hop is unavoidable
+
+## Sources
+
+- GitHub Actions limits: https://docs.github.com/actions/reference/limits (accessed 2026-07-28)
+- GitLab Runner advanced configuration (`concurrent`, per-runner `limit`, `request_concurrency`): https://docs.gitlab.com/runner/configuration/advanced-configuration/ (accessed 2026-07-28)
+- OpenTelemetry CI/CD semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/ (accessed 2026-07-28)

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import subprocess
@@ -461,10 +462,10 @@ def main() -> int:
                    help="skip job-level expansion of in-flight GitHub runs")
     a = p.parse_args()
 
-    if a.interval <= 0:
-        p.error("--interval must be greater than zero")
-    if a.heartbeat_min <= 0:
-        p.error("--heartbeat-min must be greater than zero")
+    if not math.isfinite(a.interval) or a.interval <= 0:
+        p.error("--interval must be a finite value greater than zero")
+    if not math.isfinite(a.heartbeat_min) or a.heartbeat_min <= 0:
+        p.error("--heartbeat-min must be a finite value greater than zero")
     # `gh run list --commit` silently returns ZERO rows for a short SHA, which
     # the registration deadline would then misreport as no-run. Fail fast.
     if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""ci-watch.py — emit one line per CI state change for a pushed commit, then exit.
+
+Provider-neutral watcher for agent harnesses. Built for a background monitor
+where each stdout line becomes one notification. The process ALWAYS terminates
+with an explicit `CI-DONE <verdict>` line — including on crashes and missing
+tooling — so silence past the deadline is structurally impossible.
+
+Why not a foreground `run watch`: under an agent harness it re-renders the whole
+job table each interval rather than emitting lines, gates its completion summary
+behind an interactive stdout check, and carries no deadline — so a run that never
+registers (path filter, disabled workflow) or an API outage hangs the session.
+
+Event vocabulary (one line each, diff-gated — only CHANGES emit):
+  CI-RUN   registered <n>: <name>: <state> · ...
+  CI-CHG   <name>: <state> -> <state>
+  CI-HB    <elapsed>/<deadline>m           liveness; keeps a prompt cache warm
+  CI-WARN  <detail>                        non-terminal problem, still retrying
+  CI-DONE  success|failure|cancelled|timeout|no-run|probe-dead|superseded — <detail>
+
+Exit code is 0 only for `success` and `superseded`.
+
+GitHub Actions (built in — needs authenticated `gh`, run from inside the repo
+when `--repo` is omitted):
+  ci-watch.py --sha "$(git rev-parse HEAD)" [--repo owner/name] [--branch main]
+
+Any other provider — supply a probe printing one `<name>: <state>` line per job.
+`$SHA` is exported to the probe's environment (not string-substituted):
+  ci-watch.py --sha "$(git rev-parse HEAD)" \
+      --cmd 'curl -sS "$API/pipelines?sha=$SHA" | jq -r ".[]|\\"\\(.name): \\(.status)\\""'
+
+`--branch` is opt-in: supplying it retires the watch when that branch moves past
+the pinned SHA. Omit it on feature branches, or the first poll self-retires.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+# GitHub Actions conclusions. Anything not in SUCCESS is not green — listing the
+# bad states explicitly (rather than treating "not failure" as success) is what
+# keeps a cancelled or skipped run from being reported as a false green.
+GH_SUCCESS = {"success"}
+GH_FAILURE = {"failure", "timed_out", "startup_failure", "action_required"}
+GH_CANCELLED = {"cancelled", "skipped", "stale", "neutral"}
+
+# Custom-probe state vocabulary. Exact matches on a normalised token, not
+# substrings: substring matching reports "not_failed" as a failure and never
+# terminates on "skipped".
+CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "fixed"}
+CUSTOM_FAILURE = {"failed", "failure", "failing_final", "error", "errored", "broken", "red"}
+CUSTOM_CANCELLED = {"cancelled", "canceled", "skipped", "manual", "blocked",
+                    "not_run", "neutral", "stale", "timed_out", "timeout"}
+
+
+def emit(line: str) -> None:
+    """One event per line, flushed immediately: the monitor reads stdout live."""
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def run_capture(args: list[str] | str, timeout: int, shell: bool = False,
+                env: dict[str, str] | None = None) -> subprocess.CompletedProcess | None:
+    """Every probe call is individually bounded; a missing binary is not fatal here."""
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=timeout,
+                              check=False, shell=shell, env=env)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def gh_json(args: list[str], timeout: int) -> object | None:
+    out = run_capture(args, timeout)
+    if out is None or out.returncode != 0:
+        return None
+    try:
+        return json.loads(out.stdout or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def head_sha(repo: str | None, branch: str, timeout: int = 30) -> str | None:
+    # NOT an f-string: gh expands the literal {owner}/{repo} placeholder from the
+    # git remote of the current directory. Do not "fix" the braces.
+    prefix = f"repos/{repo}" if repo else "repos/{owner}/{repo}"
+    out = run_capture(["gh", "api", f"{prefix}/commits/{branch}", "--jq", ".sha"], timeout)
+    if out is None or out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def classify_gh(conclusion: str | None, status: str) -> tuple[bool, str]:
+    """(terminal, bucket) where bucket is success|failure|cancelled|running."""
+    if status != "completed":
+        return False, "running"
+    if conclusion in GH_SUCCESS:
+        return True, "success"
+    if conclusion in GH_CANCELLED:
+        return True, "cancelled"
+    # Unknown conclusions are treated as failure: never assume green.
+    return True, "failure"
+
+
+def classify_custom(state: str) -> tuple[bool, str]:
+    token = state.strip().lower().replace("-", "_").replace(" ", "_")
+    if token in CUSTOM_SUCCESS:
+        return True, "success"
+    if token in CUSTOM_FAILURE:
+        return True, "failure"
+    if token in CUSTOM_CANCELLED:
+        return True, "cancelled"
+    return False, "running"
+
+
+def poll_gh(repo: str | None, sha: str, timeout: int) -> list[dict] | None:
+    """All runs for the pinned SHA — never 'latest', which can be another commit."""
+    args = ["gh", "run", "list", "--commit", sha, "--limit", "100",
+            "--json", "databaseId,workflowName,status,conclusion"]
+    if repo:
+        args += ["--repo", repo]
+    data = gh_json(args, timeout)
+    if not isinstance(data, list):
+        return None
+    rows = []
+    for r in data:
+        terminal, bucket = classify_gh(r.get("conclusion"), r.get("status", ""))
+        rows.append({"key": str(r["databaseId"]), "name": r["workflowName"],
+                     "state": r.get("conclusion") or r.get("status", ""),
+                     "terminal": terminal, "bucket": bucket})
+    return rows
+
+
+def poll_custom(cmd: str, sha: str, timeout: int) -> list[dict] | None:
+    """Probe contract: print one `<name>: <state>` line per job, nothing else."""
+    env = {**os.environ, "SHA": sha}
+    out = run_capture(cmd, timeout, shell=True, env=env)
+    if out is None or out.returncode != 0:
+        return None
+    rows: list[dict] = []
+    for line in out.stdout.splitlines():
+        if ":" not in line:
+            continue
+        # rpartition: job names legitimately contain ':' (GitLab `test:unit`).
+        name, _, state = line.rpartition(":")
+        name, state = name.strip(), state.strip()
+        if not name or not state:
+            continue
+        terminal, bucket = classify_custom(state)
+        rows.append({"key": name, "name": name, "state": state.lower(),
+                     "terminal": terminal, "bucket": bucket})
+    return rows
+
+
+def watch(a: argparse.Namespace) -> int:
+    started = time.monotonic()
+    deadline = started + a.deadline_min * 60
+    register_by = started + a.register_min * 60
+    next_beat = started + a.heartbeat_min * 60
+
+    seen: dict[str, str] = {}
+    registered = False
+    err_streak = 0
+    warned_at = 0
+    last_keys: frozenset[str] | None = None
+    polls_since_check = 0
+
+    while True:
+        runs = (poll_custom(a.cmd, a.sha, 45) if a.cmd
+                else poll_gh(a.repo, a.sha, 45))
+
+        if runs is None:
+            err_streak += 1
+            if err_streak >= 3 and err_streak != warned_at and err_streak % 3 == 0:
+                emit(f"CI-WARN probe failing ({err_streak}x) — still retrying")
+                warned_at = err_streak
+            if err_streak >= 10:
+                emit("CI-DONE probe-dead — 10 consecutive probe failures")
+                return 1
+        else:
+            err_streak = 0
+            if runs and not registered:
+                registered = True
+                emit(f"CI-RUN  registered {len(runs)}: "
+                     + " · ".join(f"{r['name']}: {r['state']}" for r in runs))
+
+            for r in runs:
+                if seen.get(r["key"]) != r["state"]:
+                    if r["key"] in seen:
+                        emit(f"CI-CHG  {r['name']}: {seen[r['key']]} -> {r['state']}")
+                    seen[r["key"]] = r["state"]
+
+            keys = frozenset(r["key"] for r in runs)
+            stable = last_keys == keys
+            last_keys = keys
+
+            # Do not call success while workflows may still be registering: a fast
+            # job can finish before a slower sibling is even created.
+            settled = stable or time.monotonic() > register_by
+            if registered and runs and settled and all(r["terminal"] for r in runs):
+                failed = [r for r in runs if r["bucket"] == "failure"]
+                stopped = [r for r in runs if r["bucket"] == "cancelled"]
+                if failed:
+                    hint = ""
+                    if not a.cmd:
+                        flag = f" --repo {a.repo}" if a.repo else ""
+                        hint = " — " + "; ".join(
+                            f"gh run view {r['key']}{flag} --log-failed" for r in failed[:3])
+                    emit(f"CI-DONE failure — {', '.join(r['name'] for r in failed)}{hint}")
+                    return 1
+                if stopped:
+                    emit("CI-DONE cancelled — "
+                         + ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
+                         + " — not a green result")
+                    return 1
+                emit(f"CI-DONE success — {len(runs)} workflow(s) green on {a.sha[:9]}")
+                return 0
+
+            # Opt-in supersession; polled sparsely to avoid doubling API calls.
+            polls_since_check += 1
+            if registered and a.branch and not a.cmd and polls_since_check >= 4:
+                polls_since_check = 0
+                tip = head_sha(a.repo, a.branch)
+                if tip and tip != a.sha:
+                    emit(f"CI-DONE superseded — {a.branch} moved to {tip[:9]}")
+                    return 0
+
+        now = time.monotonic()   # re-sampled: the probe above can take ~45s
+        if not registered and now > register_by:
+            emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} in "
+                 f"{a.register_min:g}m (path filter? workflow disabled? wrong branch?)")
+            return 1
+        if now > deadline:
+            pending = sum(1 for k in seen if k not in
+                          {r["key"] for r in (runs or []) if r["terminal"]})
+            emit(f"CI-DONE timeout — {a.deadline_min:g}m elapsed, {pending} still running")
+            return 1
+        if now >= next_beat:
+            emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
+            next_beat = now + a.heartbeat_min * 60
+
+        time.sleep(a.interval)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--sha", required=True, help="full commit SHA that was pushed")
+    p.add_argument("--repo", help="owner/name (GitHub mode; inferred from cwd if omitted)")
+    p.add_argument("--branch", default="",
+                   help="opt-in: retire the watch when this branch moves past --sha")
+    p.add_argument("--cmd", help="probe printing '<name>: <state>' lines; $SHA is in its env")
+    p.add_argument("--deadline-min", type=float, default=30.0)
+    p.add_argument("--interval", type=float, default=15.0)
+    p.add_argument("--heartbeat-min", type=float, default=2.5)
+    p.add_argument("--register-min", type=float, default=4.0)
+    a = p.parse_args()
+    try:
+        return watch(a)
+    except KeyboardInterrupt:
+        emit("CI-DONE timeout — interrupted")
+        return 1
+    except BaseException as exc:  # noqa: BLE001 — a crash must still emit a verdict
+        emit(f"CI-DONE probe-dead — {type(exc).__name__}: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -241,6 +241,7 @@ def watch(a: argparse.Namespace) -> int:
 
     seen: dict[str, str] = {}
     registered = False
+    successful_empty_probe = False
     err_streak = 0
     warned_at = 0
     last_keys: frozenset[str] | None = None
@@ -251,13 +252,16 @@ def watch(a: argparse.Namespace) -> int:
     while True:
         now = time.monotonic()
         if not registered and now >= register_by:
-            if a.expect_none:
+            if a.expect_none and successful_empty_probe:
                 emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
                      "expected (declared path-filtered)")
                 return 0
+            detail = ("probe never returned a successful empty snapshot"
+                      if a.expect_none else
+                      "path filter? workflow disabled? wrong branch? short SHA?")
             return done("no-run",
                         f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
-                        "(path filter? workflow disabled? wrong branch? short SHA?)")
+                        f"({detail})")
         if now >= deadline:
             pending = sum(1 for k, v in seen.items()
                           if "/" not in k and not classify_custom(v)[0]
@@ -275,11 +279,16 @@ def watch(a: argparse.Namespace) -> int:
                 warned_at = err_streak
             if err_streak >= 10:
                 return done("probe-dead", "10 consecutive probe failures")
-        elif not runs and registered:
-            # A transient empty result after registration is a blip, never a
-            # verdict: `all([])` is True, and treating it as "all terminal and
-            # nothing failed" manufactures a success out of an outage.
-            green_since = None
+        elif not runs:
+            # An empty list is a successful provider response, not another probe
+            # failure. Before registration it proves --expect-none observed the
+            # provider; after registration it remains a transient blip, never a
+            # verdict (`all([])` would otherwise manufacture a success).
+            err_streak = 0
+            if registered:
+                green_since = None
+            else:
+                successful_empty_probe = True
         else:
             err_streak = 0
             if runs and not registered:
@@ -305,9 +314,9 @@ def watch(a: argparse.Namespace) -> int:
                                              max(0.1, min(30.0, remaining))):
                             jk = j["key"]
                             if seen.get(jk) != j["state"] and j["state"]:
-                                if jk in seen:
-                                    emit(f"CI-CHG  {r['name']}/{j['name']}: "
-                                         f"{seen[jk]} -> {j['state']}")
+                                previous = seen.get(jk, "unknown")
+                                emit(f"CI-CHG  {r['name']}/{j['name']}: "
+                                     f"{previous} -> {j['state']}")
                                 seen[jk] = j["state"]
 
             keys = frozenset(r["key"] for r in runs)
@@ -408,13 +417,16 @@ def watch(a: argparse.Namespace) -> int:
 
         now = time.monotonic()   # re-sampled: the probes above can take ~45s
         if not registered and now > register_by:
-            if a.expect_none:
+            if a.expect_none and successful_empty_probe:
                 emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
                      "expected (declared path-filtered)")
                 return 0
+            detail = ("probe never returned a successful empty snapshot"
+                      if a.expect_none else
+                      "path filter? workflow disabled? wrong branch? short SHA?")
             return done("no-run",
                         f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
-                        "(path filter? workflow disabled? wrong branch? short SHA?)")
+                        f"({detail})")
         if now > deadline:
             pending = sum(1 for k, v in seen.items()
                           if "/" not in k and not classify_custom(v)[0]
@@ -449,6 +461,10 @@ def main() -> int:
                    help="skip job-level expansion of in-flight GitHub runs")
     a = p.parse_args()
 
+    if a.interval <= 0:
+        p.error("--interval must be greater than zero")
+    if a.heartbeat_min <= 0:
+        p.error("--heartbeat-min must be greater than zero")
     # `gh run list --commit` silently returns ZERO rows for a short SHA, which
     # the registration deadline would then misreport as no-run. Fail fast.
     if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -352,22 +352,27 @@ def watch(a: argparse.Namespace) -> int:
                     return done("cancelled", names + " — not a green result "
                                 "(pass --branch to distinguish supersession)")
                 if a.settle_sec > 0:
-                    now = time.monotonic()
+                    settle_now = time.monotonic()
                     if green_since is None:
-                        green_since = now
+                        green_since = settle_now
                         if not settle_announced:
                             emit(f"CI-SETTLE all green — holding {a.settle_sec:g}s "
                                  "for completion-triggered follow-ups")
                             settle_announced = True
-                    if now >= deadline:
+                    if settle_now >= deadline:
                         return done("timeout",
                                     f"{a.deadline_min:g}m elapsed while waiting to settle")
-                    if now - green_since < a.settle_sec:
-                        if now >= next_beat:
-                            emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
-                            next_beat = now + a.heartbeat_min * 60
+                    if settle_now - green_since < a.settle_sec:
+                        if settle_now >= next_beat:
+                            emit(f"CI-HB   {int((settle_now - started) / 60)}/"
+                                 f"{a.deadline_min:g}m")
+                            next_beat = settle_now + a.heartbeat_min * 60
                         wake_at = min(deadline, next_beat, green_since + a.settle_sec)
-                        time.sleep(max(0, min(a.interval, wake_at - now)))
+                        sleep_now = time.monotonic()
+                        if sleep_now >= deadline:
+                            return done("timeout",
+                                        f"{a.deadline_min:g}m elapsed while waiting to settle")
+                        time.sleep(max(0, min(a.interval, wake_at - sleep_now)))
                         continue
                 if a.branch and not a.cmd:
                     remaining = deadline - time.monotonic()

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -12,47 +12,68 @@ behind an interactive stdout check, and carries no deadline — so a run that ne
 registers (path filter, disabled workflow) or an API outage hangs the session.
 
 Event vocabulary (one line each, diff-gated — only CHANGES emit):
-  CI-RUN   registered <n>: <name>: <state> · ...
-  CI-CHG   <name>: <state> -> <state>
-  CI-HB    <elapsed>/<deadline>m           liveness; keeps a prompt cache warm
-  CI-WARN  <detail>                        non-terminal problem, still retrying
-  CI-DONE  success|failure|cancelled|timeout|no-run|probe-dead|superseded — <detail>
+  CI-RUN    registered <n>: <name>: <state> · ...
+  CI-CHG    <name>: <state> -> <state>          run-level, and job-level for
+                                                in-flight runs (react to the
+                                                first red job, not the verdict)
+  CI-HB     <elapsed>/<deadline>m               liveness tick
+  CI-SETTLE all green — holding <n>s for completion-triggered follow-ups
+  CI-WARN   <detail>                            non-terminal problem, still retrying
+  CI-DONE   success|failure|cancelled|timeout|no-run|probe-dead|superseded — <detail>
 
-Exit code is 0 only for `success` and `superseded`.
+Exit code encodes the verdict so `ci-watch.py … && deploy` is safe:
+  0 success (and no-run under --expect-none)
+  1 failure, cancelled
+  2 timeout, no-run, probe-dead      — indeterminate: you still do not know
+  3 superseded                       — the pinned SHA never reached a verdict
+Collapsing these to 0 (a tempting shortcut) makes `watch && deploy` ship a red
+build; treating 2 as red hides that the answer is "unknown", not "no".
 
-GitHub Actions (built in — needs authenticated `gh`, run from inside the repo
-when `--repo` is omitted):
+GitHub Actions (built in — needs authenticated `gh`; pass --repo when the
+session cwd is not the target repo, e.g. another worktree):
   ci-watch.py --sha "$(git rev-parse HEAD)" [--repo owner/name] [--branch main]
 
 Any other provider — supply a probe printing one `<name>: <state>` line per job.
-`$SHA` is exported to the probe's environment (not string-substituted):
+`$SHA` is exported to the probe's environment (never string-substituted into the
+command, which would be a quoting/injection hazard):
   ci-watch.py --sha "$(git rev-parse HEAD)" \
       --cmd 'curl -sS "$API/pipelines?sha=$SHA" | jq -r ".[]|\\"\\(.name): \\(.status)\\""'
 
-`--branch` is opt-in: supplying it retires the watch when that branch moves past
-the pinned SHA. Omit it on feature branches, or the first poll self-retires.
+Flags for specific pipeline shapes:
+  --settle-sec N   hold an all-green result N seconds and re-probe before
+                   declaring success. Use when one workflow triggers another on
+                   completion (deploy after build): the follow-up does not exist
+                   yet at the moment the first turns green.
+  --expect-none    a path-filtered push may legitimately trigger nothing; make
+                   "zero runs registered" an asserted expectation (exit 0)
+                   instead of an ambiguous no-run (exit 2).
+  --no-jobs        skip per-run job expansion in GitHub mode (halves API calls
+                   on busy commits; you lose early job-level failure events).
 """
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 
-# GitHub Actions conclusions. Anything not in SUCCESS is not green — listing the
-# bad states explicitly (rather than treating "not failure" as success) is what
-# keeps a cancelled or skipped run from being reported as a false green.
+EXIT = {"success": 0, "failure": 1, "cancelled": 1,
+        "timeout": 2, "no-run": 2, "probe-dead": 2, "superseded": 3}
+
+# GitHub Actions conclusions. Anything not in SUCCESS is not green — enumerating
+# success (rather than treating "not failure" as green) is what keeps a
+# cancelled or skipped run from being reported as a false green.
 GH_SUCCESS = {"success"}
-GH_FAILURE = {"failure", "timed_out", "startup_failure", "action_required"}
 GH_CANCELLED = {"cancelled", "skipped", "stale", "neutral"}
 
 # Custom-probe state vocabulary. Exact matches on a normalised token, not
 # substrings: substring matching reports "not_failed" as a failure and never
 # terminates on "skipped".
 CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "fixed"}
-CUSTOM_FAILURE = {"failed", "failure", "failing_final", "error", "errored", "broken", "red"}
+CUSTOM_FAILURE = {"failed", "failure", "error", "errored", "broken", "red"}
 CUSTOM_CANCELLED = {"cancelled", "canceled", "skipped", "manual", "blocked",
                     "not_run", "neutral", "stale", "timed_out", "timeout"}
 
@@ -63,12 +84,19 @@ def emit(line: str) -> None:
     sys.stdout.flush()
 
 
+def done(verdict: str, detail: str) -> int:
+    emit(f"CI-DONE {verdict} — {detail}")
+    return EXIT[verdict]
+
+
 def run_capture(args: list[str] | str, timeout: int, shell: bool = False,
                 env: dict[str, str] | None = None) -> subprocess.CompletedProcess | None:
-    """Every probe call is individually bounded; a missing binary is not fatal here."""
+    """Every probe call is individually bounded; a wedged request must not
+    freeze the loop, and a missing binary is handled by the caller."""
     try:
         return subprocess.run(args, capture_output=True, text=True, timeout=timeout,
-                              check=False, shell=shell, env=env)
+                              check=False, shell=shell, env=env,
+                              stdin=subprocess.DEVNULL)
     except (subprocess.TimeoutExpired, OSError):
         return None
 
@@ -84,8 +112,11 @@ def gh_json(args: list[str], timeout: int) -> object | None:
 
 
 def head_sha(repo: str | None, branch: str, timeout: int = 30) -> str | None:
-    # NOT an f-string: gh expands the literal {owner}/{repo} placeholder from the
-    # git remote of the current directory. Do not "fix" the braces.
+    """Branch tip from the API — NOT `run list --branch --limit 1`, whose newest
+    RUN can lag the newest COMMIT and report a push superseded by its own
+    ancestor."""
+    # NOT an f-string: gh expands the literal {owner}/{repo} placeholder from
+    # the git remote of the current directory. Do not "fix" the braces.
     prefix = f"repos/{repo}" if repo else "repos/{owner}/{repo}"
     out = run_capture(["gh", "api", f"{prefix}/commits/{branch}", "--jq", ".sha"], timeout)
     if out is None or out.returncode != 0:
@@ -117,9 +148,14 @@ def classify_custom(state: str) -> tuple[bool, str]:
 
 
 def poll_gh(repo: str | None, sha: str, timeout: int) -> list[dict] | None:
-    """All runs for the pinned SHA — never 'latest', which can be another commit."""
+    """All runs for the pinned SHA — never 'latest', which can be another commit.
+
+    `gh run list` returns one row per run id already reflecting the latest
+    attempt (verified against gh 2.x); providers whose listing returns one row
+    per ATTEMPT need the highest attempt kept per id or the watcher oscillates.
+    """
     args = ["gh", "run", "list", "--commit", sha, "--limit", "100",
-            "--json", "databaseId,workflowName,status,conclusion"]
+            "--json", "databaseId,workflowName,event,status,conclusion"]
     if repo:
         args += ["--repo", repo]
     data = gh_json(args, timeout)
@@ -129,9 +165,51 @@ def poll_gh(repo: str | None, sha: str, timeout: int) -> list[dict] | None:
     for r in data:
         terminal, bucket = classify_gh(r.get("conclusion"), r.get("status", ""))
         rows.append({"key": str(r["databaseId"]), "name": r["workflowName"],
+                     "group": (r["workflowName"], r.get("event", "")),
                      "state": r.get("conclusion") or r.get("status", ""),
                      "terminal": terminal, "bucket": bucket})
     return rows
+
+
+def poll_gh_jobs(repo: str | None, run_key: str, timeout: int) -> list[dict]:
+    """Jobs of one in-flight run. A run's status stays in_progress until every
+    job finishes, so run-level polling cannot surface the first red job — this
+    expansion is what makes 'react to the first failure' possible. Bounded to
+    active runs so the extra API call does not multiply on finished work."""
+    args = ["gh", "run", "view", run_key, "--json", "jobs"]
+    if repo:
+        args += ["--repo", repo]
+    data = gh_json(args, timeout)
+    if not isinstance(data, dict):
+        return []
+    rows = []
+    for j in data.get("jobs", []):
+        state = j.get("conclusion") or j.get("status") or ""
+        rows.append({"key": f"{run_key}/{j.get('name', '?')}",
+                     "name": j.get("name", "?"), "state": state})
+    return rows
+
+
+def newest_per_workflow(runs: list[dict]) -> list[dict]:
+    """One commit can carry several runs of the same workflow (a rerun, or a
+    concurrency-cancelled attempt beside its replacement). The newest run per
+    (workflow, trigger event) decides the verdict; otherwise a cancelled
+    sibling turns a green commit red. Grouping includes the EVENT because a
+    workflow_dispatch rerun is a different validation surface than the push
+    run it sits beside — a dispatch that skips a deploy job must not forgive
+    the push run whose deploy job failed. GitHub run ids are monotonic, so
+    max(id) is the newest within a group."""
+    by_group: dict[tuple, dict] = {}
+    for r in runs:
+        group = r.get("group", (r["name"],))
+        prev = by_group.get(group)
+        if prev is None or _key_order(r["key"]) > _key_order(prev["key"]):
+            by_group[group] = r
+    return list(by_group.values())
+
+
+def _key_order(key: str):
+    return (0, int(key)) if key.isdigit() else (1, key)
 
 
 def poll_custom(cmd: str, sha: str, timeout: int) -> list[dict] | None:
@@ -166,7 +244,9 @@ def watch(a: argparse.Namespace) -> int:
     err_streak = 0
     warned_at = 0
     last_keys: frozenset[str] | None = None
-    polls_since_check = 0
+    green_since: float | None = None
+    settle_announced = False
+    polls_since_branch_check = 0
 
     while True:
         runs = (poll_custom(a.cmd, a.sha, 45) if a.cmd
@@ -178,8 +258,12 @@ def watch(a: argparse.Namespace) -> int:
                 emit(f"CI-WARN probe failing ({err_streak}x) — still retrying")
                 warned_at = err_streak
             if err_streak >= 10:
-                emit("CI-DONE probe-dead — 10 consecutive probe failures")
-                return 1
+                return done("probe-dead", "10 consecutive probe failures")
+        elif not runs and registered:
+            # A transient empty result after registration is a blip, never a
+            # verdict: `all([])` is True, and treating it as "all terminal and
+            # nothing failed" manufactures a success out of an outage.
+            green_since = None
         else:
             err_streak = 0
             if runs and not registered:
@@ -193,51 +277,97 @@ def watch(a: argparse.Namespace) -> int:
                         emit(f"CI-CHG  {r['name']}: {seen[r['key']]} -> {r['state']}")
                     seen[r["key"]] = r["state"]
 
+            # Job-level expansion for in-flight runs only (GitHub mode): the
+            # first red job surfaces minutes before the run's own conclusion.
+            if not a.cmd and not a.no_jobs:
+                for r in runs:
+                    if not r["terminal"]:
+                        for j in poll_gh_jobs(a.repo, r["key"], 30):
+                            jk = j["key"]
+                            if seen.get(jk) != j["state"] and j["state"]:
+                                if jk in seen:
+                                    emit(f"CI-CHG  {r['name']}/{j['name']}: "
+                                         f"{seen[jk]} -> {j['state']}")
+                                seen[jk] = j["state"]
+
             keys = frozenset(r["key"] for r in runs)
             stable = last_keys == keys
             last_keys = keys
 
-            # Do not call success while workflows may still be registering: a fast
-            # job can finish before a slower sibling is even created.
+            # The verdict comes from the newest run per workflow, and only once
+            # the run SET has been stable across two polls (or registration has
+            # closed): a fast workflow can finish before a slower sibling is
+            # even created, and success-on-first-green would miss the sibling.
+            decisive = newest_per_workflow(runs) if not a.cmd else runs
             settled = stable or time.monotonic() > register_by
-            if registered and runs and settled and all(r["terminal"] for r in runs):
-                failed = [r for r in runs if r["bucket"] == "failure"]
-                stopped = [r for r in runs if r["bucket"] == "cancelled"]
+            if registered and decisive and settled and all(r["terminal"] for r in decisive):
+                failed = [r for r in decisive if r["bucket"] == "failure"]
+                stopped = [r for r in decisive if r["bucket"] == "cancelled"]
                 if failed:
+                    # Failure outranks supersession: a completed red answers
+                    # "did this SHA pass" regardless of where the branch went.
                     hint = ""
                     if not a.cmd:
                         flag = f" --repo {a.repo}" if a.repo else ""
                         hint = " — " + "; ".join(
                             f"gh run view {r['key']}{flag} --log-failed" for r in failed[:3])
-                    emit(f"CI-DONE failure — {', '.join(r['name'] for r in failed)}{hint}")
-                    return 1
+                    return done("failure", ", ".join(r["name"] for r in failed) + hint)
                 if stopped:
-                    emit("CI-DONE cancelled — "
-                         + ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
-                         + " — not a green result")
-                    return 1
-                emit(f"CI-DONE success — {len(runs)} workflow(s) green on {a.sha[:9]}")
-                return 0
+                    # Cancelled is ambiguous: under cancel-in-progress
+                    # concurrency, a newer push cancels this SHA's runs. Check
+                    # the branch tip to tell auto-supersession from a manual or
+                    # infrastructure cancel.
+                    names = ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
+                    if a.branch and not a.cmd:
+                        tip = head_sha(a.repo, a.branch)
+                        if tip and tip != a.sha:
+                            return done("superseded",
+                                        f"runs cancelled and {a.branch} moved to "
+                                        f"{tip[:9]} — no verdict for {a.sha[:9]}")
+                        return done("cancelled", names + " on an unmoved branch "
+                                    "— not green, not superseded")
+                    return done("cancelled", names + " — not a green result "
+                                "(pass --branch to distinguish supersession)")
+                if a.settle_sec > 0:
+                    now = time.monotonic()
+                    if green_since is None:
+                        green_since = now
+                        if not settle_announced:
+                            emit(f"CI-SETTLE all green — holding {a.settle_sec:g}s "
+                                 "for completion-triggered follow-ups")
+                            settle_announced = True
+                    if now - green_since < a.settle_sec:
+                        time.sleep(a.interval)
+                        continue
+                return done("success",
+                            f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
+            green_since = None
 
-            # Opt-in supersession; polled sparsely to avoid doubling API calls.
-            polls_since_check += 1
-            if registered and a.branch and not a.cmd and polls_since_check >= 4:
-                polls_since_check = 0
+            # Mid-flight supersession (opt-in, sparse — the branch probe would
+            # otherwise double API traffic). A moved branch retires a watch that
+            # has no verdict yet; a finished verdict above always wins.
+            polls_since_branch_check += 1
+            if registered and a.branch and not a.cmd and polls_since_branch_check >= 4:
+                polls_since_branch_check = 0
                 tip = head_sha(a.repo, a.branch)
                 if tip and tip != a.sha:
-                    emit(f"CI-DONE superseded — {a.branch} moved to {tip[:9]}")
-                    return 0
+                    return done("superseded", f"{a.branch} moved to {tip[:9]}")
 
-        now = time.monotonic()   # re-sampled: the probe above can take ~45s
+        now = time.monotonic()   # re-sampled: the probes above can take ~45s
         if not registered and now > register_by:
-            emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} in "
-                 f"{a.register_min:g}m (path filter? workflow disabled? wrong branch?)")
-            return 1
+            if a.expect_none:
+                emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
+                     "expected (declared path-filtered)")
+                return 0
+            return done("no-run",
+                        f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
+                        "(path filter? workflow disabled? wrong branch? short SHA?)")
         if now > deadline:
-            pending = sum(1 for k in seen if k not in
-                          {r["key"] for r in (runs or []) if r["terminal"]})
-            emit(f"CI-DONE timeout — {a.deadline_min:g}m elapsed, {pending} still running")
-            return 1
+            pending = sum(1 for k, v in seen.items()
+                          if "/" not in k and not classify_custom(v)[0]
+                          and v not in ("completed",))
+            return done("timeout",
+                        f"{a.deadline_min:g}m elapsed, ~{pending} still running")
         if now >= next_beat:
             emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
             next_beat = now + a.heartbeat_min * 60
@@ -247,8 +377,9 @@ def watch(a: argparse.Namespace) -> int:
 
 def main() -> int:
     p = argparse.ArgumentParser()
-    p.add_argument("--sha", required=True, help="full commit SHA that was pushed")
-    p.add_argument("--repo", help="owner/name (GitHub mode; inferred from cwd if omitted)")
+    p.add_argument("--sha", required=True, help="full 40-char commit SHA that was pushed")
+    p.add_argument("--repo", help="owner/name (GitHub mode; inferred from cwd if omitted "
+                                  "— pass it explicitly when running from another worktree)")
     p.add_argument("--branch", default="",
                    help="opt-in: retire the watch when this branch moves past --sha")
     p.add_argument("--cmd", help="probe printing '<name>: <state>' lines; $SHA is in its env")
@@ -256,15 +387,32 @@ def main() -> int:
     p.add_argument("--interval", type=float, default=15.0)
     p.add_argument("--heartbeat-min", type=float, default=2.5)
     p.add_argument("--register-min", type=float, default=4.0)
+    p.add_argument("--settle-sec", type=float, default=0.0,
+                   help="hold all-green N seconds for completion-triggered follow-ups")
+    p.add_argument("--expect-none", action="store_true",
+                   help="zero registered runs is the expected outcome (exit 0)")
+    p.add_argument("--no-jobs", action="store_true",
+                   help="skip job-level expansion of in-flight GitHub runs")
     a = p.parse_args()
+
+    # `gh run list --commit` silently returns ZERO rows for a short SHA, which
+    # the registration deadline would then misreport as no-run. Fail fast.
+    if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):
+        p.error("--sha must be the full 40-character lowercase SHA in GitHub mode "
+                "(use \"$(git rev-parse HEAD)\")")
+    # If the registration cutoff meets or exceeds the deadline, no-run becomes
+    # unreachable and every skipped pipeline misreports as timeout.
+    if a.register_min * 2 > a.deadline_min:
+        a.register_min = a.deadline_min / 2
+        emit(f"CI-WARN register window clamped to {a.register_min:g}m "
+             f"(half of the {a.deadline_min:g}m deadline)")
+
     try:
         return watch(a)
     except KeyboardInterrupt:
-        emit("CI-DONE timeout — interrupted")
-        return 1
+        return done("timeout", "interrupted")
     except BaseException as exc:  # noqa: BLE001 — a crash must still emit a verdict
-        emit(f"CI-DONE probe-dead — {type(exc).__name__}: {exc}")
-        return 1
+        return done("probe-dead", f"{type(exc).__name__}: {exc}")
 
 
 if __name__ == "__main__":

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -73,7 +73,7 @@ GH_CANCELLED = {"cancelled", "skipped", "stale", "neutral"}
 # substrings: substring matching reports "not_failed" as a failure and never
 # terminates on "skipped".
 CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "fixed"}
-CUSTOM_FAILURE = {"failed", "failure", "error", "errored", "broken", "red"}
+CUSTOM_FAILURE = {"failed", "failure", "failing_final", "error", "errored", "broken", "red"}
 CUSTOM_CANCELLED = {"cancelled", "canceled", "skipped", "manual", "blocked",
                     "not_run", "neutral", "stale", "timed_out", "timeout"}
 
@@ -249,8 +249,24 @@ def watch(a: argparse.Namespace) -> int:
     polls_since_branch_check = 0
 
     while True:
-        runs = (poll_custom(a.cmd, a.sha, 45) if a.cmd
-                else poll_gh(a.repo, a.sha, 45))
+        now = time.monotonic()
+        if not registered and now >= register_by:
+            if a.expect_none:
+                emit(f"CI-DONE no-run — nothing registered for {a.sha[:9]} — "
+                     "expected (declared path-filtered)")
+                return 0
+            return done("no-run",
+                        f"nothing registered for {a.sha[:9]} in {a.register_min:g}m "
+                        "(path filter? workflow disabled? wrong branch? short SHA?)")
+        if now >= deadline:
+            pending = sum(1 for k, v in seen.items()
+                          if "/" not in k and not classify_custom(v)[0]
+                          and v not in ("completed",))
+            return done("timeout",
+                        f"{a.deadline_min:g}m elapsed, ~{pending} still running")
+        probe_timeout = max(0.1, min(45.0, deadline - now))
+        runs = (poll_custom(a.cmd, a.sha, probe_timeout) if a.cmd
+                else poll_gh(a.repo, a.sha, probe_timeout))
 
         if runs is None:
             err_streak += 1
@@ -282,7 +298,11 @@ def watch(a: argparse.Namespace) -> int:
             if not a.cmd and not a.no_jobs:
                 for r in runs:
                     if not r["terminal"]:
-                        for j in poll_gh_jobs(a.repo, r["key"], 30):
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        for j in poll_gh_jobs(a.repo, r["key"],
+                                             max(0.1, min(30.0, remaining))):
                             jk = j["key"]
                             if seen.get(jk) != j["state"] and j["state"]:
                                 if jk in seen:
@@ -319,7 +339,10 @@ def watch(a: argparse.Namespace) -> int:
                     # infrastructure cancel.
                     names = ", ".join(f"{r['name']} ({r['state']})" for r in stopped)
                     if a.branch and not a.cmd:
-                        tip = head_sha(a.repo, a.branch)
+                        remaining = deadline - time.monotonic()
+                        tip = (head_sha(a.repo, a.branch,
+                                        max(0.1, min(30.0, remaining)))
+                               if remaining > 0 else None)
                         if tip and tip != a.sha:
                             return done("superseded",
                                         f"runs cancelled and {a.branch} moved to "
@@ -336,11 +359,33 @@ def watch(a: argparse.Namespace) -> int:
                             emit(f"CI-SETTLE all green — holding {a.settle_sec:g}s "
                                  "for completion-triggered follow-ups")
                             settle_announced = True
+                    if now >= deadline:
+                        return done("timeout",
+                                    f"{a.deadline_min:g}m elapsed while waiting to settle")
                     if now - green_since < a.settle_sec:
-                        time.sleep(a.interval)
+                        if now >= next_beat:
+                            emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
+                            next_beat = now + a.heartbeat_min * 60
+                        wake_at = min(deadline, next_beat, green_since + a.settle_sec)
+                        time.sleep(max(0, min(a.interval, wake_at - now)))
                         continue
-                return done("success",
-                            f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
+                if a.branch and not a.cmd:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return done("timeout",
+                                    f"{a.deadline_min:g}m elapsed before branch verification")
+                    tip = head_sha(a.repo, a.branch,
+                                   max(0.1, min(30.0, remaining)))
+                    if tip is None:
+                        emit("CI-WARN branch tip check failed — withholding green verdict")
+                    elif tip != a.sha:
+                        return done("superseded", f"{a.branch} moved to {tip[:9]}")
+                    else:
+                        return done("success",
+                                    f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
+                else:
+                    return done("success",
+                                f"{len(decisive)} workflow(s) green on {a.sha[:9]}")
             green_since = None
 
             # Mid-flight supersession (opt-in, sparse — the branch probe would
@@ -349,7 +394,10 @@ def watch(a: argparse.Namespace) -> int:
             polls_since_branch_check += 1
             if registered and a.branch and not a.cmd and polls_since_branch_check >= 4:
                 polls_since_branch_check = 0
-                tip = head_sha(a.repo, a.branch)
+                remaining = deadline - time.monotonic()
+                tip = (head_sha(a.repo, a.branch,
+                                max(0.1, min(30.0, remaining)))
+                       if remaining > 0 else None)
                 if tip and tip != a.sha:
                     return done("superseded", f"{a.branch} moved to {tip[:9]}")
 
@@ -372,7 +420,8 @@ def watch(a: argparse.Namespace) -> int:
             emit(f"CI-HB   {int((now - started) / 60)}/{a.deadline_min:g}m")
             next_beat = now + a.heartbeat_min * 60
 
-        time.sleep(a.interval)
+        wake_at = min(deadline, next_beat, register_by if not registered else deadline)
+        time.sleep(max(0, min(a.interval, wake_at - time.monotonic())))
 
 
 def main() -> int:
@@ -400,12 +449,12 @@ def main() -> int:
     if not a.cmd and not re.fullmatch(r"[0-9a-f]{40}", a.sha):
         p.error("--sha must be the full 40-character lowercase SHA in GitHub mode "
                 "(use \"$(git rev-parse HEAD)\")")
-    # If the registration cutoff meets or exceeds the deadline, no-run becomes
+    # If the registration cutoff exceeds the deadline, no-run becomes
     # unreachable and every skipped pipeline misreports as timeout.
-    if a.register_min * 2 > a.deadline_min:
-        a.register_min = a.deadline_min / 2
+    if a.register_min > a.deadline_min:
+        a.register_min = a.deadline_min
         emit(f"CI-WARN register window clamped to {a.register_min:g}m "
-             f"(half of the {a.deadline_min:g}m deadline)")
+             f"(the {a.deadline_min:g}m deadline)")
 
     try:
         return watch(a)


### PR DESCRIPTION
## Summary
- add a provider-neutral agent feedback-loop reference for CI
- bundle and validate a non-stalling `ci-watch.py` watcher
- strengthen Avrea guidance with measured cache and runner-sizing evidence

## Why
Making CI automatic only helps if agents can wait without stalling and react to a red check immediately. This PR adds the proven feedback-loop pattern and the reference watcher, plus the Avrea-specific measurement lessons that changed the outcome in practice.

## Validation
- `python3 skills/ci-cd-optimize/scripts/ci-watch.py` exercised in GitHub and custom-probe modes
- `python3 scripts/validate-skills.py`
- `python3 scripts/gen-marketplace.py --check`
- manual review of the generated plugin package diffs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-neutral CI feedback loop with a stdlib-only watcher so agents never stall and red checks surface fast. The watcher guarantees a clear final verdict, validates probe outputs and durations, and uses refreshed settle timing even if the probe crashes or tooling is missing.

- **New Features**
  - Added `references/agent-feedback-loop.md` and bundled `scripts/ci-watch.py`: emits one line per state change and always ends with `CI-DONE success|failure|cancelled|timeout|no-run|probe-dead|superseded`. Includes a GitHub Actions probe, a provider‑neutral `--cmd` contract, deadline enforcement, de-duplicated change events, refreshed settle timing, strict probe validation, and rejects invalid durations.
  - Added `references/capacity-and-contention.md`; updated `SKILL.md` with routing, verify-step guidance, and pitfalls.
  - Avrea: package-proxy vs store-cache guidance, runner downsizing with metrics, and corrected ARM pricing notes.

- **Migration**
  - After pushing, run: `python3 skills/ci-cd-optimize/scripts/ci-watch.py --sha "$(git rev-parse HEAD)" [--repo owner/name] [--branch main]`.
  - Other providers: supply a probe via `--cmd` that prints `<name>: <state>` per job.

<sup>Written for commit 7d8f6270f3f47171cfc57929ba0e997c3edce58e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

