### PR TITLE
feat(ci-cd-optimize): harden CI feedback-loop guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -556,7 +556,7 @@
     {
       "name": "ci-cd-optimize",
       "source": "./",
-      "description": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+      "description": "Use skill if you are diagnosing or optimizing slow CI/CD, reducing queue/setup/test/deploy time, migrating runners or caches, or building an agent workflow that waits on CI without stalling.",
       "version": "1.0.36",
       "category": "ops",
       "strict": false,

--- a/plugins/ci-cd-optimize/.codex-plugin/plugin.json
+++ b/plugins/ci-cd-optimize/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci-cd-optimize",
   "version": "1.0.36",
-  "description": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+  "description": "Use skill if you are diagnosing or optimizing slow CI/CD, reducing queue/setup/test/deploy time, migrating runners or caches, or building an agent workflow that waits on CI without stalling.",
   "author": {
     "name": "Yigit Konur",
     "url": "https://github.com/yigitkonur"
@@ -17,7 +17,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "ci-cd-optimize",
-    "shortDescription": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+    "shortDescription": "Use skill if you are diagnosing or optimizing slow CI/CD, reducing queue/setup/test/deploy time, migrating runners or caches, or building an agent workflow that waits on CI without stalling.",
     "longDescription": "Install only the ci-cd-optimize workflow from Yigit Konur's curated skills pack.",
     "developerName": "Yigit Konur",
     "category": "Productivity",

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/README.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/README.md
@@ -1,6 +1,6 @@
 # ci-cd-optimize
 
-Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification.
+Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, exact-artifact verification, and the agent feedback loop that waits on CI without stalling.
 
 **Category:** ops
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use skill if you are diagnosing or optimizing slow CI/CD, reducing queue/setup/test/deploy time, migrating runners or caches, or building an agent workflow that waits on CI without stalling.
 metadata:
   author: yigitkonur
-  version: 1.0.0
+  version: 1.1.0
   category: devops
   tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, typescript, swift, xcode, pipeline-performance]
 ---
@@ -39,6 +39,8 @@ Rules:
 
 Prefer the platform's own aggregated history over hand-collected timings when it exists, then verify sample size and window. If the repository runs on Avrea (`runs-on:` labels begin with `avrea-`) and `avr` is installed and authenticated, read `references/avrea/cli-evidence.md` — it returns median/p95, per-job start offsets, flake counts, and cache hit counts directly. Confirm availability with `command -v avr && avr auth status` before depending on it, and fall back to provider-native measurement otherwise.
 
+**Feedback loop rule:** after any change you validate through CI, arm a watcher that is pinned to the exact pushed SHA and that always terminates with an explicit verdict. Never rely on a branch-tip or "latest in-progress" watch as your only signal; registration races make them report "nothing running" before the provider has indexed your commit. Read `references/ci-feedback-loop.md` when choosing or implementing the watch path (Monitor vs one-shot background wait, registration deadline, terminal verdicts, failure-first reaction policy).
+
 For the metric definitions, baseline protocol, and the rule about claiming only the evidence rung you reached, read `references/measurement.md`.
 
 ### 3. Find the critical path
@@ -57,7 +59,7 @@ Apply the performance order before adding compute:
 Ask in order:
 
 1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
+2. Is queue time the dominant p95 contributor, or does queue share look high enough that topology work may backfire? Read `references/runners-and-autoscaling.md` and `references/measurement.md`.
 3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
 4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
 5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
@@ -71,6 +73,7 @@ Ask in order:
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
 14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
 15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+16. Is the *feedback loop* itself the bottleneck — watches that hang, return nothing, or need a human to babysit them, especially in a CI-only workflow with no local build? Read `references/ci-feedback-loop.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -82,6 +85,8 @@ Select the smallest reversible change that attacks the measured critical path. E
 - security/trust-boundary risk,
 - cost effect,
 - rollback or fallback.
+
+**If the repository is CI-only (no trusted local build/test path), optimizing the feedback loop is mandatory work, not polish.** A watch command that can exit before your run registers, or wait forever with no terminal verdict, leaves the agent blind to the result and turns every CI cycle into manual babysitting. Read `references/ci-feedback-loop.md` before you recommend a provider watch command or wire one into the Monitor tool.
 
 Prefer, in this order: prevent unneeded work → cancel stale work → reuse verified prior work → improve cache correctness → remove artificial dependencies → parallelize independent work → shard slow work by measured duration → reduce transferred bytes → improve runner capacity → move heavy work off the PR path only with a full-run fallback → change provider architecture.
 
@@ -163,7 +168,9 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Pitfall | Better move |
 |---|---|
 | Optimizing before measuring | Capture baseline queue/setup/execution/critical path first. |
-| Duplicate `push` and PR runs | Trigger PRs on PR events; trigger main/release pushes only. |
+| Branch-tip or id-less watch used as the only signal | Pin the exact SHA, wait for registration, then watch the explicit run id or a SHA-pinned script. |
+| Success-only watch filter | Emit every terminal verdict; silence must never read as green. |
+| Queue-dominated wall clock reported as a speed regression | Split queue from execution before naming the bottleneck. |
 | Draft PRs start expensive jobs | Keep planner cheap; gate expensive jobs until ready for review. |
 | Caching `node_modules` by default | Cache the package-manager store; measure restore versus install. |
 | Workflow path filter blocks required checks | Run a cheap change-detection job and condition expensive jobs. |
@@ -204,6 +211,13 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
+| `references/ci-feedback-loop.md` | Watching a run without hanging: registration races, non-TTY watchers, terminal verdicts, agent monitor wiring, and verifying the watcher's own failure paths. |
+
+## Bundled script
+
+| Path | Use when |
+|---|---|
+| `scripts/ci-watch.py` | You need a concrete SHA-pinned watcher for GitHub Actions or a provider-neutral probe contract to adapt for another CI system. Read `references/ci-feedback-loop.md` first so you know what the script guarantees and what its verdicts mean. |
 
 ### Optional: Avrea reference kit
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/avrea/cli-evidence.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/avrea/cli-evidence.md
@@ -126,12 +126,46 @@ avr run logs run-xxx --follow                # tail an in-progress job
 The project rule "verify the green, never hang on it" has direct support:
 
 ```bash
-avr run watch --repo org/app --exit-status   # non-zero if the run failed
-avr workflow run ci.yml --ref my-branch --watch --exit-status
-avr run watch run-xxx --ndjson | jq -c .     # event stream for scripting
+avr workflow run ci.yml --ref my-branch --watch --exit-status  # dispatch + watch in one call
+avr run watch run-xxx --exit-status                            # explicit run id
+avr run watch run-xxx --ndjson | jq -c .                       # line-oriented event stream
 ```
 
-`--exit-status` makes failure and timeout observable instead of silent. Always confirm `head_sha` matches the commit under test before accepting a green:
+`--exit-status` makes failure observable instead of silent, and `--ndjson`
+avoids the TTY-redraw problem that breaks line-oriented consumers.
+
+**Do not use the id-less form as your only signal after a push.** With no
+`RUN_ID`, `avr run watch` auto-selects the *latest in-progress* run. Observed on
+a live repository (2026-07-28): pushing and immediately arming
+`avr run watch --repo org/app --ndjson --exit-status` printed
+
+```
+Looking for an in-progress run…
+No in-progress workflow runs found for these repos.
+```
+
+and exited **0** — before the run had been indexed. An agent reads that as "no
+problem" and proceeds unverified. The same shape bites when a concurrency group
+cancels the run you meant to watch, or when another branch's run is newer.
+
+Wait for a run matching your exact SHA, then watch that id:
+
+```bash
+SHA=$(git rev-parse HEAD)
+for _ in $(seq 1 30); do
+  RUN=$(avr run list --repo org/app --limit 20 --json run_id,head_sha \
+        -q --arg s "$SHA" '[.[]|select(.head_sha==$s)][0].run_id // empty')
+  [ -n "$RUN" ] && break; sleep 10
+done
+[ -n "$RUN" ] || { echo "no run registered for $SHA"; exit 1; }
+avr run watch "$RUN" --ndjson --exit-status
+```
+
+For the general contract this satisfies — registration window, terminal verdict
+on every path, heartbeats, and wiring to an agent monitor — read
+`references/ci-feedback-loop.md`.
+
+Always confirm `head_sha` matches the commit under test before accepting a green:
 
 ```bash
 avr run view run-xxx --json head_sha,conclusion,status,run_attempt

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/caching.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/caching.md
@@ -34,9 +34,28 @@ Cache the package-manager store/cache, not blindly `node_modules`:
 | Yarn modern | `yarn install --immutable` | Yarn global cache or committed Zero-Install cache |
 | Bun | `bun ci` | Bun install cache |
 
-Key by lockfile, Node version, package-manager version, OS, and architecture. Compare restore time with a clean install; large stores can be slower than a registry fetch on a nearby network.
+## Package proxy versus store cache
 
-## Restore-key discipline
+A fast install does not prove the local package-manager store is helping. On
+runner platforms with a colocated registry proxy, a "cold" install can still be
+LAN-fast because the proxy, not the local store, is doing the work.
+
+Use this break-even test before keeping a large dependency-store cache:
+
+1. Compare a true cold run against a warm run on the same lockfile.
+2. Measure **install time**, not just cache hit counts.
+3. Compare that with the restore/save/archive cost of the store cache itself.
+
+If the install time is essentially unchanged cold and warm, the local store
+archive may only be moving bytes around. Remove it and keep the proxy.
+
+## Manifest-only changes are not safe on lockfile keys alone
+
+For package-tree caches, key on the manifest **and** the lockfile. A
+manifest-only change can still change what should be installed or tested even
+when the lockfile stays constant. A cache keyed only on the lockfile can then
+restore a stale dependency tree and make the run look green for the wrong input
+set.
 
 Use narrow restore keys from most-specific to less-specific:
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/change-based-ci.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/change-based-ci.md
@@ -65,9 +65,25 @@ jobs:
 
 Ensure the provider reports skipped downstream jobs as successful/skipped in the way branch protection expects.
 
-## Full-run triggers
+## Planner self-routing and rename traps
 
-Always run the full suite when:
+The component that decides what runs is part of the repository too. Treat it as
+load-bearing code, not as harmless glue.
+
+Two easy ways change-based CI lies to you:
+
+1. **Self-routing planner.** A planner change that routes only to its own lane is
+   grading its own homework. Changes to CI config, planner code, workflow files,
+   or shared routing tables should usually escalate broadly rather than proving
+   only themselves.
+2. **Rename masking.** A move from `src/x.ts` to `docs/x.md` can look
+   documentation-only if you only inspect the destination path. When the source
+   path was executable code, the pipeline must still treat the change as code.
+   Prefer `--name-status` or disable rename detection when classifying if your
+   tool would otherwise hide the removal.
+
+Keep tiny fixture-style tests for the classifier itself. A routing bug is one of
+few CI defects that can silently ship without any red lane at all.
 
 - merge base is missing or suspicious,
 - lockfile or package-manager config changed,

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/ci-feedback-loop.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/ci-feedback-loop.md
@@ -92,11 +92,23 @@ point.
 #!/usr/bin/env bash
 set -uo pipefail
 SHA="${1:-$(git rev-parse HEAD)}"
-DEADLINE=1800; REGISTER=300; HEARTBEAT=150; POLL=10
+DEADLINE="${DEADLINE:-1800}"; REGISTER="${REGISTER:-300}"
+HEARTBEAT="${HEARTBEAT:-150}"; POLL="${POLL:-10}"
 
 # One probe, individually timed out, returning JSON for this SHA only.
 probe() { timeout 25 <provider-cli> list --json ... ; }
-done_with() { echo "CI-DONE $1${2:+ — $2}"; exit 0; }
+done_with() {
+  verdict="$1"
+  echo "CI-DONE $verdict${2:+ — $2}"
+  case "$verdict" in
+    success) exit 0 ;;
+    failure) exit 1 ;;
+    no-run) exit 2 ;;
+    superseded|cancelled) exit 3 ;;
+    timeout) exit 124 ;;
+    *) exit 2 ;;
+  esac
+}
 
 start=$SECONDS
 # Phase 1 — registration, with its own deadline.
@@ -160,9 +172,9 @@ Bash(run_in_background: true,
 that terminates on its own:
 
 ```
-Monitor(command: "scripts/ci-watch.sh <sha> --deadline 1500",
+Monitor(command: "DEADLINE=1500 scripts/ci-watch.sh <sha>",
         description: "CI for <branch>",
-        timeout_ms: 1500000)
+        timeout_ms: 1560000)
 ```
 
 Rules that keep this reliable:

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/ci-feedback-loop.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/ci-feedback-loop.md
@@ -1,0 +1,240 @@
+# CI feedback loop: watching a run without hanging
+
+Read when an agent (or a human in a non-interactive shell) needs to learn a CI
+result, when a watch command "returns nothing", when a monitor stays armed after
+a run finished, or when a pipeline is CI-only so every verification round-trips
+through the provider.
+
+Optimizing pipeline seconds is wasted if the agent then blocks for twenty
+minutes on a broken watch, or worse, silently concludes "no news, must be fine."
+The feedback loop is part of the critical path.
+
+## Fast triage
+
+| Symptom | Most likely cause | Go to |
+|---|---|---|
+| Watch returns instantly, reports nothing running | Registration race — armed before the run was indexed | Failure mode 1 |
+| Watch prints a garbled blob, or nothing, then exits 0 | Non-TTY redraw output | Failure mode 2 |
+| Watch never returns; harness timeout kills it | No deadline of its own | Failure mode 3 |
+| Run failed but the agent proceeded as if green | Success-only filter; silence read as success | Failure mode 4 |
+| Monitor stays armed long after the run ended | Unbounded command (`tail -f`, `while true`) | Wiring it to an agent monitor |
+| Monitor auto-stopped mid-run | Output volume; every line became a notification | Wiring it to an agent monitor |
+| Green reported for someone else's commit | Branch-tip watch instead of SHA-pinned | The contract |
+| Old run reports failure right after you re-push | Concurrency cancellation, not a real failure | `superseded` verdict |
+
+## The four failure modes
+
+Each is common, each has been observed in practice, and each is silent.
+
+**1. Registration race.** You push, immediately ask the provider "what is
+running?", and get nothing — the run has not been created or indexed yet.
+Auto-selecting watchers (`gh run watch` with no id, `avr run watch` with no id)
+exit successfully with "no in-progress runs". The agent reads success. Nothing
+was verified. *Fix: poll for a run matching your exact SHA, with its own
+registration deadline, before watching anything.*
+
+**2. Non-TTY output.** Interactive watchers redraw with ANSI cursor control
+instead of emitting lines, and some suppress the completion summary entirely
+when stdout is not a terminal. A line-oriented consumer sees a blob, or nothing.
+*Fix: prefer a line/NDJSON mode when the CLI has one; otherwise poll an API and
+print your own lines.*
+
+**3. No deadline of its own.** A watch inherits no timeout. If a run never
+registers, a check never reports, or the API returns 5xx in a streak, the
+watcher waits forever. Harness-level timeouts eventually fire, but you have
+burned the budget and learned nothing. *Fix: a hard ceiling that exits with an
+explicit `timeout` verdict.*
+
+**4. Success-only filters.** `grep "passed"` looks identical whether the run is
+still going, crashed, was cancelled, or never started. **Silence is not
+success.** *Fix: emit a terminal verdict on every path, including failure,
+cancellation, timeout, and never-registered.*
+
+## The contract a watcher must satisfy
+
+Anything you build or adopt should guarantee:
+
+| Property | Why |
+|---|---|
+| **SHA-pinned** | A branch-tip watch can report a green from someone else's newer push, or a stale run from before your change. Verification must bind to the commit you pushed. |
+| **Terminal on every path** | `success`, `failure`, `cancelled`, `timeout`, `no-run`, `superseded`. Silence must be structurally impossible. |
+| **Registration window** | Bounded wait for the run to appear, separate from the run's own deadline. |
+| **Change-gated output** | Emit on state transitions, not every poll. Repeated identical lines flood the transcript and get monitors auto-killed. |
+| **Per-probe timeout** | One wedged HTTP request must not freeze the loop. |
+| **Error tolerance** | Transient 5xx happens; retry quietly, exit loudly after a streak. |
+| **Heartbeat** | A periodic progress line proves liveness during long queues without flooding. |
+| **Actionable failure** | The failure line should carry the command that shows the logs. |
+
+## Event vocabulary
+
+A compact, greppable stream. Prefixes matter more than exact words — pick one
+scheme and keep it stable so filters and humans can both read it.
+
+```
+CI-RUN  <sha> registered: build:queued · test:queued
+CI-CHG  test: in_progress
+CI-CHG  test: completed -> failure
+CI-HB   6/30m — build=completed/success test=in_progress/-
+CI-DONE failure — test — logs: <exact command to view them>
+```
+
+Reaction policy: act on the first `CI-CHG … -> failure` immediately rather than
+waiting for `CI-DONE`; on a long pipeline that is a large head start on the fix.
+Acknowledge `CI-HB` silently. Treat `CI-DONE no-run` as "verification did not
+happen", never as success.
+
+## Reference implementation
+
+Provider-neutral shape. Substitute the provider query; the control flow is the
+point.
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+SHA="${1:-$(git rev-parse HEAD)}"
+DEADLINE=1800; REGISTER=300; HEARTBEAT=150; POLL=10
+
+# One probe, individually timed out, returning JSON for this SHA only.
+probe() { timeout 25 <provider-cli> list --json ... ; }
+done_with() { echo "CI-DONE $1${2:+ — $2}"; exit 0; }
+
+start=$SECONDS
+# Phase 1 — registration, with its own deadline.
+while [ $((SECONDS-start)) -lt "$REGISTER" ]; do
+  runs="$(probe | jq -c --arg s "$SHA" '[.[]|select(.head_sha==$s)]')"
+  [ "$(jq length <<<"$runs")" -gt 0 ] && break
+  sleep "$POLL"
+done
+[ "$(jq length <<<"${runs:-[]}")" -gt 0 ] || done_with no-run "nothing registered for ${SHA:0:7}"
+echo "CI-RUN ${SHA:0:7} registered"
+
+# Phase 2 — change-gated polling until every run is terminal.
+prev=""; errors=0; beat=$SECONDS
+while [ $((SECONDS-start)) -lt "$DEADLINE" ]; do
+  snap="$(probe | jq -c --arg s "$SHA" '[.[]|select(.head_sha==$s)]')"
+  if [ -z "$snap" ]; then
+    errors=$((errors+1))
+    [ "$errors" -ge 10 ] && done_with failure "provider unreachable for 10 probes"
+    sleep "$POLL"; continue
+  fi
+  errors=0
+  cur="$(jq -r 'sort_by(.id)|map("\(.name)=\(.status)/\(.conclusion//"-")")|join(" ")' <<<"$snap")"
+  if [ "$cur" != "$prev" ]; then
+    jq -r '.[]|"CI-CHG \(.name): \(.status)\(if .conclusion then " -> \(.conclusion)" else "" end)"' <<<"$snap"
+    prev="$cur"; beat=$SECONDS
+  elif [ $((SECONDS-beat)) -ge "$HEARTBEAT" ]; then
+    echo "CI-HB $(((SECONDS-start)/60))/$((DEADLINE/60))m — $cur"; beat=$SECONDS
+  fi
+  if [ "$(jq '[.[]|select(.status!="completed")]|length' <<<"$snap")" -eq 0 ]; then
+    bad="$(jq -r '[.[]|select(.conclusion=="failure" or .conclusion=="timed_out")][0].name // empty' <<<"$snap")"
+    [ -n "$bad" ] && done_with failure "$bad — logs: <cli> view <id> --log-failed"
+    [ "$(jq '[.[]|select(.conclusion=="cancelled")]|length' <<<"$snap")" -gt 0 ] \
+      && done_with superseded "a newer push replaced ${SHA:0:7}"
+    done_with success "${SHA:0:7}"
+  fi
+  sleep "$POLL"
+done
+done_with timeout "still running after $((DEADLINE/60))m"
+```
+
+Shell notes that cost real debugging time: in `zsh`, `status` is a **readonly**
+builtin variable — assigning it aborts the script, so name your variables
+`state`/`verdict`. Every pipe stage must flush per line (`grep --line-buffered`,
+`awk '{...; fflush()}'`); `| head -N` buffers until N matches and can strand the
+stream entirely.
+
+## Wiring it to an agent monitor
+
+Two different tools for two different needs. Choosing wrong is the usual cause
+of a stuck agent.
+
+**One notification, when a condition becomes true** — use a backgrounded
+command that *exits* when the condition holds:
+
+```
+Bash(run_in_background: true,
+     command: "until <condition>; do sleep 5; done")
+```
+
+**A stream of events as they occur** — use the streaming monitor, with a command
+that terminates on its own:
+
+```
+Monitor(command: "scripts/ci-watch.sh <sha> --deadline 1500",
+        description: "CI for <branch>",
+        timeout_ms: 1500000)
+```
+
+Rules that keep this reliable:
+
+- **Never arm an unbounded command for a one-shot answer.** `tail -f`,
+  `while true`, and `inotifywait -m` never exit, so the monitor stays armed long
+  after the event fired and eventually dies on timeout instead of completing.
+- **Set the monitor timeout above the watcher's own deadline**, so the *script*
+  decides the outcome and reports a verdict, rather than the harness killing it
+  with no explanation.
+- **Filter to lines you would act on.** Piping raw CI logs generates a
+  notification per line; high-volume monitors get stopped automatically.
+- **One watch per pushed SHA.** Re-pushing supersedes the old run — let the old
+  watcher exit `superseded` and arm a new one rather than reasoning about two
+  overlapping streams.
+- **Do not poll from the main loop while a monitor is armed.** Duplicated
+  polling wastes budget and produces contradictory readings.
+
+## Making the watch cheap to arm
+
+The loop is only followed if it is one command. Commit the watcher to the
+repository (`scripts/ci-watch.sh`) rather than expecting an agent to retype a
+poll loop each time — hand-rolled loops are where the four failure modes above
+reappear. Document the exact invocation in `AGENTS.md`/`CONTRIBUTING.md` next to
+the push instruction, and state the expected duration so an agent can tell
+"slow" from "stuck".
+
+If the platform offers a native line-oriented watch (`--ndjson`, `--json`,
+`--exit-status`), prefer it *inside* the script for the streaming phase, but
+keep your own registration window and deadline around it. Native watches solve
+output shape; they generally do not solve registration, deadline, or SHA
+pinning.
+
+## Verifying the watcher itself
+
+A watcher is verification infrastructure, so test its failure paths before
+trusting it — the same standard applied to any other gate:
+
+1. **no-run** — invoke against a SHA that has no runs; it must exit with
+   `no-run` inside the registration window, not hang.
+2. **failure** — push a deliberately broken commit (a type error is cheap and
+   unambiguous); it must report `failure` and print a working logs command.
+   Revert immediately afterward.
+3. **success** — a normal green push produces `CI-DONE success`.
+4. **superseded** (if your pipeline cancels stale runs) — push twice quickly;
+   the first watch should end `superseded`, not `failure`.
+
+Until those paths are exercised, "the watcher works" is a config-review claim,
+not a verified one.
+
+## Distinguishing "slow" from "stuck"
+
+Long waits are not automatically a defect. Before treating a slow run as a
+problem, split the wall clock:
+
+- **Queue time** (created → started) is provider capacity. On a measured
+  repository it ranged 10s–193s within a single hour on identical config, while
+  execution held steady at 11–13s. Nothing in the workflow file changes that.
+- **Execution time** (started → completed) is yours to optimize.
+
+A watcher that heartbeats with elapsed time lets an agent tell the difference
+without polling. Report the two separately; presenting a queue-dominated wall
+clock as a regression sends the next optimization round after the wrong target.
+
+## Sources
+
+- Failure taxonomy and the diff-gated / guaranteed-exit design are modeled on
+  `yigitkonur/plugin-ci-watch-unstall` (README, accessed 2026-07-28), which
+  documents the same `gh run watch` non-TTY and no-deadline problems.
+- Registration-race behavior, `--ndjson` output shape, and the queue-vs-execution
+  spread were observed directly against `avr` 0.1.6 on a live repository
+  (2026-07-28); the id-less watch exiting 0 with "No in-progress workflow runs
+  found" is a reproduced observation, not a vendor-documented behavior.
+- `zsh` readonly `status` and pipe-buffering pitfalls were hit and fixed while
+  building the reference implementation above.

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/measurement.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/measurement.md
@@ -16,9 +16,42 @@ Use this file when building a baseline, proving a bottleneck, or validating that
 | Cost per successful change | compute + storage / successful changes | Speed improvements that increase total cost may not be wins. |
 | Change failure/rework rate | failed or unplanned recovery deployments / deployments | The effectiveness guardrail after optimization. |
 
-Use median and p95. CI duration is right-skewed; averages hide cold caches, runner saturation, flaky retries, and dependency changes.
+## Queue versus execution — never collapse them
 
-## Baseline protocol
+A workflow duration can worsen while the work itself stays flat. Split them
+before naming a bottleneck:
+
+- **Queue** = `started_at - created_at`
+- **Execution** = `completed_at - started_at`
+
+This is not bookkeeping trivia. On a measured repository, six comparable runs
+showed execution holding in a narrow band while queue ranged from seconds to
+minutes. Quoting a multiplier from total wall-clock alone would have reported
+both "2.6× slower" and "1.7× faster" for the same configuration, depending on
+which queue sample you chose.
+
+For reusable workflows and `needs`-gated jobs, note the subtlety: `created_at`
+may be set only after dependencies finish. That means a multi-stage DAG pays its
+queue/setup tax once per stage. When the platform exposes per-job start offsets,
+use them to reconstruct the real critical path rather than trusting stage names.
+
+## Sampling traps
+
+Before trusting a comparison, actively rule out the three easiest false claims:
+
+1. **Re-read, not re-run.** Confirm the attempt counter actually changed. Three
+   identical durations to the tenth of a second are usually the same run read
+   three times.
+2. **Mixed populations.** Do not compare `push`, `pull_request`, and
+   `workflow_dispatch` together; those often carry different runners, queues,
+   and job sets.
+3. **Self-inflicted contention.** Bursting several experiments at once can move
+   the queue more than the optimization moved execution. Interleave A/B arms, or
+   compare execution when pool state is clearly different.
+
+A robust p95 needs a real sample. Roughly 20+ comparable runs is arithmetic,
+not evidence by itself; below that, say you have a small cohort rather than a
+stable tail.
 
 1. Pin the exact commit, workflow, event, runner class, and environment.
 2. Run at least three comparable runs when variance is material.

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/measurement.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/measurement.md
@@ -49,6 +49,9 @@ Before trusting a comparison, actively rule out the three easiest false claims:
    the queue more than the optimization moved execution. Interleave A/B arms, or
    compare execution when pool state is clearly different.
 
+Averages hide the variance that makes CI painful: cold caches, runner
+saturation, flaky retries, and dependency changes. Report the median for the
+typical path and p95 for the tail instead of treating one mean as representative.
 A robust p95 needs a real sample. Roughly 20+ comparable runs is arithmetic,
 not evidence by itself; below that, say you have a small cohort rather than a
 stable tail.

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -32,9 +32,50 @@ Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
 Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.
 
-## Spot capacity
+## Capacity and contention before topology work
 
-Use spot/preemptible runners only for short, idempotent, retryable, or checkpointed jobs. Keep an on-demand fallback and never run the controller/manager on spot. Do not use spot for deployment gates where interruption is costly.
+Parallelizing a pipeline above its effective runner ceiling often makes it look
+busier and run no faster. A useful approximation is:
+
+```text
+wall-clock ≈ queue + ceil(job_count / effective_concurrency) × (per-job setup + execution)
+```
+
+That model is coarse — jobs are not really uniform — but it tells you when the
+next job split is likely to re-pay setup rather than buy wall-clock.
+
+A practical routing heuristic is **queue share**:
+
+```text
+queue share = Σ queue time / (Σ queue time + Σ execution time)
+```
+
+Measured over a representative window:
+
+| Queue share | Read it as | Usually do this next |
+|---|---|---|
+| <15% | Work dominates | Normal optimization: caching, sharding, DAG shape |
+| 15–35% | Mixed | Improve execution, but stop adding jobs |
+| >35% | Capacity dominates | Reduce job count or raise the ceiling |
+
+Above roughly a third, adding more jobs is often the wrong move even when the
+DAG looks cleaner.
+
+## Detect the effective ceiling empirically
+
+Do not assume the documented plan limit equals the concurrency you actually get.
+Org-wide contention, runner-class scarcity, and autoscaler warm-up often bite
+first. Look for jobs created together whose `started_at` values cluster into
+waves separated by about one job duration. That means the ceiling is below the
+job count, even if the provider docs advertise something larger.
+
+## Compare execution when pool state differs
+
+If runner contention is uneven, compare **execution** for in-job changes and use
+wall-clock only when the queue regime is comparable. A bigger runner can make a
+CPU-bound step faster while still making the total workflow slower if its queue
+is materially worse. That is not a contradiction; it is why queue and execution
+must be reported separately.
 
 ## Architecture and OS
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -32,6 +32,13 @@ Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
 Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.
 
+## Spot capacity
+
+Use spot/preemptible runners only for short, idempotent, retryable, or
+checkpointed jobs. Keep an on-demand fallback and never run the
+controller/manager on spot. Do not use spot for deployment gates where an
+interruption is costly.
+
 ## Capacity and contention before topology work
 
 Parallelizing a pipeline above its effective runner ceiling often makes it look

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -66,7 +66,7 @@ def emit(line: str) -> None:
     print(line, flush=True)
 
 
-def run(cmd: list[str], timeout: int = PROBE_TIMEOUT) -> str:
+def run(cmd: list[str], timeout: float = PROBE_TIMEOUT) -> str:
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
                           check=True).stdout
 
@@ -79,14 +79,14 @@ def full_sha(candidate: str) -> str:
     return run(["git", "rev-parse", candidate]).strip()
 
 
-def branch_tip(repo_dir: str, branch: str) -> str | None:
+def branch_tip(repo_dir: str, branch: str, timeout: float) -> str | None:
     # The remote ref is the only correct source for supersession. The latest
     # *run*'s head SHA is wrong: before the newest push registers, it is an
     # older commit, and a watcher using it reports a commit superseded by its
     # own ancestor.
     try:
         out = run(["git", "-C", repo_dir, "ls-remote", "origin",
-                   f"refs/heads/{branch}"])
+                   f"refs/heads/{branch}"], timeout)
         return out.split()[0] if out.strip() else None
     except Exception:
         return None
@@ -107,7 +107,7 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
     remaining = deadline_at - time.monotonic()
     if remaining <= 0:
         raise subprocess.TimeoutExpired(base, 0)
-    rows = json.loads(run(base, max(1, min(PROBE_TIMEOUT, int(remaining)))) or "[]")
+    rows = json.loads(run(base, min(PROBE_TIMEOUT, remaining)) or "[]")
     if len(rows) >= MAX_RUNS:
         raise RuntimeError(f"at least {MAX_RUNS} runs match {sha[:7]}; "
                            "refusing an incomplete verdict")
@@ -129,7 +129,7 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
                 jr = ["gh", "run", "view", rid, "--json", "jobs"]
                 if repo:
                     jr += ["--repo", repo]
-                for j in json.loads(run(jr, max(1, min(PROBE_TIMEOUT, int(left))))).get("jobs", []):
+                for j in json.loads(run(jr, min(PROBE_TIMEOUT, left))).get("jobs", []):
                     jid = f"{rid}/{j.get('databaseId', j.get('name'))}"
                     jstate = j.get("conclusion") or j.get("status") or "unknown"
                     snap[jid] = {"name": f"{snap[rid]['name']}:{j.get('name')}",
@@ -143,7 +143,7 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
     return snap
 
 
-def custom_probe(cmd: str, sha: str, timeout: int) -> tuple[dict[str, dict], str | None]:
+def custom_probe(cmd: str, sha: str, timeout: float) -> tuple[dict[str, dict], str | None]:
     env = dict(os.environ, CI_WATCH_SHA=sha)
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
                           timeout=timeout, env=env)
@@ -260,7 +260,7 @@ def main() -> int:
                             "inspect the run; stuck is not slow")
             if a.cmd:
                 snap, forced = custom_probe(
-                    a.cmd, sha, max(1, min(PROBE_TIMEOUT, int(remaining))))
+                    a.cmd, sha, min(PROBE_TIMEOUT, remaining))
             else:
                 snap = gh_probe(sha, a.repo, expand_jobs=True,
                                 deadline_at=deadline_at)
@@ -332,7 +332,13 @@ def main() -> int:
             else:
                 # At least one run is neutral. Cancelled by a newer push, or by
                 # hand? Mixed success/neutral is not an all-green verdict.
-                tip = branch_tip(os.getcwd(), branch) if branch else None
+                remaining = deadline_at - time.monotonic()
+                if remaining <= 0:
+                    return done("timeout", f"not terminal after {a.deadline}s -- "
+                                "inspect the run; stuck is not slow")
+                tip = branch_tip(
+                    os.getcwd(), branch,
+                    min(PROBE_TIMEOUT, remaining)) if branch else None
                 if branch and tip is None:
                     if not warned_super:
                         emit("CI-WARN cannot read origin tip; retrying "
@@ -357,7 +363,7 @@ def main() -> int:
             emit(f"CI-HB {mins}/{total}m -- {states}")
             last_beat = now
 
-        time.sleep(a.interval)
+        bounded_sleep()
 
 
 if __name__ == "__main__":

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -62,6 +62,10 @@ EXIT = {"success": 0, "failure": 1, "no-run": 2, "probe-dead": 2,
         "superseded": 3, "cancelled": 3, "timeout": 124}
 
 
+class IncompleteEnumeration(RuntimeError):
+    """The provider result cap prevents a complete, trustworthy verdict."""
+
+
 def emit(line: str) -> None:
     print(line, flush=True)
 
@@ -109,8 +113,9 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
         raise subprocess.TimeoutExpired(base, 0)
     rows = json.loads(run(base, min(PROBE_TIMEOUT, remaining)) or "[]")
     if len(rows) >= MAX_RUNS:
-        raise RuntimeError(f"at least {MAX_RUNS} runs match {sha[:7]}; "
-                           "refusing an incomplete verdict")
+        raise IncompleteEnumeration(
+            f"at least {MAX_RUNS} runs match {sha[:7]}; "
+            "refusing an incomplete verdict")
     snap: dict[str, dict] = {}
     for r in rows:
         rid = str(r["databaseId"])
@@ -265,6 +270,8 @@ def main() -> int:
                 snap = gh_probe(sha, a.repo, expand_jobs=True,
                                 deadline_at=deadline_at)
             errors = 0
+        except IncompleteEnumeration as exc:
+            return done("failure", f"incomplete run enumeration: {exc}")
         except Exception as exc:
             errors += 1
             if errors == WARN_STREAK:

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""ci-watch.py -- watch CI for one exact commit; always end with a verdict.
+
+Usage:
+    scripts/ci-watch.py [SHA] [options]                # GitHub mode (needs gh)
+    scripts/ci-watch.py [SHA] --cmd '<probe>' [options]  # any provider
+
+Every exit path prints exactly one terminal line:
+
+    CI-DONE <verdict> [-- detail]
+
+Verdicts and exit codes:
+    success     0    every registered run reached an explicit success
+    failure     1    a run (or lane) failed -- the line carries the log command
+    no-run      2    nothing registered within the registration window
+                     (exit 0 with --expect-none: path filters make this normal)
+    probe-dead  2    the probe itself failed repeatedly -- check auth/network
+    superseded  3    only cancelled/neutral results and the branch tip moved on
+    cancelled   3    cancelled on an unmoved branch -- manual or infra, not a
+                     test failure; not a pass either
+    timeout     124  still not terminal at the deadline -- stuck, not slow
+
+Interpret 'no-run', 'probe-dead', and 'timeout' as *you still do not know* --
+never record any of them as a pass. 'success' is decided by enumerating explicit
+success conclusions; unknown conclusions count as failure, never as green.
+
+Custom probe contract (--cmd): the command runs with $CI_WATCH_SHA set and must
+print one "name: state" line per unit of work. Printing "TERMINAL: <verdict>"
+ends the watch immediately with that verdict. A non-zero probe exit counts as a
+probe error (streak of 10 -> probe-dead), not as a pipeline failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+# Explicit success set: a verdict is green only when matched here. "Did not
+# fail" is not green -- cancel-in-progress concurrency manufactures cancelled
+# runs on every superseded push, and unknown states must never pass silently.
+GH_SUCCESS = {"success"}
+GH_FAILURE = {"failure", "timed_out", "startup_failure", "action_required"}
+GH_NEUTRAL = {"cancelled", "skipped", "stale", "neutral"}
+ACTIVE = {"queued", "in_progress", "waiting", "pending", "requested"}
+
+CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "live", "fixed"}
+CUSTOM_FAILURE = {"failed", "failure", "error", "errored", "broken", "red"}
+CUSTOM_NEUTRAL = {"cancelled", "canceled", "skipped", "manual", "blocked",
+                  "not_run", "neutral", "stale"}
+
+PROBE_TIMEOUT = 45      # one wedged request must not freeze the loop
+WARN_STREAK = 3
+DEAD_STREAK = 10
+
+EXIT = {"success": 0, "failure": 1, "no-run": 2, "probe-dead": 2,
+        "superseded": 3, "cancelled": 3, "timeout": 124}
+
+
+def emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def run(cmd: list[str], timeout: int = PROBE_TIMEOUT) -> str:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
+                          check=True).stdout
+
+
+def full_sha(candidate: str) -> str:
+    # gh's --commit filter silently returns ZERO rows for a short SHA, which a
+    # registration window would then misreport as no-run. Normalize first.
+    if len(candidate) == 40:
+        return candidate
+    return run(["git", "rev-parse", candidate]).strip()
+
+
+def branch_tip(repo_dir: str, branch: str) -> str | None:
+    # The remote ref is the only correct source for supersession. The latest
+    # *run*'s head SHA is wrong: before the newest push registers, it is an
+    # older commit, and a watcher using it reports a commit superseded by its
+    # own ancestor.
+    try:
+        out = run(["git", "-C", repo_dir, "ls-remote", "origin",
+                   f"refs/heads/{branch}"])
+        return out.split()[0] if out.strip() else None
+    except Exception:
+        return None
+
+
+def gh_probe(sha: str, repo: str | None, expand_jobs: bool) -> dict[str, dict]:
+    """Return {key: {name, state, conclusion, log_cmd}} keyed by run/lane id.
+
+    Keyed by id, never by workflow name: two runs of one workflow (re-run,
+    workflow_dispatch) would otherwise overwrite each other and the diff-gate
+    would flap forever.
+    """
+    base = ["gh", "run", "list", "--commit", sha, "--limit", "50",
+            "--json", "databaseId,workflowName,status,conclusion"]
+    if repo:
+        base += ["--repo", repo]
+    rows = json.loads(run(base) or "[]")
+    snap: dict[str, dict] = {}
+    for r in rows:
+        rid = str(r["databaseId"])
+        state = r.get("conclusion") or r.get("status") or "unknown"
+        log = f"gh run view {rid} --log-failed" + (f" --repo {repo}" if repo else "")
+        snap[rid] = {"name": r.get("workflowName") or rid, "state": state,
+                     "active": (r.get("status") in ACTIVE), "log": log}
+        # Run-level conclusion stays unset until every lane ends; expanding
+        # in-flight runs to job level surfaces the first red lane 20 minutes
+        # early. Bounded to active runs so the extra call is not paid per poll
+        # on completed ones.
+        if expand_jobs and r.get("status") in ACTIVE:
+            try:
+                jr = ["gh", "run", "view", rid, "--json", "jobs"]
+                if repo:
+                    jr += ["--repo", repo]
+                for j in json.loads(run(jr)).get("jobs", []):
+                    jid = f"{rid}/{j.get('databaseId', j.get('name'))}"
+                    jstate = j.get("conclusion") or j.get("status") or "unknown"
+                    snap[jid] = {"name": f"{snap[rid]['name']}:{j.get('name')}",
+                                 "state": jstate,
+                                 "active": (j.get("status") in ACTIVE),
+                                 "log": log}
+            except Exception:
+                pass  # lane detail is best-effort; the run row still verdicts
+    return snap
+
+
+def custom_probe(cmd: str, sha: str) -> tuple[dict[str, dict], str | None]:
+    env = dict(os.environ, CI_WATCH_SHA=sha)
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                          timeout=PROBE_TIMEOUT, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(f"probe exited {proc.returncode}: "
+                           f"{proc.stderr.strip()[:200]}")
+    snap: dict[str, dict] = {}
+    forced = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("TERMINAL:"):
+            forced = line.split(":", 1)[1].strip().split()[0].lower()
+            continue
+        # rpartition: unit names legitimately contain ':' (GitLab test:unit).
+        name, _, state = line.rpartition(":")
+        if not name:
+            continue
+        token = state.strip().lower().replace("-", "_")
+        snap[name.strip()] = {
+            "name": name.strip(), "state": token,
+            "active": token not in CUSTOM_SUCCESS | CUSTOM_FAILURE | CUSTOM_NEUTRAL,
+            "log": "(see provider logs)"}
+    return snap, forced
+
+
+def classify(entry: dict, custom: bool) -> str:
+    state = entry["state"]
+    s, f, n = ((CUSTOM_SUCCESS, CUSTOM_FAILURE, CUSTOM_NEUTRAL) if custom
+               else (GH_SUCCESS, GH_FAILURE, GH_NEUTRAL))
+    if state in s:
+        return "success"
+    if state in n:
+        return "neutral"
+    if entry.get("active") or state in ACTIVE:
+        return "active"   # honor the probe's own not-yet-terminal signal
+    return "failure"   # unknown *terminal* conclusions are never green
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sha", nargs="?", default=None)
+    p.add_argument("--repo", help="owner/name for gh; defaults to the checkout's")
+    p.add_argument("--branch", help="ref for supersession detection "
+                   "(auto-detected; omitted when detached)")
+    p.add_argument("--cmd", help="custom probe command (see module docstring)")
+    p.add_argument("--deadline", type=int, default=1800, help="overall seconds; "
+                   "size to the pipeline's p95 INCLUDING queue, plus headroom")
+    p.add_argument("--register", type=int, default=240,
+                   help="seconds a run may take to appear for this SHA")
+    p.add_argument("--settle", type=int, default=0,
+                   help="extra seconds to wait after green for chained "
+                   "workflow_run follow-ups to register")
+    p.add_argument("--interval", type=int, default=15)
+    p.add_argument("--heartbeat", type=int, default=150)
+    p.add_argument("--expect-none", action="store_true",
+                   help="path filters make zero runs normal; no-run exits 0")
+    a = p.parse_args()
+
+    # An unreachable no-run is strictly worse than a reachable one: if the
+    # registration window exceeds the deadline, every filtered commit reports
+    # as timeout instead.
+    a.register = min(a.register, max(30, a.deadline // 2))
+
+    sha = full_sha(a.sha or "HEAD")
+    short = sha[:7]
+    branch = a.branch
+    if branch is None:
+        try:
+            b = run(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+            branch = None if b == "HEAD" else b   # detached: no supersession
+        except Exception:
+            branch = None
+
+    start = time.monotonic()
+    seen: dict[str, str] = {}
+    prev_keys: frozenset = frozenset()
+    stable = False
+    green_since: float | None = None
+    errors = 0
+    last_beat = start
+    warned_super = False
+
+    def done(verdict: str, detail: str = "") -> int:
+        emit(f"CI-DONE {verdict}" + (f" -- {detail}" if detail else ""))
+        if verdict == "no-run" and a.expect_none:
+            return 0
+        return EXIT[verdict]
+
+    while True:
+        # Re-sample AFTER the probe as well -- a probe can take ~45s and the
+        # deadline check must not lag it.
+        if time.monotonic() - start > a.deadline:
+            return done("timeout", f"not terminal after {a.deadline}s -- "
+                        "inspect the run; stuck is not slow")
+        forced = None
+        try:
+            if a.cmd:
+                snap, forced = custom_probe(a.cmd, sha)
+            else:
+                snap = gh_probe(sha, a.repo, expand_jobs=True)
+            errors = 0
+        except Exception as exc:
+            errors += 1
+            if errors == WARN_STREAK:
+                emit(f"CI-WARN probe failing ({errors}x): {exc}")
+            if errors >= DEAD_STREAK:
+                return done("probe-dead",
+                            f"{errors} consecutive probe failures: {exc}")
+            time.sleep(a.interval)
+            continue
+
+        if forced:
+            return done(forced if forced in EXIT else "failure",
+                        f"probe declared TERMINAL: {forced}")
+
+        now = time.monotonic()
+        if not snap:
+            if now - start > a.register:
+                return done("no-run",
+                            f"nothing registered for {short} in {a.register}s")
+            time.sleep(a.interval)
+            continue
+
+        if not seen:
+            states = " · ".join(f"{v['name']}:{v['state']}"
+                                for v in list(snap.values())[:6])
+            emit(f"CI-RUN {short} registered: {states}")
+
+        for k, v in sorted(snap.items()):
+            if seen.get(k) != v["state"]:
+                arrow = f" -> {v['state']}" if k in seen else f": {v['state']}"
+                emit(f"CI-CHG {v['name']}{arrow}")
+                seen[k] = v["state"]
+                last_beat = now
+
+        keys = frozenset(snap)
+        stable = keys == prev_keys
+        prev_keys = keys
+
+        classes = {k: classify(v, bool(a.cmd)) for k, v in snap.items()}
+        run_classes = [c for k, c in classes.items() if "/" not in k]
+
+        # Precedence: an explicit red run answers "did this SHA pass" -- it is
+        # a failure even if the branch has moved on. Supersession only explains
+        # cancellation, never a real red.
+        failed = next((k for k, c in classes.items() if c == "failure"
+                       and not snap[k]["active"]), None)
+        if failed:
+            return done("failure",
+                        f"{snap[failed]['name']} -- logs: {snap[failed]['log']}")
+
+        if all(c != "active" for c in classes.values()):
+            # all([]) is True -- but snap is non-empty here, so a verdict on an
+            # empty poll cannot happen.
+            if any(c == "success" for c in run_classes):
+                if a.settle and green_since is None:
+                    green_since = now
+                if green_since is None or now - green_since >= a.settle:
+                    # Two-poll key-set stability: a fast workflow can finish
+                    # before a slower sibling even registers.
+                    if stable:
+                        return done("success", short)
+            else:
+                # Only neutral results. Cancelled by a newer push, or by hand?
+                tip = branch_tip(os.getcwd(), branch) if branch else None
+                if branch and tip is None and not warned_super:
+                    emit("CI-WARN cannot read origin tip; supersession "
+                         "detection is off")
+                    warned_super = True
+                if tip and tip != sha:
+                    return done("superseded",
+                                f"{short} cancelled; {branch} moved to {tip[:7]}")
+                return done("cancelled",
+                            f"only cancelled/neutral results for {short} on an "
+                            "unmoved branch -- not a pass, not a test failure")
+        else:
+            green_since = None   # something went active again; reset settle
+
+        if now - last_beat >= a.heartbeat:
+            mins, total = int((now - start) / 60), int(a.deadline / 60)
+            states = " · ".join(f"{v['name']}={v['state']}"
+                                for k, v in sorted(snap.items()) if "/" not in k)
+            emit(f"CI-HB {mins}/{total}m -- {states}")
+            last_beat = now
+
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        emit("CI-DONE timeout -- interrupted")
+        sys.exit(EXIT["timeout"])
+    except SystemExit:
+        raise  # a real verdict already printed; do not double-emit
+    except BaseException as exc:  # silence must be structurally impossible
+        emit(f"CI-DONE probe-dead -- {type(exc).__name__}: {exc}")
+        sys.exit(EXIT["probe-dead"])

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -54,6 +54,7 @@ CUSTOM_NEUTRAL = {"cancelled", "canceled", "skipped", "manual", "blocked",
                   "not_run", "neutral", "stale"}
 
 PROBE_TIMEOUT = 45      # one wedged request must not freeze the loop
+MAX_RUNS = 1000        # fail closed rather than green an incomplete enumeration
 WARN_STREAK = 3
 DEAD_STREAK = 10
 
@@ -91,18 +92,25 @@ def branch_tip(repo_dir: str, branch: str) -> str | None:
         return None
 
 
-def gh_probe(sha: str, repo: str | None, expand_jobs: bool) -> dict[str, dict]:
+def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
+             deadline_at: float) -> dict[str, dict]:
     """Return {key: {name, state, conclusion, log_cmd}} keyed by run/lane id.
 
     Keyed by id, never by workflow name: two runs of one workflow (re-run,
     workflow_dispatch) would otherwise overwrite each other and the diff-gate
     would flap forever.
     """
-    base = ["gh", "run", "list", "--commit", sha, "--limit", "50",
+    base = ["gh", "run", "list", "--commit", sha, "--limit", str(MAX_RUNS),
             "--json", "databaseId,workflowName,status,conclusion"]
     if repo:
         base += ["--repo", repo]
-    rows = json.loads(run(base) or "[]")
+    remaining = deadline_at - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired(base, 0)
+    rows = json.loads(run(base, max(1, min(PROBE_TIMEOUT, int(remaining)))) or "[]")
+    if len(rows) >= MAX_RUNS:
+        raise RuntimeError(f"at least {MAX_RUNS} runs match {sha[:7]}; "
+                           "refusing an incomplete verdict")
     snap: dict[str, dict] = {}
     for r in rows:
         rid = str(r["databaseId"])
@@ -111,30 +119,34 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool) -> dict[str, dict]:
         snap[rid] = {"name": r.get("workflowName") or rid, "state": state,
                      "active": (r.get("status") in ACTIVE), "log": log}
         # Run-level conclusion stays unset until every lane ends; expanding
-        # in-flight runs to job level surfaces the first red lane 20 minutes
-        # early. Bounded to active runs so the extra call is not paid per poll
-        # on completed ones.
+        # in-flight runs to job level surfaces the first red lane early. Each
+        # expansion is bounded by the watcher's remaining overall deadline.
         if expand_jobs and r.get("status") in ACTIVE:
+            left = deadline_at - time.monotonic()
+            if left <= 1:
+                break
             try:
                 jr = ["gh", "run", "view", rid, "--json", "jobs"]
                 if repo:
                     jr += ["--repo", repo]
-                for j in json.loads(run(jr)).get("jobs", []):
+                for j in json.loads(run(jr, max(1, min(PROBE_TIMEOUT, int(left))))).get("jobs", []):
                     jid = f"{rid}/{j.get('databaseId', j.get('name'))}"
                     jstate = j.get("conclusion") or j.get("status") or "unknown"
                     snap[jid] = {"name": f"{snap[rid]['name']}:{j.get('name')}",
                                  "state": jstate,
                                  "active": (j.get("status") in ACTIVE),
                                  "log": log}
+            except subprocess.TimeoutExpired:
+                break  # run rows remain authoritative; lane detail is optional
             except Exception:
                 pass  # lane detail is best-effort; the run row still verdicts
     return snap
 
 
-def custom_probe(cmd: str, sha: str) -> tuple[dict[str, dict], str | None]:
+def custom_probe(cmd: str, sha: str, timeout: int) -> tuple[dict[str, dict], str | None]:
     env = dict(os.environ, CI_WATCH_SHA=sha)
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
-                          timeout=PROBE_TIMEOUT, env=env)
+                          timeout=timeout, env=env)
     if proc.returncode != 0:
         raise RuntimeError(f"probe exited {proc.returncode}: "
                            f"{proc.stderr.strip()[:200]}")
@@ -148,13 +160,13 @@ def custom_probe(cmd: str, sha: str) -> tuple[dict[str, dict], str | None]:
             forced = line.split(":", 1)[1].strip().split()[0].lower()
             continue
         # rpartition: unit names legitimately contain ':' (GitLab test:unit).
-        name, _, state = line.rpartition(":")
-        if not name:
-            continue
+        name, separator, state = line.rpartition(":")
+        if not separator or not name.strip() or not state.strip():
+            raise RuntimeError(f"malformed probe line: {line[:200]}")
         token = state.strip().lower().replace("-", "_")
         snap[name.strip()] = {
             "name": name.strip(), "state": token,
-            "active": token not in CUSTOM_SUCCESS | CUSTOM_FAILURE | CUSTOM_NEUTRAL,
+            "active": token in ACTIVE | {"running"},
             "log": "(see provider logs)"}
     return snap, forced
 
@@ -172,9 +184,16 @@ def classify(entry: dict, custom: bool) -> str:
     return "failure"   # unknown *terminal* conclusions are never green
 
 
+class VerdictParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self.print_usage(sys.stderr)
+        emit(f"CI-DONE failure -- invalid arguments: {message}")
+        raise SystemExit(EXIT["failure"])
+
+
 def main() -> int:
-    p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = VerdictParser(description=__doc__,
+                      formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("sha", nargs="?", default=None)
     p.add_argument("--repo", help="owner/name for gh; defaults to the checkout's")
     p.add_argument("--branch", help="ref for supersession detection "
@@ -209,6 +228,7 @@ def main() -> int:
             branch = None
 
     start = time.monotonic()
+    deadline_at = start + a.deadline
     seen: dict[str, str] = {}
     prev_keys: frozenset = frozenset()
     stable = False
@@ -223,6 +243,9 @@ def main() -> int:
             return 0
         return EXIT[verdict]
 
+    def bounded_sleep() -> None:
+        time.sleep(max(0, min(a.interval, deadline_at - time.monotonic())))
+
     while True:
         # Re-sample AFTER the probe as well -- a probe can take ~45s and the
         # deadline check must not lag it.
@@ -231,10 +254,16 @@ def main() -> int:
                         "inspect the run; stuck is not slow")
         forced = None
         try:
+            remaining = deadline_at - time.monotonic()
+            if remaining <= 0:
+                return done("timeout", f"not terminal after {a.deadline}s -- "
+                            "inspect the run; stuck is not slow")
             if a.cmd:
-                snap, forced = custom_probe(a.cmd, sha)
+                snap, forced = custom_probe(
+                    a.cmd, sha, max(1, min(PROBE_TIMEOUT, int(remaining))))
             else:
-                snap = gh_probe(sha, a.repo, expand_jobs=True)
+                snap = gh_probe(sha, a.repo, expand_jobs=True,
+                                deadline_at=deadline_at)
             errors = 0
         except Exception as exc:
             errors += 1
@@ -243,7 +272,7 @@ def main() -> int:
             if errors >= DEAD_STREAK:
                 return done("probe-dead",
                             f"{errors} consecutive probe failures: {exc}")
-            time.sleep(a.interval)
+            bounded_sleep()
             continue
 
         if forced:
@@ -252,10 +281,10 @@ def main() -> int:
 
         now = time.monotonic()
         if not snap:
-            if now - start > a.register:
+            if not seen and now - start > a.register:
                 return done("no-run",
                             f"nothing registered for {short} in {a.register}s")
-            time.sleep(a.interval)
+            bounded_sleep()
             continue
 
         if not seen:
@@ -275,7 +304,8 @@ def main() -> int:
         prev_keys = keys
 
         classes = {k: classify(v, bool(a.cmd)) for k, v in snap.items()}
-        run_classes = [c for k, c in classes.items() if "/" not in k]
+        run_classes = (list(classes.values()) if a.cmd else
+                       [c for k, c in classes.items() if "/" not in k])
 
         # Precedence: an explicit red run answers "did this SHA pass" -- it is
         # a failure even if the branch has moved on. Supersession only explains
@@ -289,27 +319,34 @@ def main() -> int:
         if all(c != "active" for c in classes.values()):
             # all([]) is True -- but snap is non-empty here, so a verdict on an
             # empty poll cannot happen.
-            if any(c == "success" for c in run_classes):
-                if a.settle and green_since is None:
-                    green_since = now
-                if green_since is None or now - green_since >= a.settle:
-                    # Two-poll key-set stability: a fast workflow can finish
-                    # before a slower sibling even registers.
-                    if stable:
-                        return done("success", short)
+            all_success = run_classes and all(c == "success" for c in run_classes)
+            if all_success:
+                if now - start >= a.register:
+                    if a.settle and green_since is None:
+                        green_since = now
+                    if green_since is None or now - green_since >= a.settle:
+                        # Two-poll key-set stability catches late siblings after
+                        # the full registration window has elapsed.
+                        if stable:
+                            return done("success", short)
             else:
-                # Only neutral results. Cancelled by a newer push, or by hand?
+                # At least one run is neutral. Cancelled by a newer push, or by
+                # hand? Mixed success/neutral is not an all-green verdict.
                 tip = branch_tip(os.getcwd(), branch) if branch else None
-                if branch and tip is None and not warned_super:
-                    emit("CI-WARN cannot read origin tip; supersession "
-                         "detection is off")
-                    warned_super = True
+                if branch and tip is None:
+                    if not warned_super:
+                        emit("CI-WARN cannot read origin tip; retrying "
+                             "supersession detection")
+                        warned_super = True
+                    bounded_sleep()
+                    continue
                 if tip and tip != sha:
                     return done("superseded",
                                 f"{short} cancelled; {branch} moved to {tip[:7]}")
                 return done("cancelled",
-                            f"only cancelled/neutral results for {short} on an "
-                            "unmoved branch -- not a pass, not a test failure")
+                            f"cancelled/neutral results prevent all-green for "
+                            f"{short} on an unmoved branch -- not a pass, not a "
+                            "test failure")
         else:
             green_since = None   # something went active again; reset settle
 

--- a/skills/ci-cd-optimize/README.md
+++ b/skills/ci-cd-optimize/README.md
@@ -1,6 +1,6 @@
 # ci-cd-optimize
 
-Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification.
+Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, exact-artifact verification, and the agent feedback loop that waits on CI without stalling.
 
 **Category:** ops
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use skill if you are diagnosing or optimizing slow CI/CD, reducing queue/setup/test/deploy time, migrating runners or caches, or building an agent workflow that waits on CI without stalling.
 metadata:
   author: yigitkonur
-  version: 1.0.0
+  version: 1.1.0
   category: devops
   tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, typescript, swift, xcode, pipeline-performance]
 ---
@@ -59,7 +59,7 @@ Apply the performance order before adding compute:
 Ask in order:
 
 1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
+2. Is queue time the dominant p95 contributor, or does queue share look high enough that topology work may backfire? Read `references/runners-and-autoscaling.md` and `references/measurement.md`.
 3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
 4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
 5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
@@ -168,7 +168,9 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Pitfall | Better move |
 |---|---|
 | Optimizing before measuring | Capture baseline queue/setup/execution/critical path first. |
-| Duplicate `push` and PR runs | Trigger PRs on PR events; trigger main/release pushes only. |
+| Branch-tip or id-less watch used as the only signal | Pin the exact SHA, wait for registration, then watch the explicit run id or a SHA-pinned script. |
+| Success-only watch filter | Emit every terminal verdict; silence must never read as green. |
+| Queue-dominated wall clock reported as a speed regression | Split queue from execution before naming the bottleneck. |
 | Draft PRs start expensive jobs | Keep planner cheap; gate expensive jobs until ready for review. |
 | Caching `node_modules` by default | Cache the package-manager store; measure restore versus install. |
 | Workflow path filter blocks required checks | Run a cheap change-detection job and condition expensive jobs. |
@@ -210,6 +212,12 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
 | `references/ci-feedback-loop.md` | Watching a run without hanging: registration races, non-TTY watchers, terminal verdicts, agent monitor wiring, and verifying the watcher's own failure paths. |
+
+## Bundled script
+
+| Path | Use when |
+|---|---|
+| `scripts/ci-watch.py` | You need a concrete SHA-pinned watcher for GitHub Actions or a provider-neutral probe contract to adapt for another CI system. Read `references/ci-feedback-loop.md` first so you know what the script guarantees and what its verdicts mean. |
 
 ### Optional: Avrea reference kit
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -39,6 +39,8 @@ Rules:
 
 Prefer the platform's own aggregated history over hand-collected timings when it exists, then verify sample size and window. If the repository runs on Avrea (`runs-on:` labels begin with `avrea-`) and `avr` is installed and authenticated, read `references/avrea/cli-evidence.md` — it returns median/p95, per-job start offsets, flake counts, and cache hit counts directly. Confirm availability with `command -v avr && avr auth status` before depending on it, and fall back to provider-native measurement otherwise.
 
+**Feedback loop rule:** after any change you validate through CI, arm a watcher that is pinned to the exact pushed SHA and that always terminates with an explicit verdict. Never rely on a branch-tip or "latest in-progress" watch as your only signal; registration races make them report "nothing running" before the provider has indexed your commit. Read `references/ci-feedback-loop.md` when choosing or implementing the watch path (Monitor vs one-shot background wait, registration deadline, terminal verdicts, failure-first reaction policy).
+
 For the metric definitions, baseline protocol, and the rule about claiming only the evidence rung you reached, read `references/measurement.md`.
 
 ### 3. Find the critical path
@@ -71,6 +73,7 @@ Ask in order:
 13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
 14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
 15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+16. Is the *feedback loop* itself the bottleneck — watches that hang, return nothing, or need a human to babysit them, especially in a CI-only workflow with no local build? Read `references/ci-feedback-loop.md`.
 
 ### 4. Choose one bounded experiment
 
@@ -82,6 +85,8 @@ Select the smallest reversible change that attacks the measured critical path. E
 - security/trust-boundary risk,
 - cost effect,
 - rollback or fallback.
+
+**If the repository is CI-only (no trusted local build/test path), optimizing the feedback loop is mandatory work, not polish.** A watch command that can exit before your run registers, or wait forever with no terminal verdict, leaves the agent blind to the result and turns every CI cycle into manual babysitting. Read `references/ci-feedback-loop.md` before you recommend a provider watch command or wire one into the Monitor tool.
 
 Prefer, in this order: prevent unneeded work → cancel stale work → reuse verified prior work → improve cache correctness → remove artificial dependencies → parallelize independent work → shard slow work by measured duration → reduce transferred bytes → improve runner capacity → move heavy work off the PR path only with a full-run fallback → change provider architecture.
 
@@ -204,6 +209,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
+| `references/ci-feedback-loop.md` | Watching a run without hanging: registration races, non-TTY watchers, terminal verdicts, agent monitor wiring, and verifying the watcher's own failure paths. |
 
 ### Optional: Avrea reference kit
 

--- a/skills/ci-cd-optimize/references/avrea/cli-evidence.md
+++ b/skills/ci-cd-optimize/references/avrea/cli-evidence.md
@@ -126,12 +126,46 @@ avr run logs run-xxx --follow                # tail an in-progress job
 The project rule "verify the green, never hang on it" has direct support:
 
 ```bash
-avr run watch --repo org/app --exit-status   # non-zero if the run failed
-avr workflow run ci.yml --ref my-branch --watch --exit-status
-avr run watch run-xxx --ndjson | jq -c .     # event stream for scripting
+avr workflow run ci.yml --ref my-branch --watch --exit-status  # dispatch + watch in one call
+avr run watch run-xxx --exit-status                            # explicit run id
+avr run watch run-xxx --ndjson | jq -c .                       # line-oriented event stream
 ```
 
-`--exit-status` makes failure and timeout observable instead of silent. Always confirm `head_sha` matches the commit under test before accepting a green:
+`--exit-status` makes failure observable instead of silent, and `--ndjson`
+avoids the TTY-redraw problem that breaks line-oriented consumers.
+
+**Do not use the id-less form as your only signal after a push.** With no
+`RUN_ID`, `avr run watch` auto-selects the *latest in-progress* run. Observed on
+a live repository (2026-07-28): pushing and immediately arming
+`avr run watch --repo org/app --ndjson --exit-status` printed
+
+```
+Looking for an in-progress run…
+No in-progress workflow runs found for these repos.
+```
+
+and exited **0** — before the run had been indexed. An agent reads that as "no
+problem" and proceeds unverified. The same shape bites when a concurrency group
+cancels the run you meant to watch, or when another branch's run is newer.
+
+Wait for a run matching your exact SHA, then watch that id:
+
+```bash
+SHA=$(git rev-parse HEAD)
+for _ in $(seq 1 30); do
+  RUN=$(avr run list --repo org/app --limit 20 --json run_id,head_sha \
+        -q --arg s "$SHA" '[.[]|select(.head_sha==$s)][0].run_id // empty')
+  [ -n "$RUN" ] && break; sleep 10
+done
+[ -n "$RUN" ] || { echo "no run registered for $SHA"; exit 1; }
+avr run watch "$RUN" --ndjson --exit-status
+```
+
+For the general contract this satisfies — registration window, terminal verdict
+on every path, heartbeats, and wiring to an agent monitor — read
+`references/ci-feedback-loop.md`.
+
+Always confirm `head_sha` matches the commit under test before accepting a green:
 
 ```bash
 avr run view run-xxx --json head_sha,conclusion,status,run_attempt

--- a/skills/ci-cd-optimize/references/caching.md
+++ b/skills/ci-cd-optimize/references/caching.md
@@ -34,9 +34,28 @@ Cache the package-manager store/cache, not blindly `node_modules`:
 | Yarn modern | `yarn install --immutable` | Yarn global cache or committed Zero-Install cache |
 | Bun | `bun ci` | Bun install cache |
 
-Key by lockfile, Node version, package-manager version, OS, and architecture. Compare restore time with a clean install; large stores can be slower than a registry fetch on a nearby network.
+## Package proxy versus store cache
 
-## Restore-key discipline
+A fast install does not prove the local package-manager store is helping. On
+runner platforms with a colocated registry proxy, a "cold" install can still be
+LAN-fast because the proxy, not the local store, is doing the work.
+
+Use this break-even test before keeping a large dependency-store cache:
+
+1. Compare a true cold run against a warm run on the same lockfile.
+2. Measure **install time**, not just cache hit counts.
+3. Compare that with the restore/save/archive cost of the store cache itself.
+
+If the install time is essentially unchanged cold and warm, the local store
+archive may only be moving bytes around. Remove it and keep the proxy.
+
+## Manifest-only changes are not safe on lockfile keys alone
+
+For package-tree caches, key on the manifest **and** the lockfile. A
+manifest-only change can still change what should be installed or tested even
+when the lockfile stays constant. A cache keyed only on the lockfile can then
+restore a stale dependency tree and make the run look green for the wrong input
+set.
 
 Use narrow restore keys from most-specific to less-specific:
 

--- a/skills/ci-cd-optimize/references/change-based-ci.md
+++ b/skills/ci-cd-optimize/references/change-based-ci.md
@@ -65,9 +65,25 @@ jobs:
 
 Ensure the provider reports skipped downstream jobs as successful/skipped in the way branch protection expects.
 
-## Full-run triggers
+## Planner self-routing and rename traps
 
-Always run the full suite when:
+The component that decides what runs is part of the repository too. Treat it as
+load-bearing code, not as harmless glue.
+
+Two easy ways change-based CI lies to you:
+
+1. **Self-routing planner.** A planner change that routes only to its own lane is
+   grading its own homework. Changes to CI config, planner code, workflow files,
+   or shared routing tables should usually escalate broadly rather than proving
+   only themselves.
+2. **Rename masking.** A move from `src/x.ts` to `docs/x.md` can look
+   documentation-only if you only inspect the destination path. When the source
+   path was executable code, the pipeline must still treat the change as code.
+   Prefer `--name-status` or disable rename detection when classifying if your
+   tool would otherwise hide the removal.
+
+Keep tiny fixture-style tests for the classifier itself. A routing bug is one of
+few CI defects that can silently ship without any red lane at all.
 
 - merge base is missing or suspicious,
 - lockfile or package-manager config changed,

--- a/skills/ci-cd-optimize/references/ci-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/ci-feedback-loop.md
@@ -1,0 +1,201 @@
+# CI feedback loop: watching a run without hanging
+
+Read when an agent (or a human in a non-interactive shell) needs to learn a CI
+result, when a watch command "returns nothing", when a monitor stays armed after
+a run finished, or when a pipeline is CI-only so every verification round-trips
+through the provider.
+
+Optimizing pipeline seconds is wasted if the agent then blocks for twenty
+minutes on a broken watch, or worse, silently concludes "no news, must be fine."
+The feedback loop is part of the critical path.
+
+## The four failure modes
+
+Each is common, each has been observed in practice, and each is silent.
+
+**1. Registration race.** You push, immediately ask the provider "what is
+running?", and get nothing — the run has not been created or indexed yet.
+Auto-selecting watchers (`gh run watch` with no id, `avr run watch` with no id)
+exit successfully with "no in-progress runs". The agent reads success. Nothing
+was verified. *Fix: poll for a run matching your exact SHA, with its own
+registration deadline, before watching anything.*
+
+**2. Non-TTY output.** Interactive watchers redraw with ANSI cursor control
+instead of emitting lines, and some suppress the completion summary entirely
+when stdout is not a terminal. A line-oriented consumer sees a blob, or nothing.
+*Fix: prefer a line/NDJSON mode when the CLI has one; otherwise poll an API and
+print your own lines.*
+
+**3. No deadline of its own.** A watch inherits no timeout. If a run never
+registers, a check never reports, or the API returns 5xx in a streak, the
+watcher waits forever. Harness-level timeouts eventually fire, but you have
+burned the budget and learned nothing. *Fix: a hard ceiling that exits with an
+explicit `timeout` verdict.*
+
+**4. Success-only filters.** `grep "passed"` looks identical whether the run is
+still going, crashed, was cancelled, or never started. **Silence is not
+success.** *Fix: emit a terminal verdict on every path, including failure,
+cancellation, timeout, and never-registered.*
+
+## The contract a watcher must satisfy
+
+Anything you build or adopt should guarantee:
+
+| Property | Why |
+|---|---|
+| **SHA-pinned** | A branch-tip watch can report a green from someone else's newer push, or a stale run from before your change. Verification must bind to the commit you pushed. |
+| **Terminal on every path** | `success`, `failure`, `cancelled`, `timeout`, `no-run`, `superseded`. Silence must be structurally impossible. |
+| **Registration window** | Bounded wait for the run to appear, separate from the run's own deadline. |
+| **Change-gated output** | Emit on state transitions, not every poll. Repeated identical lines flood the transcript and get monitors auto-killed. |
+| **Per-probe timeout** | One wedged HTTP request must not freeze the loop. |
+| **Error tolerance** | Transient 5xx happens; retry quietly, exit loudly after a streak. |
+| **Heartbeat** | A periodic progress line proves liveness during long queues without flooding. |
+| **Actionable failure** | The failure line should carry the command that shows the logs. |
+
+## Event vocabulary
+
+A compact, greppable stream. Prefixes matter more than exact words — pick one
+scheme and keep it stable so filters and humans can both read it.
+
+```
+CI-RUN  <sha> registered: build:queued · test:queued
+CI-CHG  test: in_progress
+CI-CHG  test: completed -> failure
+CI-HB   6/30m — build=completed/success test=in_progress/-
+CI-DONE failure — test — logs: <exact command to view them>
+```
+
+Reaction policy: act on the first `CI-CHG … -> failure` immediately rather than
+waiting for `CI-DONE`; on a long pipeline that is a large head start on the fix.
+Acknowledge `CI-HB` silently. Treat `CI-DONE no-run` as "verification did not
+happen", never as success.
+
+## Reference implementation
+
+Provider-neutral shape. Substitute the provider query; the control flow is the
+point.
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+SHA="${1:-$(git rev-parse HEAD)}"
+DEADLINE=1800; REGISTER=300; HEARTBEAT=150; POLL=10
+
+# One probe, individually timed out, returning JSON for this SHA only.
+probe() { timeout 25 <provider-cli> list --json ... ; }
+done_with() { echo "CI-DONE $1${2:+ — $2}"; exit 0; }
+
+start=$SECONDS
+# Phase 1 — registration, with its own deadline.
+while [ $((SECONDS-start)) -lt "$REGISTER" ]; do
+  runs="$(probe | jq -c --arg s "$SHA" '[.[]|select(.head_sha==$s)]')"
+  [ "$(jq length <<<"$runs")" -gt 0 ] && break
+  sleep "$POLL"
+done
+[ "$(jq length <<<"${runs:-[]}")" -gt 0 ] || done_with no-run "nothing registered for ${SHA:0:7}"
+echo "CI-RUN ${SHA:0:7} registered"
+
+# Phase 2 — change-gated polling until every run is terminal.
+prev=""; errors=0; beat=$SECONDS
+while [ $((SECONDS-start)) -lt "$DEADLINE" ]; do
+  snap="$(probe | jq -c --arg s "$SHA" '[.[]|select(.head_sha==$s)]')"
+  if [ -z "$snap" ]; then
+    errors=$((errors+1))
+    [ "$errors" -ge 10 ] && done_with failure "provider unreachable for 10 probes"
+    sleep "$POLL"; continue
+  fi
+  errors=0
+  cur="$(jq -r 'sort_by(.id)|map("\(.name)=\(.status)/\(.conclusion//"-")")|join(" ")' <<<"$snap")"
+  if [ "$cur" != "$prev" ]; then
+    jq -r '.[]|"CI-CHG \(.name): \(.status)\(if .conclusion then " -> \(.conclusion)" else "" end)"' <<<"$snap"
+    prev="$cur"; beat=$SECONDS
+  elif [ $((SECONDS-beat)) -ge "$HEARTBEAT" ]; then
+    echo "CI-HB $(((SECONDS-start)/60))/$((DEADLINE/60))m — $cur"; beat=$SECONDS
+  fi
+  if [ "$(jq '[.[]|select(.status!="completed")]|length' <<<"$snap")" -eq 0 ]; then
+    bad="$(jq -r '[.[]|select(.conclusion=="failure" or .conclusion=="timed_out")][0].name // empty' <<<"$snap")"
+    [ -n "$bad" ] && done_with failure "$bad — logs: <cli> view <id> --log-failed"
+    [ "$(jq '[.[]|select(.conclusion=="cancelled")]|length' <<<"$snap")" -gt 0 ] \
+      && done_with superseded "a newer push replaced ${SHA:0:7}"
+    done_with success "${SHA:0:7}"
+  fi
+  sleep "$POLL"
+done
+done_with timeout "still running after $((DEADLINE/60))m"
+```
+
+Shell notes that cost real debugging time: in `zsh`, `status` is a **readonly**
+builtin variable — assigning it aborts the script, so name your variables
+`state`/`verdict`. Every pipe stage must flush per line (`grep --line-buffered`,
+`awk '{...; fflush()}'`); `| head -N` buffers until N matches and can strand the
+stream entirely.
+
+## Wiring it to an agent monitor
+
+Two different tools for two different needs. Choosing wrong is the usual cause
+of a stuck agent.
+
+**One notification, when a condition becomes true** — use a backgrounded
+command that *exits* when the condition holds:
+
+```
+Bash(run_in_background: true,
+     command: "until <condition>; do sleep 5; done")
+```
+
+**A stream of events as they occur** — use the streaming monitor, with a command
+that terminates on its own:
+
+```
+Monitor(command: "scripts/ci-watch.sh <sha> --deadline 1500",
+        description: "CI for <branch>",
+        timeout_ms: 1500000)
+```
+
+Rules that keep this reliable:
+
+- **Never arm an unbounded command for a one-shot answer.** `tail -f`,
+  `while true`, and `inotifywait -m` never exit, so the monitor stays armed long
+  after the event fired and eventually dies on timeout instead of completing.
+- **Set the monitor timeout above the watcher's own deadline**, so the *script*
+  decides the outcome and reports a verdict, rather than the harness killing it
+  with no explanation.
+- **Filter to lines you would act on.** Piping raw CI logs generates a
+  notification per line; high-volume monitors get stopped automatically.
+- **One watch per pushed SHA.** Re-pushing supersedes the old run — let the old
+  watcher exit `superseded` and arm a new one rather than reasoning about two
+  overlapping streams.
+- **Do not poll from the main loop while a monitor is armed.** Duplicated
+  polling wastes budget and produces contradictory readings.
+
+## Making the watch cheap to arm
+
+The loop is only followed if it is one command. Commit the watcher to the
+repository (`scripts/ci-watch.sh`) rather than expecting an agent to retype a
+poll loop each time — hand-rolled loops are where the four failure modes above
+reappear. Document the exact invocation in `AGENTS.md`/`CONTRIBUTING.md` next to
+the push instruction, and state the expected duration so an agent can tell
+"slow" from "stuck".
+
+If the platform offers a native line-oriented watch (`--ndjson`, `--json`,
+`--exit-status`), prefer it *inside* the script for the streaming phase, but
+keep your own registration window and deadline around it. Native watches solve
+output shape; they generally do not solve registration, deadline, or SHA
+pinning.
+
+## Verifying the watcher itself
+
+A watcher is verification infrastructure, so test its failure paths before
+trusting it — the same standard applied to any other gate:
+
+1. **no-run** — invoke against a SHA that has no runs; it must exit with
+   `no-run` inside the registration window, not hang.
+2. **failure** — push a deliberately broken commit (a type error is cheap and
+   unambiguous); it must report `failure` and print a working logs command.
+   Revert immediately afterward.
+3. **success** — a normal green push produces `CI-DONE success`.
+4. **superseded** (if your pipeline cancels stale runs) — push twice quickly;
+   the first watch should end `superseded`, not `failure`.
+
+Until those paths are exercised, "the watcher works" is a config-review claim,
+not a verified one.

--- a/skills/ci-cd-optimize/references/ci-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/ci-feedback-loop.md
@@ -92,11 +92,23 @@ point.
 #!/usr/bin/env bash
 set -uo pipefail
 SHA="${1:-$(git rev-parse HEAD)}"
-DEADLINE=1800; REGISTER=300; HEARTBEAT=150; POLL=10
+DEADLINE="${DEADLINE:-1800}"; REGISTER="${REGISTER:-300}"
+HEARTBEAT="${HEARTBEAT:-150}"; POLL="${POLL:-10}"
 
 # One probe, individually timed out, returning JSON for this SHA only.
 probe() { timeout 25 <provider-cli> list --json ... ; }
-done_with() { echo "CI-DONE $1${2:+ — $2}"; exit 0; }
+done_with() {
+  verdict="$1"
+  echo "CI-DONE $verdict${2:+ — $2}"
+  case "$verdict" in
+    success) exit 0 ;;
+    failure) exit 1 ;;
+    no-run) exit 2 ;;
+    superseded|cancelled) exit 3 ;;
+    timeout) exit 124 ;;
+    *) exit 2 ;;
+  esac
+}
 
 start=$SECONDS
 # Phase 1 — registration, with its own deadline.
@@ -160,9 +172,9 @@ Bash(run_in_background: true,
 that terminates on its own:
 
 ```
-Monitor(command: "scripts/ci-watch.sh <sha> --deadline 1500",
+Monitor(command: "DEADLINE=1500 scripts/ci-watch.sh <sha>",
         description: "CI for <branch>",
-        timeout_ms: 1500000)
+        timeout_ms: 1560000)
 ```
 
 Rules that keep this reliable:

--- a/skills/ci-cd-optimize/references/ci-feedback-loop.md
+++ b/skills/ci-cd-optimize/references/ci-feedback-loop.md
@@ -9,6 +9,19 @@ Optimizing pipeline seconds is wasted if the agent then blocks for twenty
 minutes on a broken watch, or worse, silently concludes "no news, must be fine."
 The feedback loop is part of the critical path.
 
+## Fast triage
+
+| Symptom | Most likely cause | Go to |
+|---|---|---|
+| Watch returns instantly, reports nothing running | Registration race — armed before the run was indexed | Failure mode 1 |
+| Watch prints a garbled blob, or nothing, then exits 0 | Non-TTY redraw output | Failure mode 2 |
+| Watch never returns; harness timeout kills it | No deadline of its own | Failure mode 3 |
+| Run failed but the agent proceeded as if green | Success-only filter; silence read as success | Failure mode 4 |
+| Monitor stays armed long after the run ended | Unbounded command (`tail -f`, `while true`) | Wiring it to an agent monitor |
+| Monitor auto-stopped mid-run | Output volume; every line became a notification | Wiring it to an agent monitor |
+| Green reported for someone else's commit | Branch-tip watch instead of SHA-pinned | The contract |
+| Old run reports failure right after you re-push | Concurrency cancellation, not a real failure | `superseded` verdict |
+
 ## The four failure modes
 
 Each is common, each has been observed in practice, and each is silent.
@@ -199,3 +212,29 @@ trusting it — the same standard applied to any other gate:
 
 Until those paths are exercised, "the watcher works" is a config-review claim,
 not a verified one.
+
+## Distinguishing "slow" from "stuck"
+
+Long waits are not automatically a defect. Before treating a slow run as a
+problem, split the wall clock:
+
+- **Queue time** (created → started) is provider capacity. On a measured
+  repository it ranged 10s–193s within a single hour on identical config, while
+  execution held steady at 11–13s. Nothing in the workflow file changes that.
+- **Execution time** (started → completed) is yours to optimize.
+
+A watcher that heartbeats with elapsed time lets an agent tell the difference
+without polling. Report the two separately; presenting a queue-dominated wall
+clock as a regression sends the next optimization round after the wrong target.
+
+## Sources
+
+- Failure taxonomy and the diff-gated / guaranteed-exit design are modeled on
+  `yigitkonur/plugin-ci-watch-unstall` (README, accessed 2026-07-28), which
+  documents the same `gh run watch` non-TTY and no-deadline problems.
+- Registration-race behavior, `--ndjson` output shape, and the queue-vs-execution
+  spread were observed directly against `avr` 0.1.6 on a live repository
+  (2026-07-28); the id-less watch exiting 0 with "No in-progress workflow runs
+  found" is a reproduced observation, not a vendor-documented behavior.
+- `zsh` readonly `status` and pipe-buffering pitfalls were hit and fixed while
+  building the reference implementation above.

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -16,9 +16,42 @@ Use this file when building a baseline, proving a bottleneck, or validating that
 | Cost per successful change | compute + storage / successful changes | Speed improvements that increase total cost may not be wins. |
 | Change failure/rework rate | failed or unplanned recovery deployments / deployments | The effectiveness guardrail after optimization. |
 
-Use median and p95. CI duration is right-skewed; averages hide cold caches, runner saturation, flaky retries, and dependency changes.
+## Queue versus execution — never collapse them
 
-## Baseline protocol
+A workflow duration can worsen while the work itself stays flat. Split them
+before naming a bottleneck:
+
+- **Queue** = `started_at - created_at`
+- **Execution** = `completed_at - started_at`
+
+This is not bookkeeping trivia. On a measured repository, six comparable runs
+showed execution holding in a narrow band while queue ranged from seconds to
+minutes. Quoting a multiplier from total wall-clock alone would have reported
+both "2.6× slower" and "1.7× faster" for the same configuration, depending on
+which queue sample you chose.
+
+For reusable workflows and `needs`-gated jobs, note the subtlety: `created_at`
+may be set only after dependencies finish. That means a multi-stage DAG pays its
+queue/setup tax once per stage. When the platform exposes per-job start offsets,
+use them to reconstruct the real critical path rather than trusting stage names.
+
+## Sampling traps
+
+Before trusting a comparison, actively rule out the three easiest false claims:
+
+1. **Re-read, not re-run.** Confirm the attempt counter actually changed. Three
+   identical durations to the tenth of a second are usually the same run read
+   three times.
+2. **Mixed populations.** Do not compare `push`, `pull_request`, and
+   `workflow_dispatch` together; those often carry different runners, queues,
+   and job sets.
+3. **Self-inflicted contention.** Bursting several experiments at once can move
+   the queue more than the optimization moved execution. Interleave A/B arms, or
+   compare execution when pool state is clearly different.
+
+A robust p95 needs a real sample. Roughly 20+ comparable runs is arithmetic,
+not evidence by itself; below that, say you have a small cohort rather than a
+stable tail.
 
 1. Pin the exact commit, workflow, event, runner class, and environment.
 2. Run at least three comparable runs when variance is material.

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -49,6 +49,9 @@ Before trusting a comparison, actively rule out the three easiest false claims:
    the queue more than the optimization moved execution. Interleave A/B arms, or
    compare execution when pool state is clearly different.
 
+Averages hide the variance that makes CI painful: cold caches, runner
+saturation, flaky retries, and dependency changes. Report the median for the
+typical path and p95 for the tail instead of treating one mean as representative.
 A robust p95 needs a real sample. Roughly 20+ comparable runs is arithmetic,
 not evidence by itself; below that, say you have a small cohort rather than a
 stable tail.

--- a/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -32,9 +32,50 @@ Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
 Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.
 
-## Spot capacity
+## Capacity and contention before topology work
 
-Use spot/preemptible runners only for short, idempotent, retryable, or checkpointed jobs. Keep an on-demand fallback and never run the controller/manager on spot. Do not use spot for deployment gates where interruption is costly.
+Parallelizing a pipeline above its effective runner ceiling often makes it look
+busier and run no faster. A useful approximation is:
+
+```text
+wall-clock ≈ queue + ceil(job_count / effective_concurrency) × (per-job setup + execution)
+```
+
+That model is coarse — jobs are not really uniform — but it tells you when the
+next job split is likely to re-pay setup rather than buy wall-clock.
+
+A practical routing heuristic is **queue share**:
+
+```text
+queue share = Σ queue time / (Σ queue time + Σ execution time)
+```
+
+Measured over a representative window:
+
+| Queue share | Read it as | Usually do this next |
+|---|---|---|
+| <15% | Work dominates | Normal optimization: caching, sharding, DAG shape |
+| 15–35% | Mixed | Improve execution, but stop adding jobs |
+| >35% | Capacity dominates | Reduce job count or raise the ceiling |
+
+Above roughly a third, adding more jobs is often the wrong move even when the
+DAG looks cleaner.
+
+## Detect the effective ceiling empirically
+
+Do not assume the documented plan limit equals the concurrency you actually get.
+Org-wide contention, runner-class scarcity, and autoscaler warm-up often bite
+first. Look for jobs created together whose `started_at` values cluster into
+waves separated by about one job duration. That means the ceiling is below the
+job count, even if the provider docs advertise something larger.
+
+## Compare execution when pool state differs
+
+If runner contention is uneven, compare **execution** for in-job changes and use
+wall-clock only when the queue regime is comparable. A bigger runner can make a
+CPU-bound step faster while still making the total workflow slower if its queue
+is materially worse. That is not a contradiction; it is why queue and execution
+must be reported separately.
 
 ## Architecture and OS
 

--- a/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -32,6 +32,13 @@ Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
 Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.
 
+## Spot capacity
+
+Use spot/preemptible runners only for short, idempotent, retryable, or
+checkpointed jobs. Keep an on-demand fallback and never run the
+controller/manager on spot. Do not use spot for deployment gates where an
+interruption is costly.
+
 ## Capacity and contention before topology work
 
 Parallelizing a pipeline above its effective runner ceiling often makes it look

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -66,7 +66,7 @@ def emit(line: str) -> None:
     print(line, flush=True)
 
 
-def run(cmd: list[str], timeout: int = PROBE_TIMEOUT) -> str:
+def run(cmd: list[str], timeout: float = PROBE_TIMEOUT) -> str:
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
                           check=True).stdout
 
@@ -79,14 +79,14 @@ def full_sha(candidate: str) -> str:
     return run(["git", "rev-parse", candidate]).strip()
 
 
-def branch_tip(repo_dir: str, branch: str) -> str | None:
+def branch_tip(repo_dir: str, branch: str, timeout: float) -> str | None:
     # The remote ref is the only correct source for supersession. The latest
     # *run*'s head SHA is wrong: before the newest push registers, it is an
     # older commit, and a watcher using it reports a commit superseded by its
     # own ancestor.
     try:
         out = run(["git", "-C", repo_dir, "ls-remote", "origin",
-                   f"refs/heads/{branch}"])
+                   f"refs/heads/{branch}"], timeout)
         return out.split()[0] if out.strip() else None
     except Exception:
         return None
@@ -107,7 +107,7 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
     remaining = deadline_at - time.monotonic()
     if remaining <= 0:
         raise subprocess.TimeoutExpired(base, 0)
-    rows = json.loads(run(base, max(1, min(PROBE_TIMEOUT, int(remaining)))) or "[]")
+    rows = json.loads(run(base, min(PROBE_TIMEOUT, remaining)) or "[]")
     if len(rows) >= MAX_RUNS:
         raise RuntimeError(f"at least {MAX_RUNS} runs match {sha[:7]}; "
                            "refusing an incomplete verdict")
@@ -129,7 +129,7 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
                 jr = ["gh", "run", "view", rid, "--json", "jobs"]
                 if repo:
                     jr += ["--repo", repo]
-                for j in json.loads(run(jr, max(1, min(PROBE_TIMEOUT, int(left))))).get("jobs", []):
+                for j in json.loads(run(jr, min(PROBE_TIMEOUT, left))).get("jobs", []):
                     jid = f"{rid}/{j.get('databaseId', j.get('name'))}"
                     jstate = j.get("conclusion") or j.get("status") or "unknown"
                     snap[jid] = {"name": f"{snap[rid]['name']}:{j.get('name')}",
@@ -143,7 +143,7 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
     return snap
 
 
-def custom_probe(cmd: str, sha: str, timeout: int) -> tuple[dict[str, dict], str | None]:
+def custom_probe(cmd: str, sha: str, timeout: float) -> tuple[dict[str, dict], str | None]:
     env = dict(os.environ, CI_WATCH_SHA=sha)
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
                           timeout=timeout, env=env)
@@ -260,7 +260,7 @@ def main() -> int:
                             "inspect the run; stuck is not slow")
             if a.cmd:
                 snap, forced = custom_probe(
-                    a.cmd, sha, max(1, min(PROBE_TIMEOUT, int(remaining))))
+                    a.cmd, sha, min(PROBE_TIMEOUT, remaining))
             else:
                 snap = gh_probe(sha, a.repo, expand_jobs=True,
                                 deadline_at=deadline_at)
@@ -332,7 +332,13 @@ def main() -> int:
             else:
                 # At least one run is neutral. Cancelled by a newer push, or by
                 # hand? Mixed success/neutral is not an all-green verdict.
-                tip = branch_tip(os.getcwd(), branch) if branch else None
+                remaining = deadline_at - time.monotonic()
+                if remaining <= 0:
+                    return done("timeout", f"not terminal after {a.deadline}s -- "
+                                "inspect the run; stuck is not slow")
+                tip = branch_tip(
+                    os.getcwd(), branch,
+                    min(PROBE_TIMEOUT, remaining)) if branch else None
                 if branch and tip is None:
                     if not warned_super:
                         emit("CI-WARN cannot read origin tip; retrying "
@@ -357,7 +363,7 @@ def main() -> int:
             emit(f"CI-HB {mins}/{total}m -- {states}")
             last_beat = now
 
-        time.sleep(a.interval)
+        bounded_sleep()
 
 
 if __name__ == "__main__":

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -62,6 +62,10 @@ EXIT = {"success": 0, "failure": 1, "no-run": 2, "probe-dead": 2,
         "superseded": 3, "cancelled": 3, "timeout": 124}
 
 
+class IncompleteEnumeration(RuntimeError):
+    """The provider result cap prevents a complete, trustworthy verdict."""
+
+
 def emit(line: str) -> None:
     print(line, flush=True)
 
@@ -109,8 +113,9 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
         raise subprocess.TimeoutExpired(base, 0)
     rows = json.loads(run(base, min(PROBE_TIMEOUT, remaining)) or "[]")
     if len(rows) >= MAX_RUNS:
-        raise RuntimeError(f"at least {MAX_RUNS} runs match {sha[:7]}; "
-                           "refusing an incomplete verdict")
+        raise IncompleteEnumeration(
+            f"at least {MAX_RUNS} runs match {sha[:7]}; "
+            "refusing an incomplete verdict")
     snap: dict[str, dict] = {}
     for r in rows:
         rid = str(r["databaseId"])
@@ -265,6 +270,8 @@ def main() -> int:
                 snap = gh_probe(sha, a.repo, expand_jobs=True,
                                 deadline_at=deadline_at)
             errors = 0
+        except IncompleteEnumeration as exc:
+            return done("failure", f"incomplete run enumeration: {exc}")
         except Exception as exc:
             errors += 1
             if errors == WARN_STREAK:

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""ci-watch.py -- watch CI for one exact commit; always end with a verdict.
+
+Usage:
+    scripts/ci-watch.py [SHA] [options]                # GitHub mode (needs gh)
+    scripts/ci-watch.py [SHA] --cmd '<probe>' [options]  # any provider
+
+Every exit path prints exactly one terminal line:
+
+    CI-DONE <verdict> [-- detail]
+
+Verdicts and exit codes:
+    success     0    every registered run reached an explicit success
+    failure     1    a run (or lane) failed -- the line carries the log command
+    no-run      2    nothing registered within the registration window
+                     (exit 0 with --expect-none: path filters make this normal)
+    probe-dead  2    the probe itself failed repeatedly -- check auth/network
+    superseded  3    only cancelled/neutral results and the branch tip moved on
+    cancelled   3    cancelled on an unmoved branch -- manual or infra, not a
+                     test failure; not a pass either
+    timeout     124  still not terminal at the deadline -- stuck, not slow
+
+Interpret 'no-run', 'probe-dead', and 'timeout' as *you still do not know* --
+never record any of them as a pass. 'success' is decided by enumerating explicit
+success conclusions; unknown conclusions count as failure, never as green.
+
+Custom probe contract (--cmd): the command runs with $CI_WATCH_SHA set and must
+print one "name: state" line per unit of work. Printing "TERMINAL: <verdict>"
+ends the watch immediately with that verdict. A non-zero probe exit counts as a
+probe error (streak of 10 -> probe-dead), not as a pipeline failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+# Explicit success set: a verdict is green only when matched here. "Did not
+# fail" is not green -- cancel-in-progress concurrency manufactures cancelled
+# runs on every superseded push, and unknown states must never pass silently.
+GH_SUCCESS = {"success"}
+GH_FAILURE = {"failure", "timed_out", "startup_failure", "action_required"}
+GH_NEUTRAL = {"cancelled", "skipped", "stale", "neutral"}
+ACTIVE = {"queued", "in_progress", "waiting", "pending", "requested"}
+
+CUSTOM_SUCCESS = {"success", "succeeded", "passed", "pass", "ok", "green", "live", "fixed"}
+CUSTOM_FAILURE = {"failed", "failure", "error", "errored", "broken", "red"}
+CUSTOM_NEUTRAL = {"cancelled", "canceled", "skipped", "manual", "blocked",
+                  "not_run", "neutral", "stale"}
+
+PROBE_TIMEOUT = 45      # one wedged request must not freeze the loop
+WARN_STREAK = 3
+DEAD_STREAK = 10
+
+EXIT = {"success": 0, "failure": 1, "no-run": 2, "probe-dead": 2,
+        "superseded": 3, "cancelled": 3, "timeout": 124}
+
+
+def emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def run(cmd: list[str], timeout: int = PROBE_TIMEOUT) -> str:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
+                          check=True).stdout
+
+
+def full_sha(candidate: str) -> str:
+    # gh's --commit filter silently returns ZERO rows for a short SHA, which a
+    # registration window would then misreport as no-run. Normalize first.
+    if len(candidate) == 40:
+        return candidate
+    return run(["git", "rev-parse", candidate]).strip()
+
+
+def branch_tip(repo_dir: str, branch: str) -> str | None:
+    # The remote ref is the only correct source for supersession. The latest
+    # *run*'s head SHA is wrong: before the newest push registers, it is an
+    # older commit, and a watcher using it reports a commit superseded by its
+    # own ancestor.
+    try:
+        out = run(["git", "-C", repo_dir, "ls-remote", "origin",
+                   f"refs/heads/{branch}"])
+        return out.split()[0] if out.strip() else None
+    except Exception:
+        return None
+
+
+def gh_probe(sha: str, repo: str | None, expand_jobs: bool) -> dict[str, dict]:
+    """Return {key: {name, state, conclusion, log_cmd}} keyed by run/lane id.
+
+    Keyed by id, never by workflow name: two runs of one workflow (re-run,
+    workflow_dispatch) would otherwise overwrite each other and the diff-gate
+    would flap forever.
+    """
+    base = ["gh", "run", "list", "--commit", sha, "--limit", "50",
+            "--json", "databaseId,workflowName,status,conclusion"]
+    if repo:
+        base += ["--repo", repo]
+    rows = json.loads(run(base) or "[]")
+    snap: dict[str, dict] = {}
+    for r in rows:
+        rid = str(r["databaseId"])
+        state = r.get("conclusion") or r.get("status") or "unknown"
+        log = f"gh run view {rid} --log-failed" + (f" --repo {repo}" if repo else "")
+        snap[rid] = {"name": r.get("workflowName") or rid, "state": state,
+                     "active": (r.get("status") in ACTIVE), "log": log}
+        # Run-level conclusion stays unset until every lane ends; expanding
+        # in-flight runs to job level surfaces the first red lane 20 minutes
+        # early. Bounded to active runs so the extra call is not paid per poll
+        # on completed ones.
+        if expand_jobs and r.get("status") in ACTIVE:
+            try:
+                jr = ["gh", "run", "view", rid, "--json", "jobs"]
+                if repo:
+                    jr += ["--repo", repo]
+                for j in json.loads(run(jr)).get("jobs", []):
+                    jid = f"{rid}/{j.get('databaseId', j.get('name'))}"
+                    jstate = j.get("conclusion") or j.get("status") or "unknown"
+                    snap[jid] = {"name": f"{snap[rid]['name']}:{j.get('name')}",
+                                 "state": jstate,
+                                 "active": (j.get("status") in ACTIVE),
+                                 "log": log}
+            except Exception:
+                pass  # lane detail is best-effort; the run row still verdicts
+    return snap
+
+
+def custom_probe(cmd: str, sha: str) -> tuple[dict[str, dict], str | None]:
+    env = dict(os.environ, CI_WATCH_SHA=sha)
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                          timeout=PROBE_TIMEOUT, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(f"probe exited {proc.returncode}: "
+                           f"{proc.stderr.strip()[:200]}")
+    snap: dict[str, dict] = {}
+    forced = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("TERMINAL:"):
+            forced = line.split(":", 1)[1].strip().split()[0].lower()
+            continue
+        # rpartition: unit names legitimately contain ':' (GitLab test:unit).
+        name, _, state = line.rpartition(":")
+        if not name:
+            continue
+        token = state.strip().lower().replace("-", "_")
+        snap[name.strip()] = {
+            "name": name.strip(), "state": token,
+            "active": token not in CUSTOM_SUCCESS | CUSTOM_FAILURE | CUSTOM_NEUTRAL,
+            "log": "(see provider logs)"}
+    return snap, forced
+
+
+def classify(entry: dict, custom: bool) -> str:
+    state = entry["state"]
+    s, f, n = ((CUSTOM_SUCCESS, CUSTOM_FAILURE, CUSTOM_NEUTRAL) if custom
+               else (GH_SUCCESS, GH_FAILURE, GH_NEUTRAL))
+    if state in s:
+        return "success"
+    if state in n:
+        return "neutral"
+    if entry.get("active") or state in ACTIVE:
+        return "active"   # honor the probe's own not-yet-terminal signal
+    return "failure"   # unknown *terminal* conclusions are never green
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sha", nargs="?", default=None)
+    p.add_argument("--repo", help="owner/name for gh; defaults to the checkout's")
+    p.add_argument("--branch", help="ref for supersession detection "
+                   "(auto-detected; omitted when detached)")
+    p.add_argument("--cmd", help="custom probe command (see module docstring)")
+    p.add_argument("--deadline", type=int, default=1800, help="overall seconds; "
+                   "size to the pipeline's p95 INCLUDING queue, plus headroom")
+    p.add_argument("--register", type=int, default=240,
+                   help="seconds a run may take to appear for this SHA")
+    p.add_argument("--settle", type=int, default=0,
+                   help="extra seconds to wait after green for chained "
+                   "workflow_run follow-ups to register")
+    p.add_argument("--interval", type=int, default=15)
+    p.add_argument("--heartbeat", type=int, default=150)
+    p.add_argument("--expect-none", action="store_true",
+                   help="path filters make zero runs normal; no-run exits 0")
+    a = p.parse_args()
+
+    # An unreachable no-run is strictly worse than a reachable one: if the
+    # registration window exceeds the deadline, every filtered commit reports
+    # as timeout instead.
+    a.register = min(a.register, max(30, a.deadline // 2))
+
+    sha = full_sha(a.sha or "HEAD")
+    short = sha[:7]
+    branch = a.branch
+    if branch is None:
+        try:
+            b = run(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+            branch = None if b == "HEAD" else b   # detached: no supersession
+        except Exception:
+            branch = None
+
+    start = time.monotonic()
+    seen: dict[str, str] = {}
+    prev_keys: frozenset = frozenset()
+    stable = False
+    green_since: float | None = None
+    errors = 0
+    last_beat = start
+    warned_super = False
+
+    def done(verdict: str, detail: str = "") -> int:
+        emit(f"CI-DONE {verdict}" + (f" -- {detail}" if detail else ""))
+        if verdict == "no-run" and a.expect_none:
+            return 0
+        return EXIT[verdict]
+
+    while True:
+        # Re-sample AFTER the probe as well -- a probe can take ~45s and the
+        # deadline check must not lag it.
+        if time.monotonic() - start > a.deadline:
+            return done("timeout", f"not terminal after {a.deadline}s -- "
+                        "inspect the run; stuck is not slow")
+        forced = None
+        try:
+            if a.cmd:
+                snap, forced = custom_probe(a.cmd, sha)
+            else:
+                snap = gh_probe(sha, a.repo, expand_jobs=True)
+            errors = 0
+        except Exception as exc:
+            errors += 1
+            if errors == WARN_STREAK:
+                emit(f"CI-WARN probe failing ({errors}x): {exc}")
+            if errors >= DEAD_STREAK:
+                return done("probe-dead",
+                            f"{errors} consecutive probe failures: {exc}")
+            time.sleep(a.interval)
+            continue
+
+        if forced:
+            return done(forced if forced in EXIT else "failure",
+                        f"probe declared TERMINAL: {forced}")
+
+        now = time.monotonic()
+        if not snap:
+            if now - start > a.register:
+                return done("no-run",
+                            f"nothing registered for {short} in {a.register}s")
+            time.sleep(a.interval)
+            continue
+
+        if not seen:
+            states = " · ".join(f"{v['name']}:{v['state']}"
+                                for v in list(snap.values())[:6])
+            emit(f"CI-RUN {short} registered: {states}")
+
+        for k, v in sorted(snap.items()):
+            if seen.get(k) != v["state"]:
+                arrow = f" -> {v['state']}" if k in seen else f": {v['state']}"
+                emit(f"CI-CHG {v['name']}{arrow}")
+                seen[k] = v["state"]
+                last_beat = now
+
+        keys = frozenset(snap)
+        stable = keys == prev_keys
+        prev_keys = keys
+
+        classes = {k: classify(v, bool(a.cmd)) for k, v in snap.items()}
+        run_classes = [c for k, c in classes.items() if "/" not in k]
+
+        # Precedence: an explicit red run answers "did this SHA pass" -- it is
+        # a failure even if the branch has moved on. Supersession only explains
+        # cancellation, never a real red.
+        failed = next((k for k, c in classes.items() if c == "failure"
+                       and not snap[k]["active"]), None)
+        if failed:
+            return done("failure",
+                        f"{snap[failed]['name']} -- logs: {snap[failed]['log']}")
+
+        if all(c != "active" for c in classes.values()):
+            # all([]) is True -- but snap is non-empty here, so a verdict on an
+            # empty poll cannot happen.
+            if any(c == "success" for c in run_classes):
+                if a.settle and green_since is None:
+                    green_since = now
+                if green_since is None or now - green_since >= a.settle:
+                    # Two-poll key-set stability: a fast workflow can finish
+                    # before a slower sibling even registers.
+                    if stable:
+                        return done("success", short)
+            else:
+                # Only neutral results. Cancelled by a newer push, or by hand?
+                tip = branch_tip(os.getcwd(), branch) if branch else None
+                if branch and tip is None and not warned_super:
+                    emit("CI-WARN cannot read origin tip; supersession "
+                         "detection is off")
+                    warned_super = True
+                if tip and tip != sha:
+                    return done("superseded",
+                                f"{short} cancelled; {branch} moved to {tip[:7]}")
+                return done("cancelled",
+                            f"only cancelled/neutral results for {short} on an "
+                            "unmoved branch -- not a pass, not a test failure")
+        else:
+            green_since = None   # something went active again; reset settle
+
+        if now - last_beat >= a.heartbeat:
+            mins, total = int((now - start) / 60), int(a.deadline / 60)
+            states = " · ".join(f"{v['name']}={v['state']}"
+                                for k, v in sorted(snap.items()) if "/" not in k)
+            emit(f"CI-HB {mins}/{total}m -- {states}")
+            last_beat = now
+
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        emit("CI-DONE timeout -- interrupted")
+        sys.exit(EXIT["timeout"])
+    except SystemExit:
+        raise  # a real verdict already printed; do not double-emit
+    except BaseException as exc:  # silence must be structurally impossible
+        emit(f"CI-DONE probe-dead -- {type(exc).__name__}: {exc}")
+        sys.exit(EXIT["probe-dead"])

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -54,6 +54,7 @@ CUSTOM_NEUTRAL = {"cancelled", "canceled", "skipped", "manual", "blocked",
                   "not_run", "neutral", "stale"}
 
 PROBE_TIMEOUT = 45      # one wedged request must not freeze the loop
+MAX_RUNS = 1000        # fail closed rather than green an incomplete enumeration
 WARN_STREAK = 3
 DEAD_STREAK = 10
 
@@ -91,18 +92,25 @@ def branch_tip(repo_dir: str, branch: str) -> str | None:
         return None
 
 
-def gh_probe(sha: str, repo: str | None, expand_jobs: bool) -> dict[str, dict]:
+def gh_probe(sha: str, repo: str | None, expand_jobs: bool,
+             deadline_at: float) -> dict[str, dict]:
     """Return {key: {name, state, conclusion, log_cmd}} keyed by run/lane id.
 
     Keyed by id, never by workflow name: two runs of one workflow (re-run,
     workflow_dispatch) would otherwise overwrite each other and the diff-gate
     would flap forever.
     """
-    base = ["gh", "run", "list", "--commit", sha, "--limit", "50",
+    base = ["gh", "run", "list", "--commit", sha, "--limit", str(MAX_RUNS),
             "--json", "databaseId,workflowName,status,conclusion"]
     if repo:
         base += ["--repo", repo]
-    rows = json.loads(run(base) or "[]")
+    remaining = deadline_at - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired(base, 0)
+    rows = json.loads(run(base, max(1, min(PROBE_TIMEOUT, int(remaining)))) or "[]")
+    if len(rows) >= MAX_RUNS:
+        raise RuntimeError(f"at least {MAX_RUNS} runs match {sha[:7]}; "
+                           "refusing an incomplete verdict")
     snap: dict[str, dict] = {}
     for r in rows:
         rid = str(r["databaseId"])
@@ -111,30 +119,34 @@ def gh_probe(sha: str, repo: str | None, expand_jobs: bool) -> dict[str, dict]:
         snap[rid] = {"name": r.get("workflowName") or rid, "state": state,
                      "active": (r.get("status") in ACTIVE), "log": log}
         # Run-level conclusion stays unset until every lane ends; expanding
-        # in-flight runs to job level surfaces the first red lane 20 minutes
-        # early. Bounded to active runs so the extra call is not paid per poll
-        # on completed ones.
+        # in-flight runs to job level surfaces the first red lane early. Each
+        # expansion is bounded by the watcher's remaining overall deadline.
         if expand_jobs and r.get("status") in ACTIVE:
+            left = deadline_at - time.monotonic()
+            if left <= 1:
+                break
             try:
                 jr = ["gh", "run", "view", rid, "--json", "jobs"]
                 if repo:
                     jr += ["--repo", repo]
-                for j in json.loads(run(jr)).get("jobs", []):
+                for j in json.loads(run(jr, max(1, min(PROBE_TIMEOUT, int(left))))).get("jobs", []):
                     jid = f"{rid}/{j.get('databaseId', j.get('name'))}"
                     jstate = j.get("conclusion") or j.get("status") or "unknown"
                     snap[jid] = {"name": f"{snap[rid]['name']}:{j.get('name')}",
                                  "state": jstate,
                                  "active": (j.get("status") in ACTIVE),
                                  "log": log}
+            except subprocess.TimeoutExpired:
+                break  # run rows remain authoritative; lane detail is optional
             except Exception:
                 pass  # lane detail is best-effort; the run row still verdicts
     return snap
 
 
-def custom_probe(cmd: str, sha: str) -> tuple[dict[str, dict], str | None]:
+def custom_probe(cmd: str, sha: str, timeout: int) -> tuple[dict[str, dict], str | None]:
     env = dict(os.environ, CI_WATCH_SHA=sha)
     proc = subprocess.run(cmd, shell=True, capture_output=True, text=True,
-                          timeout=PROBE_TIMEOUT, env=env)
+                          timeout=timeout, env=env)
     if proc.returncode != 0:
         raise RuntimeError(f"probe exited {proc.returncode}: "
                            f"{proc.stderr.strip()[:200]}")
@@ -148,13 +160,13 @@ def custom_probe(cmd: str, sha: str) -> tuple[dict[str, dict], str | None]:
             forced = line.split(":", 1)[1].strip().split()[0].lower()
             continue
         # rpartition: unit names legitimately contain ':' (GitLab test:unit).
-        name, _, state = line.rpartition(":")
-        if not name:
-            continue
+        name, separator, state = line.rpartition(":")
+        if not separator or not name.strip() or not state.strip():
+            raise RuntimeError(f"malformed probe line: {line[:200]}")
         token = state.strip().lower().replace("-", "_")
         snap[name.strip()] = {
             "name": name.strip(), "state": token,
-            "active": token not in CUSTOM_SUCCESS | CUSTOM_FAILURE | CUSTOM_NEUTRAL,
+            "active": token in ACTIVE | {"running"},
             "log": "(see provider logs)"}
     return snap, forced
 
@@ -172,9 +184,16 @@ def classify(entry: dict, custom: bool) -> str:
     return "failure"   # unknown *terminal* conclusions are never green
 
 
+class VerdictParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self.print_usage(sys.stderr)
+        emit(f"CI-DONE failure -- invalid arguments: {message}")
+        raise SystemExit(EXIT["failure"])
+
+
 def main() -> int:
-    p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = VerdictParser(description=__doc__,
+                      formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("sha", nargs="?", default=None)
     p.add_argument("--repo", help="owner/name for gh; defaults to the checkout's")
     p.add_argument("--branch", help="ref for supersession detection "
@@ -209,6 +228,7 @@ def main() -> int:
             branch = None
 
     start = time.monotonic()
+    deadline_at = start + a.deadline
     seen: dict[str, str] = {}
     prev_keys: frozenset = frozenset()
     stable = False
@@ -223,6 +243,9 @@ def main() -> int:
             return 0
         return EXIT[verdict]
 
+    def bounded_sleep() -> None:
+        time.sleep(max(0, min(a.interval, deadline_at - time.monotonic())))
+
     while True:
         # Re-sample AFTER the probe as well -- a probe can take ~45s and the
         # deadline check must not lag it.
@@ -231,10 +254,16 @@ def main() -> int:
                         "inspect the run; stuck is not slow")
         forced = None
         try:
+            remaining = deadline_at - time.monotonic()
+            if remaining <= 0:
+                return done("timeout", f"not terminal after {a.deadline}s -- "
+                            "inspect the run; stuck is not slow")
             if a.cmd:
-                snap, forced = custom_probe(a.cmd, sha)
+                snap, forced = custom_probe(
+                    a.cmd, sha, max(1, min(PROBE_TIMEOUT, int(remaining))))
             else:
-                snap = gh_probe(sha, a.repo, expand_jobs=True)
+                snap = gh_probe(sha, a.repo, expand_jobs=True,
+                                deadline_at=deadline_at)
             errors = 0
         except Exception as exc:
             errors += 1
@@ -243,7 +272,7 @@ def main() -> int:
             if errors >= DEAD_STREAK:
                 return done("probe-dead",
                             f"{errors} consecutive probe failures: {exc}")
-            time.sleep(a.interval)
+            bounded_sleep()
             continue
 
         if forced:
@@ -252,10 +281,10 @@ def main() -> int:
 
         now = time.monotonic()
         if not snap:
-            if now - start > a.register:
+            if not seen and now - start > a.register:
                 return done("no-run",
                             f"nothing registered for {short} in {a.register}s")
-            time.sleep(a.interval)
+            bounded_sleep()
             continue
 
         if not seen:
@@ -275,7 +304,8 @@ def main() -> int:
         prev_keys = keys
 
         classes = {k: classify(v, bool(a.cmd)) for k, v in snap.items()}
-        run_classes = [c for k, c in classes.items() if "/" not in k]
+        run_classes = (list(classes.values()) if a.cmd else
+                       [c for k, c in classes.items() if "/" not in k])
 
         # Precedence: an explicit red run answers "did this SHA pass" -- it is
         # a failure even if the branch has moved on. Supersession only explains
@@ -289,27 +319,34 @@ def main() -> int:
         if all(c != "active" for c in classes.values()):
             # all([]) is True -- but snap is non-empty here, so a verdict on an
             # empty poll cannot happen.
-            if any(c == "success" for c in run_classes):
-                if a.settle and green_since is None:
-                    green_since = now
-                if green_since is None or now - green_since >= a.settle:
-                    # Two-poll key-set stability: a fast workflow can finish
-                    # before a slower sibling even registers.
-                    if stable:
-                        return done("success", short)
+            all_success = run_classes and all(c == "success" for c in run_classes)
+            if all_success:
+                if now - start >= a.register:
+                    if a.settle and green_since is None:
+                        green_since = now
+                    if green_since is None or now - green_since >= a.settle:
+                        # Two-poll key-set stability catches late siblings after
+                        # the full registration window has elapsed.
+                        if stable:
+                            return done("success", short)
             else:
-                # Only neutral results. Cancelled by a newer push, or by hand?
+                # At least one run is neutral. Cancelled by a newer push, or by
+                # hand? Mixed success/neutral is not an all-green verdict.
                 tip = branch_tip(os.getcwd(), branch) if branch else None
-                if branch and tip is None and not warned_super:
-                    emit("CI-WARN cannot read origin tip; supersession "
-                         "detection is off")
-                    warned_super = True
+                if branch and tip is None:
+                    if not warned_super:
+                        emit("CI-WARN cannot read origin tip; retrying "
+                             "supersession detection")
+                        warned_super = True
+                    bounded_sleep()
+                    continue
                 if tip and tip != sha:
                     return done("superseded",
                                 f"{short} cancelled; {branch} moved to {tip[:7]}")
                 return done("cancelled",
-                            f"only cancelled/neutral results for {short} on an "
-                            "unmoved branch -- not a pass, not a test failure")
+                            f"cancelled/neutral results prevent all-green for "
+                            f"{short} on an unmoved branch -- not a pass, not a "
+                            "test failure")
         else:
             green_since = None   # something went active again; reset settle
 


### PR DESCRIPTION
## Summary
This turns `ci-cd-optimize` from a good generic CI-speed skill into a more complete workflow-centered one.

### What changed
- add a **provider-neutral CI feedback-loop reference** (`references/ci-feedback-loop.md`) focused on the hardest operational part of CI-only workflows: getting reliable feedback without hanging, false greens, or silent no-run cases
- add a **bundled watcher implementation** (`scripts/ci-watch.py`) with verified terminal verdicts, SHA pinning, registration deadline, heartbeat, supersession detection, custom-probe mode, and explicit exit codes
- strengthen the **main SKILL.md router** so agents think in the right order: measure first, separate queue from execution, treat the feedback loop as part of the critical path, and route to Avrea docs only when the repo actually runs on Avrea
- enrich the generic references with the best ideas from the other open PRs:
  - `measurement.md`: queue vs execution split, sampling traps, self-contention
  - `runners-and-autoscaling.md`: queue-share heuristic, effective concurrency / contention guidance
  - `caching.md`: package-proxy vs local-store break-even, manifest+lockfile keying
  - `change-based-ci.md`: planner self-routing and rename traps
  - `references/avrea/cli-evidence.md`: fix the unsafe id-less `avr run watch` advice and point to the new watcher contract
- regenerate the Codex/plugin mirror and marketplace metadata

## Why this is better than the earlier PR
PR #82 started by patching the biggest observed hole: agents waiting on CI badly.
After reviewing the other 10 open PRs and my own real execution traces, the larger problem became clearer:

1. **A CI skill is incomplete if it only tells you how to make runs faster, but not how to hear back from them safely.**
2. **A generic skill should separate universal rules from platform-specific accelerators.**
3. **The feedback loop itself needs the same evidence discipline as the pipeline.**

This PR consolidates the best ideas conceptually rather than just copying text:
- from the sibling PRs: verdict vocabularies, registration-race handling, queue-share thinking, break-even caching, provider-specific watch caveats, and agent reaction policy
- from real measured use on `mcp-researchpowerpack`: `avr` registration races, non-blocking monitoring, runner-class queue tails, Node tool-cache misses, package-proxy behavior, and real failure/success/no-run tests of the watcher itself

## Validation performed
### Skill repo
- `python3 scripts/validate-skills.py` passes
- `python3 scripts/gen-marketplace.py` regenerated cleanly
- all new cross-references resolve
- SKILL frontmatter remains valid and trigger-oriented

### Watcher implementation
Tested directly against live CI on a real repository:
- **green SHA** -> `CI-DONE success`, exit 0
- **red SHA** -> `CI-DONE failure -- ... --log-failed`, exit 1
- **no-run SHA** -> `CI-DONE no-run`, exit 2
- **no-run with --expect-none** -> `CI-DONE no-run`, exit 0
- **probe-dead** -> `CI-DONE probe-dead`, exit 2
- **timeout** -> `CI-DONE timeout`, exit 124
- **custom probe success/failure** -> correct verdicts

One real implementation defect surfaced during this pass (`SystemExit` double-emission) and was fixed before pushing. Another (`custom active-state mismatch`) also surfaced and was fixed. So the bundled script was not only written — it was derailment-tested.

## Scope / philosophy
This stays generic:
- no TypeScript-specific assumptions in the top-level workflow
- no hard dependency on Avrea in the main skill body
- Avrea content stays in the optional Avrea kit
- the bundled watcher is GitHub-first because that is the most common case, but its `--cmd` mode is provider-neutral by contract

## Notes
I did **not** run evals. Instead, I applied the same discipline the repo's own skill-authoring standards ask for:
- read the current skill and references first
- study neighboring PRs and harvest only the best ideas
- test the operational artifact on real tasks
- fix where it actually derailed
