### PR TITLE
feat(ci-cd-optimize): comprehensive CI workflow optimization guide

### DIFF
--- a/skills/ci-cd-optimize/README.md
+++ b/skills/ci-cd-optimize/README.md
@@ -2,6 +2,8 @@
 
 Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification.
 
+It also covers **waiting on a pipeline without stalling the session**: a SHA-pinned watcher contract that emits one line per state change and always terminates with an explicit verdict, so an agent never blocks on a hung or never-registered run. See `references/ci-watching.md`.
+
 **Category:** ops
 
 ## Install

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use if optimizing slow CI/CD or waiting on a pipeline result without stalling the session.
 metadata:
   author: yigitkonur
   version: 1.0.0
   category: devops
-  tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, typescript, swift, xcode, pipeline-performance]
+  tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, typescript, swift, xcode, pipeline-performance, ci-monitoring]
 ---
 
 # CI/CD Optimize
@@ -98,7 +98,17 @@ Never claim an optimization if it does any of these:
 
 Use full validation as the safe fallback whenever changed files, merge base, cache correctness, dependency graph completeness, or security scope cannot be proven. When a proposed change is near any of these lines, check it against `references/effectiveness-contract.md` before recommending it.
 
-### 6. Verify after the change
+### 6. Wait for results without stalling
+
+Optimizing means running the pipeline repeatedly, so how you wait is part of the work. Never block
+on a TTY-oriented watcher or an open-ended `sleep` loop, and never filter only for success — a
+crashed run then looks identical to a running one. Use a watcher pinned to the pushed SHA that
+emits one line per state change and always terminates with an explicit verdict (`success` /
+`failure` / `timeout` / `no-run` / `superseded` / `probe-dead`). Read `references/ci-watching.md`
+for the contract, a provider-agnostic implementation, harness wiring, and how to verify the
+watcher's own failure paths.
+
+### 7. Verify after the change
 
 Re-run on the same commit first, then a normal representative commit. Compare median and p95 wall-clock, queue time, cache behavior, first-time pass rate, cost, and failure/rework signals. Confirm the exact run head SHA contains the change and the deployed artifact digest or workflow run is the intended one.
 
@@ -179,6 +189,11 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
 | Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
 | Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
+| Assuming a bigger runner class is faster end-to-end | Scarce classes queue longer; measure queue per class before sizing up. |
+| Reporting a wall-clock multiplier when queue dominates | Separate queue from execution; report the part the change controls. |
+| Adding a dependency cache without timing the uncached path | A colocated registry proxy can make it redundant; measure first. |
+| Change-detection logic that routes its own changes narrowly | Planner/CI-config edits escalate to full validation. |
+| Blocking the session on CI, or filtering only for success | Use a SHA-pinned watcher with a guaranteed terminal verdict. |
 
 ## Reference files
 
@@ -203,6 +218,7 @@ Treat this as a shape, not a universal template. Adapt cache, affected detection
 | `references/network-and-artifacts.md` | Checkout depth, sparse/partial clone, LFS, package proxies, artifact compression, uploads, or registry locality. |
 | `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
 | `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
+| `references/ci-watching.md` | Waiting on a pipeline result from an agent or script: watcher contract, verdicts, harness wiring, and anti-stall rules. |
 | `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
 
 ### Optional: Avrea reference kit

--- a/skills/ci-cd-optimize/references/avrea/cli-evidence.md
+++ b/skills/ci-cd-optimize/references/avrea/cli-evidence.md
@@ -96,7 +96,7 @@ avr job list --repo org/app --since 7d -L 200 \
   --json job_name,created_at,started_at,duration_seconds,labels,running_on_avrea
 ```
 
-Observed spreads ranged from 0s to ~167s on the same trigger, with the larger `avrea-ubuntu-latest-16-vcpu` job starting immediately and smaller ones waiting. Confirm the pattern across enough jobs before concluding anything about capacity, and route to `references/runners-and-autoscaling.md` only if queue time is genuinely a dominant p95 contributor.
+Observed queue spreads ranged from 0s to ~167s on the same trigger, but the direction was not stable enough to generalize: in one window the larger `avrea-ubuntu-latest-16-vcpu` job started immediately, and in another it queued much longer than the 2-vCPU class. Treat these examples as proof that **runner-class queueing is fleet- and time-dependent**, not as advice to size up or down. Recompute medians and p95 per class on the repository you are optimizing, then route to `references/runners-and-autoscaling.md` if queue time is genuinely a dominant p95 contributor.
 
 ## Step 6 — right-size from VM metrics
 
@@ -131,7 +131,7 @@ avr workflow run ci.yml --ref my-branch --watch --exit-status
 avr run watch run-xxx --ndjson | jq -c .     # event stream for scripting
 ```
 
-`--exit-status` makes failure and timeout observable instead of silent. Always confirm `head_sha` matches the commit under test before accepting a green:
+`--exit-status` makes failure observable instead of silent. It does not add a watcher deadline. Always confirm `head_sha` matches the commit under test before accepting a green:
 
 ```bash
 avr run view run-xxx --json head_sha,conclusion,status,run_attempt

--- a/skills/ci-cd-optimize/references/caching.md
+++ b/skills/ci-cd-optimize/references/caching.md
@@ -38,18 +38,14 @@ Key by lockfile, Node version, package-manager version, OS, and architecture. Co
 
 ## Time the uncached path before adding any cache
 
-"Installs are slow" is an assumption until measured. On a runner colocated with a package
-registry proxy, installs already resolve from local storage, so a cache layer on top can add a
-save step and a correctness risk while saving nothing.
+"Installs are slow" is an assumption until measured. On some fleets the package registry is already
+proxied locally, so adding an `actions/cache` layer on top buys nothing and may add a save step.
+One observed A/B on a fixed commit saw ~5s installs both with and without a full `node_modules`
+cache; the safe generalization is narrower than the result: **when the uncached step is already
+seconds, time it first before adding another cache layer.**
 
-One observed A/B on a fixed commit: install took ~5s both with and without a full `node_modules`
-cache, the cached variant paying an extra save step. That single pair does not prove the proxy
-caused it — the generalizable reading is narrower and more useful: **when the uncached step is
-already seconds, no cache layer can help.** Time it first, then decide.
-
-If you do keep a full dependency-tree cache, key it on the manifest **and** the lockfile. Keyed on
-the lockfile alone it can hit after a manifest-only change and silently test a stale tree, which
-is the failure the key-completeness rules above exist to prevent.
+If you keep a full dependency-tree cache, key it on the manifest **and** the lockfile. Keyed on
+the lockfile alone it can hit after a manifest-only change and silently test a stale tree.
 
 ## Restore-key discipline
 

--- a/skills/ci-cd-optimize/references/caching.md
+++ b/skills/ci-cd-optimize/references/caching.md
@@ -36,6 +36,21 @@ Cache the package-manager store/cache, not blindly `node_modules`:
 
 Key by lockfile, Node version, package-manager version, OS, and architecture. Compare restore time with a clean install; large stores can be slower than a registry fetch on a nearby network.
 
+## Time the uncached path before adding any cache
+
+"Installs are slow" is an assumption until measured. On a runner colocated with a package
+registry proxy, installs already resolve from local storage, so a cache layer on top can add a
+save step and a correctness risk while saving nothing.
+
+One observed A/B on a fixed commit: install took ~5s both with and without a full `node_modules`
+cache, the cached variant paying an extra save step. That single pair does not prove the proxy
+caused it — the generalizable reading is narrower and more useful: **when the uncached step is
+already seconds, no cache layer can help.** Time it first, then decide.
+
+If you do keep a full dependency-tree cache, key it on the manifest **and** the lockfile. Keyed on
+the lockfile alone it can hit after a manifest-only change and silently test a stale tree, which
+is the failure the key-completeness rules above exist to prevent.
+
 ## Restore-key discipline
 
 Use narrow restore keys from most-specific to less-specific:

--- a/skills/ci-cd-optimize/references/change-based-ci.md
+++ b/skills/ci-cd-optimize/references/change-based-ci.md
@@ -20,6 +20,34 @@ If any step fails, run the full pipeline.
 - Merge queues create a predictive branch; PR-only base/head assumptions may test the wrong change set.
 - Lockfile, CI config, dependency graph, generated-code schema, and shared-global changes usually escalate to full validation.
 
+## The planner must not route itself narrowly
+
+The component that decides what runs is part of the repository. If a change to the
+change-detection logic routes only the lanes that logic happens to name, a routing bug can ship
+having validated a fraction of the repo. Escalate planner, CI-config, and shared CI-helper
+changes to full validation (see "Full-run triggers" below).
+
+Two failures worth testing for explicitly, both observed in practice rather than derived:
+
+1. **Config fan-out gaps.** A rule mapping `.github/**` to "the main lanes" silently excludes
+   specialized ones, so editing a specialized workflow never exercises it.
+2. **Self-routing.** A planner change mapping only to its own directory's lane grades its own
+   homework.
+
+Guard both with unit fixtures over the classifier — it is a pure path-to-lane function and costs
+milliseconds to test:
+
+```
+classify(['.github/workflows/<specialized>.yml']) -> that lane is true
+classify(['<planner-path>'])                      -> every lane is true
+classify(['docs/x.md'])                           -> no heavy lane
+classify(['src/a.ts', 'docs/a.md'])               -> code wins over docs-only
+```
+
+Also test the rename case. Rename detection is on by default, and `git diff --name-only` prints
+only the destination, so moving `src/x.ts` to `docs/x.md` reads as docs-only while executable
+source was removed. Use `--no-renames`, or parse `--name-status` and route both paths.
+
 ## Path filters versus graph-aware affected
 
 Path filters are acceptable for flat repos with no shared package consumers. They are dangerous when a shared library affects multiple apps.

--- a/skills/ci-cd-optimize/references/ci-watching.md
+++ b/skills/ci-cd-optimize/references/ci-watching.md
@@ -71,7 +71,7 @@ def watch(repo, sha, branch, deadline, register_by, settle_secs, interval, heart
             emit("CI-DONE timeout"); return 2
 
         try:
-            runs = probe(repo, sha)          # ALL runs for this commit
+            runs = list(probe(repo, sha))    # ALL runs for this commit; safely reusable
             errors = 0
         except Exception:
             errors += 1
@@ -94,12 +94,12 @@ def watch(repo, sha, branch, deadline, register_by, settle_secs, interval, heart
 
         if registered and runs and all(r.done for r in runs):
             bad = [r for r in runs if r.conclusion not in OK]
-            cancelled = any(r.conclusion == "cancelled" for r in runs)
+            genuine_failures = [r for r in bad if r.conclusion != "cancelled"]
             try:
                 superseded = branch and head_of(branch) != sha
             except Exception:
                 superseded = False         # a lookup failure is not supersession
-            if superseded and (cancelled or not bad):
+            if superseded and not genuine_failures:
                 emit("CI-DONE superseded"); return 3
             if bad:
                 emit(f"CI-DONE failure — {bad[0].name} — logs: <log-cmd {bad[0].id}>")

--- a/skills/ci-cd-optimize/references/ci-watching.md
+++ b/skills/ci-cd-optimize/references/ci-watching.md
@@ -61,9 +61,9 @@ never has to work out how to see the cause.
 Provider-agnostic; swap `probe()` for your platform's CLI or API.
 
 ```python
-def watch(repo, sha, branch, deadline, register_by, interval, heartbeat) -> int:
-    start = last_beat = monotonic()
-    seen, errors, registered, settled_once = {}, 0, False, False
+def watch(repo, sha, branch, deadline, register_by, settle_secs, interval, heartbeat) -> int:
+    start = last_beat = all_done_since = monotonic()
+    seen, errors, registered = {}, 0, False
 
     while True:
         elapsed = monotonic() - start
@@ -92,20 +92,24 @@ def watch(repo, sha, branch, deadline, register_by, interval, heartbeat) -> int:
                 emit(f"CI-CHG {r.name}: {seen[r.id]} -> {r.state}")
             seen[r.id] = r.state
 
-        if branch and head_of(branch) != sha:
-            emit("CI-DONE superseded"); return 3
-
         if registered and runs and all(r.done for r in runs):
-            if not settled_once and elapsed < register_by:
-                settled_once = True          # one extra probe catches late registrations
-            else:
-                bad = [r for r in runs if r.conclusion not in OK]
-                if bad:
-                    emit(f"CI-DONE failure — {bad[0].name} — logs: <log-cmd {bad[0].id}>")
-                    return 1
+            bad = [r for r in runs if r.conclusion not in OK]
+            cancelled = any(r.conclusion == "cancelled" for r in runs)
+            try:
+                superseded = branch and head_of(branch) != sha
+            except Exception:
+                superseded = False         # a lookup failure is not supersession
+            if superseded and (cancelled or not bad):
+                emit("CI-DONE superseded"); return 3
+            if bad:
+                emit(f"CI-DONE failure — {bad[0].name} — logs: <log-cmd {bad[0].id}>")
+                return 1
+            # Hold all-green for a settle window so late-registering workflows
+            # (e.g. workflow_run chains) are observed before declaring success.
+            if monotonic() - all_done_since >= settle_secs:
                 emit("CI-DONE success"); return 0
         else:
-            settled_once = False
+            all_done_since = monotonic()
 
         now = monotonic()
         if now - last_beat >= heartbeat:
@@ -115,11 +119,19 @@ def watch(repo, sha, branch, deadline, register_by, interval, heartbeat) -> int:
         sleep(interval)
 ```
 
-Two judgement calls to make explicit for your setup:
+Three judgement calls to make explicit for your setup:
 
 - **`OK` set.** `{success, skipped, neutral}` is a reasonable default — a skipped job is usually an
   intentional route. Verify against your own gating rules.
-- **`cancelled`.** With `cancel-in-progress: true`, superseded runs are cancelled by design.
+- **`settle_secs`.** How long to hold an all-green state before declaring success, to catch
+  late-registering workflows. A single poll interval (~15s) covers pipelines that register seconds
+  apart; `workflow_run` chains register *after* their trigger completes, so give those 60–120s or
+  watch the downstream workflow explicitly.
+- **`cancelled` and supersession.** Check supersession only when a run was cancelled or nothing
+  failed; a completed red run must report `failure` even if the branch moved, because the question
+  "did this SHA pass" matters more than "did the branch move." A `cancelled` run on an *unmoved*
+  branch is a distinct signal — manual cancel or infrastructure — not a test failure, so it is not
+  silently treated as `OK`.
   Check supersession *before* concluding failure (as above) so a correctly retired run is not
   reported red.
 

--- a/skills/ci-cd-optimize/references/ci-watching.md
+++ b/skills/ci-cd-optimize/references/ci-watching.md
@@ -1,0 +1,198 @@
+# Watching CI Without Stalling
+
+Use this file when an agent or script must wait for a pipeline result — after a push, a dispatch,
+or a deploy — and the wait must be bounded, observable, and impossible to hang.
+
+This is a correctness problem, not a convenience one. A session blocked on CI with no deadline is
+indistinguishable from a session that has crashed.
+
+## What actually goes wrong
+
+| Anti-pattern | Failure |
+|---|---|
+| A TTY-oriented watcher with no machine-readable stream | Off-TTY, `gh run watch` appends the whole run table every interval (its `RefreshScreen`/alternate-buffer paths are TTY-gated) and its final `✓ Run … completed` summary is suppressed entirely. You get unparseable repetition and no completion line. |
+| Any watcher without its own deadline | A run that never registers, or a hung job, waits forever. `--exit-status` gives a pass/fail code but no time bound. |
+| `while true; do sleep 30; done` | No deadline, no registration timeout, usually no failure path. |
+| Filtering only for success | A crashed, cancelled, or never-registered run looks identical to a running one: silence. |
+| Watching one workflow by name | A second pipeline on the same commit can fail while the watched one passes — a false green. |
+| Echoing the full job table each poll | Burns context; most harnesses rate-limit or kill noisy monitors. |
+| Blocking the session while waiting | Forfeits the point: you learn about a minute-3 failure at minute 25. |
+
+A provider CLI that emits a structured event stream and a nonzero exit on failure (for example
+`avr run watch --ndjson`, or any `--json`/NDJSON mode) already satisfies most of the contract
+below — prefer it over hand-rolling. What such CLIs typically still lack is a self-imposed
+deadline, registration timeout, and coverage of *every* run for the commit. Wrap rather than
+replace.
+
+## The contract
+
+1. **Always terminates with an explicit verdict.** Silence past the deadline must be structurally
+   impossible: emit exactly one terminal line, then exit.
+2. **Pins to a commit, not a workflow.** Watch every run for the SHA so a second pipeline failing
+   is visible.
+3. **Emits only state changes.** Diff-gate output; a green 20-minute run should produce a handful
+   of lines.
+4. **Has a registration deadline.** If nothing appears for the SHA within a few minutes, say so —
+   a path filter, wrong ref, or failed push must not read as "still running."
+5. **Waits for late registration before declaring success.** Runs can register seconds apart, and
+   `workflow_run`-style pipelines register much later. Require a settle condition.
+6. **Detects supersession.** If the branch moves past the watched SHA, retire.
+7. **Survives transient errors.** Per-probe timeout, quiet retry, warn on a short streak, exit on
+   a long one.
+8. **Heartbeats.** A periodic liveness tick separates "still working" from "wedged."
+
+### Verdict vocabulary
+
+| Verdict | Meaning | Caller's move | Suggested exit |
+|---|---|---|---|
+| `success` | every run for the SHA is green | proceed | 0 |
+| `failure` | a run went red | fetch that job's failing logs now | 1 |
+| `timeout` | not terminal within the deadline | inspect; stuck, not slow | 2 |
+| `no-run` | nothing registered for the SHA | wrong ref, path filter, failed push | 2 |
+| `probe-dead` | repeated API/CLI failures | check auth, network, rate limits | 2 |
+| `superseded` | branch moved past the SHA | re-arm on the new SHA | 3 |
+
+Distinct exit codes matter: `watch && deploy` must not proceed on a `superseded` watch that never
+reached a real verdict. Put the failing run's log command inside the `failure` line so the caller
+never has to work out how to see the cause.
+
+## Reference implementation shape
+
+Provider-agnostic; swap `probe()` for your platform's CLI or API.
+
+```python
+def watch(repo, sha, branch, deadline, register_by, interval, heartbeat) -> int:
+    start = last_beat = monotonic()
+    seen, errors, registered, settled_once = {}, 0, False, False
+
+    while True:
+        elapsed = monotonic() - start
+        if elapsed > deadline:
+            emit("CI-DONE timeout"); return 2
+
+        try:
+            runs = probe(repo, sha)          # ALL runs for this commit
+            errors = 0
+        except Exception:
+            errors += 1
+            if errors == WARN_AFTER: emit(f"CI-WARN probe failing ({errors}x)")
+            if errors >= DIE_AFTER:  emit("CI-DONE probe-dead"); return 2
+            sleep(interval); continue
+
+        if runs and not registered:
+            registered = True
+            emit(f"CI-RUN registered {len(runs)}: ...")
+        if not registered and elapsed > register_by:
+            emit("CI-DONE no-run"); return 2
+
+        for r in runs:                       # diff-gated; announce new runs too
+            if r.id not in seen:
+                if registered: emit(f"CI-CHG {r.name}: registered ({r.state})")
+            elif seen[r.id] != r.state:
+                emit(f"CI-CHG {r.name}: {seen[r.id]} -> {r.state}")
+            seen[r.id] = r.state
+
+        if branch and head_of(branch) != sha:
+            emit("CI-DONE superseded"); return 3
+
+        if registered and runs and all(r.done for r in runs):
+            if not settled_once and elapsed < register_by:
+                settled_once = True          # one extra probe catches late registrations
+            else:
+                bad = [r for r in runs if r.conclusion not in OK]
+                if bad:
+                    emit(f"CI-DONE failure — {bad[0].name} — logs: <log-cmd {bad[0].id}>")
+                    return 1
+                emit("CI-DONE success"); return 0
+        else:
+            settled_once = False
+
+        now = monotonic()
+        if now - last_beat >= heartbeat:
+            last_beat = now                  # must reset, or it fires every poll
+            emit(f"CI-HB {int((now - start) / 60)}m")
+
+        sleep(interval)
+```
+
+Two judgement calls to make explicit for your setup:
+
+- **`OK` set.** `{success, skipped, neutral}` is a reasonable default — a skipped job is usually an
+  intentional route. Verify against your own gating rules.
+- **`cancelled`.** With `cancel-in-progress: true`, superseded runs are cancelled by design.
+  Check supersession *before* concluding failure (as above) so a correctly retired run is not
+  reported red.
+
+## Wiring it to an agent harness
+
+Run the watcher as a background process whose **stdout lines become notifications**, so the agent
+keeps working and reacts on arrival. If your harness exposes a streaming background-process tool
+(for example Claude Code's `Monitor`), wire it like this:
+
+```
+Monitor(
+  command: "python3 <your-watcher>.py --repo <owner/repo> --sha <full-sha> \
+            --branch <branch> --deadline-min 25 --register-min 4",
+  description: "CI for <short-sha>",
+  timeout_ms: 1800000        # comfortably longer than --deadline-min
+)
+```
+
+Rules that matter in practice:
+
+- **Set the harness timeout longer than the watcher's own deadline**, so the watcher is what ends
+  the watch and you get a verdict instead of a truncated stream.
+- **Arm it last.** Any commit after arming moves the branch and the watcher retires as
+  `superseded` — correct, but you lose the watch. Finish committing, then arm.
+- **Never hand-type the SHA.** Use `$(git rev-parse HEAD)`; a wrong SHA reports `superseded` or
+  `no-run` against the real head and teaches you nothing.
+- **One watch per SHA.** After a re-push, arm a fresh one.
+- **If any stage is a shell pipeline, flush per line** — `grep --line-buffered`, `awk` +
+  `fflush()`. A buffered stage silently withholds events, and `| head -N` cannot flush at all.
+  (In `zsh`, also avoid a variable named `status`; it is readonly and the loop dies instantly.)
+
+### When one notification is enough
+
+For "tell me when it is done", a bounded background command that exits on the condition is
+simpler than a streaming watcher:
+
+```bash
+until <terminal-state-check>; do sleep 20; done
+```
+
+Use the streaming watcher when you want to react to the *first* red check while other jobs still
+run — on a 25-minute pipeline that is roughly a 20-minute head start.
+
+## Reacting to events
+
+| Event | Response |
+|---|---|
+| `CI-RUN` / `CI-CHG … registered` | Note the count. Fewer runs than expected means a routing problem. |
+| `CI-CHG … -> failure` | Act now; pull that job's failing step logs without waiting for the rest. |
+| `CI-CHG in_progress -> queued` | Normal on platforms that reclaim runners. Not a fault. |
+| `CI-HB` | Acknowledge silently. |
+| `CI-DONE` | The only line that is a verdict. |
+
+State is **not** monotonic on every platform. Only a terminal line means terminal.
+
+## Verify the watcher before trusting it
+
+Exercise the paths that would otherwise hang:
+
+| Path | How to force it |
+|---|---|
+| `no-run` | Watch an all-zeros or unpushed SHA with a short `--register-min`. |
+| `failure` | Watch a known-red historical SHA. |
+| `success` | Watch a known-green historical SHA. |
+| `superseded` | Watch a SHA, then push one more commit to the branch. |
+
+A watcher you have not seen fail correctly is not yet a safety mechanism.
+
+## Sources
+
+- `gh run watch` TTY gating of screen refresh and of the completion summary: `cli/cli`
+  `pkg/cmd/run/watch/watch.go`, `pkg/iostreams/iostreams.go` (read 2026-07-28)
+- `gh run watch` flags (`--exit-status`, `--interval`, `--compact`):
+  https://cli.github.com/manual/gh_run_watch (accessed 2026-07-28)
+- Implementation example of the same contract (not a source for the claims above):
+  https://github.com/yigitkonur/plugin-ci-watch-unstall (accessed 2026-07-28)

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -28,6 +28,37 @@ Use median and p95. CI duration is right-skewed; averages hide cold caches, runn
 
 If a queue-time baseline is unavailable, start with provider run timestamps and job logs. Do not invent missing precision.
 
+## Separate queue from execution before reporting anything
+
+Total wall clock mixes two independent things: work you control (execution) and capacity you
+usually do not (provisioning). When queue variance is high, the total stops being a usable
+measure of an optimization.
+
+Per job:
+
+```
+queue     = started_at - created_at     # runner-acquisition latency
+execution = completed_at - started_at
+```
+
+Note this is *per job*: for a `needs`-gated job, `created_at` is set after its dependencies
+finish, so this measures time waiting for a runner, not time since the trigger. A multi-stage DAG
+pays that latency once per stage, which is why a run's total is much larger than any single
+job's `queue + execution`.
+
+A worked example from six runs of one unchanged pipeline: the longest job's execution stayed
+within 56–68s every time, while the per-run median queue ranged 16s to 416s. Totals ranged 133s
+to 596s. Quoting "1.7× faster" from the fast run or "2.6× slower" from the slow one would both be
+derivable from the data and both meaningless.
+
+Rules:
+
+- If execution is stable and totals swing, say so and report execution as the result.
+- Never quote a multiplier from a single run when queue p95 exceeds execution p50.
+- If queue dominates, the next experiment belongs in `references/runners-and-autoscaling.md`. No
+  in-job optimization moves provisioning time, though reducing job count or avoiding a scarce
+  runner label can reduce exposure to it.
+
 ## Critical-path analysis
 
 Build a DAG from declared dependencies. For every job, compute:

--- a/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -28,6 +28,34 @@ Use this file when queue time, runner capacity, runner isolation, or fleet cost 
 
 Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
+## Queue time varies by runner class — measure it, do not assume
+
+A larger instance class is not automatically faster end-to-end. Scarcity, pool warmth, and
+time-of-day decide whether the bigger class is provisioned sooner or later than the small one,
+and the answer differs per fleet and per hour.
+
+Two real observations from the *same* provider illustrate the spread:
+
+- One window: the 16-vCPU class was provisioned immediately while smaller classes waited.
+- Another window: 16-vCPU jobs waited ~6-7× longer than 2-vCPU jobs (medians over tens of
+  launches), and a job that executed in ~60s spent nearly twice that waiting for its runner.
+
+Neither generalizes. What generalizes is the method:
+
+1. Record `started_at - created_at` per job, grouped by runner label.
+2. Report median and p95 per class (averages hide exactly the skew you are looking for).
+3. Compare the queue penalty of the larger class against the execution gain it buys.
+4. Confirm the job is actually CPU- or memory-bound first — per-core idle ratios and peak versus
+   average utilization, not job duration.
+
+Size up only when utilization proves the job is compute-bound *and* the class's measured queue
+penalty is smaller than the execution gain. When a job is queue-bound, a bigger runner makes it
+slower.
+
+Corollary: fanning many concurrent jobs onto one scarce large label can exhaust that pool and
+serialize your own pipeline. Several of your runs queueing simultaneously on the same big label
+is capacity starvation, not slow CI — reduce job count, spread across labels, or collocate work.
+
 ## Autoscaling signals
 
 Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.


### PR DESCRIPTION
## Summary
- turn `ci-cd-optimize` into a fuller workflow skill, not just a YAML-tuning checklist
- add a generic `ci-watching.md` reference covering bounded, SHA-pinned CI watching that never stalls the session
- strengthen the measurement guidance so queue time is separated from execution before claiming speedups
- refine runner-sizing guidance with the key nuance that bigger classes can queue longer, so class choice must be measured per fleet
- refine caching guidance so agents time the uncached path first and avoid redundant dependency caches on colocated registry proxies
- strengthen change-based CI guidance so planners and workflow-config changes force the right validation scope

## Why this adds value
This PR folds in real execution lessons from a full CI rebuild on a large production repo, but rewrites them into **generic guidance**:
- no project-specific file paths, providers, or frameworks are required
- provider-specific advice is explicitly isolated to optional references
- the watcher guidance is framed as a reusable contract any agent can implement, not a repo-specific script

## Key additions
1. **Non-blocking CI watching**
   - terminal verdict vocabulary (`success`, `failure`, `timeout`, `no-run`, `superseded`, `probe-dead`)
   - bounded waiting, registration deadline, settle window, supersession handling, and error-streak handling
   - harness wiring guidance plus a shell fallback and its tradeoffs
2. **Measured performance framing**
   - separate queue from execution before reporting wall-clock wins
   - only claim the part the change actually controls
3. **Measured runner guidance**
   - larger runners can be slower end-to-end if they queue longer
   - right-size from utilization and per-class queue measurements, not folklore
4. **Measured cache guidance**
   - time the uncached path before adding any cache layer
   - registry proxies can make extra dependency caches redundant
   - manifest+lockfile warning for full dependency-tree caches
5. **Planner / change-detection hardening**
   - planners must not route themselves narrowly
   - workflow/config changes may need to fan out to every lane they can affect
   - rename handling guidance to avoid docs-only false negatives

## Validation
- `python3 scripts/validate-skills.py`
- self-review against the repo's contribution/style constraints
- independent re-review of the watcher logic and cross-reference consistency
