### PR TITLE
feat(ci-cd-optimize): comprehensive workflow-first CI/CD optimization skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -556,7 +556,7 @@
     {
       "name": "ci-cd-optimize",
       "source": "./",
-      "description": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+      "description": "Use if diagnosing or optimizing slow CI/CD, or if an agent must wait on CI without stalling, while preserving required checks.",
       "version": "1.0.36",
       "category": "ops",
       "strict": false,

--- a/plugins/ci-cd-optimize/.codex-plugin/plugin.json
+++ b/plugins/ci-cd-optimize/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci-cd-optimize",
   "version": "1.0.36",
-  "description": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+  "description": "Use if diagnosing or optimizing slow CI/CD, or if an agent must wait on CI without stalling, while preserving required checks.",
   "author": {
     "name": "Yigit Konur",
     "url": "https://github.com/yigitkonur"
@@ -17,7 +17,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "ci-cd-optimize",
-    "shortDescription": "Use if diagnosing or optimizing slow CI/CD while preserving required checks.",
+    "shortDescription": "Use if diagnosing or optimizing slow CI/CD, or if an agent must wait on CI without stalling, while preserving required checks.",
     "longDescription": "Install only the ci-cd-optimize workflow from Yigit Konur's curated skills pack.",
     "developerName": "Yigit Konur",
     "category": "Productivity",

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/README.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/README.md
@@ -1,6 +1,16 @@
 # ci-cd-optimize
 
-Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification.
+Diagnose and optimize slow CI/CD pipelines by **measured bottleneck, not folklore** — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, Swift/Xcode CI, and the adjacent problem of **waiting on CI without stalling the session**.
+
+The skill is workflow-first:
+
+1. read prior runs and separate queue / setup / execution / transfer,
+2. find the true critical path,
+3. choose the smallest reversible experiment,
+4. preserve required checks and trust boundaries,
+5. close the feedback loop with a bounded, SHA-pinned watcher when CI is the only verification surface.
+
+It ships a provider-neutral watcher contract plus a stdlib-only `ci-watch.py`, and routes to detailed references for capacity/contention, change-based CI, caching, testing/flakiness, runners, deployment, containers, monorepos, and vendor-specific behavior.
 
 **Category:** ops
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/SKILL.md
@@ -1,110 +1,209 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use if diagnosing or optimizing slow CI/CD, or if an agent must wait on CI without stalling, while preserving required checks.
 metadata:
   author: yigitkonur
-  version: 1.0.0
+  version: 1.1.0
   category: devops
-  tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, typescript, swift, xcode, pipeline-performance]
+  tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, monorepo, docker, swift, xcode, pipeline-performance, ci-monitoring]
 ---
 
 # CI/CD Optimize
 
-Diagnose slow CI/CD from evidence, optimize the critical path, and prove the pipeline remains effective. Do not make pipelines faster by deleting the checks that make them useful.
+Diagnose slow CI/CD from evidence, choose the smallest reversible improvement,
+and prove the pipeline is still effective afterward. Treat the **feedback loop**
+(the way a human or agent learns the result) as part of the pipeline, not as
+something outside it. A 90-second pipeline is not fast if the caller waits 20
+minutes to notice the red check.
+
+## What this skill is for
+
+Use this skill to optimize any delivery pipeline that has a real correctness or
+cost surface: GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepo task
+runners, Docker/OCI build pipelines, test matrices, Swift/Xcode CI, or a deploy
+pipeline whose run time dominates development or release flow.
+
+It is workflow-first, not YAML-first. Start from **what is slow, what is risky,
+and what proof is needed**, then route to the narrowest reference that answers
+that question.
 
 ## Operating loop
 
-### 1. Frame the target and constraints
+### 1. Frame the target and the verification surface
 
-Identify the exact pipeline, branch/event, current median and p95 time-to-feedback, failure rate, and required gates. Separate these before recommending anything:
+Start by naming exactly what is being optimized:
 
-- **Queue time** — trigger to runner start: capacity, scheduling, concurrency, or runner topology.
-- **Setup time** — checkout, runtime install, dependency restore, environment boot.
-- **Execution time** — lint, typecheck, build, tests, package, scan, deploy.
-- **Transfer time** — cache/artifact downloads and uploads, Docker layers, registries, LFS.
-- **Finalization** — reporting, merge status, deployment health, cleanup.
+- workflow / pipeline name
+- trigger (`push`, `pull_request`, merge queue, schedule, deploy, release)
+- branch or commit under study
+- what the caller actually cares about: first failure, first green, deploy live,
+  artifact published, release signed, etc.
+- required gates that must not weaken
+- whether CI is the **only** trusted verification surface
 
-Required gates are requirements, not bottlenecks. If a gate must stay, optimize its scope, parallelism, cache, or placement.
+If CI is the only trusted verification surface, the feedback loop is mandatory
+work, not polish. An agent that pushes and then waits badly is blind to the
+result even if the pipeline itself is well-designed.
 
-### 2. Measure the exact baseline
+### 2. Read history before touching config
 
-Use the same commit and comparable runner class. Prefer at least three runs when timings vary. Capture queue, setup, execution, transfer, per-job duration, dependency graph, cache hit/miss, retry count, and artifact identity.
+Read previous runs first. Do not start with a config rewrite.
 
-Rules:
+Build the baseline from the platform's own history when it exists, then verify
+sample size, time window, runner class, and commit identity. Separate these
+components before proposing anything:
 
-- Use median and p95; CI timings are right-skewed.
-- A green run on a stale SHA, empty diff, or different workflow is not evidence.
-- A cache hit is useful only if restore plus post-hit work beats a clean run.
-- Flaky retry-pass is instability and cost, not proof of reliability.
+- **Queue time** — trigger to runner start
+- **Setup time** — checkout, runtime install, dependency restore, env boot
+- **Execution time** — tests, build, scans, package, deploy
+- **Transfer time** — caches, artifacts, Docker layers, registries, LFS
+- **Finalization** — reports, deploy health, cleanup, status aggregation
 
-Prefer the platform's own aggregated history over hand-collected timings when it exists, then verify sample size and window. If the repository runs on Avrea (`runs-on:` labels begin with `avrea-`) and `avr` is installed and authenticated, read `references/avrea/cli-evidence.md` — it returns median/p95, per-job start offsets, flake counts, and cache hit counts directly. Confirm availability with `command -v avr && avr auth status` before depending on it, and fall back to provider-native measurement otherwise.
+Read `references/measurement.md` first whenever the bottleneck is not already
+obvious. If the repository runs on Avrea and the `avr` CLI is available and
+authenticated, `references/avrea/cli-evidence.md` gives the direct evidence path
+for medians, p95s, per-job start offsets, queue time, flake counts, and cache
+hits.
 
-For the metric definitions, baseline protocol, and the rule about claiming only the evidence rung you reached, read `references/measurement.md`.
+### 3. Find the true bottleneck, not the loudest one
 
-### 3. Find the critical path
+Build the job DAG from actual dependencies, not stage labels. Optimize the work
+that dominates the **critical path**.
 
-Build the job DAG from actual dependencies, not stage labels. Optimize jobs with high critical-path rate and high exclusive time. A large total CPU-time reduction on parallel non-critical work may produce zero wall-clock improvement.
+A large CPU-time reduction on parallel non-critical work can move wall-clock by
+zero. Likewise, a larger runner can make execution faster and wall-clock slower
+if queue time dominates.
 
-Apply the performance order before adding compute:
+Apply the optimization order in this sequence:
 
-1. **Do not start it** — duplicate triggers, draft-PR work, irrelevant events, unrelated packages, full checkout, redundant matrices.
-2. **Cancel it when stale** — superseded PR runs, obsolete deployments only when safe, hung tail jobs.
-3. **Reuse previous work** — correct caches, remote task cache, immutable build artifacts, prebuilt toolchains.
-4. **Shorten the critical path** — DAG shape, split long jobs only when setup is amortized, historical test sharding.
-5. **Move fewer bytes** — checkout scope, cache size, Docker context/layers, artifact paths/compression.
-6. **Only then add compute** — larger runners, more workers, more capacity after queue and utilization evidence.
+1. **Do not start the work** — duplicates, draft PR work, irrelevant events,
+   unrelated packages, redundant matrices.
+2. **Retire stale work** — superseded runs, obsolete deploys, hung tail jobs when
+   safe.
+3. **Reuse correct previous work** — caches, immutable artifacts, remote task
+   caches, prebuilt toolchains.
+4. **Shorten the critical path** — remove artificial dependencies, fix topology,
+   shard only when setup is amortized.
+5. **Move fewer bytes** — sparse checkout, smaller cache/artifact payloads,
+   tighter Docker context, local registry/proxy.
+6. **Only then add compute or capacity** — more workers, larger runners, more
+   slots, a different fleet.
 
-Ask in order:
+### 4. Route by measured symptom
 
-1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
-3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
-4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
-5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
-6. Are tests dominant? Read `references/testing-and-flakiness.md` and `references/integration-environments.md`.
-7. Is Docker/OCI work dominant? Read `references/containers.md`.
+Ask these in order and read only the matching references:
+
+1. Is duplicate, stale, draft-only, or unrelated work running? Read
+   `references/change-based-ci.md` and the provider reference.
+2. Is queue p95 a large part of total wall-clock, or is job count already at the
+   platform's concurrency ceiling? Read `references/capacity-and-contention.md`
+   before touching parallelism.
+3. Is setup or dependency restore dominant? Read `references/caching.md` and the
+   language/toolchain reference (`references/typescript-toolchain.md`,
+   `references/swift-xcode.md`, etc.).
+4. Is checkout, cache transfer, Docker context, or artifact motion dominant?
+   Read `references/network-and-artifacts.md` and `references/containers.md`.
+5. Is the pipeline running work unrelated to this change? Read
+   `references/change-based-ci.md` and, for monorepos, `references/monorepos.md`.
+6. Are tests dominant or flaky? Read `references/testing-and-flakiness.md` and
+   `references/integration-environments.md`.
+7. Is Docker/OCI build work dominant? Read `references/containers.md`.
 8. Are security scans dominant? Read `references/security-gates.md`.
-9. Is deployment slow or repeated? Read `references/deployment.md`.
-10. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
-11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
-12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
-13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+9. Is deployment or rollout the long pole? Read `references/deployment.md`.
+10. Is runner class or autoscaling the suspected cause? Read
+    `references/runners-and-autoscaling.md`.
+11. Is the build graph/cache correctness itself suspect? Read
+    `references/bazel-and-remote-execution.md`.
+12. Is the provider workflow/config itself the issue? Route to the provider file:
+    `references/github-actions.md`, `references/gitlab-ci.md`,
+    `references/circleci.md`, `references/buildkite.md`.
+13. Must a human or agent wait on the result without stalling? Read
+    `references/feedback-loops.md` and, if a bundled watcher is appropriate,
+    `scripts/ci-watch.py`.
+14. Is the proposed speedup near a trust boundary, required check, cache
+    namespace, or artifact identity? Read `references/effectiveness-contract.md`
+    before recommending it.
+15. Is a vendor claim or cited example stale or load-bearing? Read
+    `references/evidence-and-sources.md`.
 
-### 4. Choose one bounded experiment
+### 5. Choose one bounded experiment
 
-Select the smallest reversible change that attacks the measured critical path. Every recommendation must state:
+Select the smallest reversible change that attacks the measured bottleneck.
 
-- evidence observed,
-- expected wall-clock impact,
-- effectiveness risk,
-- security/trust-boundary risk,
-- cost effect,
-- rollback or fallback.
+For every recommendation, state all six:
 
-Prefer, in this order: prevent unneeded work → cancel stale work → reuse verified prior work → improve cache correctness → remove artificial dependencies → parallelize independent work → shard slow work by measured duration → reduce transferred bytes → improve runner capacity → move heavy work off the PR path only with a full-run fallback → change provider architecture.
+- evidence observed
+- expected wall-clock effect
+- effectiveness / correctness risk
+- security / trust-boundary risk
+- cost effect
+- rollback or fallback
 
-### 5. Preserve effectiveness
+Prefer, in this order: prevent work → cancel stale work → reuse safe work → fix
+cache correctness → remove artificial dependencies → parallelize/shard measured
+work → reduce transferred bytes → change runner capacity → move heavy work off
+PR path only with a full-run fallback → change provider architecture.
+
+### 6. Treat the feedback loop as part of the optimization
+
+Whoever waits on CI needs a mechanism that always terminates with a verdict.
+Never block the session on a foreground `watch`, a TTY-oriented CLI, or a
+success-only loop. Arm a bounded watcher pinned to the exact pushed SHA, then
+keep working.
+
+A good watcher must:
+
+- terminate on success, failure, timeout, no-run, superseded, and probe-dead
+- emit on failure, not just success
+- emit only state changes plus heartbeats
+- be pinned to the exact commit or build id
+- have a registration deadline and an overall deadline
+- wait a settle window before all-green success, so late follow-up workflows are
+  observed
+
+Read `references/feedback-loops.md` for the contract, anti-patterns,
+provider-neutral wiring, and flake triage. `scripts/ci-watch.py` is the bundled
+reference implementation.
+
+### 7. Preserve effectiveness
 
 Never claim an optimization if it does any of these:
 
-- skips required tests, coverage, type checking, or security gates,
-- lets untrusted code write to a cache trusted branches consume,
-- accepts a green check on a stale or unrelated commit,
-- replaces immutable artifact promotion with rebuilds per environment,
-- hides failures behind retries, broad `continue-on-error`, or weakened assertions,
-- makes change detection use an unverified merge base.
+- skips required tests, coverage, typing, security gates, or release checks
+- lets untrusted code write a cache trusted branches consume
+- accepts a green check on a stale or unrelated commit
+- replaces immutable artifact promotion with rebuilds per environment
+- hides failures behind retries, broad `continue-on-error`, or weakened
+  assertions
+- relies on an unverified merge base or partial graph
 
-Use full validation as the safe fallback whenever changed files, merge base, cache correctness, dependency graph completeness, or security scope cannot be proven. When a proposed change is near any of these lines, check it against `references/effectiveness-contract.md` before recommending it.
+If the repo is CI-only, remember that the watcher itself is part of
+preserving effectiveness: a hang, stale green, or never-registered run is a
+broken verification path.
 
-### 6. Verify after the change
+Use `references/effectiveness-contract.md` whenever a proposed change approaches
+one of these lines.
 
-Re-run on the same commit first, then a normal representative commit. Compare median and p95 wall-clock, queue time, cache behavior, first-time pass rate, cost, and failure/rework signals. Confirm the exact run head SHA contains the change and the deployed artifact digest or workflow run is the intended one.
+### 8. Verify after the change
 
-Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
+Re-run on the same commit first, then a normal representative commit. When the
+change is in-job, compare arms under the **same contention state**; a run against
+an idle pool and one against a saturated pool are not comparable even on the same
+commit and runner class. Interleave arms when practical.
 
-## Minimal TypeScript example
+Report only the rung actually reached:
+
+- config review
+- syntax/schema validation
+- one exact-commit CI run
+- repeated comparable CI runs
+- production/trend evidence
+
+Always confirm the run's head SHA contains the change and that the expected
+workflows/jobs actually ran. A green on the wrong workflow or wrong commit is a
+false green.
+
+## Minimal example — use as a shape, not a template
 
 ```yaml
 name: ci
@@ -130,14 +229,14 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: filter
         run: |
-          git diff --name-only "${{ github.event.pull_request.base.sha || 'HEAD~1' }}...${{ github.sha }}" \
-            | grep -E '^(src|packages|apps|package.json|pnpm-lock.yaml|tsconfig)' \
-            && echo "source=true" >> "$GITHUB_OUTPUT" || echo "source=false" >> "$GITHUB_OUTPUT"
+          git diff --name-only "$BASE...$HEAD" \
+            | grep -qE '^(src|packages|apps|package.json|pnpm-lock.yaml|tsconfig)' \
+            && echo source=true >> "$GITHUB_OUTPUT" || echo source=false >> "$GITHUB_OUTPUT"
 
   verify:
     needs: changes
@@ -145,8 +244,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -156,75 +255,74 @@ jobs:
       - run: corepack pnpm test -- --run
 ```
 
-Treat this as a shape, not a universal template. Adapt cache, affected detection, and jobs from measured evidence.
-
 ## Common pitfalls
 
 | Pitfall | Better move |
 |---|---|
-| Optimizing before measuring | Capture baseline queue/setup/execution/critical path first. |
-| Duplicate `push` and PR runs | Trigger PRs on PR events; trigger main/release pushes only. |
-| Draft PRs start expensive jobs | Keep planner cheap; gate expensive jobs until ready for review. |
-| Caching `node_modules` by default | Cache the package-manager store; measure restore versus install. |
-| Workflow path filter blocks required checks | Run a cheap change-detection job and condition expensive jobs. |
-| Affected detection on shallow clone | Fetch required history or use event SHAs; otherwise run all. |
-| Artificial `needs` chains | Start independent lint/typecheck/build work together. |
-| More runners without queue evidence | Measure queue p95 and runner utilization before spending. |
-| Full suite duplicated in every shard | Split tests by file/timing so each test runs once. |
-| Tiny jobs with heavy setup | Collocate work until separate runner setup is amortized. |
-| Coverage off PR path with no fallback | Keep a required scheduled/merge-queue full run. |
-| Remote cache writable by untrusted PRs | Read-only PR cache or isolated cache namespace. |
-| Retrying flakes forever | Bound retries, quarantine, assign ownership, track flake rate. |
-| Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
-| Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
-| Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
-| Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
+| Optimizing before measuring | Capture a baseline first. |
+| Duplicate `push` and PR runs | Trigger PRs on PR events; trigger pushes only where they matter. |
+| Draft PRs start expensive jobs | Gate expensive work until ready for review. |
+| Caching `node_modules` by default | Cache the package-manager store and measure restore vs clean install. |
+| Planner/CI config routes itself narrowly | Escalate planner and CI config changes to full validation. |
+| Affected detection on shallow history | Fetch enough history or use provider SHAs; otherwise run all. |
+| Adding a planner or aggregate job "for clarity" | Price the queue/setup hop against the work it does. |
+| Splitting while already at the concurrency ceiling | Establish the ceiling first; when capped, merge work that shares setup. |
+| Comparing contended and uncontended runs | Match contention state; compare execution time for in-job changes. |
+| Blocking on a vendor `watch` command | Arm a bounded SHA-pinned watcher and keep working. |
+| Reading a branch-tip green | Pin the pushed SHA and verify the run's head commit. |
+| Treating `timeout` as pass or failure | It means no verdict yet; inspect the run and re-arm if needed. |
+| Full suite duplicated in every shard | Split so each required test runs exactly once. |
+| Tiny jobs with heavy setup | Collocate work until separate setup is amortized. |
+| Coverage off PR path with no fallback | Keep a required full-run path. |
+| Remote cache writable by untrusted PRs | Read-only PR cache or isolated namespace. |
+| Flake "fixed" by retry/skip | Re-run the identical commit to prove a flake; do not weaken the test. |
+| First default-branch run after a cache-key change called a regression | Branch caches cannot seed default branch; prove the expected cold-first pattern. |
+| Larger runners chosen by intuition | Measure queue per class and utilization first; downsizing is common. |
+
+## Bundled script
+
+| Script | Use when |
+|---|---|
+| `scripts/ci-watch.py` | Wait on the exact pushed SHA without stalling. GitHub Actions works out of the box; any other provider via `--cmd` printing `<name>: <state>` lines. Stdlib-only Python. |
 
 ## Reference files
 
 | File | Read when |
 |---|---|
-| `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, or proving a result. |
-| `references/effectiveness-contract.md` | Deciding whether a proposed speedup weakens validation, security, or artifact identity. |
-| `references/caching.md` | Any dependency/build cache design, restore-key, cache-hit, cache-poisoning, or transfer-cost question. |
-| `references/change-based-ci.md` | Path filters, affected commands, merge queues, merge-base correctness, or full-run fallback rules. |
-| `references/github-actions.md` | GitHub Actions workflows, caches, concurrency, artifacts, merge queues, required checks, or larger runners. |
-| `references/gitlab-ci.md` | GitLab `needs`, child pipelines, cache/artifacts, interruptible jobs, resource groups, rules, or runners. |
-| `references/circleci.md` | CircleCI caching, workspaces, test splitting, dynamic config, Docker layer caching, or resource classes. |
-| `references/buildkite.md` | Buildkite dynamic pipelines, queues, autoscaling, concurrency groups, artifacts, or hosted agents. |
-| `references/monorepos.md` | Nx, Turborepo, affected graphs, remote caches, distributed execution, or package/task inputs. |
-| `references/bazel-and-remote-execution.md` | Bazel query, hermetic builds, remote cache/execution, or choosing graph-native builds. |
-| `references/typescript-toolchain.md` | npm/pnpm/Yarn/Bun installs, Corepack, TypeScript project references, `tsbuildinfo`, bundlers, or generated code. |
-| `references/testing-and-flakiness.md` | Sharding, historical timing, retries, flaky ownership, coverage merging, Jest/Vitest/Playwright. |
-| `references/integration-environments.md` | Testcontainers, service containers, database templates, fixtures, contract tests, or preview databases. |
-| `references/containers.md` | BuildKit, multi-stage Dockerfiles, cache mounts/backends, multi-platform builds, provenance, or image security. |
-| `references/security-gates.md` | Fast but effective SAST, dependency, secret, container, SBOM, provenance, and policy gates. |
-| `references/runners-and-autoscaling.md` | Hosted versus self-hosted, ephemeral runners, queues, spot capacity, ARM/x64/macOS, Kubernetes fleets. |
-| `references/network-and-artifacts.md` | Checkout depth, sparse/partial clone, LFS, package proxies, artifact compression, uploads, or registry locality. |
-| `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
-| `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
-| `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
-
-### Optional: Avrea reference kit
-
-Read only when the repository runs on Avrea (`runs-on:` labels start with `avrea-`) or Avrea is being evaluated as a runner change. The core loop above is provider-neutral and does not depend on these files.
-
-| File | Read when |
-|---|---|
-| `references/avrea/cli-evidence.md` | Using the `avr` CLI to build a baseline: median/p95, per-job start offsets, queue time, VM metrics, flake counts, cache hit counts, or driving a run to a terminal state. |
-| `references/avrea/platform-and-runners.md` | Runner labels and sizing, migration from GitHub-hosted runners, A/B shadowing, observability, OTel export, live SSH debugging, or the third-party trust boundary. |
-| `references/avrea/caching.md` | Actions/build/package cache layers, Turborepo or Docker `url_v2` wiring, registry proxy caveats, quota and LRU eviction, or diagnosing cold cache entries. |
+| `references/measurement.md` | Building the baseline, critical-path analysis, percentiles, or proving a result. |
+| `references/capacity-and-contention.md` | Queue share is high, parallelism stopped paying off, before sharding/splitting, or when comparing arms under different load. |
+| `references/feedback-loops.md` | An agent or human must wait on CI without stalling: watcher contract, verdicts, settle windows, flake triage. |
+| `references/effectiveness-contract.md` | Deciding whether a speedup weakens validation, security, or artifact identity. |
+| `references/caching.md` | Dependency/build/compiler/remote cache design and invalidation. |
+| `references/change-based-ci.md` | Path filters, affected commands, merge-base correctness, and full-run fallback rules. |
+| `references/github-actions.md` | GitHub Actions workflows, concurrency, caches, artifacts, merge queue, required checks. |
+| `references/gitlab-ci.md` | GitLab `needs`, child pipelines, caches/artifacts, interruptible jobs, resource groups. |
+| `references/circleci.md` | CircleCI caching, workspaces, test splitting, dynamic config, resource classes. |
+| `references/buildkite.md` | Buildkite dynamic pipelines, queues, autoscaling, concurrency groups, artifacts. |
+| `references/monorepos.md` | Nx, Turborepo, affected graphs, task inputs, remote caches, distributed execution. |
+| `references/bazel-and-remote-execution.md` | Bazel query, hermeticity, remote cache/execution, graph-native builds. |
+| `references/typescript-toolchain.md` | npm/pnpm/Yarn/Bun, Corepack, TS project references, `tsbuildinfo`, bundlers, generated code. |
+| `references/testing-and-flakiness.md` | Sharding, historical timing, flaky ownership, retries, coverage merging, Jest/Vitest/Playwright. |
+| `references/integration-environments.md` | Testcontainers, service containers, fixture DBs, contract tests, preview DBs. |
+| `references/containers.md` | BuildKit, multi-stage Dockerfiles, cache mounts/backends, provenance, image security. |
+| `references/security-gates.md` | Fast but effective SAST, dependency, secret, container, SBOM, provenance, policy gates. |
+| `references/runners-and-autoscaling.md` | Runner classes, queues, hosted vs self-hosted, spot capacity, ARM/x64/macOS, Kubernetes fleets. |
+| `references/network-and-artifacts.md` | Checkout depth, sparse/partial clone, LFS, package proxies, artifact compression/uploads. |
+| `references/deployment.md` | Build-once deploy-many, canary/blue-green, migrations, previews, rollback, exact-artifact verification. |
+| `references/swift-xcode.md` | Swift/Xcode builds, test plans, simulator sharding, macOS runners, xcresult, DerivedData. |
+| `references/evidence-and-sources.md` | Checking whether a CI/CD claim is current, resolving conflicts, and refreshing this skill. |
+| `references/avrea/*.md` | Optional Avrea kit: CLI evidence, runner sizing, and cache behavior when the repo runs on Avrea. |
 
 ## Guardrails
 
-- Do not recommend vendor-specific flags from memory; verify mutable provider behavior against current official docs when it is load-bearing, and record the check per `references/evidence-and-sources.md`.
-- Do not assume a CI platform or its CLI is present; probe first (`command -v`, `--version`, auth check) and fall back to provider-native evidence when it is not.
-- Do not run a platform CLI's mutating commands without authorization — cache deletion, run cancel/rerun, org or repository settings, and firewall rules change shared state.
+- Do not recommend provider-specific commands from memory when the behavior is load-bearing; verify against current docs or provider source and record the check.
+- Do not assume a CLI or platform exists; probe first (`command -v`, `--version`, auth check) and fall back to provider-native evidence if absent.
+- Do not mutate shared CI state (cache deletion, run cancel/rerun, org settings, firewall rules) without authorization.
 - Do not ask for approval before a reversible, measured optimization; ask before weakening a gate, changing production deployment behavior, or introducing a shared trust boundary.
 - Do not add a large tool (Bazel, remote execution, self-hosted fleet, commercial TIA) unless the measured bottleneck and operating capacity justify it.
-- Do not bundle generated pipeline templates blindly; produce the smallest config change justified by evidence.
+- Do not bundle generated pipeline templates blindly; produce the smallest change justified by evidence.
 - Do not report "CI is faster" without the before/after evidence and the exact run identity.
 
 ## Done criteria
 
-The work is complete only when the baseline, chosen bottleneck, changed files/config, measured result, effectiveness checks, remaining risks, and verification level are all reported. If a provider branch was not exercised, say so explicitly rather than implying coverage.
+The work is complete only when the baseline, chosen bottleneck, changed files/config, measured result, effectiveness checks, remaining risks, and verification rung are all reported. If a provider branch or feedback-loop path was not exercised, say so explicitly rather than implying coverage.

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/caching.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/caching.md
@@ -1,10 +1,16 @@
 # Caching
 
-Use this file for dependency, build, compiler, Docker, and remote-cache decisions. The goal is saved wall-clock time with correct invalidation—not a high hit-rate vanity metric.
+Use this file for dependency, build, compiler, Docker, and remote-cache
+decisions. The goal is saved wall-clock time with correct invalidation — not a
+high hit-rate vanity metric.
+
+If the cache debate starts from “installs are slow”, read
+`measurement.md` first and time the uncached path before adding anything.
 
 ## Cache design checklist
 
-A cache entry is safe only when its key includes every input that changes its output:
+A cache entry is safe only when its key includes every input that changes its
+output:
 
 - source content and relevant config,
 - lockfile or resolved dependency graph,
@@ -14,56 +20,114 @@ A cache entry is safe only when its key includes every input that changes its ou
 - generator/schema versions for generated code,
 - cache namespace/version so you can intentionally invalidate it.
 
-If any input is missing, a hit can be silently wrong. If any irrelevant input is included, hits collapse.
+If any input is missing, a hit can be silently wrong. If any irrelevant input is
+included, hits collapse.
 
 ## Trust boundaries
 
-- Untrusted PRs must not write cache entries that protected branches later consume as trusted.
-- Prefer read-only PR cache access or isolated PR namespaces with protected-branch promotion.
-- Sign or verify artifacts where the backend supports integrity checks; signatures do not replace authorization.
+- Untrusted PRs must not write cache entries that protected branches later
+  consume as trusted.
+- Prefer read-only PR cache access or isolated PR namespaces with protected-branch
+  promotion.
+- Sign or verify artifacts where the backend supports integrity checks; signatures
+  do not replace authorization.
 - Do not put secrets in cache keys or cached files.
 
-## TypeScript package caches
+Read `effectiveness-contract.md` before recommending a shared namespace or a
+trusted-branch restore key.
+
+## Time the uncached path first
+
+“Installs are slow” is an assumption until measured. On some fleets the package
+registry is already proxied locally, so adding a dependency-store cache on top of
+it buys nothing and may add a save step.
+
+The safe generalization is narrow but useful:
+
+- when the uncached step is already seconds, measure it before caching;
+- when the cold path is materially slower than the warm path, the cache may be earning its keep;
+- when restore + post-hit work exceeds a clean run, delete the cache.
+
+This is why the headline metric is **cache saved time**, not hit rate. A 100% hit
+rate on a cache that saves nothing is wasted bytes.
+
+## TypeScript and package-manager caches
 
 Cache the package-manager store/cache, not blindly `node_modules`:
 
 | Manager | CI command | Cache target |
 |---|---|---|
-| npm | `npm ci` | npm cache, usually via setup action or `~/.npm` |
+| npm | `npm ci` | npm cache (`~/.npm` or setup action cache) |
 | pnpm | `pnpm install --frozen-lockfile` | pnpm store |
 | Yarn modern | `yarn install --immutable` | Yarn global cache or committed Zero-Install cache |
 | Bun | `bun ci` | Bun install cache |
 
-Key by lockfile, Node version, package-manager version, OS, and architecture. Compare restore time with a clean install; large stores can be slower than a registry fetch on a nearby network.
+Key by:
+
+- lockfile,
+- runtime version,
+- package-manager version,
+- OS,
+- architecture,
+- and for monorepos, any manifest/config whose drift changes the dependency tree.
+
+### Default-branch cold starts are normal
+
+Branch-scoped caches cannot seed the default branch. After a cache-key change (a
+schema bump, adding OS/arch/toolchain identity, changing restore paths), the
+first default-branch run is legitimately cold even though the branch runs that
+validated the change were warm. Verify with the run's own log lines before
+calling it a regression.
 
 ## Restore-key discipline
 
 Use narrow restore keys from most-specific to less-specific:
 
 ```yaml
-key: linux-x64-node24-pnpm10-${{ hashFiles('pnpm-lock.yaml') }}
+key: linux-x64-node24-pnpm10-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}
 restore-keys: |
   linux-x64-node24-pnpm10-
 ```
 
-Avoid keys that rotate every run (`epoch`, build number) and broad fallbacks that restore a different runtime, branch dependency set, or architecture.
+Avoid keys that rotate every run (`epoch`, build number) and broad fallbacks that
+restore a different runtime, branch dependency set, or architecture.
 
-## Build/compiler caches
+Keying a dependency cache on the lockfile **alone** can still be stale after a
+manifest-only change if the manifest influences the resolved tree without a lock
+rewrite. Manifest + lockfile is the safer default.
 
-- TypeScript `.tsbuildinfo` and emitted outputs must be keyed with TypeScript version, lockfile, and every relevant `tsconfig`.
+## Build, compiler, and remote caches
+
+- TypeScript `.tsbuildinfo` and emitted outputs must be keyed with TypeScript
+  version, lockfile, and every relevant `tsconfig`.
 - Generated code must hash schemas, generator version, and config.
-- Xcode DerivedData requires exact project/toolchain keys and timestamp restoration.
-- BuildKit layer caches require external backends on ephemeral runners; cache mounts do not automatically persist across runners.
+- Xcode DerivedData requires exact project/toolchain keys and timestamp-safe
+  restoration.
+- BuildKit layer caches require external backends on ephemeral runners; cache
+  mounts do not automatically persist across runners.
+- Remote task caches (Nx, Turborepo, Bazel) must prove their input graph is
+  complete; otherwise a hit can be wrong, not merely stale. Cross-link:
+  `change-based-ci.md`, `bazel-and-remote-execution.md`, and `monorepos.md`.
 
 ## Failure modes
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Passes on miss, fails on hit | Missing output or undeclared input | Complete inputs/outputs; invalidate namespace. |
-| Zero exact hits | Key rotates every run | Remove build IDs/timestamps from key. |
-| Slow despite hit | Transfer exceeds recomputation | Cache smaller store, nearby backend, or stop caching. |
-| Cross-branch stale behavior | Fallback too broad or shared trust scope | Narrow key; separate protected/untrusted scopes. |
+| Zero exact hits | Key rotates every run | Remove build IDs/timestamps from the key. |
+| Slow despite hit | Transfer exceeds recomputation | Cache a smaller store, use a nearer backend, or stop caching. |
+| Cross-branch stale behavior | Fallback too broad or shared trust scope | Narrow the key; separate protected/untrusted scopes. |
 | Poisoned shared cache | Untrusted writes accepted | Read-only PR access or isolated namespace. |
+| First default-branch run unexpectedly cold | Branch caches cannot seed default branch | Expect one cold run after a key change; verify from log lines. |
+
+## Cross-links
+
+- `measurement.md` — how to tell whether the cache saved real wall-clock time.
+- `change-based-ci.md` — when a partial run plus remote cache can mask skipped work.
+- `network-and-artifacts.md` — when transfer cost, not invalidation, is the problem.
+- `containers.md` — Docker layer cache and BuildKit specifics.
+- `effectiveness-contract.md` — before sharing a cache across trust boundaries.
+- `monorepos.md` and `bazel-and-remote-execution.md` — when cache correctness depends on graph completeness.
 
 ## Sources
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/capacity-and-contention.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/capacity-and-contention.md
@@ -1,0 +1,152 @@
+# Capacity and Contention
+
+Use this file when queue time is a material share of wall-clock, when adding jobs
+stopped helping, before sharding or fanning out work, or when a supposedly faster
+change measured neutral because the fleet was busy.
+
+This is the reference for the failure mode a fast local benchmark misses: the job
+itself got shorter, but the pipeline did not, because the platform had no free
+slots to run the extra work. Read `references/measurement.md` first so queue and
+execution are already separated.
+
+## The inversion to watch for
+
+Two otherwise-good optimizations **invert** above a platform concurrency ceiling:
+
+- parallelize independent work
+- shard a slow lane into more jobs
+
+Both raise **job count**. Once job count exceeds available slots, the surplus
+queues while re-paying per-job setup. The DAG looks more parallel and the wall
+clock does not improve — sometimes it gets worse.
+
+A neutral or negative result here is not evidence that sharding is bad in
+principle; it is evidence that the platform was capacity-bound for that shape.
+
+## Diagnose contention first
+
+Use this checklist before splitting anything:
+
+1. Separate **queue** from **execution** per job (`references/measurement.md`).
+2. Count how many jobs are runnable at the peak fan-out point.
+3. Compare that count with the provider's available slots for this repository,
+   queue, label, or runner class.
+4. Measure the per-job setup tax: queue + VM boot + checkout + toolchain restore.
+5. Ask whether the proposed split reduces execution by more than it increases the
+   number of queued/setup-paying jobs.
+
+A quick heuristic:
+
+- If queue is a small tail and execution dominates, sharding may help.
+- If queue is a large share of p95, do **not** add jobs until capacity is
+  measured and, if needed, fixed.
+- If the lane is short and setup-heavy, merging jobs that share setup is usually
+  better than splitting them.
+
+## Price the hop
+
+A new job is not free. It pays its own queue wait, VM provisioning, checkout, and
+runtime setup before doing useful work. Call that the **hop cost**.
+
+Price it with the median and p95 from real runs:
+
+```text
+hop_cost = queue + setup
+work_saved = old_execution - new_execution
+```
+
+Only split when `work_saved` clearly beats the hop cost *in the same contention
+state*.
+
+Typical bad shapes:
+
+| Shape | Why it loses |
+|---|---|
+| Planner job in front of the matrix | Adds one full queue/setup hop before any useful lane starts. |
+| Aggregate status job at the end | Adds one more hop after all real work is already done. |
+| Tiny shards on cold runners | Each shard re-pays setup; the serial tail moves from execution to orchestration. |
+| More jobs on a scarce large runner class | Queue rises faster than execution falls. See `references/runners-and-autoscaling.md`. |
+
+## Compare arms under the same load
+
+A run against an idle pool and a run against a saturated one are not comparable,
+even on the same commit and runner class. The difference can exceed the effect you
+are testing.
+
+For in-job changes, compare **execution time** first. For topology changes, either:
+
+- interleave arms (`A, B, A, B`) and compare medians, or
+- run both during the same fleet conditions and treat any delta smaller than the
+  queue-time spread as noise.
+
+A useful report shape:
+
+```text
+Queue p50/p95: 18s / 97s   (noise floor)
+Execution p50/p95: 62s / 66s
+Change A -> B execution delta: -4s
+Conclusion: within queue noise, not proven at wall-clock level
+```
+
+That is a real result. Report neutral experiments instead of silently dropping
+them and letting the next person re-run the same dead idea.
+
+## What to do when capped
+
+When the ceiling is the problem, the next move is usually **fewer jobs**, not
+more hardware. Try, in order:
+
+1. Merge jobs that share expensive setup.
+2. Remove planner/aggregator hops that exist only for ergonomic reporting.
+3. Collapse tiny shards until setup is amortized.
+4. Move non-critical parallel work off the PR critical path with a full-run
+   fallback (`references/change-based-ci.md`).
+5. Only then add slots, resize runners, or change queue placement
+   (`references/runners-and-autoscaling.md`).
+
+Examples of "merge, don't split":
+
+- lint + typecheck on the same checkout/runtime when each is short
+- unit tests and small static analysis sharing the same dependency install
+- one workflow with multiple short jobs that all queue behind the same scarce
+  label
+
+Examples where splitting still wins:
+
+- genuinely long, independent test groups with modest setup
+- jobs whose runtime dominates queue+setup by a wide margin
+- sharding on a fleet with spare slots and stable startup latency
+
+## Provider-specific ceilings
+
+The ceiling is provider- and fleet-specific. It can be:
+
+- a repository concurrency limit
+- a queue label with few warm runners
+- a scarce runner class (large x64, macOS, GPU, ARM)
+- an autoscaler that reacts more slowly than the fan-out burst
+- a self-hosted fleet sharing slots across several repositories
+
+Do not infer the ceiling from docs alone. Infer it from queue share and from the
+point where adding jobs stops reducing wall-clock. Then route to the provider file
+or `references/runners-and-autoscaling.md` for the capacity-side fix.
+
+## Connections to other references
+
+- Read `references/measurement.md` first — this file assumes queue vs execution is
+  already separated.
+- Read `references/runners-and-autoscaling.md` when the fix is more slots, a
+  different runner class, or a fleet change.
+- Read `references/change-based-ci.md` when the best answer is to avoid starting
+  unrelated work at all.
+- Read `references/testing-and-flakiness.md` before sharding tests, especially
+  when setup or report merging is non-trivial.
+- Read `references/feedback-loops.md` when a topology change also alters how the
+  result is consumed (aggregate jobs, follow-up workflows, late registration).
+
+## Sources
+
+- GitHub Actions limits: https://docs.github.com/en/actions/reference/limits (accessed 2026-07-28)
+- GitLab runner autoscaling: https://docs.gitlab.com/runner/runner_autoscale/ (accessed 2026-07-28)
+- CircleCI parallelism/resource classes: https://circleci.com/docs/guides/optimize/parallelism-faster-jobs/ (accessed 2026-07-28)
+- Buildkite queue and concurrency docs: https://buildkite.com/docs/pipelines/configure/workflows/controlling-concurrency (accessed 2026-07-28)

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/change-based-ci.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/change-based-ci.md
@@ -1,16 +1,23 @@
 # Change-Based CI
 
-Use this file for path filters, affected commands, merge-base correctness, merge queues, and deciding when partial validation is safe.
+Use this file for path filters, affected commands, merge-base correctness, merge
+queues, and deciding when partial validation is safe.
+
+This file answers a stricter question than “can we skip work?” It answers “what
+must be true before skipping work is still honest?” If any step below cannot be
+proved, run the full pipeline.
 
 ## The correctness ladder
 
 1. **Compute the changed set** from reliable event SHAs or complete history.
 2. **Map changed files to owners/packages/tasks** using a dependency graph or explicit rules.
-3. **Include transitive consumers** that can be affected by shared code, schema, lockfile, generated code, CI config, and build config.
+3. **Include transitive consumers** that can be affected by shared code, schema,
+   lockfile, generated code, CI config, and build config.
 4. **Prove the graph is complete** for the defect classes you are skipping.
-5. **Run full validation defensively** on merge queue, schedule, release, or uncertainty.
+5. **Escalate to a full run** on merge queue, release, schedule, uncertainty, or
+   any change to the planner itself.
 
-If any step fails, run the full pipeline.
+If any step fails, the correct answer is the full pipeline.
 
 ## Merge-base rules
 
@@ -20,22 +27,57 @@ If any step fails, run the full pipeline.
 - Merge queues create a predictive branch; PR-only base/head assumptions may test the wrong change set.
 - Lockfile, CI config, dependency graph, generated-code schema, and shared-global changes usually escalate to full validation.
 
+## The planner must not route itself narrowly
+
+The component that decides what runs is part of the repository. If a change to
+that logic routes only the lanes it already knows how to name, a routing bug can
+ship having validated a fraction of the repo.
+
+Two failures worth guarding against explicitly:
+
+1. **Config fan-out gaps.** A rule mapping `.github/**` to “the main lanes” silently
+   excludes specialized ones, so editing a specialized workflow never exercises it.
+2. **Self-routing.** A planner change that maps only to its own directory's lane
+   grades its own homework.
+
+Guard both with unit fixtures over the classifier when possible — it is usually a
+pure path-to-lane function and costs milliseconds to test.
+
 ## Path filters versus graph-aware affected
 
-Path filters are acceptable for flat repos with no shared package consumers. They are dangerous when a shared library affects multiple apps.
+Path filters are acceptable for flat repos with no shared package consumers. They
+are dangerous when a shared library affects multiple apps.
 
-Graph-aware affected commands (`nx affected`, Turborepo affected/filter, Bazel reverse dependencies) are better only when:
+Graph-aware affected commands (`nx affected`, Turborepo filters, Bazel reverse
+queries) are better only when:
 
-- package/task graph is complete,
+- the package/task graph is complete,
 - task inputs include external files that feed generation,
 - base and head are correct,
 - remote/local cache behavior does not mask skipped work.
 
-Package-level affected detection can miss a file outside package roots that feeds a task. Enable task-input-aware filtering when supported; otherwise add explicit escalation paths.
+Package-level affected detection can miss a file outside package roots that feeds
+a task. Enable task-input-aware filtering when supported; otherwise add explicit
+escalation paths.
+
+## Rename and non-code edge cases
+
+Two subtle misses recur in real repos:
+
+- **Rename drift.** `git diff --name-only` prints only the destination path when
+  rename detection is on. Moving `src/x.ts` to `docs/x.md` can therefore read as a
+  docs-only change while executable source was removed. Use `--no-renames`, or
+  parse `--name-status` and route both paths.
+- **Generated inputs outside the package root.** A package-level planner may miss a
+  schema, template, or CI helper outside its tree that still changes its build.
+
+These are reasons to escalate, not special cases to wave through.
 
 ## Required-check pattern
 
-Do not skip an entire required workflow by a path filter and leave the check pending. Use an always-running change-detection job, then condition expensive jobs:
+Do not skip an entire required workflow by a path filter and leave the check
+pending. Use an always-running change-detection job, then condition expensive
+jobs:
 
 ```yaml
 jobs:
@@ -44,7 +86,7 @@ jobs:
     outputs:
       source: ${{ steps.detect.outputs.source }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: detect
@@ -63,7 +105,8 @@ jobs:
       - run: corepack pnpm test -- --run
 ```
 
-Ensure the provider reports skipped downstream jobs as successful/skipped in the way branch protection expects.
+Ensure the provider reports skipped downstream jobs as successful/skipped in the
+way branch protection expects.
 
 ## Full-run triggers
 
@@ -75,7 +118,16 @@ Always run the full suite when:
 - generated-code schema or generator changed,
 - shared global tsconfig/build config changed,
 - release, merge queue, nightly, or scheduled defensive run,
-- previous partial run escaped a defect.
+- a previous partial run escaped a defect,
+- the planner itself changed.
+
+## Cross-links
+
+- `measurement.md` — how to baseline a partial-vs-full comparison honestly.
+- `caching.md` — when a remote cache can hide skipped work instead of saving it.
+- `effectiveness-contract.md` — why uncertainty here always resolves to a full run.
+- `feedback-loops.md` — the `no-run` verdict and how a watcher should report a path-filtered commit.
+- `monorepos.md` — when the graph and the planner are the optimization surface.
 
 ## Sources
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/evidence-and-sources.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/evidence-and-sources.md
@@ -1,6 +1,12 @@
 # Evidence and Sources
 
-Use this file when checking whether a CI/CD claim is current, resolving conflicting guidance, or refreshing this skill.
+Use this file when checking whether a CI/CD claim is current, resolving
+conflicting guidance, or refreshing this skill.
+
+This skill is only as good as the evidence behind it. CI providers change cache
+limits, runner images, CLI behavior, action versions, pricing, and defaults
+frequently; a plausible stale claim is worse than silence when it becomes
+load-bearing.
 
 ## Source hierarchy
 
@@ -10,38 +16,30 @@ Use this file when checking whether a CI/CD claim is current, resolving conflict
 4. Named production case studies with before/after metrics.
 5. Community anecdotes and marketing comparisons — leads only, never final evidence.
 
-Record access date. CI providers change cache limits, runner images, action versions, pricing, and defaults frequently.
+Record access date.
 
 ## Verification rules
 
-- Verify mutable facts before making them load-bearing: action SHAs, runner image names, Xcode versions, cache limits, provider pricing, and beta flags.
-- Do not quote a benchmark without workload, hardware, run count, and whether it was cold or warm.
+- Verify mutable facts before making them load-bearing: action SHAs, runner image
+  names, Xcode versions, cache limits, provider pricing, CLI behavior, and beta
+  flags.
+- Do not quote a benchmark without workload, hardware, run count, and whether it
+  was cold or warm.
 - Separate confirmed facts from inference.
 - If official sources conflict, prefer observed behavior from a controlled run.
-- If the repo's current config contradicts generic best practice, measure the repo's critical path before changing it.
+- If the repo's current config contradicts generic best practice, measure the
+  repo's critical path before changing it.
 
-## Research method used for this skill
+## Route claims by use case
 
-Twenty independent research tracks covered: measurement, GitHub Actions, GitLab CI, CircleCI, Buildkite, Bazel, Nx, Turborepo, TypeScript/Node, testing, containers, security gates, Xcode builds, iOS tests, runners, network/artifacts, deployment, integration environments, observability, and change-based orchestration. The comparison corpus also reviewed five existing CI/CD-related skills for structure and anti-patterns.
-
-## Core source map
-
-| Domain | Primary starting points |
+| Claim type | Primary evidence |
 |---|---|
-| Metrics | OpenTelemetry CI/CD semconv; DORA; provider pipeline analytics |
-| GitHub Actions | GitHub Docs caching, concurrency, larger runners, merge queue, secure use |
-| GitLab | GitLab CI YAML, caching, downstream pipelines, resource groups, runner autoscaling |
-| CircleCI | CircleCI caching, parallelism/test splitting, workspaces, rerun failed tests |
-| Buildkite | Dynamic pipelines, queues, agent management, concurrency, queue metrics |
-| Monorepo | Nx affected/cache security/DTE; Turborepo configuration/caching/CI |
-| Bazel | Bazel hermeticity, sandboxing, remote caching/execution, Bzlmod docs |
-| TypeScript | npm/pnpm/Yarn/Bun docs, Corepack, TypeScript project references |
-| Tests | Playwright/Vitest/Jest docs; CircleCI timing split; Google/Meta/Uber engineering |
-| Containers | Docker BuildKit cache, multi-stage, multi-platform, provenance, security |
-| Security | SLSA, in-toto, CodeQL, push protection, Semgrep, Trivy |
-| Runners | GitHub/GitLab/Buildkite runner and autoscaling docs; Kubernetes scheduling |
-| Deployment | Argo Rollouts/CD, Kubernetes probes, immutable-artifact guidance |
-| Swift/Xcode | Apple Xcode docs/release notes, Swift compiler performance, Swift library evolution |
+| Runner speed / queue differences | provider timestamps + historical runs on the same class |
+| Cache effectiveness | paired cold/warm timing on the same commit |
+| Watcher behavior / CLI output shape | provider docs + CLI source code or repeated live probes |
+| Flakiness | identical-commit re-run |
+| Deployment correctness | exact artifact digest, rollout state, and health checks |
+| Change-based safety | graph completeness proof + full-run fallback behavior |
 
 ## Refresh checklist
 
@@ -51,4 +49,37 @@ When updating this skill:
 2. Replace stale examples with current stable syntax.
 3. Preserve the effectiveness contract unless a control has formally changed.
 4. Add new sources with access dates.
-5. Re-run trigger and functional tests after edits.
+5. Re-run structural validation after edits (`scripts/validate-skills.py`).
+
+## Cross-links
+
+- `measurement.md` — for the baseline and evidence rung you can safely claim.
+- `feedback-loops.md` — when the mutable fact is CLI watch behavior or run-state semantics.
+- `testing-and-flakiness.md` — when the source question is whether a red check is real.
+- `effectiveness-contract.md` — when a proposed change is tempting but weakens the proof surface.
+
+## Core source map
+
+| Domain | Primary starting points |
+|---|---|
+| Metrics | OpenTelemetry CI/CD semantic conventions; DORA; provider analytics |
+| GitHub Actions | GitHub Docs on caching, concurrency, larger runners, merge queue, secure use |
+| GitLab | GitLab CI YAML, caching, downstream pipelines, resource groups, runner autoscaling |
+| CircleCI | CircleCI caching, parallelism/test splitting, workspaces, rerun failed tests |
+| Buildkite | Dynamic pipelines, queues, agent management, concurrency, queue metrics |
+| Monorepo | Nx affected/cache security/DTE; Turborepo configuration/caching/CI |
+| Bazel | Bazel hermeticity, sandboxing, remote caching/execution, Bzlmod |
+| TypeScript | npm/pnpm/Yarn/Bun docs, Corepack, TS project references |
+| Tests | Playwright/Vitest/Jest docs; provider timing split; Google/Meta/Uber engineering |
+| Containers | Docker BuildKit cache, multi-stage, multi-platform, provenance, security |
+| Security | SLSA, in-toto, CodeQL, push protection, Semgrep, Trivy |
+| Runners | GitHub/GitLab/Buildkite runner docs; Kubernetes scheduling |
+| Deployment | Argo Rollouts/CD, Kubernetes probes, immutable-artifact guidance |
+| Swift/Xcode | Apple Xcode docs/release notes, Swift compiler performance, Swift library evolution |
+
+## Sources
+
+- GitHub Actions docs: https://docs.github.com/en/actions (accessed 2026-07-28)
+- GitLab CI/CD docs: https://docs.gitlab.com/ee/ci/ (accessed 2026-07-28)
+- CircleCI docs: https://circleci.com/docs/ (accessed 2026-07-28)
+- Buildkite docs: https://buildkite.com/docs (accessed 2026-07-28)

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/feedback-loops.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/feedback-loops.md
@@ -1,0 +1,300 @@
+# Feedback Loops: Receiving a Pipeline Result Without Stalling
+
+Read this when work is validated *through* CI — an agent or long-running session
+pushes, dispatches, re-runs, or deploys, then must learn the outcome before
+continuing. Also read it when a wait command hangs, floods the context, or reports
+a verdict that turns out to be for the wrong commit.
+
+Making a pipeline fast is only half the job. The other half is consuming the
+result. A 60-second pipeline still costs ten minutes of wall-clock if the waiter
+blocks on it, and it is *dangerous* if the waiter concludes "green" from a run
+that never started. This is a correctness problem, not a convenience one: a
+session blocked on CI with no deadline is indistinguishable from a session that
+crashed.
+
+The failure is provider-neutral, so the contract here is too. Only the probe
+command changes between GitHub Actions, GitLab, Buildkite, CircleCI, or a deploy
+API.
+
+## Why the obvious approaches fail
+
+Every naive wait shares one of a few defects. Naming them is what lets an agent
+recognize its own stall:
+
+| Attempt | Failure mode |
+|---|---|
+| A vendor `watch` subcommand piped into a harness (`gh run watch`, `avr run watch`, …) | Off a TTY these redraw the whole run table each interval instead of emitting lines, and many suppress their completion summary entirely when stdout is not a terminal. You get unparseable repetition and no terminal line. None carry a deadline of their own. |
+| `while true; do sleep 30; done` with a success-only `grep` | A crashed, cancelled, or never-registered run emits nothing — identical to a healthy one. Silence reads as patience. No deadline. |
+| `tail -f log \| grep "BUILD OK"` | Same silence-on-failure defect, plus unflushed pipe buffers hide matches until far too late. |
+| A single-condition `until` loop | Correct for "tell me when X exists"; emits nothing if X never happens, and cannot report failure. |
+| Polling the branch tip instead of the pushed commit | Returns a newer run from someone else's push, or your own previous one — a false green on a commit that was never tested. |
+| Re-printing the full job table each poll | Burns context until the harness rate-limits or kills the monitor, which reintroduces the stall. |
+| Blocking the session while waiting | Forfeits the entire point: a failure at minute 3 of a 25-minute pipeline is learned at minute 25. |
+
+The cost is asymmetric, which is why this matters. A failure detected early gives
+back most of the pipeline's duration; the same failure detected at the deadline
+gives back nothing. On a 25-minute pipeline, reacting to the *first* red lane
+rather than the final verdict is roughly a 20-minute head start on the fix.
+
+## The contract a watcher must satisfy
+
+Any wait mechanism armed after a trigger must guarantee all of these. Each maps to
+a specific observed failure when missing:
+
+1. **Terminates on every path, with an explicit verdict.** Silence past the
+   deadline must be structurally impossible — emit exactly one terminal line, then
+   exit. This is the load-bearing property; the rest refine it.
+2. **Pins to an immutable identifier**, captured *before* arming — a commit SHA,
+   build id, or deploy id. Never a moving ref like a branch tip.
+3. **Covers every run the identifier triggered**, not just one workflow by name. A
+   second pipeline on the same commit can fail while the watched one passes.
+4. **Emits only state changes**, plus a low-frequency heartbeat. A green 20-minute
+   run should cost a handful of lines, not fifty identical tables.
+5. **Has a registration deadline** distinct from the run deadline. If nothing
+   appears for the identifier within a few minutes, say so — a path filter, wrong
+   ref, disabled workflow, or failed push must not read as "still running."
+6. **Waits for late registration before declaring success.** Runs register seconds
+   apart; `workflow_run`-style chains (a deploy triggered on build completion)
+   register much later. Require a settle condition before green.
+7. **Detects supersession.** If the branch moves past the identifier, retire.
+8. **Bounds each probe and survives transient errors.** One wedged API call must
+   not freeze the loop; warn on a short streak, exit loudly on a long one.
+9. **Heartbeats.** A periodic liveness tick separates "still queued" from "watcher
+   died." Keep the interval under the consuming model's prompt-cache TTL (commonly
+   ~5 min; ~2–3 min is a safe default) so a long wait stays cheap.
+
+### Verdict vocabulary
+
+A small, stable set of terminal verdicts lets the caller react without parsing
+prose. Each implies a different next move — which is the whole reason to
+distinguish them:
+
+| Verdict | Meaning | Caller's next move | Exit |
+|---|---|---|---|
+| `success` | every run for the identifier is green | proceed | 0 |
+| `failure` | a run went red | fetch that job's failing log now | 1 |
+| `timeout` | not terminal within the deadline | inspect the run; stuck, not slow | 2 |
+| `no-run` | nothing registered for the identifier | path filter, wrong ref, disabled workflow, failed push — all actionable, none a hang | 2 |
+| `probe-dead` | repeated API/CLI failures | check auth, network, rate limits | 2 |
+| `cancelled` | terminal but not green, branch unmoved | usually a manual stop or infra event — decide whether the commit was ever validated | 1 |
+| `superseded` | the branch moved past the identifier | retire; arm a fresh watch on the new id | 3 |
+
+Two rules make this vocabulary safe:
+
+**Enumerate success, not failure.** The most dangerous watcher bug is treating
+"did not fail" as green. A run that ends `cancelled`, `skipped`, `stale`, or
+`neutral` is terminal but *not* validated. Match an explicit success set and treat
+every other terminal conclusion — including ones never seen before — as not-green.
+
+**Evaluate supersession before calling anything a failure.** The
+`cancel-in-progress: true` concurrency pattern this skill recommends elsewhere
+(see `references/github-actions.md`) cancels the previous commit's run when a fix
+lands. A watcher that checks failure first reports `failure` for a run nobody
+should act on, and the agent chases a phantom break. `no-run` and `superseded` are
+the two verdicts hand-rolled loops almost always omit, and the two that waste the
+most wall-clock.
+
+Distinct exit codes matter for chaining: `watch && deploy` must not proceed on a
+`superseded` watch that never reached a real verdict. Put the failing run's log
+command *inside* the `failure` line so the caller never has to reconstruct it.
+
+## Reference implementation shape
+
+Provider-agnostic; swap `probe()` for the platform's CLI or API. The bundled
+`scripts/ci-watch.py` implements this exactly, with a built-in GitHub Actions probe
+and a custom-probe mode for everything else.
+
+```python
+def watch(sha, branch, deadline, register_by, settle, interval, heartbeat) -> int:
+    start = last_beat = all_green_since = now()
+    seen, errors, registered = {}, 0, False
+
+    while True:
+        if now() - start > deadline:
+            emit("CI-DONE timeout"); return 2
+
+        try:
+            runs = probe(sha)                # ALL runs for this id, never "latest"
+            errors = 0
+        except Exception:
+            errors += 1
+            if errors == 3:  emit("CI-WARN probe failing (3x)")
+            if errors >= 10: emit("CI-DONE probe-dead"); return 2
+            sleep(interval); continue
+
+        if runs and not registered:
+            registered = True; emit(f"CI-RUN registered {len(runs)}")
+        if not registered and now() - start > register_by:
+            emit("CI-DONE no-run"); return 2
+
+        for r in runs:                       # diff-gated: emit only on change
+            if seen.get(r.id) != r.state:
+                if r.id in seen: emit(f"CI-CHG {r.name}: {seen[r.id]} -> {r.state}")
+                seen[r.id] = r.state
+
+        if registered and runs and all(r.terminal for r in runs):
+            superseded = branch and head_of(branch) != sha   # a lookup error is NOT supersession
+            bad = [r for r in runs if r.conclusion not in SUCCESS_SET]
+            if superseded and not any(r.conclusion in FAILURE_SET for r in runs):
+                emit("CI-DONE superseded"); return 3
+            if bad:
+                emit(f"CI-DONE failure — {bad[0].name} — logs: <log-cmd {bad[0].id}>"); return 1
+            if now() - all_green_since >= settle:            # hold for late workflow_run chains
+                emit("CI-DONE success"); return 0
+        else:
+            all_green_since = now()
+
+        if now() - last_beat >= heartbeat:
+            last_beat = now(); emit(f"CI-HB {int((now()-start)/60)}m")   # MUST reset, or it fires every poll
+        sleep(interval)
+```
+
+Three judgement calls to make explicit for the target setup:
+
+- **`SUCCESS_SET`.** `{success, skipped, neutral}` is a reasonable default — a
+  skipped job is usually an intentional route. Verify against the repo's own gating
+  rules before trusting it.
+- **`settle`.** How long to hold an all-green state before declaring success. One
+  poll interval (~15s) covers workflows that register seconds apart;
+  `workflow_run` chains register *after* their trigger completes, so give those
+  60–120s or watch the downstream workflow explicitly.
+- **`FAILURE_SET` vs `cancelled`.** A *completed red* run reports `failure` even if
+  the branch later moved — "did this SHA pass" matters more than "did the branch
+  move." A `cancelled` run on an *unmoved* branch is a distinct signal (manual
+  cancel or infra), not a test failure, so it is not silently folded into success.
+
+## Per-provider probes
+
+Only the poll step changes. Everything above is identical.
+
+| Provider | Poll for one commit |
+|---|---|
+| GitHub Actions | `gh run list --commit <sha> --json databaseId,workflowName,status,conclusion` |
+| GitLab CI | pipelines API filtered by `sha` |
+| Buildkite | builds API filtered by commit |
+| CircleCI | pipeline → workflow status by revision |
+| A deploy / anything else | any command printing `<name>: <state>` lines and a terminal marker |
+
+A provider CLI that emits a structured event stream and a nonzero exit on failure
+(NDJSON, `--json`) already satisfies most of the contract — prefer wrapping it over
+hand-rolling. What such CLIs typically still lack is a self-imposed deadline, a
+registration timeout, and coverage of *every* run for the commit. Wrap, do not
+replace.
+
+## Run granularity: run-level status hides an early failing job
+
+A run-level status stays `in_progress` until *every* job finishes, and its
+conclusion is unset until then. If a pipeline is one workflow with several jobs,
+polling run status alone cannot tell you a lane already failed — which defeats the
+"react to the first red" payoff. Either split genuinely independent lanes into
+separate workflows (they then appear as separate runs for the commit), or expand
+in-flight runs to job level when polling (`gh run view <id> --json jobs`). Expand
+only *in-flight* runs; completed ones already carry a conclusion, so the extra call
+is bounded to work that is still moving.
+
+## Wiring it to an agent harness
+
+Run the watcher as a background process whose **stdout lines become
+notifications**, so the agent keeps working and reacts on arrival. With a streaming
+background-process tool (for example Claude Code's `Monitor`):
+
+```
+Monitor(
+  command: "python3 scripts/ci-watch.py --sha <full-sha> --branch <branch> --deadline-min 25",
+  description: "CI for <short-sha>",
+  timeout_ms: 1800000        # comfortably longer than the watcher's own deadline
+)
+```
+
+Rules that matter in practice:
+
+- **Set the harness timeout longer than the watcher's deadline**, so the watcher is
+  what ends the watch and you get a verdict instead of a truncated stream.
+- **Arm it last, in the same turn as the push.** Any commit after arming moves the
+  branch and the watcher correctly retires as `superseded` — but you lose the
+  watch. Finish committing, then arm, then keep working.
+- **Never hand-type the identifier.** Use `$(git rev-parse HEAD)`; a wrong SHA
+  reports `no-run` or `superseded` against the real head and teaches nothing.
+- **One watch per identifier.** After a re-push, arm a fresh one.
+- **A heartbeat is not a result.** Acknowledge it silently; never report it as
+  progress or treat it as a user message.
+- **If any stage is a shell pipeline, flush per line** — `grep --line-buffered`,
+  `awk` with `fflush()`. A buffered stage silently withholds events, and `| head -N`
+  cannot flush at all. In `zsh`, avoid a variable named `status`; it is a readonly
+  builtin and the loop dies instantly, emitting nothing.
+
+### When one notification is enough
+
+For plain "tell me when it is done," a bounded background command that exits on the
+condition is simpler than a streaming watcher:
+
+```bash
+until <terminal-state-check>; do sleep 20; done
+```
+
+Reach for the streaming watcher when you want to react to the *first* red lane while
+others still run — the head-start described above.
+
+## Reacting to events
+
+| Event | Response |
+|---|---|
+| `CI-RUN` / `CI-CHG … registered` | Note the count. Fewer runs than expected is a routing problem — see `references/change-based-ci.md`. |
+| `CI-CHG … -> failure` | Act now; pull that job's failing step log without waiting for the rest. |
+| `CI-CHG in_progress -> queued` | Normal on platforms that reclaim runners mid-run. Not a fault. |
+| `CI-HB` | Acknowledge silently. |
+| `CI-DONE` | The only line that is a verdict. |
+
+State is **not** monotonic on every platform. Only a terminal line means terminal.
+
+## Reacting to a red check without corrupting the measurement
+
+A red check is a real finding, not an obstacle to route around. Deciding *whether
+it is your failure* comes before changing code:
+
+1. Run the exact log command the verdict printed. Do not re-derive it.
+2. Diff the failing commit against the last green one: `git diff --stat <green>..<red>`.
+   If nothing in that diff can plausibly reach the failing test, re-run the
+   **identical commit** rather than pushing a speculative fix.
+3. A pass on the unchanged commit demonstrates a flaky test — a separate defect to
+   own, never "fixed" by relaxing the assertion, adding a retry, mocking the failure
+   away, or `skip`ping to green. Each of those corrupts the measurement instead of
+   fixing the pipeline (`references/effectiveness-contract.md`). Quarantine and
+   ownership belong in `references/testing-and-flakiness.md`.
+4. If the failure is genuine, reproduce it with the narrowest local command. If it
+   is CI-only, reproduce the *CI condition* — job-wide environment variables, a
+   clean checkout, a different working directory, absent secrets — not the whole
+   pipeline.
+5. Verify red-first: confirm the test fails without the fix and passes with it. A
+   fix never seen to fail is a fix you cannot vouch for.
+
+A provider flake counter, where one exists, is a useful prior but not a substitute:
+it typically only catches a step that succeeded on retry, so a
+consistently-failing-then-passing test can read as zero flakes. The identical-commit
+re-run is the reliable test.
+
+## A collateral benefit: automatic CI surfaces hidden defects
+
+Moving from a manual, hand-dispatched pipeline to one that runs on every push
+surfaces defects the manual flow hid — environment leakage between jobs, assertions
+that drifted from the contract they check, pre-existing flakes. Treat each as a real
+finding and root-cause it red-first. Reaching green by weakening the check trades a
+slow local loop for a silent remote one that lies.
+
+## Verify the watcher before trusting it
+
+A watcher never seen to fail correctly is not yet a safety mechanism. Exercise the
+paths that would otherwise hang:
+
+| Path | How to force it |
+|---|---|
+| `no-run` | Watch an all-zeros or unpushed SHA with a short registration deadline. |
+| `failure` | Watch a known-red historical SHA. |
+| `success` | Watch a known-green historical SHA. |
+| `superseded` | Watch a SHA, then push one more commit to the branch. |
+
+## Sources
+
+- `gh run watch` TTY-gating of screen refresh and of the completion summary: `cli/cli` `pkg/cmd/run/watch/watch.go`, `pkg/iostreams/iostreams.go` (read 2026-07-28)
+- `gh run watch` flags (`--exit-status`, `--interval`, `--compact`): https://cli.github.com/manual/gh_run_watch (accessed 2026-07-28)
+- GitHub Actions `workflow_run` trigger semantics (late follow-up registration): https://docs.github.com/actions/reference/events-that-trigger-workflows (accessed 2026-07-28)

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/measurement.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/measurement.md
@@ -1,49 +1,110 @@
 # Measurement and Verification
 
-Use this file when building a baseline, proving a bottleneck, or validating that an optimization helped without weakening delivery outcomes.
+Use this file when building a baseline, proving a bottleneck, sizing an
+experiment, or deciding whether a claimed speedup is real. The goal is to measure
+what the change controls, not to quote the best-looking total from a noisy set of
+runs.
+
+If the question is *whether adding jobs will help or whether the pool is already
+contended*, read `capacity-and-contention.md` next. If the question is *how the
+result gets back to an agent without stalling*, read `feedback-loops.md`.
 
 ## Metrics that matter
 
-| Metric | Formula | Interpretation |
+| Metric | Formula | What it answers |
 |---|---|---|
-| Queue time | execution start - trigger time | Capacity, scheduling, concurrency, runner topology. |
-| Setup time | first real task - runner start | Checkout, runtime, dependency install, environment boot. |
-| Execution time | finish - execution start | Workload inside jobs. |
+| Queue time | job `started_at - created_at` | Capacity, scheduling, runner scarcity, queue placement. |
+| Setup time | first real task - runner start | Checkout, runtime install, dependency restore, environment boot. |
+| Execution time | finish - execution start | The work the job itself performs. |
 | Critical-path duration | longest dependency chain through the DAG | The only sequence that directly governs wall-clock feedback. |
-| Cache exact-hit rate | exact key hits / cache attempts | Cache-key precision, not necessarily saved time. |
-| Cache saved time | clean path time - (restore + post-hit work) | Whether a cache is worth keeping. |
-| First-time pass rate | runs green without retry / all runs | Flakiness and reliability. |
-| Cost per successful change | compute + storage / successful changes | Speed improvements that increase total cost may not be wins. |
-| Change failure/rework rate | failed or unplanned recovery deployments / deployments | The effectiveness guardrail after optimization. |
+| Cache exact-hit rate | exact key hits / cache attempts | Key precision, not necessarily saved time. |
+| Cache saved time | clean path - (restore + post-hit work) | Whether a cache is worth keeping. |
+| First-time pass rate | runs green without retry / all runs | Reliability, flakiness, and hidden rework. |
+| Cost per successful change | compute + storage / successful changes | Whether a “speedup” just bought more cost. |
+| Change failure / rework rate | failed or unplanned recovery deploys / deploys | Whether the faster path weakened effectiveness. |
 
-Use median and p95. CI duration is right-skewed; averages hide cold caches, runner saturation, flaky retries, and dependency changes.
+Use **median and p95**. CI duration is right-skewed; averages hide cold caches,
+runner saturation, flaky retries, and setup spikes.
 
 ## Baseline protocol
 
 1. Pin the exact commit, workflow, event, runner class, and environment.
-2. Run at least three comparable runs when variance is material.
+2. Use at least three comparable runs when variance is material.
 3. Record queue, setup, execution, transfer, finalization, and per-job duration.
 4. Record exact cache hit/miss, retry count, artifact names/digests, and run head SHA.
 5. Reject baselines from stale branches, empty diffs, disabled jobs, or different runners.
 
-If a queue-time baseline is unavailable, start with provider run timestamps and job logs. Do not invent missing precision.
+If queue-time history is unavailable, start from provider timestamps and job logs.
+Do not invent missing precision.
+
+## Separate queue from execution before claiming anything
+
+Total wall-clock mixes two different things:
+
+```text
+queue     = started_at - created_at
+execution = completed_at - started_at
+```
+
+Queue is fleet behavior; execution is the part your in-job change usually
+controls. If execution is stable and totals swing, say that explicitly and report
+execution as the result.
+
+### Compare arms under the same contention state
+
+A run against an idle pool and a run against a saturated one are not comparable,
+even on the same commit and runner class. Interleave arms when practical (`A, B,
+A, B`) and compare execution time when the change is in-job. Treat any delta
+smaller than the queue-time spread as noise.
+
+A good summary looks like:
+
+```text
+Queue p50/p95: 18s / 97s   (noise floor)
+Execution p50/p95: 62s / 66s
+Change A -> B execution delta: -4s
+Conclusion: within queue noise, not proven at wall-clock level
+```
+
+That is a valid result. Report disproved hypotheses too — silently dropping a
+neutral experiment invites the next person to retry the same dead idea.
 
 ## Critical-path analysis
 
-Build a DAG from declared dependencies. For every job, compute:
+Build the DAG from actual dependencies, not stage labels. For each job, compute:
 
 - duration,
-- exclusive time (time it blocks the critical path),
+- exclusive time (how long it blocks the critical path),
 - critical-path rate (how often it determines total duration),
-- setup/execute/transfer breakdown.
+- queue/setup/execute/transfer breakdown.
 
-Prioritize `critical-path rate × exclusive time`. A job consuming CPU in parallel with a longer job is not the current bottleneck.
+Prioritize:
 
-Where the platform records per-job start offsets, derive the DAG shape empirically instead of trusting declared dependencies: a gap between a job's `start + duration` and its dependents' start is scheduling and per-job setup overhead, which no amount of in-job optimization removes. On Avrea, `references/avrea/cli-evidence.md` shows how to extract these offsets.
+```text
+critical-path rate × exclusive time
+```
 
-## Experiment verification
+A job burning a lot of CPU in parallel with a longer job is not the current
+bottleneck. Large total CPU-time savings on non-critical work can produce zero
+wall-clock change.
 
-Before changing config, write down:
+Where the platform records per-job start offsets, derive the DAG shape
+empirically instead of trusting declared dependencies. A gap between a job's end
+and its dependents' start is scheduling and per-job setup overhead — work no
+in-job optimization will remove.
+
+## Job topology: price the hop before adding one
+
+A new job pays its own queue, VM boot, checkout, and toolchain setup. That **hop
+cost** belongs in the baseline before adding planner jobs, aggregate status jobs,
+fan-out helpers, or tiny shards.
+
+If the question is specifically *when splitting or sharding stops helping*, route
+immediately to `capacity-and-contention.md`.
+
+## Experiment definition
+
+Before changing config, write down the experiment in plain language:
 
 ```text
 Baseline: p50 14.2m / p95 18.7m on commit abc123
@@ -53,23 +114,36 @@ Expected: test critical path under 4m; no test-count loss
 Risk: uneven shard due to one long spec; rollback is remove matrix
 ```
 
-After the change:
+If the plan cannot name the bottleneck and expected wall-clock effect, it is not
+ready to run.
 
-1. Re-run the same commit if possible.
+## Verify after the change
+
+1. Re-run the **same commit** first when possible.
 2. Confirm the run's head SHA contains the change and the expected jobs ran.
-3. Compare p50/p95 wall-clock, queue time, cost, cache behavior, and first-time pass rate.
-4. Confirm no tests/gates disappeared from the merged result.
+3. Compare p50/p95 wall-clock, queue time, cost, cache behavior, and first-time
+   pass rate.
+4. Confirm no tests/gates/artifact identities disappeared from the merged result.
 5. Repeat on a normal representative commit.
 
 ## Claim only the rung reached
 
-| Evidence | You may say |
+| Evidence | Safe wording |
 |---|---|
-| Config inspected | "The bottleneck hypothesis is plausible." |
-| Syntax/schema validated | "The config is valid; runtime not exercised." |
-| One exact-commit run | "One measured run improved; variance not established." |
-| Three+ comparable runs | "The measured median/p95 improved on these runs." |
-| Production/trend evidence | "The optimization held in normal operation." |
+| Config inspected | “The bottleneck hypothesis is plausible.” |
+| Syntax/schema validated | “The config is valid; runtime not exercised.” |
+| One exact-commit run | “One measured run improved; variance not established.” |
+| Three+ comparable runs | “The measured median/p95 improved on these runs.” |
+| Production/trend evidence | “The optimization held in normal operation.” |
+
+## Cross-links
+
+- `capacity-and-contention.md` — when queue share is high or added parallelism measured neutral.
+- `feedback-loops.md` — when the optimization includes how a person or agent waits on CI.
+- `runners-and-autoscaling.md` — when the next experiment is runner class or slot count.
+- `caching.md` — when setup/restore is the bottleneck and cache saved time is the question.
+- `testing-and-flakiness.md` — when retries or reruns dominate the metric.
+- `effectiveness-contract.md` — before weakening any gate, cache trust scope, or artifact identity.
 
 ## Sources
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -1,6 +1,12 @@
 # Runners and Autoscaling
 
-Use this file when queue time, runner capacity, runner isolation, or fleet cost is the bottleneck.
+Use this file when queue time, runner capacity, runner isolation, or fleet cost
+is the bottleneck.
+
+Read `measurement.md` first if queue and execution have not yet been separated.
+Read `capacity-and-contention.md` next when the suspected fix is “add more jobs”
+or “increase parallelism” — that file decides whether the fleet has enough slots
+for the change to pay off at all.
 
 ## Decision order
 
@@ -13,8 +19,10 @@ Use this file when queue time, runner capacity, runner isolation, or fleet cost 
 
 ## Trust boundaries
 
-- Untrusted public PRs belong on vendor-isolated hosted runners or equivalent one-job sandboxes.
-- Persistent self-hosted runners can retain malicious processes, files, credentials, and network access.
+- Untrusted public PRs belong on vendor-isolated hosted runners or equivalent
+  one-job sandboxes.
+- Persistent self-hosted runners can retain malicious processes, files,
+  credentials, and network access.
 - Do not share runner groups across trust levels.
 - Prefer OIDC and short-lived credentials over stored cloud secrets.
 
@@ -28,18 +36,59 @@ Use this file when queue time, runner capacity, runner isolation, or fleet cost 
 
 Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
+## Queue time varies by class — measure it, do not assume
+
+A larger instance class is not automatically faster end-to-end. Scarcity, pool
+warmth, and time-of-day decide whether the bigger class is provisioned sooner or
+later than the small one, and the answer differs per fleet and per hour.
+
+What generalizes is the method:
+
+1. Record `started_at - created_at` per job, grouped by runner label.
+2. Report median and p95 per class.
+3. Compare the queue penalty of the larger class against the execution gain it buys.
+4. Confirm the job is actually CPU- or memory-bound first — per-core idle ratios
+   and peak versus average utilization, not just duration.
+
+Size up only when utilization proves the job is compute-bound **and** the class's
+measured queue penalty is smaller than the execution gain. When a job is
+queue-bound, a bigger runner makes it slower.
+
+## Downsizing is often the real win
+
+“Start large, then step down” sounds prudent but silently overpays if the
+step-down half never gets measured. Peak memory far below allocation, CPU average
+well under 100%, and wall-clock flat across sizes is the signature of a job that
+should shrink.
+
+Treat a downsizing experiment as first-class, not as a consolation prize.
+
 ## Autoscaling signals
 
-Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.
+Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU
+utilization alone misses jobs waiting for a runner. Keep the runner
+manager/controller on persistent on-demand infrastructure.
+
+Corollary: fanning many concurrent jobs onto one scarce large label can exhaust
+that pool and serialize your own pipeline. Several runs of *your own* repository
+queueing simultaneously on the same large label is capacity starvation, not slow
+CI — reduce job count, spread across labels, or collocate work before buying
+more hardware.
 
 ## Spot capacity
 
-Use spot/preemptible runners only for short, idempotent, retryable, or checkpointed jobs. Keep an on-demand fallback and never run the controller/manager on spot. Do not use spot for deployment gates where interruption is costly.
+Use spot/preemptible runners only for short, idempotent, retryable, or
+checkpointed jobs. Keep an on-demand fallback and never run the
+controller/manager on spot. Do not use spot for deployment gates where
+interruption is costly.
 
 ## Architecture and OS
 
-- ARM64 Linux can reduce cost when toolchain and actions support it; benchmark compatibility.
-- macOS is scarce and expensive. Move lint/typecheck/cross-platform tests to Linux and reserve macOS for Xcode, signing, simulator, and Apple-specific validation.
+- ARM64 Linux can reduce cost when toolchain and actions support it; benchmark
+  compatibility first.
+- macOS is scarce and expensive. Move lint/typecheck/cross-platform tests to
+  Linux and reserve macOS for Xcode, signing, simulator, and Apple-specific
+  validation.
 - Pin runner images and Xcode versions; avoid `-latest` for reproducible timing.
 
 ## Kubernetes fleets
@@ -49,6 +98,14 @@ Use spot/preemptible runners only for short, idempotent, retryable, or checkpoin
 - Set security contexts and least-privilege service accounts.
 - Use bin packing that lets the cluster autoscaler remove cold nodes.
 - Isolate namespaces for multi-tenant workloads.
+
+## Cross-links
+
+- `capacity-and-contention.md` — when the queue ceiling, not runner speed, is the issue.
+- `measurement.md` — how to prove a bigger/smaller class changed execution rather than queue.
+- `network-and-artifacts.md` — when registry or artifact locality dominates more than CPU/RAM.
+- `deployment.md` — runner choices for rollout and release paths.
+- `swift-xcode.md` — macOS-specific constraints and where to optimize instead.
 
 ## Sources
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/testing-and-flakiness.md
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/references/testing-and-flakiness.md
@@ -1,6 +1,12 @@
 # Testing and Flakiness
 
-Use this file when test execution dominates the critical path or retries/reruns inflate pipeline time.
+Use this file when test execution dominates the critical path, when retries or
+re-runs inflate wall-clock, or when a green run still leaves doubt about whether
+the failure was real.
+
+Read `measurement.md` first if the slowdown has not been separated into queue vs
+execution. Read `feedback-loops.md` when the question is how to learn the result
+without blocking.
 
 ## Sharding principles
 
@@ -10,6 +16,9 @@ Use this file when test execution dominates the critical path or retries/reruns 
 - Increase shard count only while p95 wall-clock improves. Setup/reporting is the serial tail.
 - Merge results and coverage in a fan-in job; gate on the merged result.
 
+If the first shard plan that looks parallel also adds a heavy planner job or
+several short setup-heavy lanes, price the hop first in `capacity-and-contention.md`.
+
 ## Playwright
 
 ```bash
@@ -17,7 +26,8 @@ npx playwright test --shard=${SHARD_INDEX}/${SHARD_COUNT} --reporter=blob
 npx playwright merge-reports --reporter=html ./all-blob-reports
 ```
 
-Use `fullyParallel: true` only when tests are isolated enough for test-level distribution. Upload each shard's blob report and merge them.
+Use `fullyParallel: true` only when tests are isolated enough for test-level
+distribution. Upload each shard's blob report and merge them.
 
 ## Vitest
 
@@ -26,11 +36,13 @@ vitest run --reporter=blob --shard=${SHARD_INDEX}/${SHARD_COUNT}
 vitest run --merge-reports
 ```
 
-Vitest distributes by test file by default. A few large files can still dominate; split large files or use provider timing-aware splitting.
+Vitest distributes by test file by default. A few large files can still dominate;
+split large files or use provider timing-aware splitting.
 
 ## Jest
 
-Jest `--shard` balances by file count unless a custom sequencer uses historical timings. CircleCI and similar providers can split by JUnit timing metadata:
+Jest `--shard` balances by file count unless a custom sequencer uses historical
+timings. CircleCI and similar providers can split by JUnit timing metadata:
 
 ```bash
 npx jest --listTests | circleci tests run \
@@ -47,7 +59,29 @@ npx jest --listTests | circleci tests run \
 | Recovered test | Automatic re-entry into the blocking suite. |
 | Chronic flake | Fix infrastructure/test design or remove from required path with explicit risk acceptance. |
 
-Retries are a detection and temporary-confidence mechanism. A retry-pass is still evidence of instability. Track flake rate, rerun count, owner, and age.
+Retries are a detection and temporary-confidence mechanism. A retry-pass is still
+evidence of instability. Track flake rate, rerun count, owner, and age.
+
+## Re-run the identical commit before changing code
+
+If a red check appears on a commit whose diff does not plausibly reach the failing
+test, re-run the **identical commit** before touching code. A pass on the
+unchanged tree demonstrates flakiness or infrastructure drift, not a fixed bug.
+
+That is the reliable test. Provider flake counters are useful priors, not proof:
+they often only count a step that eventually succeeded, so a
+failing-then-passing test can still read as zero flakes.
+
+Do **not** “fix” a flake by:
+
+- widening a threshold,
+- adding an unconditional retry,
+- skipping the test,
+- mocking the failure away,
+- rerunning until green and calling it solved.
+
+Those weaken the measurement instead of fixing the pipeline. Cross-link:
+`effectiveness-contract.md`.
 
 ## Coverage
 
@@ -60,6 +94,14 @@ Retries are a detection and temporary-confidence mechanism. A retry-pass is stil
 - Use fail-fast between serial stages when downstream cannot succeed.
 - Avoid cancelling every matrix shard on the first failure when full shard signal helps diagnose systemic issues.
 - Preserve JUnit/blob/report artifacts on failure.
+
+## Cross-links
+
+- `feedback-loops.md` — how to surface the first failing lane without blocking.
+- `capacity-and-contention.md` — when sharding neutralizes or worsens wall-clock.
+- `measurement.md` — how to compare sharded and unsharded runs honestly.
+- `integration-environments.md` — when the flake is shared state, ports, or services rather than test logic.
+- `effectiveness-contract.md` — why retries and skips are not optimization.
 
 ## Sources
 

--- a/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/plugins/ci-cd-optimize/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Watch CI for one exact commit and emit a bounded, diff-gated event stream.
+
+Built for agents and unattended sessions that must learn the result of a push,
+re-run, dispatch, or deploy without blocking. One stdout line = one event, so it
+fits background monitor tools naturally.
+
+Guarantees:
+  - one line per state CHANGE (never re-prints unchanged state)
+  - a heartbeat while healthy, so a long queue is never ambiguous
+  - exactly one `CI-DONE <verdict>` on every path, then exit
+  - a hard deadline, a registration deadline, and a settle window for
+    workflow_run-style follow-up workflows that register after the first run turns green
+
+Verdicts: success | failure | cancelled | timeout | no-run | superseded | probe-dead
+Exit status: 0 only for `success`.
+
+Modes
+-----
+GitHub Actions (built in, zero config beyond authenticated `gh`):
+
+    ci-watch.py --sha "$(git rev-parse HEAD)" --branch main
+
+Any other provider: supply a probe command that prints one `<name>: <state>`
+line per unit of work, and optionally `TERMINAL: <verdict>` once all are
+terminal:
+
+    ci-watch.py --sha "$SHA" --cmd './ci/probe.sh'
+
+The probe receives the watched commit as `$CI_WATCH_SHA` and should exit non-zero
+only when the probe itself failed, never because the pipeline failed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+TERMINAL_OK = {"success", "skipped", "neutral"}
+ACTIVE = {"queued", "in_progress", "waiting", "pending", "requested"}
+
+
+def emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def run(cmd: list[str] | str, timeout: int, env: dict[str, str] | None = None):
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            shell=isinstance(cmd, str),
+            env=env,
+        )
+        return proc.returncode, proc.stdout
+    except (subprocess.TimeoutExpired, OSError):
+        return 1, ""
+
+
+def probe_gh(sha: str, timeout: int, expand_jobs: bool = True):
+    """Return {name: (state, run_id)} for the exact SHA, or None if unavailable."""
+    code, out = run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--commit",
+            sha,
+            "--limit",
+            "100",
+            "--json",
+            "databaseId,name,status,conclusion,attempt",
+        ],
+        timeout,
+    )
+    if code != 0:
+        return None
+    try:
+        runs = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        return None
+
+    # Defensive: some providers return one record per attempt. `gh` already
+    # collapses, but this keeps the logic safe if the backing command is swapped.
+    latest: dict[object, dict] = {}
+    for r in runs:
+        rid = r.get("databaseId")
+        if rid not in latest or (r.get("attempt") or 1) > (latest[rid].get("attempt") or 1):
+            latest[rid] = r
+
+    result = {}
+    for r in latest.values():
+        rid = r.get("databaseId")
+        wf = r.get("name") or "?"
+        status = r.get("status") or "unknown"
+        if expand_jobs and status in ACTIVE:
+            jcode, jout = run(["gh", "run", "view", str(rid), "--json", "jobs"], timeout)
+            if jcode == 0:
+                try:
+                    jobs = (json.loads(jout or "{}") or {}).get("jobs") or []
+                except json.JSONDecodeError:
+                    jobs = []
+                if jobs:
+                    for j in jobs:
+                        jstate = j.get("conclusion") or j.get("status") or "unknown"
+                        result[f"{wf}/{j.get('name', '?')}"] = (jstate, rid)
+                    continue
+        result[f"{wf}#{rid}"] = (r.get("conclusion") or status, rid)
+    return result
+
+
+def probe_cmd(command: str, timeout: int, sha: str):
+    env = dict(os.environ, CI_WATCH_SHA=sha)
+    code, out = run(command, timeout, env=env)
+    if code != 0 and not out.strip():
+        return None, None
+    states, terminal = {}, None
+    for raw in out.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.upper().startswith("TERMINAL:"):
+            terminal = (line.split(":", 1)[1].strip() or "success").lower()
+            continue
+        if ":" in line:
+            name, state = line.split(":", 1)
+            states[name.strip()] = (state.strip(), None)
+    return states, terminal
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sha", required=True, help="exact commit to watch")
+    ap.add_argument("--branch", default="", help="retire if this branch moves past --sha")
+    ap.add_argument("--cmd", default="", help="custom probe command (non-GitHub providers)")
+    ap.add_argument("--deadline", type=int, default=1800, help="hard stop, seconds")
+    ap.add_argument("--register-deadline", type=int, default=240, help="give up waiting for a run to appear, seconds")
+    ap.add_argument("--settle", type=int, default=90, help="grace period after all-green for late follow-up workflows")
+    ap.add_argument("--interval", type=int, default=20, help="poll interval, seconds")
+    ap.add_argument("--heartbeat", type=int, default=150, help="heartbeat interval, seconds")
+    ap.add_argument("--no-expand-jobs", action="store_true", help="GitHub mode: skip per-job expansion of in-progress runs")
+    a = ap.parse_args()
+
+    start = time.monotonic()
+    last_hb = start
+    seen: dict[str, str] = {}
+    registered = False
+    green_since = None
+    fail_streak = 0
+    supersede_warned = False
+    probe_timeout = max(20, a.interval)
+
+    def done(verdict: str, detail: str = ""):
+        emit(f"CI-DONE {verdict}" + (f" — {detail}" if detail else ""))
+        raise SystemExit(0 if verdict == "success" else 1)
+
+    while True:
+        now = time.monotonic()
+        elapsed = now - start
+        if elapsed > a.deadline:
+            last = "; ".join(f"{k}:{v}" for k, v in seen.items()) or "none"
+            done("timeout", f"{int(elapsed)}s elapsed; last state: {last}")
+
+        explicit_terminal = None
+        if a.cmd:
+            states, explicit_terminal = probe_cmd(a.cmd, probe_timeout, a.sha)
+        else:
+            states = probe_gh(a.sha, probe_timeout, expand_jobs=not a.no_expand_jobs)
+
+        if states is None:
+            fail_streak += 1
+            if fail_streak == 3:
+                emit("CI-WARN probe failing (3 consecutive); still trying")
+            if fail_streak >= 10:
+                done("probe-dead", "10 consecutive probe failures; result unknown")
+            time.sleep(a.interval)
+            continue
+        fail_streak = 0
+
+        if explicit_terminal:
+            done(explicit_terminal)
+
+        changes = []
+        for name, (state, _hint) in states.items():
+            if name not in seen:
+                if registered:
+                    changes.append(f"{name}: {state}")
+            elif seen[name] != state:
+                changes.append(f"{name}: {seen[name]} -> {state}")
+            seen[name] = state
+
+        if states and not registered:
+            registered = True
+            emit(
+                f"CI-RUN registered {len(states)}: "
+                + " · ".join(f"{n}: {s}" for n, (s, _) in states.items())
+            )
+        elif changes:
+            emit("CI-CHG " + " · ".join(changes))
+
+        if not registered and elapsed > a.register_deadline:
+            done(
+                "no-run",
+                f"nothing registered for {a.sha[:8]} within {a.register_deadline}s (path filters may exclude this change)",
+            )
+
+        if a.branch and registered and not a.cmd:
+            code, out = run(["git", "ls-remote", "origin", f"refs/heads/{a.branch}"], 15)
+            if code != 0 or not out.split():
+                if not supersede_warned:
+                    supersede_warned = True
+                    emit(f"CI-WARN cannot read origin/{a.branch}; supersede detection is OFF")
+            else:
+                tip = out.split()[0]
+                if not (tip.startswith(a.sha[:12]) or a.sha.startswith(tip[:12])):
+                    done("superseded", f"branch {a.branch} moved to {tip[:8]}")
+
+        if registered:
+            pending = [n for n, (s, _) in states.items() if s in ACTIVE]
+            if not pending:
+                bad = [(n, s) for n, (s, _) in states.items() if s not in TERMINAL_OK]
+                if bad:
+                    n, s = bad[0]
+                    hint = states[n][1]
+                    tail = f" — logs: gh run view {hint} --log-failed" if hint else ""
+                    verdict = "cancelled" if all(x[1] == "cancelled" for x in bad) else "failure"
+                    done(verdict, f"{n} -> {s}{tail}")
+                if green_since is None:
+                    green_since = now
+                    if a.settle > 0:
+                        emit(f"CI-SETTLE all green; waiting {a.settle}s for follow-up workflows")
+                elif now - green_since >= a.settle:
+                    done("success", " · ".join(sorted(seen)))
+            else:
+                green_since = None
+
+        if now - last_hb >= a.heartbeat:
+            last_hb = now
+            emit(f"CI-HB {int(elapsed)}s/{a.deadline}s — {len(seen)} run(s) tracked")
+
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ci-cd-optimize/README.md
+++ b/skills/ci-cd-optimize/README.md
@@ -1,6 +1,16 @@
 # ci-cd-optimize
 
-Diagnose or optimize slow CI/CD pipelines by measured bottleneck, not folklore — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, and Swift/Xcode CI — while preserving required checks, cache correctness, and exact-artifact verification.
+Diagnose and optimize slow CI/CD pipelines by **measured bottleneck, not folklore** — GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepos, Docker builds, runner queues, deployment paths, Swift/Xcode CI, and the adjacent problem of **waiting on CI without stalling the session**.
+
+The skill is workflow-first:
+
+1. read prior runs and separate queue / setup / execution / transfer,
+2. find the true critical path,
+3. choose the smallest reversible experiment,
+4. preserve required checks and trust boundaries,
+5. close the feedback loop with a bounded, SHA-pinned watcher when CI is the only verification surface.
+
+It ships a provider-neutral watcher contract plus a stdlib-only `ci-watch.py`, and routes to detailed references for capacity/contention, change-based CI, caching, testing/flakiness, runners, deployment, containers, monorepos, and vendor-specific behavior.
 
 **Category:** ops
 

--- a/skills/ci-cd-optimize/SKILL.md
+++ b/skills/ci-cd-optimize/SKILL.md
@@ -1,110 +1,209 @@
 ---
 name: ci-cd-optimize
-description: Use if diagnosing or optimizing slow CI/CD while preserving required checks.
+description: Use if diagnosing or optimizing slow CI/CD, or if an agent must wait on CI without stalling, while preserving required checks.
 metadata:
   author: yigitkonur
-  version: 1.0.0
+  version: 1.1.0
   category: devops
-  tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, typescript, swift, xcode, pipeline-performance]
+  tags: [ci-cd, github-actions, gitlab-ci, buildkite, circleci, monorepo, docker, swift, xcode, pipeline-performance, ci-monitoring]
 ---
 
 # CI/CD Optimize
 
-Diagnose slow CI/CD from evidence, optimize the critical path, and prove the pipeline remains effective. Do not make pipelines faster by deleting the checks that make them useful.
+Diagnose slow CI/CD from evidence, choose the smallest reversible improvement,
+and prove the pipeline is still effective afterward. Treat the **feedback loop**
+(the way a human or agent learns the result) as part of the pipeline, not as
+something outside it. A 90-second pipeline is not fast if the caller waits 20
+minutes to notice the red check.
+
+## What this skill is for
+
+Use this skill to optimize any delivery pipeline that has a real correctness or
+cost surface: GitHub Actions, GitLab CI, CircleCI, Buildkite, monorepo task
+runners, Docker/OCI build pipelines, test matrices, Swift/Xcode CI, or a deploy
+pipeline whose run time dominates development or release flow.
+
+It is workflow-first, not YAML-first. Start from **what is slow, what is risky,
+and what proof is needed**, then route to the narrowest reference that answers
+that question.
 
 ## Operating loop
 
-### 1. Frame the target and constraints
+### 1. Frame the target and the verification surface
 
-Identify the exact pipeline, branch/event, current median and p95 time-to-feedback, failure rate, and required gates. Separate these before recommending anything:
+Start by naming exactly what is being optimized:
 
-- **Queue time** — trigger to runner start: capacity, scheduling, concurrency, or runner topology.
-- **Setup time** — checkout, runtime install, dependency restore, environment boot.
-- **Execution time** — lint, typecheck, build, tests, package, scan, deploy.
-- **Transfer time** — cache/artifact downloads and uploads, Docker layers, registries, LFS.
-- **Finalization** — reporting, merge status, deployment health, cleanup.
+- workflow / pipeline name
+- trigger (`push`, `pull_request`, merge queue, schedule, deploy, release)
+- branch or commit under study
+- what the caller actually cares about: first failure, first green, deploy live,
+  artifact published, release signed, etc.
+- required gates that must not weaken
+- whether CI is the **only** trusted verification surface
 
-Required gates are requirements, not bottlenecks. If a gate must stay, optimize its scope, parallelism, cache, or placement.
+If CI is the only trusted verification surface, the feedback loop is mandatory
+work, not polish. An agent that pushes and then waits badly is blind to the
+result even if the pipeline itself is well-designed.
 
-### 2. Measure the exact baseline
+### 2. Read history before touching config
 
-Use the same commit and comparable runner class. Prefer at least three runs when timings vary. Capture queue, setup, execution, transfer, per-job duration, dependency graph, cache hit/miss, retry count, and artifact identity.
+Read previous runs first. Do not start with a config rewrite.
 
-Rules:
+Build the baseline from the platform's own history when it exists, then verify
+sample size, time window, runner class, and commit identity. Separate these
+components before proposing anything:
 
-- Use median and p95; CI timings are right-skewed.
-- A green run on a stale SHA, empty diff, or different workflow is not evidence.
-- A cache hit is useful only if restore plus post-hit work beats a clean run.
-- Flaky retry-pass is instability and cost, not proof of reliability.
+- **Queue time** — trigger to runner start
+- **Setup time** — checkout, runtime install, dependency restore, env boot
+- **Execution time** — tests, build, scans, package, deploy
+- **Transfer time** — caches, artifacts, Docker layers, registries, LFS
+- **Finalization** — reports, deploy health, cleanup, status aggregation
 
-Prefer the platform's own aggregated history over hand-collected timings when it exists, then verify sample size and window. If the repository runs on Avrea (`runs-on:` labels begin with `avrea-`) and `avr` is installed and authenticated, read `references/avrea/cli-evidence.md` — it returns median/p95, per-job start offsets, flake counts, and cache hit counts directly. Confirm availability with `command -v avr && avr auth status` before depending on it, and fall back to provider-native measurement otherwise.
+Read `references/measurement.md` first whenever the bottleneck is not already
+obvious. If the repository runs on Avrea and the `avr` CLI is available and
+authenticated, `references/avrea/cli-evidence.md` gives the direct evidence path
+for medians, p95s, per-job start offsets, queue time, flake counts, and cache
+hits.
 
-For the metric definitions, baseline protocol, and the rule about claiming only the evidence rung you reached, read `references/measurement.md`.
+### 3. Find the true bottleneck, not the loudest one
 
-### 3. Find the critical path
+Build the job DAG from actual dependencies, not stage labels. Optimize the work
+that dominates the **critical path**.
 
-Build the job DAG from actual dependencies, not stage labels. Optimize jobs with high critical-path rate and high exclusive time. A large total CPU-time reduction on parallel non-critical work may produce zero wall-clock improvement.
+A large CPU-time reduction on parallel non-critical work can move wall-clock by
+zero. Likewise, a larger runner can make execution faster and wall-clock slower
+if queue time dominates.
 
-Apply the performance order before adding compute:
+Apply the optimization order in this sequence:
 
-1. **Do not start it** — duplicate triggers, draft-PR work, irrelevant events, unrelated packages, full checkout, redundant matrices.
-2. **Cancel it when stale** — superseded PR runs, obsolete deployments only when safe, hung tail jobs.
-3. **Reuse previous work** — correct caches, remote task cache, immutable build artifacts, prebuilt toolchains.
-4. **Shorten the critical path** — DAG shape, split long jobs only when setup is amortized, historical test sharding.
-5. **Move fewer bytes** — checkout scope, cache size, Docker context/layers, artifact paths/compression.
-6. **Only then add compute** — larger runners, more workers, more capacity after queue and utilization evidence.
+1. **Do not start the work** — duplicates, draft PR work, irrelevant events,
+   unrelated packages, redundant matrices.
+2. **Retire stale work** — superseded runs, obsolete deploys, hung tail jobs when
+   safe.
+3. **Reuse correct previous work** — caches, immutable artifacts, remote task
+   caches, prebuilt toolchains.
+4. **Shorten the critical path** — remove artificial dependencies, fix topology,
+   shard only when setup is amortized.
+5. **Move fewer bytes** — sparse checkout, smaller cache/artifact payloads,
+   tighter Docker context, local registry/proxy.
+6. **Only then add compute or capacity** — more workers, larger runners, more
+   slots, a different fleet.
 
-Ask in order:
+### 4. Route by measured symptom
 
-1. Is the pipeline starting duplicate, stale, draft-only, or unrelated work? Read `references/github-actions.md` and `references/change-based-ci.md`.
-2. Is queue time the dominant p95 contributor? Read `references/runners-and-autoscaling.md`.
-3. Is setup or dependency restore dominant? Read `references/typescript-toolchain.md` and `references/caching.md`.
-4. Is checkout, cache, Docker context, or artifact transfer dominant? Read `references/network-and-artifacts.md`.
-5. Is the pipeline running work unrelated to this change? Read `references/change-based-ci.md` and `references/monorepos.md`.
-6. Are tests dominant? Read `references/testing-and-flakiness.md` and `references/integration-environments.md`.
-7. Is Docker/OCI work dominant? Read `references/containers.md`.
+Ask these in order and read only the matching references:
+
+1. Is duplicate, stale, draft-only, or unrelated work running? Read
+   `references/change-based-ci.md` and the provider reference.
+2. Is queue p95 a large part of total wall-clock, or is job count already at the
+   platform's concurrency ceiling? Read `references/capacity-and-contention.md`
+   before touching parallelism.
+3. Is setup or dependency restore dominant? Read `references/caching.md` and the
+   language/toolchain reference (`references/typescript-toolchain.md`,
+   `references/swift-xcode.md`, etc.).
+4. Is checkout, cache transfer, Docker context, or artifact motion dominant?
+   Read `references/network-and-artifacts.md` and `references/containers.md`.
+5. Is the pipeline running work unrelated to this change? Read
+   `references/change-based-ci.md` and, for monorepos, `references/monorepos.md`.
+6. Are tests dominant or flaky? Read `references/testing-and-flakiness.md` and
+   `references/integration-environments.md`.
+7. Is Docker/OCI build work dominant? Read `references/containers.md`.
 8. Are security scans dominant? Read `references/security-gates.md`.
-9. Is deployment slow or repeated? Read `references/deployment.md`.
-10. Is it a Swift/Xcode pipeline? Read `references/swift-xcode.md`.
-11. Is the provider config itself the issue? Route to `references/github-actions.md`, `references/gitlab-ci.md`, `references/circleci.md`, or `references/buildkite.md`.
-12. Is the build graph/cache correctness itself suspect? Read `references/bazel-and-remote-execution.md`.
-13. Does the repository already run on Avrea, or is runner hardware the measured bottleneck? Read `references/avrea/platform-and-runners.md` and `references/avrea/caching.md`; for building the baseline with the `avr` CLI, read `references/avrea/cli-evidence.md`.
-14. Is the proposed speedup about to weaken a required check, a trust boundary, or artifact identity? Read `references/effectiveness-contract.md` before recommending it.
-15. Is a load-bearing claim about vendor behavior unverified, or is a cited source stale? Read `references/evidence-and-sources.md`.
+9. Is deployment or rollout the long pole? Read `references/deployment.md`.
+10. Is runner class or autoscaling the suspected cause? Read
+    `references/runners-and-autoscaling.md`.
+11. Is the build graph/cache correctness itself suspect? Read
+    `references/bazel-and-remote-execution.md`.
+12. Is the provider workflow/config itself the issue? Route to the provider file:
+    `references/github-actions.md`, `references/gitlab-ci.md`,
+    `references/circleci.md`, `references/buildkite.md`.
+13. Must a human or agent wait on the result without stalling? Read
+    `references/feedback-loops.md` and, if a bundled watcher is appropriate,
+    `scripts/ci-watch.py`.
+14. Is the proposed speedup near a trust boundary, required check, cache
+    namespace, or artifact identity? Read `references/effectiveness-contract.md`
+    before recommending it.
+15. Is a vendor claim or cited example stale or load-bearing? Read
+    `references/evidence-and-sources.md`.
 
-### 4. Choose one bounded experiment
+### 5. Choose one bounded experiment
 
-Select the smallest reversible change that attacks the measured critical path. Every recommendation must state:
+Select the smallest reversible change that attacks the measured bottleneck.
 
-- evidence observed,
-- expected wall-clock impact,
-- effectiveness risk,
-- security/trust-boundary risk,
-- cost effect,
-- rollback or fallback.
+For every recommendation, state all six:
 
-Prefer, in this order: prevent unneeded work → cancel stale work → reuse verified prior work → improve cache correctness → remove artificial dependencies → parallelize independent work → shard slow work by measured duration → reduce transferred bytes → improve runner capacity → move heavy work off the PR path only with a full-run fallback → change provider architecture.
+- evidence observed
+- expected wall-clock effect
+- effectiveness / correctness risk
+- security / trust-boundary risk
+- cost effect
+- rollback or fallback
 
-### 5. Preserve effectiveness
+Prefer, in this order: prevent work → cancel stale work → reuse safe work → fix
+cache correctness → remove artificial dependencies → parallelize/shard measured
+work → reduce transferred bytes → change runner capacity → move heavy work off
+PR path only with a full-run fallback → change provider architecture.
+
+### 6. Treat the feedback loop as part of the optimization
+
+Whoever waits on CI needs a mechanism that always terminates with a verdict.
+Never block the session on a foreground `watch`, a TTY-oriented CLI, or a
+success-only loop. Arm a bounded watcher pinned to the exact pushed SHA, then
+keep working.
+
+A good watcher must:
+
+- terminate on success, failure, timeout, no-run, superseded, and probe-dead
+- emit on failure, not just success
+- emit only state changes plus heartbeats
+- be pinned to the exact commit or build id
+- have a registration deadline and an overall deadline
+- wait a settle window before all-green success, so late follow-up workflows are
+  observed
+
+Read `references/feedback-loops.md` for the contract, anti-patterns,
+provider-neutral wiring, and flake triage. `scripts/ci-watch.py` is the bundled
+reference implementation.
+
+### 7. Preserve effectiveness
 
 Never claim an optimization if it does any of these:
 
-- skips required tests, coverage, type checking, or security gates,
-- lets untrusted code write to a cache trusted branches consume,
-- accepts a green check on a stale or unrelated commit,
-- replaces immutable artifact promotion with rebuilds per environment,
-- hides failures behind retries, broad `continue-on-error`, or weakened assertions,
-- makes change detection use an unverified merge base.
+- skips required tests, coverage, typing, security gates, or release checks
+- lets untrusted code write a cache trusted branches consume
+- accepts a green check on a stale or unrelated commit
+- replaces immutable artifact promotion with rebuilds per environment
+- hides failures behind retries, broad `continue-on-error`, or weakened
+  assertions
+- relies on an unverified merge base or partial graph
 
-Use full validation as the safe fallback whenever changed files, merge base, cache correctness, dependency graph completeness, or security scope cannot be proven. When a proposed change is near any of these lines, check it against `references/effectiveness-contract.md` before recommending it.
+If the repo is CI-only, remember that the watcher itself is part of
+preserving effectiveness: a hang, stale green, or never-registered run is a
+broken verification path.
 
-### 6. Verify after the change
+Use `references/effectiveness-contract.md` whenever a proposed change approaches
+one of these lines.
 
-Re-run on the same commit first, then a normal representative commit. Compare median and p95 wall-clock, queue time, cache behavior, first-time pass rate, cost, and failure/rework signals. Confirm the exact run head SHA contains the change and the deployed artifact digest or workflow run is the intended one.
+### 8. Verify after the change
 
-Report only the level actually verified: config review, syntax validation, one CI run, repeated CI runs, or production evidence.
+Re-run on the same commit first, then a normal representative commit. When the
+change is in-job, compare arms under the **same contention state**; a run against
+an idle pool and one against a saturated pool are not comparable even on the same
+commit and runner class. Interleave arms when practical.
 
-## Minimal TypeScript example
+Report only the rung actually reached:
+
+- config review
+- syntax/schema validation
+- one exact-commit CI run
+- repeated comparable CI runs
+- production/trend evidence
+
+Always confirm the run's head SHA contains the change and that the expected
+workflows/jobs actually ran. A green on the wrong workflow or wrong commit is a
+false green.
+
+## Minimal example — use as a shape, not a template
 
 ```yaml
 name: ci
@@ -130,14 +229,14 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: filter
         run: |
-          git diff --name-only "${{ github.event.pull_request.base.sha || 'HEAD~1' }}...${{ github.sha }}" \
-            | grep -E '^(src|packages|apps|package.json|pnpm-lock.yaml|tsconfig)' \
-            && echo "source=true" >> "$GITHUB_OUTPUT" || echo "source=false" >> "$GITHUB_OUTPUT"
+          git diff --name-only "$BASE...$HEAD" \
+            | grep -qE '^(src|packages|apps|package.json|pnpm-lock.yaml|tsconfig)' \
+            && echo source=true >> "$GITHUB_OUTPUT" || echo source=false >> "$GITHUB_OUTPUT"
 
   verify:
     needs: changes
@@ -145,8 +244,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -156,75 +255,74 @@ jobs:
       - run: corepack pnpm test -- --run
 ```
 
-Treat this as a shape, not a universal template. Adapt cache, affected detection, and jobs from measured evidence.
-
 ## Common pitfalls
 
 | Pitfall | Better move |
 |---|---|
-| Optimizing before measuring | Capture baseline queue/setup/execution/critical path first. |
-| Duplicate `push` and PR runs | Trigger PRs on PR events; trigger main/release pushes only. |
-| Draft PRs start expensive jobs | Keep planner cheap; gate expensive jobs until ready for review. |
-| Caching `node_modules` by default | Cache the package-manager store; measure restore versus install. |
-| Workflow path filter blocks required checks | Run a cheap change-detection job and condition expensive jobs. |
-| Affected detection on shallow clone | Fetch required history or use event SHAs; otherwise run all. |
-| Artificial `needs` chains | Start independent lint/typecheck/build work together. |
-| More runners without queue evidence | Measure queue p95 and runner utilization before spending. |
-| Full suite duplicated in every shard | Split tests by file/timing so each test runs once. |
-| Tiny jobs with heavy setup | Collocate work until separate runner setup is amortized. |
-| Coverage off PR path with no fallback | Keep a required scheduled/merge-queue full run. |
-| Remote cache writable by untrusted PRs | Read-only PR cache or isolated cache namespace. |
-| Retrying flakes forever | Bound retries, quarantine, assign ownership, track flake rate. |
-| Rebuilding deploy artifacts per environment | Build once; promote the same immutable digest. |
-| Artifact upload on every success | Upload exact outputs; diagnostics on failure; summaries for small values. |
-| Large cache entries with zero hits | Check hit counts; cold entries consume quota and slow every save. |
-| Upgrading the whole matrix to bigger runners | Resize only CPU-bound critical-path jobs proven by VM utilization. |
+| Optimizing before measuring | Capture a baseline first. |
+| Duplicate `push` and PR runs | Trigger PRs on PR events; trigger pushes only where they matter. |
+| Draft PRs start expensive jobs | Gate expensive work until ready for review. |
+| Caching `node_modules` by default | Cache the package-manager store and measure restore vs clean install. |
+| Planner/CI config routes itself narrowly | Escalate planner and CI config changes to full validation. |
+| Affected detection on shallow history | Fetch enough history or use provider SHAs; otherwise run all. |
+| Adding a planner or aggregate job "for clarity" | Price the queue/setup hop against the work it does. |
+| Splitting while already at the concurrency ceiling | Establish the ceiling first; when capped, merge work that shares setup. |
+| Comparing contended and uncontended runs | Match contention state; compare execution time for in-job changes. |
+| Blocking on a vendor `watch` command | Arm a bounded SHA-pinned watcher and keep working. |
+| Reading a branch-tip green | Pin the pushed SHA and verify the run's head commit. |
+| Treating `timeout` as pass or failure | It means no verdict yet; inspect the run and re-arm if needed. |
+| Full suite duplicated in every shard | Split so each required test runs exactly once. |
+| Tiny jobs with heavy setup | Collocate work until separate setup is amortized. |
+| Coverage off PR path with no fallback | Keep a required full-run path. |
+| Remote cache writable by untrusted PRs | Read-only PR cache or isolated namespace. |
+| Flake "fixed" by retry/skip | Re-run the identical commit to prove a flake; do not weaken the test. |
+| First default-branch run after a cache-key change called a regression | Branch caches cannot seed default branch; prove the expected cold-first pattern. |
+| Larger runners chosen by intuition | Measure queue per class and utilization first; downsizing is common. |
+
+## Bundled script
+
+| Script | Use when |
+|---|---|
+| `scripts/ci-watch.py` | Wait on the exact pushed SHA without stalling. GitHub Actions works out of the box; any other provider via `--cmd` printing `<name>: <state>` lines. Stdlib-only Python. |
 
 ## Reference files
 
 | File | Read when |
 |---|---|
-| `references/measurement.md` | Building the baseline, percentiles, critical path, telemetry, or proving a result. |
-| `references/effectiveness-contract.md` | Deciding whether a proposed speedup weakens validation, security, or artifact identity. |
-| `references/caching.md` | Any dependency/build cache design, restore-key, cache-hit, cache-poisoning, or transfer-cost question. |
-| `references/change-based-ci.md` | Path filters, affected commands, merge queues, merge-base correctness, or full-run fallback rules. |
-| `references/github-actions.md` | GitHub Actions workflows, caches, concurrency, artifacts, merge queues, required checks, or larger runners. |
-| `references/gitlab-ci.md` | GitLab `needs`, child pipelines, cache/artifacts, interruptible jobs, resource groups, rules, or runners. |
-| `references/circleci.md` | CircleCI caching, workspaces, test splitting, dynamic config, Docker layer caching, or resource classes. |
-| `references/buildkite.md` | Buildkite dynamic pipelines, queues, autoscaling, concurrency groups, artifacts, or hosted agents. |
-| `references/monorepos.md` | Nx, Turborepo, affected graphs, remote caches, distributed execution, or package/task inputs. |
-| `references/bazel-and-remote-execution.md` | Bazel query, hermetic builds, remote cache/execution, or choosing graph-native builds. |
-| `references/typescript-toolchain.md` | npm/pnpm/Yarn/Bun installs, Corepack, TypeScript project references, `tsbuildinfo`, bundlers, or generated code. |
-| `references/testing-and-flakiness.md` | Sharding, historical timing, retries, flaky ownership, coverage merging, Jest/Vitest/Playwright. |
-| `references/integration-environments.md` | Testcontainers, service containers, database templates, fixtures, contract tests, or preview databases. |
-| `references/containers.md` | BuildKit, multi-stage Dockerfiles, cache mounts/backends, multi-platform builds, provenance, or image security. |
-| `references/security-gates.md` | Fast but effective SAST, dependency, secret, container, SBOM, provenance, and policy gates. |
-| `references/runners-and-autoscaling.md` | Hosted versus self-hosted, ephemeral runners, queues, spot capacity, ARM/x64/macOS, Kubernetes fleets. |
-| `references/network-and-artifacts.md` | Checkout depth, sparse/partial clone, LFS, package proxies, artifact compression, uploads, or registry locality. |
-| `references/deployment.md` | Immutable artifacts, build-once-deploy-many, canary/blue-green, migrations, previews, rollback, and exact-artifact verification. |
-| `references/swift-xcode.md` | Swift/Xcode builds, SwiftPM, test plans, simulator sharding, macOS runners, xcresult, or DerivedData. |
-| `references/evidence-and-sources.md` | Checking claims, dated source ledger, research method, or refreshing stale vendor behavior. |
-
-### Optional: Avrea reference kit
-
-Read only when the repository runs on Avrea (`runs-on:` labels start with `avrea-`) or Avrea is being evaluated as a runner change. The core loop above is provider-neutral and does not depend on these files.
-
-| File | Read when |
-|---|---|
-| `references/avrea/cli-evidence.md` | Using the `avr` CLI to build a baseline: median/p95, per-job start offsets, queue time, VM metrics, flake counts, cache hit counts, or driving a run to a terminal state. |
-| `references/avrea/platform-and-runners.md` | Runner labels and sizing, migration from GitHub-hosted runners, A/B shadowing, observability, OTel export, live SSH debugging, or the third-party trust boundary. |
-| `references/avrea/caching.md` | Actions/build/package cache layers, Turborepo or Docker `url_v2` wiring, registry proxy caveats, quota and LRU eviction, or diagnosing cold cache entries. |
+| `references/measurement.md` | Building the baseline, critical-path analysis, percentiles, or proving a result. |
+| `references/capacity-and-contention.md` | Queue share is high, parallelism stopped paying off, before sharding/splitting, or when comparing arms under different load. |
+| `references/feedback-loops.md` | An agent or human must wait on CI without stalling: watcher contract, verdicts, settle windows, flake triage. |
+| `references/effectiveness-contract.md` | Deciding whether a speedup weakens validation, security, or artifact identity. |
+| `references/caching.md` | Dependency/build/compiler/remote cache design and invalidation. |
+| `references/change-based-ci.md` | Path filters, affected commands, merge-base correctness, and full-run fallback rules. |
+| `references/github-actions.md` | GitHub Actions workflows, concurrency, caches, artifacts, merge queue, required checks. |
+| `references/gitlab-ci.md` | GitLab `needs`, child pipelines, caches/artifacts, interruptible jobs, resource groups. |
+| `references/circleci.md` | CircleCI caching, workspaces, test splitting, dynamic config, resource classes. |
+| `references/buildkite.md` | Buildkite dynamic pipelines, queues, autoscaling, concurrency groups, artifacts. |
+| `references/monorepos.md` | Nx, Turborepo, affected graphs, task inputs, remote caches, distributed execution. |
+| `references/bazel-and-remote-execution.md` | Bazel query, hermeticity, remote cache/execution, graph-native builds. |
+| `references/typescript-toolchain.md` | npm/pnpm/Yarn/Bun, Corepack, TS project references, `tsbuildinfo`, bundlers, generated code. |
+| `references/testing-and-flakiness.md` | Sharding, historical timing, flaky ownership, retries, coverage merging, Jest/Vitest/Playwright. |
+| `references/integration-environments.md` | Testcontainers, service containers, fixture DBs, contract tests, preview DBs. |
+| `references/containers.md` | BuildKit, multi-stage Dockerfiles, cache mounts/backends, provenance, image security. |
+| `references/security-gates.md` | Fast but effective SAST, dependency, secret, container, SBOM, provenance, policy gates. |
+| `references/runners-and-autoscaling.md` | Runner classes, queues, hosted vs self-hosted, spot capacity, ARM/x64/macOS, Kubernetes fleets. |
+| `references/network-and-artifacts.md` | Checkout depth, sparse/partial clone, LFS, package proxies, artifact compression/uploads. |
+| `references/deployment.md` | Build-once deploy-many, canary/blue-green, migrations, previews, rollback, exact-artifact verification. |
+| `references/swift-xcode.md` | Swift/Xcode builds, test plans, simulator sharding, macOS runners, xcresult, DerivedData. |
+| `references/evidence-and-sources.md` | Checking whether a CI/CD claim is current, resolving conflicts, and refreshing this skill. |
+| `references/avrea/*.md` | Optional Avrea kit: CLI evidence, runner sizing, and cache behavior when the repo runs on Avrea. |
 
 ## Guardrails
 
-- Do not recommend vendor-specific flags from memory; verify mutable provider behavior against current official docs when it is load-bearing, and record the check per `references/evidence-and-sources.md`.
-- Do not assume a CI platform or its CLI is present; probe first (`command -v`, `--version`, auth check) and fall back to provider-native evidence when it is not.
-- Do not run a platform CLI's mutating commands without authorization — cache deletion, run cancel/rerun, org or repository settings, and firewall rules change shared state.
+- Do not recommend provider-specific commands from memory when the behavior is load-bearing; verify against current docs or provider source and record the check.
+- Do not assume a CLI or platform exists; probe first (`command -v`, `--version`, auth check) and fall back to provider-native evidence if absent.
+- Do not mutate shared CI state (cache deletion, run cancel/rerun, org settings, firewall rules) without authorization.
 - Do not ask for approval before a reversible, measured optimization; ask before weakening a gate, changing production deployment behavior, or introducing a shared trust boundary.
 - Do not add a large tool (Bazel, remote execution, self-hosted fleet, commercial TIA) unless the measured bottleneck and operating capacity justify it.
-- Do not bundle generated pipeline templates blindly; produce the smallest config change justified by evidence.
+- Do not bundle generated pipeline templates blindly; produce the smallest change justified by evidence.
 - Do not report "CI is faster" without the before/after evidence and the exact run identity.
 
 ## Done criteria
 
-The work is complete only when the baseline, chosen bottleneck, changed files/config, measured result, effectiveness checks, remaining risks, and verification level are all reported. If a provider branch was not exercised, say so explicitly rather than implying coverage.
+The work is complete only when the baseline, chosen bottleneck, changed files/config, measured result, effectiveness checks, remaining risks, and verification rung are all reported. If a provider branch or feedback-loop path was not exercised, say so explicitly rather than implying coverage.

--- a/skills/ci-cd-optimize/references/caching.md
+++ b/skills/ci-cd-optimize/references/caching.md
@@ -1,10 +1,16 @@
 # Caching
 
-Use this file for dependency, build, compiler, Docker, and remote-cache decisions. The goal is saved wall-clock time with correct invalidation—not a high hit-rate vanity metric.
+Use this file for dependency, build, compiler, Docker, and remote-cache
+decisions. The goal is saved wall-clock time with correct invalidation — not a
+high hit-rate vanity metric.
+
+If the cache debate starts from “installs are slow”, read
+`measurement.md` first and time the uncached path before adding anything.
 
 ## Cache design checklist
 
-A cache entry is safe only when its key includes every input that changes its output:
+A cache entry is safe only when its key includes every input that changes its
+output:
 
 - source content and relevant config,
 - lockfile or resolved dependency graph,
@@ -14,56 +20,114 @@ A cache entry is safe only when its key includes every input that changes its ou
 - generator/schema versions for generated code,
 - cache namespace/version so you can intentionally invalidate it.
 
-If any input is missing, a hit can be silently wrong. If any irrelevant input is included, hits collapse.
+If any input is missing, a hit can be silently wrong. If any irrelevant input is
+included, hits collapse.
 
 ## Trust boundaries
 
-- Untrusted PRs must not write cache entries that protected branches later consume as trusted.
-- Prefer read-only PR cache access or isolated PR namespaces with protected-branch promotion.
-- Sign or verify artifacts where the backend supports integrity checks; signatures do not replace authorization.
+- Untrusted PRs must not write cache entries that protected branches later
+  consume as trusted.
+- Prefer read-only PR cache access or isolated PR namespaces with protected-branch
+  promotion.
+- Sign or verify artifacts where the backend supports integrity checks; signatures
+  do not replace authorization.
 - Do not put secrets in cache keys or cached files.
 
-## TypeScript package caches
+Read `effectiveness-contract.md` before recommending a shared namespace or a
+trusted-branch restore key.
+
+## Time the uncached path first
+
+“Installs are slow” is an assumption until measured. On some fleets the package
+registry is already proxied locally, so adding a dependency-store cache on top of
+it buys nothing and may add a save step.
+
+The safe generalization is narrow but useful:
+
+- when the uncached step is already seconds, measure it before caching;
+- when the cold path is materially slower than the warm path, the cache may be earning its keep;
+- when restore + post-hit work exceeds a clean run, delete the cache.
+
+This is why the headline metric is **cache saved time**, not hit rate. A 100% hit
+rate on a cache that saves nothing is wasted bytes.
+
+## TypeScript and package-manager caches
 
 Cache the package-manager store/cache, not blindly `node_modules`:
 
 | Manager | CI command | Cache target |
 |---|---|---|
-| npm | `npm ci` | npm cache, usually via setup action or `~/.npm` |
+| npm | `npm ci` | npm cache (`~/.npm` or setup action cache) |
 | pnpm | `pnpm install --frozen-lockfile` | pnpm store |
 | Yarn modern | `yarn install --immutable` | Yarn global cache or committed Zero-Install cache |
 | Bun | `bun ci` | Bun install cache |
 
-Key by lockfile, Node version, package-manager version, OS, and architecture. Compare restore time with a clean install; large stores can be slower than a registry fetch on a nearby network.
+Key by:
+
+- lockfile,
+- runtime version,
+- package-manager version,
+- OS,
+- architecture,
+- and for monorepos, any manifest/config whose drift changes the dependency tree.
+
+### Default-branch cold starts are normal
+
+Branch-scoped caches cannot seed the default branch. After a cache-key change (a
+schema bump, adding OS/arch/toolchain identity, changing restore paths), the
+first default-branch run is legitimately cold even though the branch runs that
+validated the change were warm. Verify with the run's own log lines before
+calling it a regression.
 
 ## Restore-key discipline
 
 Use narrow restore keys from most-specific to less-specific:
 
 ```yaml
-key: linux-x64-node24-pnpm10-${{ hashFiles('pnpm-lock.yaml') }}
+key: linux-x64-node24-pnpm10-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}
 restore-keys: |
   linux-x64-node24-pnpm10-
 ```
 
-Avoid keys that rotate every run (`epoch`, build number) and broad fallbacks that restore a different runtime, branch dependency set, or architecture.
+Avoid keys that rotate every run (`epoch`, build number) and broad fallbacks that
+restore a different runtime, branch dependency set, or architecture.
 
-## Build/compiler caches
+Keying a dependency cache on the lockfile **alone** can still be stale after a
+manifest-only change if the manifest influences the resolved tree without a lock
+rewrite. Manifest + lockfile is the safer default.
 
-- TypeScript `.tsbuildinfo` and emitted outputs must be keyed with TypeScript version, lockfile, and every relevant `tsconfig`.
+## Build, compiler, and remote caches
+
+- TypeScript `.tsbuildinfo` and emitted outputs must be keyed with TypeScript
+  version, lockfile, and every relevant `tsconfig`.
 - Generated code must hash schemas, generator version, and config.
-- Xcode DerivedData requires exact project/toolchain keys and timestamp restoration.
-- BuildKit layer caches require external backends on ephemeral runners; cache mounts do not automatically persist across runners.
+- Xcode DerivedData requires exact project/toolchain keys and timestamp-safe
+  restoration.
+- BuildKit layer caches require external backends on ephemeral runners; cache
+  mounts do not automatically persist across runners.
+- Remote task caches (Nx, Turborepo, Bazel) must prove their input graph is
+  complete; otherwise a hit can be wrong, not merely stale. Cross-link:
+  `change-based-ci.md`, `bazel-and-remote-execution.md`, and `monorepos.md`.
 
 ## Failure modes
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Passes on miss, fails on hit | Missing output or undeclared input | Complete inputs/outputs; invalidate namespace. |
-| Zero exact hits | Key rotates every run | Remove build IDs/timestamps from key. |
-| Slow despite hit | Transfer exceeds recomputation | Cache smaller store, nearby backend, or stop caching. |
-| Cross-branch stale behavior | Fallback too broad or shared trust scope | Narrow key; separate protected/untrusted scopes. |
+| Zero exact hits | Key rotates every run | Remove build IDs/timestamps from the key. |
+| Slow despite hit | Transfer exceeds recomputation | Cache a smaller store, use a nearer backend, or stop caching. |
+| Cross-branch stale behavior | Fallback too broad or shared trust scope | Narrow the key; separate protected/untrusted scopes. |
 | Poisoned shared cache | Untrusted writes accepted | Read-only PR access or isolated namespace. |
+| First default-branch run unexpectedly cold | Branch caches cannot seed default branch | Expect one cold run after a key change; verify from log lines. |
+
+## Cross-links
+
+- `measurement.md` — how to tell whether the cache saved real wall-clock time.
+- `change-based-ci.md` — when a partial run plus remote cache can mask skipped work.
+- `network-and-artifacts.md` — when transfer cost, not invalidation, is the problem.
+- `containers.md` — Docker layer cache and BuildKit specifics.
+- `effectiveness-contract.md` — before sharing a cache across trust boundaries.
+- `monorepos.md` and `bazel-and-remote-execution.md` — when cache correctness depends on graph completeness.
 
 ## Sources
 

--- a/skills/ci-cd-optimize/references/capacity-and-contention.md
+++ b/skills/ci-cd-optimize/references/capacity-and-contention.md
@@ -1,0 +1,152 @@
+# Capacity and Contention
+
+Use this file when queue time is a material share of wall-clock, when adding jobs
+stopped helping, before sharding or fanning out work, or when a supposedly faster
+change measured neutral because the fleet was busy.
+
+This is the reference for the failure mode a fast local benchmark misses: the job
+itself got shorter, but the pipeline did not, because the platform had no free
+slots to run the extra work. Read `references/measurement.md` first so queue and
+execution are already separated.
+
+## The inversion to watch for
+
+Two otherwise-good optimizations **invert** above a platform concurrency ceiling:
+
+- parallelize independent work
+- shard a slow lane into more jobs
+
+Both raise **job count**. Once job count exceeds available slots, the surplus
+queues while re-paying per-job setup. The DAG looks more parallel and the wall
+clock does not improve — sometimes it gets worse.
+
+A neutral or negative result here is not evidence that sharding is bad in
+principle; it is evidence that the platform was capacity-bound for that shape.
+
+## Diagnose contention first
+
+Use this checklist before splitting anything:
+
+1. Separate **queue** from **execution** per job (`references/measurement.md`).
+2. Count how many jobs are runnable at the peak fan-out point.
+3. Compare that count with the provider's available slots for this repository,
+   queue, label, or runner class.
+4. Measure the per-job setup tax: queue + VM boot + checkout + toolchain restore.
+5. Ask whether the proposed split reduces execution by more than it increases the
+   number of queued/setup-paying jobs.
+
+A quick heuristic:
+
+- If queue is a small tail and execution dominates, sharding may help.
+- If queue is a large share of p95, do **not** add jobs until capacity is
+  measured and, if needed, fixed.
+- If the lane is short and setup-heavy, merging jobs that share setup is usually
+  better than splitting them.
+
+## Price the hop
+
+A new job is not free. It pays its own queue wait, VM provisioning, checkout, and
+runtime setup before doing useful work. Call that the **hop cost**.
+
+Price it with the median and p95 from real runs:
+
+```text
+hop_cost = queue + setup
+work_saved = old_execution - new_execution
+```
+
+Only split when `work_saved` clearly beats the hop cost *in the same contention
+state*.
+
+Typical bad shapes:
+
+| Shape | Why it loses |
+|---|---|
+| Planner job in front of the matrix | Adds one full queue/setup hop before any useful lane starts. |
+| Aggregate status job at the end | Adds one more hop after all real work is already done. |
+| Tiny shards on cold runners | Each shard re-pays setup; the serial tail moves from execution to orchestration. |
+| More jobs on a scarce large runner class | Queue rises faster than execution falls. See `references/runners-and-autoscaling.md`. |
+
+## Compare arms under the same load
+
+A run against an idle pool and a run against a saturated one are not comparable,
+even on the same commit and runner class. The difference can exceed the effect you
+are testing.
+
+For in-job changes, compare **execution time** first. For topology changes, either:
+
+- interleave arms (`A, B, A, B`) and compare medians, or
+- run both during the same fleet conditions and treat any delta smaller than the
+  queue-time spread as noise.
+
+A useful report shape:
+
+```text
+Queue p50/p95: 18s / 97s   (noise floor)
+Execution p50/p95: 62s / 66s
+Change A -> B execution delta: -4s
+Conclusion: within queue noise, not proven at wall-clock level
+```
+
+That is a real result. Report neutral experiments instead of silently dropping
+them and letting the next person re-run the same dead idea.
+
+## What to do when capped
+
+When the ceiling is the problem, the next move is usually **fewer jobs**, not
+more hardware. Try, in order:
+
+1. Merge jobs that share expensive setup.
+2. Remove planner/aggregator hops that exist only for ergonomic reporting.
+3. Collapse tiny shards until setup is amortized.
+4. Move non-critical parallel work off the PR critical path with a full-run
+   fallback (`references/change-based-ci.md`).
+5. Only then add slots, resize runners, or change queue placement
+   (`references/runners-and-autoscaling.md`).
+
+Examples of "merge, don't split":
+
+- lint + typecheck on the same checkout/runtime when each is short
+- unit tests and small static analysis sharing the same dependency install
+- one workflow with multiple short jobs that all queue behind the same scarce
+  label
+
+Examples where splitting still wins:
+
+- genuinely long, independent test groups with modest setup
+- jobs whose runtime dominates queue+setup by a wide margin
+- sharding on a fleet with spare slots and stable startup latency
+
+## Provider-specific ceilings
+
+The ceiling is provider- and fleet-specific. It can be:
+
+- a repository concurrency limit
+- a queue label with few warm runners
+- a scarce runner class (large x64, macOS, GPU, ARM)
+- an autoscaler that reacts more slowly than the fan-out burst
+- a self-hosted fleet sharing slots across several repositories
+
+Do not infer the ceiling from docs alone. Infer it from queue share and from the
+point where adding jobs stops reducing wall-clock. Then route to the provider file
+or `references/runners-and-autoscaling.md` for the capacity-side fix.
+
+## Connections to other references
+
+- Read `references/measurement.md` first — this file assumes queue vs execution is
+  already separated.
+- Read `references/runners-and-autoscaling.md` when the fix is more slots, a
+  different runner class, or a fleet change.
+- Read `references/change-based-ci.md` when the best answer is to avoid starting
+  unrelated work at all.
+- Read `references/testing-and-flakiness.md` before sharding tests, especially
+  when setup or report merging is non-trivial.
+- Read `references/feedback-loops.md` when a topology change also alters how the
+  result is consumed (aggregate jobs, follow-up workflows, late registration).
+
+## Sources
+
+- GitHub Actions limits: https://docs.github.com/en/actions/reference/limits (accessed 2026-07-28)
+- GitLab runner autoscaling: https://docs.gitlab.com/runner/runner_autoscale/ (accessed 2026-07-28)
+- CircleCI parallelism/resource classes: https://circleci.com/docs/guides/optimize/parallelism-faster-jobs/ (accessed 2026-07-28)
+- Buildkite queue and concurrency docs: https://buildkite.com/docs/pipelines/configure/workflows/controlling-concurrency (accessed 2026-07-28)

--- a/skills/ci-cd-optimize/references/change-based-ci.md
+++ b/skills/ci-cd-optimize/references/change-based-ci.md
@@ -1,16 +1,23 @@
 # Change-Based CI
 
-Use this file for path filters, affected commands, merge-base correctness, merge queues, and deciding when partial validation is safe.
+Use this file for path filters, affected commands, merge-base correctness, merge
+queues, and deciding when partial validation is safe.
+
+This file answers a stricter question than “can we skip work?” It answers “what
+must be true before skipping work is still honest?” If any step below cannot be
+proved, run the full pipeline.
 
 ## The correctness ladder
 
 1. **Compute the changed set** from reliable event SHAs or complete history.
 2. **Map changed files to owners/packages/tasks** using a dependency graph or explicit rules.
-3. **Include transitive consumers** that can be affected by shared code, schema, lockfile, generated code, CI config, and build config.
+3. **Include transitive consumers** that can be affected by shared code, schema,
+   lockfile, generated code, CI config, and build config.
 4. **Prove the graph is complete** for the defect classes you are skipping.
-5. **Run full validation defensively** on merge queue, schedule, release, or uncertainty.
+5. **Escalate to a full run** on merge queue, release, schedule, uncertainty, or
+   any change to the planner itself.
 
-If any step fails, run the full pipeline.
+If any step fails, the correct answer is the full pipeline.
 
 ## Merge-base rules
 
@@ -20,22 +27,57 @@ If any step fails, run the full pipeline.
 - Merge queues create a predictive branch; PR-only base/head assumptions may test the wrong change set.
 - Lockfile, CI config, dependency graph, generated-code schema, and shared-global changes usually escalate to full validation.
 
+## The planner must not route itself narrowly
+
+The component that decides what runs is part of the repository. If a change to
+that logic routes only the lanes it already knows how to name, a routing bug can
+ship having validated a fraction of the repo.
+
+Two failures worth guarding against explicitly:
+
+1. **Config fan-out gaps.** A rule mapping `.github/**` to “the main lanes” silently
+   excludes specialized ones, so editing a specialized workflow never exercises it.
+2. **Self-routing.** A planner change that maps only to its own directory's lane
+   grades its own homework.
+
+Guard both with unit fixtures over the classifier when possible — it is usually a
+pure path-to-lane function and costs milliseconds to test.
+
 ## Path filters versus graph-aware affected
 
-Path filters are acceptable for flat repos with no shared package consumers. They are dangerous when a shared library affects multiple apps.
+Path filters are acceptable for flat repos with no shared package consumers. They
+are dangerous when a shared library affects multiple apps.
 
-Graph-aware affected commands (`nx affected`, Turborepo affected/filter, Bazel reverse dependencies) are better only when:
+Graph-aware affected commands (`nx affected`, Turborepo filters, Bazel reverse
+queries) are better only when:
 
-- package/task graph is complete,
+- the package/task graph is complete,
 - task inputs include external files that feed generation,
 - base and head are correct,
 - remote/local cache behavior does not mask skipped work.
 
-Package-level affected detection can miss a file outside package roots that feeds a task. Enable task-input-aware filtering when supported; otherwise add explicit escalation paths.
+Package-level affected detection can miss a file outside package roots that feeds
+a task. Enable task-input-aware filtering when supported; otherwise add explicit
+escalation paths.
+
+## Rename and non-code edge cases
+
+Two subtle misses recur in real repos:
+
+- **Rename drift.** `git diff --name-only` prints only the destination path when
+  rename detection is on. Moving `src/x.ts` to `docs/x.md` can therefore read as a
+  docs-only change while executable source was removed. Use `--no-renames`, or
+  parse `--name-status` and route both paths.
+- **Generated inputs outside the package root.** A package-level planner may miss a
+  schema, template, or CI helper outside its tree that still changes its build.
+
+These are reasons to escalate, not special cases to wave through.
 
 ## Required-check pattern
 
-Do not skip an entire required workflow by a path filter and leave the check pending. Use an always-running change-detection job, then condition expensive jobs:
+Do not skip an entire required workflow by a path filter and leave the check
+pending. Use an always-running change-detection job, then condition expensive
+jobs:
 
 ```yaml
 jobs:
@@ -44,7 +86,7 @@ jobs:
     outputs:
       source: ${{ steps.detect.outputs.source }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: detect
@@ -63,7 +105,8 @@ jobs:
       - run: corepack pnpm test -- --run
 ```
 
-Ensure the provider reports skipped downstream jobs as successful/skipped in the way branch protection expects.
+Ensure the provider reports skipped downstream jobs as successful/skipped in the
+way branch protection expects.
 
 ## Full-run triggers
 
@@ -75,7 +118,16 @@ Always run the full suite when:
 - generated-code schema or generator changed,
 - shared global tsconfig/build config changed,
 - release, merge queue, nightly, or scheduled defensive run,
-- previous partial run escaped a defect.
+- a previous partial run escaped a defect,
+- the planner itself changed.
+
+## Cross-links
+
+- `measurement.md` — how to baseline a partial-vs-full comparison honestly.
+- `caching.md` — when a remote cache can hide skipped work instead of saving it.
+- `effectiveness-contract.md` — why uncertainty here always resolves to a full run.
+- `feedback-loops.md` — the `no-run` verdict and how a watcher should report a path-filtered commit.
+- `monorepos.md` — when the graph and the planner are the optimization surface.
 
 ## Sources
 

--- a/skills/ci-cd-optimize/references/evidence-and-sources.md
+++ b/skills/ci-cd-optimize/references/evidence-and-sources.md
@@ -1,6 +1,12 @@
 # Evidence and Sources
 
-Use this file when checking whether a CI/CD claim is current, resolving conflicting guidance, or refreshing this skill.
+Use this file when checking whether a CI/CD claim is current, resolving
+conflicting guidance, or refreshing this skill.
+
+This skill is only as good as the evidence behind it. CI providers change cache
+limits, runner images, CLI behavior, action versions, pricing, and defaults
+frequently; a plausible stale claim is worse than silence when it becomes
+load-bearing.
 
 ## Source hierarchy
 
@@ -10,38 +16,30 @@ Use this file when checking whether a CI/CD claim is current, resolving conflict
 4. Named production case studies with before/after metrics.
 5. Community anecdotes and marketing comparisons — leads only, never final evidence.
 
-Record access date. CI providers change cache limits, runner images, action versions, pricing, and defaults frequently.
+Record access date.
 
 ## Verification rules
 
-- Verify mutable facts before making them load-bearing: action SHAs, runner image names, Xcode versions, cache limits, provider pricing, and beta flags.
-- Do not quote a benchmark without workload, hardware, run count, and whether it was cold or warm.
+- Verify mutable facts before making them load-bearing: action SHAs, runner image
+  names, Xcode versions, cache limits, provider pricing, CLI behavior, and beta
+  flags.
+- Do not quote a benchmark without workload, hardware, run count, and whether it
+  was cold or warm.
 - Separate confirmed facts from inference.
 - If official sources conflict, prefer observed behavior from a controlled run.
-- If the repo's current config contradicts generic best practice, measure the repo's critical path before changing it.
+- If the repo's current config contradicts generic best practice, measure the
+  repo's critical path before changing it.
 
-## Research method used for this skill
+## Route claims by use case
 
-Twenty independent research tracks covered: measurement, GitHub Actions, GitLab CI, CircleCI, Buildkite, Bazel, Nx, Turborepo, TypeScript/Node, testing, containers, security gates, Xcode builds, iOS tests, runners, network/artifacts, deployment, integration environments, observability, and change-based orchestration. The comparison corpus also reviewed five existing CI/CD-related skills for structure and anti-patterns.
-
-## Core source map
-
-| Domain | Primary starting points |
+| Claim type | Primary evidence |
 |---|---|
-| Metrics | OpenTelemetry CI/CD semconv; DORA; provider pipeline analytics |
-| GitHub Actions | GitHub Docs caching, concurrency, larger runners, merge queue, secure use |
-| GitLab | GitLab CI YAML, caching, downstream pipelines, resource groups, runner autoscaling |
-| CircleCI | CircleCI caching, parallelism/test splitting, workspaces, rerun failed tests |
-| Buildkite | Dynamic pipelines, queues, agent management, concurrency, queue metrics |
-| Monorepo | Nx affected/cache security/DTE; Turborepo configuration/caching/CI |
-| Bazel | Bazel hermeticity, sandboxing, remote caching/execution, Bzlmod docs |
-| TypeScript | npm/pnpm/Yarn/Bun docs, Corepack, TypeScript project references |
-| Tests | Playwright/Vitest/Jest docs; CircleCI timing split; Google/Meta/Uber engineering |
-| Containers | Docker BuildKit cache, multi-stage, multi-platform, provenance, security |
-| Security | SLSA, in-toto, CodeQL, push protection, Semgrep, Trivy |
-| Runners | GitHub/GitLab/Buildkite runner and autoscaling docs; Kubernetes scheduling |
-| Deployment | Argo Rollouts/CD, Kubernetes probes, immutable-artifact guidance |
-| Swift/Xcode | Apple Xcode docs/release notes, Swift compiler performance, Swift library evolution |
+| Runner speed / queue differences | provider timestamps + historical runs on the same class |
+| Cache effectiveness | paired cold/warm timing on the same commit |
+| Watcher behavior / CLI output shape | provider docs + CLI source code or repeated live probes |
+| Flakiness | identical-commit re-run |
+| Deployment correctness | exact artifact digest, rollout state, and health checks |
+| Change-based safety | graph completeness proof + full-run fallback behavior |
 
 ## Refresh checklist
 
@@ -51,4 +49,37 @@ When updating this skill:
 2. Replace stale examples with current stable syntax.
 3. Preserve the effectiveness contract unless a control has formally changed.
 4. Add new sources with access dates.
-5. Re-run trigger and functional tests after edits.
+5. Re-run structural validation after edits (`scripts/validate-skills.py`).
+
+## Cross-links
+
+- `measurement.md` — for the baseline and evidence rung you can safely claim.
+- `feedback-loops.md` — when the mutable fact is CLI watch behavior or run-state semantics.
+- `testing-and-flakiness.md` — when the source question is whether a red check is real.
+- `effectiveness-contract.md` — when a proposed change is tempting but weakens the proof surface.
+
+## Core source map
+
+| Domain | Primary starting points |
+|---|---|
+| Metrics | OpenTelemetry CI/CD semantic conventions; DORA; provider analytics |
+| GitHub Actions | GitHub Docs on caching, concurrency, larger runners, merge queue, secure use |
+| GitLab | GitLab CI YAML, caching, downstream pipelines, resource groups, runner autoscaling |
+| CircleCI | CircleCI caching, parallelism/test splitting, workspaces, rerun failed tests |
+| Buildkite | Dynamic pipelines, queues, agent management, concurrency, queue metrics |
+| Monorepo | Nx affected/cache security/DTE; Turborepo configuration/caching/CI |
+| Bazel | Bazel hermeticity, sandboxing, remote caching/execution, Bzlmod |
+| TypeScript | npm/pnpm/Yarn/Bun docs, Corepack, TS project references |
+| Tests | Playwright/Vitest/Jest docs; provider timing split; Google/Meta/Uber engineering |
+| Containers | Docker BuildKit cache, multi-stage, multi-platform, provenance, security |
+| Security | SLSA, in-toto, CodeQL, push protection, Semgrep, Trivy |
+| Runners | GitHub/GitLab/Buildkite runner docs; Kubernetes scheduling |
+| Deployment | Argo Rollouts/CD, Kubernetes probes, immutable-artifact guidance |
+| Swift/Xcode | Apple Xcode docs/release notes, Swift compiler performance, Swift library evolution |
+
+## Sources
+
+- GitHub Actions docs: https://docs.github.com/en/actions (accessed 2026-07-28)
+- GitLab CI/CD docs: https://docs.gitlab.com/ee/ci/ (accessed 2026-07-28)
+- CircleCI docs: https://circleci.com/docs/ (accessed 2026-07-28)
+- Buildkite docs: https://buildkite.com/docs (accessed 2026-07-28)

--- a/skills/ci-cd-optimize/references/feedback-loops.md
+++ b/skills/ci-cd-optimize/references/feedback-loops.md
@@ -1,0 +1,300 @@
+# Feedback Loops: Receiving a Pipeline Result Without Stalling
+
+Read this when work is validated *through* CI — an agent or long-running session
+pushes, dispatches, re-runs, or deploys, then must learn the outcome before
+continuing. Also read it when a wait command hangs, floods the context, or reports
+a verdict that turns out to be for the wrong commit.
+
+Making a pipeline fast is only half the job. The other half is consuming the
+result. A 60-second pipeline still costs ten minutes of wall-clock if the waiter
+blocks on it, and it is *dangerous* if the waiter concludes "green" from a run
+that never started. This is a correctness problem, not a convenience one: a
+session blocked on CI with no deadline is indistinguishable from a session that
+crashed.
+
+The failure is provider-neutral, so the contract here is too. Only the probe
+command changes between GitHub Actions, GitLab, Buildkite, CircleCI, or a deploy
+API.
+
+## Why the obvious approaches fail
+
+Every naive wait shares one of a few defects. Naming them is what lets an agent
+recognize its own stall:
+
+| Attempt | Failure mode |
+|---|---|
+| A vendor `watch` subcommand piped into a harness (`gh run watch`, `avr run watch`, …) | Off a TTY these redraw the whole run table each interval instead of emitting lines, and many suppress their completion summary entirely when stdout is not a terminal. You get unparseable repetition and no terminal line. None carry a deadline of their own. |
+| `while true; do sleep 30; done` with a success-only `grep` | A crashed, cancelled, or never-registered run emits nothing — identical to a healthy one. Silence reads as patience. No deadline. |
+| `tail -f log \| grep "BUILD OK"` | Same silence-on-failure defect, plus unflushed pipe buffers hide matches until far too late. |
+| A single-condition `until` loop | Correct for "tell me when X exists"; emits nothing if X never happens, and cannot report failure. |
+| Polling the branch tip instead of the pushed commit | Returns a newer run from someone else's push, or your own previous one — a false green on a commit that was never tested. |
+| Re-printing the full job table each poll | Burns context until the harness rate-limits or kills the monitor, which reintroduces the stall. |
+| Blocking the session while waiting | Forfeits the entire point: a failure at minute 3 of a 25-minute pipeline is learned at minute 25. |
+
+The cost is asymmetric, which is why this matters. A failure detected early gives
+back most of the pipeline's duration; the same failure detected at the deadline
+gives back nothing. On a 25-minute pipeline, reacting to the *first* red lane
+rather than the final verdict is roughly a 20-minute head start on the fix.
+
+## The contract a watcher must satisfy
+
+Any wait mechanism armed after a trigger must guarantee all of these. Each maps to
+a specific observed failure when missing:
+
+1. **Terminates on every path, with an explicit verdict.** Silence past the
+   deadline must be structurally impossible — emit exactly one terminal line, then
+   exit. This is the load-bearing property; the rest refine it.
+2. **Pins to an immutable identifier**, captured *before* arming — a commit SHA,
+   build id, or deploy id. Never a moving ref like a branch tip.
+3. **Covers every run the identifier triggered**, not just one workflow by name. A
+   second pipeline on the same commit can fail while the watched one passes.
+4. **Emits only state changes**, plus a low-frequency heartbeat. A green 20-minute
+   run should cost a handful of lines, not fifty identical tables.
+5. **Has a registration deadline** distinct from the run deadline. If nothing
+   appears for the identifier within a few minutes, say so — a path filter, wrong
+   ref, disabled workflow, or failed push must not read as "still running."
+6. **Waits for late registration before declaring success.** Runs register seconds
+   apart; `workflow_run`-style chains (a deploy triggered on build completion)
+   register much later. Require a settle condition before green.
+7. **Detects supersession.** If the branch moves past the identifier, retire.
+8. **Bounds each probe and survives transient errors.** One wedged API call must
+   not freeze the loop; warn on a short streak, exit loudly on a long one.
+9. **Heartbeats.** A periodic liveness tick separates "still queued" from "watcher
+   died." Keep the interval under the consuming model's prompt-cache TTL (commonly
+   ~5 min; ~2–3 min is a safe default) so a long wait stays cheap.
+
+### Verdict vocabulary
+
+A small, stable set of terminal verdicts lets the caller react without parsing
+prose. Each implies a different next move — which is the whole reason to
+distinguish them:
+
+| Verdict | Meaning | Caller's next move | Exit |
+|---|---|---|---|
+| `success` | every run for the identifier is green | proceed | 0 |
+| `failure` | a run went red | fetch that job's failing log now | 1 |
+| `timeout` | not terminal within the deadline | inspect the run; stuck, not slow | 2 |
+| `no-run` | nothing registered for the identifier | path filter, wrong ref, disabled workflow, failed push — all actionable, none a hang | 2 |
+| `probe-dead` | repeated API/CLI failures | check auth, network, rate limits | 2 |
+| `cancelled` | terminal but not green, branch unmoved | usually a manual stop or infra event — decide whether the commit was ever validated | 1 |
+| `superseded` | the branch moved past the identifier | retire; arm a fresh watch on the new id | 3 |
+
+Two rules make this vocabulary safe:
+
+**Enumerate success, not failure.** The most dangerous watcher bug is treating
+"did not fail" as green. A run that ends `cancelled`, `skipped`, `stale`, or
+`neutral` is terminal but *not* validated. Match an explicit success set and treat
+every other terminal conclusion — including ones never seen before — as not-green.
+
+**Evaluate supersession before calling anything a failure.** The
+`cancel-in-progress: true` concurrency pattern this skill recommends elsewhere
+(see `references/github-actions.md`) cancels the previous commit's run when a fix
+lands. A watcher that checks failure first reports `failure` for a run nobody
+should act on, and the agent chases a phantom break. `no-run` and `superseded` are
+the two verdicts hand-rolled loops almost always omit, and the two that waste the
+most wall-clock.
+
+Distinct exit codes matter for chaining: `watch && deploy` must not proceed on a
+`superseded` watch that never reached a real verdict. Put the failing run's log
+command *inside* the `failure` line so the caller never has to reconstruct it.
+
+## Reference implementation shape
+
+Provider-agnostic; swap `probe()` for the platform's CLI or API. The bundled
+`scripts/ci-watch.py` implements this exactly, with a built-in GitHub Actions probe
+and a custom-probe mode for everything else.
+
+```python
+def watch(sha, branch, deadline, register_by, settle, interval, heartbeat) -> int:
+    start = last_beat = all_green_since = now()
+    seen, errors, registered = {}, 0, False
+
+    while True:
+        if now() - start > deadline:
+            emit("CI-DONE timeout"); return 2
+
+        try:
+            runs = probe(sha)                # ALL runs for this id, never "latest"
+            errors = 0
+        except Exception:
+            errors += 1
+            if errors == 3:  emit("CI-WARN probe failing (3x)")
+            if errors >= 10: emit("CI-DONE probe-dead"); return 2
+            sleep(interval); continue
+
+        if runs and not registered:
+            registered = True; emit(f"CI-RUN registered {len(runs)}")
+        if not registered and now() - start > register_by:
+            emit("CI-DONE no-run"); return 2
+
+        for r in runs:                       # diff-gated: emit only on change
+            if seen.get(r.id) != r.state:
+                if r.id in seen: emit(f"CI-CHG {r.name}: {seen[r.id]} -> {r.state}")
+                seen[r.id] = r.state
+
+        if registered and runs and all(r.terminal for r in runs):
+            superseded = branch and head_of(branch) != sha   # a lookup error is NOT supersession
+            bad = [r for r in runs if r.conclusion not in SUCCESS_SET]
+            if superseded and not any(r.conclusion in FAILURE_SET for r in runs):
+                emit("CI-DONE superseded"); return 3
+            if bad:
+                emit(f"CI-DONE failure — {bad[0].name} — logs: <log-cmd {bad[0].id}>"); return 1
+            if now() - all_green_since >= settle:            # hold for late workflow_run chains
+                emit("CI-DONE success"); return 0
+        else:
+            all_green_since = now()
+
+        if now() - last_beat >= heartbeat:
+            last_beat = now(); emit(f"CI-HB {int((now()-start)/60)}m")   # MUST reset, or it fires every poll
+        sleep(interval)
+```
+
+Three judgement calls to make explicit for the target setup:
+
+- **`SUCCESS_SET`.** `{success, skipped, neutral}` is a reasonable default — a
+  skipped job is usually an intentional route. Verify against the repo's own gating
+  rules before trusting it.
+- **`settle`.** How long to hold an all-green state before declaring success. One
+  poll interval (~15s) covers workflows that register seconds apart;
+  `workflow_run` chains register *after* their trigger completes, so give those
+  60–120s or watch the downstream workflow explicitly.
+- **`FAILURE_SET` vs `cancelled`.** A *completed red* run reports `failure` even if
+  the branch later moved — "did this SHA pass" matters more than "did the branch
+  move." A `cancelled` run on an *unmoved* branch is a distinct signal (manual
+  cancel or infra), not a test failure, so it is not silently folded into success.
+
+## Per-provider probes
+
+Only the poll step changes. Everything above is identical.
+
+| Provider | Poll for one commit |
+|---|---|
+| GitHub Actions | `gh run list --commit <sha> --json databaseId,workflowName,status,conclusion` |
+| GitLab CI | pipelines API filtered by `sha` |
+| Buildkite | builds API filtered by commit |
+| CircleCI | pipeline → workflow status by revision |
+| A deploy / anything else | any command printing `<name>: <state>` lines and a terminal marker |
+
+A provider CLI that emits a structured event stream and a nonzero exit on failure
+(NDJSON, `--json`) already satisfies most of the contract — prefer wrapping it over
+hand-rolling. What such CLIs typically still lack is a self-imposed deadline, a
+registration timeout, and coverage of *every* run for the commit. Wrap, do not
+replace.
+
+## Run granularity: run-level status hides an early failing job
+
+A run-level status stays `in_progress` until *every* job finishes, and its
+conclusion is unset until then. If a pipeline is one workflow with several jobs,
+polling run status alone cannot tell you a lane already failed — which defeats the
+"react to the first red" payoff. Either split genuinely independent lanes into
+separate workflows (they then appear as separate runs for the commit), or expand
+in-flight runs to job level when polling (`gh run view <id> --json jobs`). Expand
+only *in-flight* runs; completed ones already carry a conclusion, so the extra call
+is bounded to work that is still moving.
+
+## Wiring it to an agent harness
+
+Run the watcher as a background process whose **stdout lines become
+notifications**, so the agent keeps working and reacts on arrival. With a streaming
+background-process tool (for example Claude Code's `Monitor`):
+
+```
+Monitor(
+  command: "python3 scripts/ci-watch.py --sha <full-sha> --branch <branch> --deadline-min 25",
+  description: "CI for <short-sha>",
+  timeout_ms: 1800000        # comfortably longer than the watcher's own deadline
+)
+```
+
+Rules that matter in practice:
+
+- **Set the harness timeout longer than the watcher's deadline**, so the watcher is
+  what ends the watch and you get a verdict instead of a truncated stream.
+- **Arm it last, in the same turn as the push.** Any commit after arming moves the
+  branch and the watcher correctly retires as `superseded` — but you lose the
+  watch. Finish committing, then arm, then keep working.
+- **Never hand-type the identifier.** Use `$(git rev-parse HEAD)`; a wrong SHA
+  reports `no-run` or `superseded` against the real head and teaches nothing.
+- **One watch per identifier.** After a re-push, arm a fresh one.
+- **A heartbeat is not a result.** Acknowledge it silently; never report it as
+  progress or treat it as a user message.
+- **If any stage is a shell pipeline, flush per line** — `grep --line-buffered`,
+  `awk` with `fflush()`. A buffered stage silently withholds events, and `| head -N`
+  cannot flush at all. In `zsh`, avoid a variable named `status`; it is a readonly
+  builtin and the loop dies instantly, emitting nothing.
+
+### When one notification is enough
+
+For plain "tell me when it is done," a bounded background command that exits on the
+condition is simpler than a streaming watcher:
+
+```bash
+until <terminal-state-check>; do sleep 20; done
+```
+
+Reach for the streaming watcher when you want to react to the *first* red lane while
+others still run — the head-start described above.
+
+## Reacting to events
+
+| Event | Response |
+|---|---|
+| `CI-RUN` / `CI-CHG … registered` | Note the count. Fewer runs than expected is a routing problem — see `references/change-based-ci.md`. |
+| `CI-CHG … -> failure` | Act now; pull that job's failing step log without waiting for the rest. |
+| `CI-CHG in_progress -> queued` | Normal on platforms that reclaim runners mid-run. Not a fault. |
+| `CI-HB` | Acknowledge silently. |
+| `CI-DONE` | The only line that is a verdict. |
+
+State is **not** monotonic on every platform. Only a terminal line means terminal.
+
+## Reacting to a red check without corrupting the measurement
+
+A red check is a real finding, not an obstacle to route around. Deciding *whether
+it is your failure* comes before changing code:
+
+1. Run the exact log command the verdict printed. Do not re-derive it.
+2. Diff the failing commit against the last green one: `git diff --stat <green>..<red>`.
+   If nothing in that diff can plausibly reach the failing test, re-run the
+   **identical commit** rather than pushing a speculative fix.
+3. A pass on the unchanged commit demonstrates a flaky test — a separate defect to
+   own, never "fixed" by relaxing the assertion, adding a retry, mocking the failure
+   away, or `skip`ping to green. Each of those corrupts the measurement instead of
+   fixing the pipeline (`references/effectiveness-contract.md`). Quarantine and
+   ownership belong in `references/testing-and-flakiness.md`.
+4. If the failure is genuine, reproduce it with the narrowest local command. If it
+   is CI-only, reproduce the *CI condition* — job-wide environment variables, a
+   clean checkout, a different working directory, absent secrets — not the whole
+   pipeline.
+5. Verify red-first: confirm the test fails without the fix and passes with it. A
+   fix never seen to fail is a fix you cannot vouch for.
+
+A provider flake counter, where one exists, is a useful prior but not a substitute:
+it typically only catches a step that succeeded on retry, so a
+consistently-failing-then-passing test can read as zero flakes. The identical-commit
+re-run is the reliable test.
+
+## A collateral benefit: automatic CI surfaces hidden defects
+
+Moving from a manual, hand-dispatched pipeline to one that runs on every push
+surfaces defects the manual flow hid — environment leakage between jobs, assertions
+that drifted from the contract they check, pre-existing flakes. Treat each as a real
+finding and root-cause it red-first. Reaching green by weakening the check trades a
+slow local loop for a silent remote one that lies.
+
+## Verify the watcher before trusting it
+
+A watcher never seen to fail correctly is not yet a safety mechanism. Exercise the
+paths that would otherwise hang:
+
+| Path | How to force it |
+|---|---|
+| `no-run` | Watch an all-zeros or unpushed SHA with a short registration deadline. |
+| `failure` | Watch a known-red historical SHA. |
+| `success` | Watch a known-green historical SHA. |
+| `superseded` | Watch a SHA, then push one more commit to the branch. |
+
+## Sources
+
+- `gh run watch` TTY-gating of screen refresh and of the completion summary: `cli/cli` `pkg/cmd/run/watch/watch.go`, `pkg/iostreams/iostreams.go` (read 2026-07-28)
+- `gh run watch` flags (`--exit-status`, `--interval`, `--compact`): https://cli.github.com/manual/gh_run_watch (accessed 2026-07-28)
+- GitHub Actions `workflow_run` trigger semantics (late follow-up registration): https://docs.github.com/actions/reference/events-that-trigger-workflows (accessed 2026-07-28)

--- a/skills/ci-cd-optimize/references/measurement.md
+++ b/skills/ci-cd-optimize/references/measurement.md
@@ -1,49 +1,110 @@
 # Measurement and Verification
 
-Use this file when building a baseline, proving a bottleneck, or validating that an optimization helped without weakening delivery outcomes.
+Use this file when building a baseline, proving a bottleneck, sizing an
+experiment, or deciding whether a claimed speedup is real. The goal is to measure
+what the change controls, not to quote the best-looking total from a noisy set of
+runs.
+
+If the question is *whether adding jobs will help or whether the pool is already
+contended*, read `capacity-and-contention.md` next. If the question is *how the
+result gets back to an agent without stalling*, read `feedback-loops.md`.
 
 ## Metrics that matter
 
-| Metric | Formula | Interpretation |
+| Metric | Formula | What it answers |
 |---|---|---|
-| Queue time | execution start - trigger time | Capacity, scheduling, concurrency, runner topology. |
-| Setup time | first real task - runner start | Checkout, runtime, dependency install, environment boot. |
-| Execution time | finish - execution start | Workload inside jobs. |
+| Queue time | job `started_at - created_at` | Capacity, scheduling, runner scarcity, queue placement. |
+| Setup time | first real task - runner start | Checkout, runtime install, dependency restore, environment boot. |
+| Execution time | finish - execution start | The work the job itself performs. |
 | Critical-path duration | longest dependency chain through the DAG | The only sequence that directly governs wall-clock feedback. |
-| Cache exact-hit rate | exact key hits / cache attempts | Cache-key precision, not necessarily saved time. |
-| Cache saved time | clean path time - (restore + post-hit work) | Whether a cache is worth keeping. |
-| First-time pass rate | runs green without retry / all runs | Flakiness and reliability. |
-| Cost per successful change | compute + storage / successful changes | Speed improvements that increase total cost may not be wins. |
-| Change failure/rework rate | failed or unplanned recovery deployments / deployments | The effectiveness guardrail after optimization. |
+| Cache exact-hit rate | exact key hits / cache attempts | Key precision, not necessarily saved time. |
+| Cache saved time | clean path - (restore + post-hit work) | Whether a cache is worth keeping. |
+| First-time pass rate | runs green without retry / all runs | Reliability, flakiness, and hidden rework. |
+| Cost per successful change | compute + storage / successful changes | Whether a “speedup” just bought more cost. |
+| Change failure / rework rate | failed or unplanned recovery deploys / deploys | Whether the faster path weakened effectiveness. |
 
-Use median and p95. CI duration is right-skewed; averages hide cold caches, runner saturation, flaky retries, and dependency changes.
+Use **median and p95**. CI duration is right-skewed; averages hide cold caches,
+runner saturation, flaky retries, and setup spikes.
 
 ## Baseline protocol
 
 1. Pin the exact commit, workflow, event, runner class, and environment.
-2. Run at least three comparable runs when variance is material.
+2. Use at least three comparable runs when variance is material.
 3. Record queue, setup, execution, transfer, finalization, and per-job duration.
 4. Record exact cache hit/miss, retry count, artifact names/digests, and run head SHA.
 5. Reject baselines from stale branches, empty diffs, disabled jobs, or different runners.
 
-If a queue-time baseline is unavailable, start with provider run timestamps and job logs. Do not invent missing precision.
+If queue-time history is unavailable, start from provider timestamps and job logs.
+Do not invent missing precision.
+
+## Separate queue from execution before claiming anything
+
+Total wall-clock mixes two different things:
+
+```text
+queue     = started_at - created_at
+execution = completed_at - started_at
+```
+
+Queue is fleet behavior; execution is the part your in-job change usually
+controls. If execution is stable and totals swing, say that explicitly and report
+execution as the result.
+
+### Compare arms under the same contention state
+
+A run against an idle pool and a run against a saturated one are not comparable,
+even on the same commit and runner class. Interleave arms when practical (`A, B,
+A, B`) and compare execution time when the change is in-job. Treat any delta
+smaller than the queue-time spread as noise.
+
+A good summary looks like:
+
+```text
+Queue p50/p95: 18s / 97s   (noise floor)
+Execution p50/p95: 62s / 66s
+Change A -> B execution delta: -4s
+Conclusion: within queue noise, not proven at wall-clock level
+```
+
+That is a valid result. Report disproved hypotheses too — silently dropping a
+neutral experiment invites the next person to retry the same dead idea.
 
 ## Critical-path analysis
 
-Build a DAG from declared dependencies. For every job, compute:
+Build the DAG from actual dependencies, not stage labels. For each job, compute:
 
 - duration,
-- exclusive time (time it blocks the critical path),
+- exclusive time (how long it blocks the critical path),
 - critical-path rate (how often it determines total duration),
-- setup/execute/transfer breakdown.
+- queue/setup/execute/transfer breakdown.
 
-Prioritize `critical-path rate × exclusive time`. A job consuming CPU in parallel with a longer job is not the current bottleneck.
+Prioritize:
 
-Where the platform records per-job start offsets, derive the DAG shape empirically instead of trusting declared dependencies: a gap between a job's `start + duration` and its dependents' start is scheduling and per-job setup overhead, which no amount of in-job optimization removes. On Avrea, `references/avrea/cli-evidence.md` shows how to extract these offsets.
+```text
+critical-path rate × exclusive time
+```
 
-## Experiment verification
+A job burning a lot of CPU in parallel with a longer job is not the current
+bottleneck. Large total CPU-time savings on non-critical work can produce zero
+wall-clock change.
 
-Before changing config, write down:
+Where the platform records per-job start offsets, derive the DAG shape
+empirically instead of trusting declared dependencies. A gap between a job's end
+and its dependents' start is scheduling and per-job setup overhead — work no
+in-job optimization will remove.
+
+## Job topology: price the hop before adding one
+
+A new job pays its own queue, VM boot, checkout, and toolchain setup. That **hop
+cost** belongs in the baseline before adding planner jobs, aggregate status jobs,
+fan-out helpers, or tiny shards.
+
+If the question is specifically *when splitting or sharding stops helping*, route
+immediately to `capacity-and-contention.md`.
+
+## Experiment definition
+
+Before changing config, write down the experiment in plain language:
 
 ```text
 Baseline: p50 14.2m / p95 18.7m on commit abc123
@@ -53,23 +114,36 @@ Expected: test critical path under 4m; no test-count loss
 Risk: uneven shard due to one long spec; rollback is remove matrix
 ```
 
-After the change:
+If the plan cannot name the bottleneck and expected wall-clock effect, it is not
+ready to run.
 
-1. Re-run the same commit if possible.
+## Verify after the change
+
+1. Re-run the **same commit** first when possible.
 2. Confirm the run's head SHA contains the change and the expected jobs ran.
-3. Compare p50/p95 wall-clock, queue time, cost, cache behavior, and first-time pass rate.
-4. Confirm no tests/gates disappeared from the merged result.
+3. Compare p50/p95 wall-clock, queue time, cost, cache behavior, and first-time
+   pass rate.
+4. Confirm no tests/gates/artifact identities disappeared from the merged result.
 5. Repeat on a normal representative commit.
 
 ## Claim only the rung reached
 
-| Evidence | You may say |
+| Evidence | Safe wording |
 |---|---|
-| Config inspected | "The bottleneck hypothesis is plausible." |
-| Syntax/schema validated | "The config is valid; runtime not exercised." |
-| One exact-commit run | "One measured run improved; variance not established." |
-| Three+ comparable runs | "The measured median/p95 improved on these runs." |
-| Production/trend evidence | "The optimization held in normal operation." |
+| Config inspected | “The bottleneck hypothesis is plausible.” |
+| Syntax/schema validated | “The config is valid; runtime not exercised.” |
+| One exact-commit run | “One measured run improved; variance not established.” |
+| Three+ comparable runs | “The measured median/p95 improved on these runs.” |
+| Production/trend evidence | “The optimization held in normal operation.” |
+
+## Cross-links
+
+- `capacity-and-contention.md` — when queue share is high or added parallelism measured neutral.
+- `feedback-loops.md` — when the optimization includes how a person or agent waits on CI.
+- `runners-and-autoscaling.md` — when the next experiment is runner class or slot count.
+- `caching.md` — when setup/restore is the bottleneck and cache saved time is the question.
+- `testing-and-flakiness.md` — when retries or reruns dominate the metric.
+- `effectiveness-contract.md` — before weakening any gate, cache trust scope, or artifact identity.
 
 ## Sources
 

--- a/skills/ci-cd-optimize/references/runners-and-autoscaling.md
+++ b/skills/ci-cd-optimize/references/runners-and-autoscaling.md
@@ -1,6 +1,12 @@
 # Runners and Autoscaling
 
-Use this file when queue time, runner capacity, runner isolation, or fleet cost is the bottleneck.
+Use this file when queue time, runner capacity, runner isolation, or fleet cost
+is the bottleneck.
+
+Read `measurement.md` first if queue and execution have not yet been separated.
+Read `capacity-and-contention.md` next when the suspected fix is “add more jobs”
+or “increase parallelism” — that file decides whether the fleet has enough slots
+for the change to pay off at all.
 
 ## Decision order
 
@@ -13,8 +19,10 @@ Use this file when queue time, runner capacity, runner isolation, or fleet cost 
 
 ## Trust boundaries
 
-- Untrusted public PRs belong on vendor-isolated hosted runners or equivalent one-job sandboxes.
-- Persistent self-hosted runners can retain malicious processes, files, credentials, and network access.
+- Untrusted public PRs belong on vendor-isolated hosted runners or equivalent
+  one-job sandboxes.
+- Persistent self-hosted runners can retain malicious processes, files,
+  credentials, and network access.
 - Do not share runner groups across trust levels.
 - Prefer OIDC and short-lived credentials over stored cloud secrets.
 
@@ -28,18 +36,59 @@ Use this file when queue time, runner capacity, runner isolation, or fleet cost 
 
 Keep orchestration/upload capacity warm separately from scale-to-zero workers.
 
+## Queue time varies by class — measure it, do not assume
+
+A larger instance class is not automatically faster end-to-end. Scarcity, pool
+warmth, and time-of-day decide whether the bigger class is provisioned sooner or
+later than the small one, and the answer differs per fleet and per hour.
+
+What generalizes is the method:
+
+1. Record `started_at - created_at` per job, grouped by runner label.
+2. Report median and p95 per class.
+3. Compare the queue penalty of the larger class against the execution gain it buys.
+4. Confirm the job is actually CPU- or memory-bound first — per-core idle ratios
+   and peak versus average utilization, not just duration.
+
+Size up only when utilization proves the job is compute-bound **and** the class's
+measured queue penalty is smaller than the execution gain. When a job is
+queue-bound, a bigger runner makes it slower.
+
+## Downsizing is often the real win
+
+“Start large, then step down” sounds prudent but silently overpays if the
+step-down half never gets measured. Peak memory far below allocation, CPU average
+well under 100%, and wall-clock flat across sizes is the signature of a job that
+should shrink.
+
+Treat a downsizing experiment as first-class, not as a consolation prize.
+
 ## Autoscaling signals
 
-Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU utilization alone misses jobs waiting for an available runner. Keep the runner manager/controller on persistent on-demand infrastructure.
+Scale from queued/assigned jobs, job startup latency, and wait percentiles. CPU
+utilization alone misses jobs waiting for a runner. Keep the runner
+manager/controller on persistent on-demand infrastructure.
+
+Corollary: fanning many concurrent jobs onto one scarce large label can exhaust
+that pool and serialize your own pipeline. Several runs of *your own* repository
+queueing simultaneously on the same large label is capacity starvation, not slow
+CI — reduce job count, spread across labels, or collocate work before buying
+more hardware.
 
 ## Spot capacity
 
-Use spot/preemptible runners only for short, idempotent, retryable, or checkpointed jobs. Keep an on-demand fallback and never run the controller/manager on spot. Do not use spot for deployment gates where interruption is costly.
+Use spot/preemptible runners only for short, idempotent, retryable, or
+checkpointed jobs. Keep an on-demand fallback and never run the
+controller/manager on spot. Do not use spot for deployment gates where
+interruption is costly.
 
 ## Architecture and OS
 
-- ARM64 Linux can reduce cost when toolchain and actions support it; benchmark compatibility.
-- macOS is scarce and expensive. Move lint/typecheck/cross-platform tests to Linux and reserve macOS for Xcode, signing, simulator, and Apple-specific validation.
+- ARM64 Linux can reduce cost when toolchain and actions support it; benchmark
+  compatibility first.
+- macOS is scarce and expensive. Move lint/typecheck/cross-platform tests to
+  Linux and reserve macOS for Xcode, signing, simulator, and Apple-specific
+  validation.
 - Pin runner images and Xcode versions; avoid `-latest` for reproducible timing.
 
 ## Kubernetes fleets
@@ -49,6 +98,14 @@ Use spot/preemptible runners only for short, idempotent, retryable, or checkpoin
 - Set security contexts and least-privilege service accounts.
 - Use bin packing that lets the cluster autoscaler remove cold nodes.
 - Isolate namespaces for multi-tenant workloads.
+
+## Cross-links
+
+- `capacity-and-contention.md` — when the queue ceiling, not runner speed, is the issue.
+- `measurement.md` — how to prove a bigger/smaller class changed execution rather than queue.
+- `network-and-artifacts.md` — when registry or artifact locality dominates more than CPU/RAM.
+- `deployment.md` — runner choices for rollout and release paths.
+- `swift-xcode.md` — macOS-specific constraints and where to optimize instead.
 
 ## Sources
 

--- a/skills/ci-cd-optimize/references/testing-and-flakiness.md
+++ b/skills/ci-cd-optimize/references/testing-and-flakiness.md
@@ -1,6 +1,12 @@
 # Testing and Flakiness
 
-Use this file when test execution dominates the critical path or retries/reruns inflate pipeline time.
+Use this file when test execution dominates the critical path, when retries or
+re-runs inflate wall-clock, or when a green run still leaves doubt about whether
+the failure was real.
+
+Read `measurement.md` first if the slowdown has not been separated into queue vs
+execution. Read `feedback-loops.md` when the question is how to learn the result
+without blocking.
 
 ## Sharding principles
 
@@ -10,6 +16,9 @@ Use this file when test execution dominates the critical path or retries/reruns 
 - Increase shard count only while p95 wall-clock improves. Setup/reporting is the serial tail.
 - Merge results and coverage in a fan-in job; gate on the merged result.
 
+If the first shard plan that looks parallel also adds a heavy planner job or
+several short setup-heavy lanes, price the hop first in `capacity-and-contention.md`.
+
 ## Playwright
 
 ```bash
@@ -17,7 +26,8 @@ npx playwright test --shard=${SHARD_INDEX}/${SHARD_COUNT} --reporter=blob
 npx playwright merge-reports --reporter=html ./all-blob-reports
 ```
 
-Use `fullyParallel: true` only when tests are isolated enough for test-level distribution. Upload each shard's blob report and merge them.
+Use `fullyParallel: true` only when tests are isolated enough for test-level
+distribution. Upload each shard's blob report and merge them.
 
 ## Vitest
 
@@ -26,11 +36,13 @@ vitest run --reporter=blob --shard=${SHARD_INDEX}/${SHARD_COUNT}
 vitest run --merge-reports
 ```
 
-Vitest distributes by test file by default. A few large files can still dominate; split large files or use provider timing-aware splitting.
+Vitest distributes by test file by default. A few large files can still dominate;
+split large files or use provider timing-aware splitting.
 
 ## Jest
 
-Jest `--shard` balances by file count unless a custom sequencer uses historical timings. CircleCI and similar providers can split by JUnit timing metadata:
+Jest `--shard` balances by file count unless a custom sequencer uses historical
+timings. CircleCI and similar providers can split by JUnit timing metadata:
 
 ```bash
 npx jest --listTests | circleci tests run \
@@ -47,7 +59,29 @@ npx jest --listTests | circleci tests run \
 | Recovered test | Automatic re-entry into the blocking suite. |
 | Chronic flake | Fix infrastructure/test design or remove from required path with explicit risk acceptance. |
 
-Retries are a detection and temporary-confidence mechanism. A retry-pass is still evidence of instability. Track flake rate, rerun count, owner, and age.
+Retries are a detection and temporary-confidence mechanism. A retry-pass is still
+evidence of instability. Track flake rate, rerun count, owner, and age.
+
+## Re-run the identical commit before changing code
+
+If a red check appears on a commit whose diff does not plausibly reach the failing
+test, re-run the **identical commit** before touching code. A pass on the
+unchanged tree demonstrates flakiness or infrastructure drift, not a fixed bug.
+
+That is the reliable test. Provider flake counters are useful priors, not proof:
+they often only count a step that eventually succeeded, so a
+failing-then-passing test can still read as zero flakes.
+
+Do **not** “fix” a flake by:
+
+- widening a threshold,
+- adding an unconditional retry,
+- skipping the test,
+- mocking the failure away,
+- rerunning until green and calling it solved.
+
+Those weaken the measurement instead of fixing the pipeline. Cross-link:
+`effectiveness-contract.md`.
 
 ## Coverage
 
@@ -60,6 +94,14 @@ Retries are a detection and temporary-confidence mechanism. A retry-pass is stil
 - Use fail-fast between serial stages when downstream cannot succeed.
 - Avoid cancelling every matrix shard on the first failure when full shard signal helps diagnose systemic issues.
 - Preserve JUnit/blob/report artifacts on failure.
+
+## Cross-links
+
+- `feedback-loops.md` — how to surface the first failing lane without blocking.
+- `capacity-and-contention.md` — when sharding neutralizes or worsens wall-clock.
+- `measurement.md` — how to compare sharded and unsharded runs honestly.
+- `integration-environments.md` — when the flake is shared state, ports, or services rather than test logic.
+- `effectiveness-contract.md` — why retries and skips are not optimization.
 
 ## Sources
 

--- a/skills/ci-cd-optimize/scripts/ci-watch.py
+++ b/skills/ci-cd-optimize/scripts/ci-watch.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Watch CI for one exact commit and emit a bounded, diff-gated event stream.
+
+Built for agents and unattended sessions that must learn the result of a push,
+re-run, dispatch, or deploy without blocking. One stdout line = one event, so it
+fits background monitor tools naturally.
+
+Guarantees:
+  - one line per state CHANGE (never re-prints unchanged state)
+  - a heartbeat while healthy, so a long queue is never ambiguous
+  - exactly one `CI-DONE <verdict>` on every path, then exit
+  - a hard deadline, a registration deadline, and a settle window for
+    workflow_run-style follow-up workflows that register after the first run turns green
+
+Verdicts: success | failure | cancelled | timeout | no-run | superseded | probe-dead
+Exit status: 0 only for `success`.
+
+Modes
+-----
+GitHub Actions (built in, zero config beyond authenticated `gh`):
+
+    ci-watch.py --sha "$(git rev-parse HEAD)" --branch main
+
+Any other provider: supply a probe command that prints one `<name>: <state>`
+line per unit of work, and optionally `TERMINAL: <verdict>` once all are
+terminal:
+
+    ci-watch.py --sha "$SHA" --cmd './ci/probe.sh'
+
+The probe receives the watched commit as `$CI_WATCH_SHA` and should exit non-zero
+only when the probe itself failed, never because the pipeline failed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+TERMINAL_OK = {"success", "skipped", "neutral"}
+ACTIVE = {"queued", "in_progress", "waiting", "pending", "requested"}
+
+
+def emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def run(cmd: list[str] | str, timeout: int, env: dict[str, str] | None = None):
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            shell=isinstance(cmd, str),
+            env=env,
+        )
+        return proc.returncode, proc.stdout
+    except (subprocess.TimeoutExpired, OSError):
+        return 1, ""
+
+
+def probe_gh(sha: str, timeout: int, expand_jobs: bool = True):
+    """Return {name: (state, run_id)} for the exact SHA, or None if unavailable."""
+    code, out = run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--commit",
+            sha,
+            "--limit",
+            "100",
+            "--json",
+            "databaseId,name,status,conclusion,attempt",
+        ],
+        timeout,
+    )
+    if code != 0:
+        return None
+    try:
+        runs = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        return None
+
+    # Defensive: some providers return one record per attempt. `gh` already
+    # collapses, but this keeps the logic safe if the backing command is swapped.
+    latest: dict[object, dict] = {}
+    for r in runs:
+        rid = r.get("databaseId")
+        if rid not in latest or (r.get("attempt") or 1) > (latest[rid].get("attempt") or 1):
+            latest[rid] = r
+
+    result = {}
+    for r in latest.values():
+        rid = r.get("databaseId")
+        wf = r.get("name") or "?"
+        status = r.get("status") or "unknown"
+        if expand_jobs and status in ACTIVE:
+            jcode, jout = run(["gh", "run", "view", str(rid), "--json", "jobs"], timeout)
+            if jcode == 0:
+                try:
+                    jobs = (json.loads(jout or "{}") or {}).get("jobs") or []
+                except json.JSONDecodeError:
+                    jobs = []
+                if jobs:
+                    for j in jobs:
+                        jstate = j.get("conclusion") or j.get("status") or "unknown"
+                        result[f"{wf}/{j.get('name', '?')}"] = (jstate, rid)
+                    continue
+        result[f"{wf}#{rid}"] = (r.get("conclusion") or status, rid)
+    return result
+
+
+def probe_cmd(command: str, timeout: int, sha: str):
+    env = dict(os.environ, CI_WATCH_SHA=sha)
+    code, out = run(command, timeout, env=env)
+    if code != 0 and not out.strip():
+        return None, None
+    states, terminal = {}, None
+    for raw in out.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.upper().startswith("TERMINAL:"):
+            terminal = (line.split(":", 1)[1].strip() or "success").lower()
+            continue
+        if ":" in line:
+            name, state = line.split(":", 1)
+            states[name.strip()] = (state.strip(), None)
+    return states, terminal
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sha", required=True, help="exact commit to watch")
+    ap.add_argument("--branch", default="", help="retire if this branch moves past --sha")
+    ap.add_argument("--cmd", default="", help="custom probe command (non-GitHub providers)")
+    ap.add_argument("--deadline", type=int, default=1800, help="hard stop, seconds")
+    ap.add_argument("--register-deadline", type=int, default=240, help="give up waiting for a run to appear, seconds")
+    ap.add_argument("--settle", type=int, default=90, help="grace period after all-green for late follow-up workflows")
+    ap.add_argument("--interval", type=int, default=20, help="poll interval, seconds")
+    ap.add_argument("--heartbeat", type=int, default=150, help="heartbeat interval, seconds")
+    ap.add_argument("--no-expand-jobs", action="store_true", help="GitHub mode: skip per-job expansion of in-progress runs")
+    a = ap.parse_args()
+
+    start = time.monotonic()
+    last_hb = start
+    seen: dict[str, str] = {}
+    registered = False
+    green_since = None
+    fail_streak = 0
+    supersede_warned = False
+    probe_timeout = max(20, a.interval)
+
+    def done(verdict: str, detail: str = ""):
+        emit(f"CI-DONE {verdict}" + (f" — {detail}" if detail else ""))
+        raise SystemExit(0 if verdict == "success" else 1)
+
+    while True:
+        now = time.monotonic()
+        elapsed = now - start
+        if elapsed > a.deadline:
+            last = "; ".join(f"{k}:{v}" for k, v in seen.items()) or "none"
+            done("timeout", f"{int(elapsed)}s elapsed; last state: {last}")
+
+        explicit_terminal = None
+        if a.cmd:
+            states, explicit_terminal = probe_cmd(a.cmd, probe_timeout, a.sha)
+        else:
+            states = probe_gh(a.sha, probe_timeout, expand_jobs=not a.no_expand_jobs)
+
+        if states is None:
+            fail_streak += 1
+            if fail_streak == 3:
+                emit("CI-WARN probe failing (3 consecutive); still trying")
+            if fail_streak >= 10:
+                done("probe-dead", "10 consecutive probe failures; result unknown")
+            time.sleep(a.interval)
+            continue
+        fail_streak = 0
+
+        if explicit_terminal:
+            done(explicit_terminal)
+
+        changes = []
+        for name, (state, _hint) in states.items():
+            if name not in seen:
+                if registered:
+                    changes.append(f"{name}: {state}")
+            elif seen[name] != state:
+                changes.append(f"{name}: {seen[name]} -> {state}")
+            seen[name] = state
+
+        if states and not registered:
+            registered = True
+            emit(
+                f"CI-RUN registered {len(states)}: "
+                + " · ".join(f"{n}: {s}" for n, (s, _) in states.items())
+            )
+        elif changes:
+            emit("CI-CHG " + " · ".join(changes))
+
+        if not registered and elapsed > a.register_deadline:
+            done(
+                "no-run",
+                f"nothing registered for {a.sha[:8]} within {a.register_deadline}s (path filters may exclude this change)",
+            )
+
+        if a.branch and registered and not a.cmd:
+            code, out = run(["git", "ls-remote", "origin", f"refs/heads/{a.branch}"], 15)
+            if code != 0 or not out.split():
+                if not supersede_warned:
+                    supersede_warned = True
+                    emit(f"CI-WARN cannot read origin/{a.branch}; supersede detection is OFF")
+            else:
+                tip = out.split()[0]
+                if not (tip.startswith(a.sha[:12]) or a.sha.startswith(tip[:12])):
+                    done("superseded", f"branch {a.branch} moved to {tip[:8]}")
+
+        if registered:
+            pending = [n for n, (s, _) in states.items() if s in ACTIVE]
+            if not pending:
+                bad = [(n, s) for n, (s, _) in states.items() if s not in TERMINAL_OK]
+                if bad:
+                    n, s = bad[0]
+                    hint = states[n][1]
+                    tail = f" — logs: gh run view {hint} --log-failed" if hint else ""
+                    verdict = "cancelled" if all(x[1] == "cancelled" for x in bad) else "failure"
+                    done(verdict, f"{n} -> {s}{tail}")
+                if green_since is None:
+                    green_since = now
+                    if a.settle > 0:
+                        emit(f"CI-SETTLE all green; waiting {a.settle}s for follow-up workflows")
+                elif now - green_since >= a.settle:
+                    done("success", " · ".join(sorted(seen)))
+            else:
+                green_since = None
+
+        if now - last_hb >= a.heartbeat:
+            last_hb = now
+            emit(f"CI-HB {int(elapsed)}s/{a.deadline}s — {len(seen)} run(s) tracked")
+
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- turn `ci-cd-optimize` into a workflow-first skill rather than a YAML tuning checklist
- add a provider-neutral feedback-loop reference plus bundled `ci-watch.py`
- add capacity/contention guidance so agents know when parallelism inverts
- deepen the core references (measurement, caching, change-based CI, runners, flakiness, evidence)
- regenerate the plugin mirrors and marketplace metadata

## Why
The open PRs all surfaced the same missing half: the skill knew how to make a pipeline fast, but not how an agent should **think** about the whole loop — reading prior runs first, separating queue from execution, pricing job-topology hops, recognizing concurrency ceilings, and waiting on CI without stalling or hallucinating a green.

This PR merges the strongest ideas conceptually into one generic skill for any project type:
- measure before editing config
- route by the measured symptom
- choose the smallest reversible experiment
- preserve the effectiveness contract
- close the feedback loop with a bounded watcher

## What changed
### New reference + script
- `references/feedback-loops.md`
- `references/capacity-and-contention.md`
- `scripts/ci-watch.py`

### Revamped core files
- `SKILL.md`
- `README.md`
- `references/measurement.md`
- `references/caching.md`
- `references/change-based-ci.md`
- `references/runners-and-autoscaling.md`
- `references/testing-and-flakiness.md`
- `references/evidence-and-sources.md`

## Notes
- Canonical source lives under `skills/`; the second commit regenerates the plugin mirrors.
- Validation passes: `python3 scripts/validate-skills.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt `ci-cd-optimize` as a workflow-first skill with a provider-neutral feedback loop, not just YAML tweaks. Adds `ci-watch.py` to wait on exact commit results safely and tightens guidance on capacity, measurement, and correctness.

- **New Features**
  - Workflow-first playbook: read prior runs, split queue/setup/exec/transfer, pick the smallest reversible change, keep required checks.
  - New `feedback-loops.md` and `capacity-and-contention.md`; expanded measurement, caching, change-based CI, runners, flakiness, evidence.
  - `scripts/ci-watch.py`: SHA-pinned watcher with heartbeat, single verdict, deadlines; native GitHub Actions via `gh`; pluggable probe for other CI.
  - Updated marketplace/plugin descriptions and tags; version set to 1.1.0; regenerated mirrors.

- **Migration**
  - No breaking changes.
  - Optional: start `scripts/ci-watch.py --sha $(git rev-parse HEAD) --branch <default-branch>` for GitHub; provide a probe command for other providers.

<sup>Written for commit 5d271829d3f324e3eafda092ca5d092add86f9b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/skills-by-yigitkonur/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

